### PR TITLE
Changes to support building on Snow Leopard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,11 +158,11 @@ IF(WIN32)
 ENDIF(WIN32)
 
 # Add a definition to fix some 64 bit linux system builds
-IF (NOT WIN32)
+IF (NOT WIN32 AND NOT APPLE)
       IF (CMAKE_SIZEOF_VOID_P MATCHES "8")
             ADD_DEFINITIONS("`pkg-config --cflags --libs gtk+-2.0`")
       ENDIF (CMAKE_SIZEOF_VOID_P MATCHES "8")
-ENDIF (NOT WIN32)
+ENDIF (NOT WIN32 AND NOT APPLE)
 
 
 # Location where cmake first looks for cmake modules.

--- a/src/tri.c
+++ b/src/tri.c
@@ -3091,8 +3091,12 @@ may need to traverse here
       return 0;
 }
 
-
+#ifdef __clang__
+int int_locate_endpoint_a(ipoint_t *v, ipoint_t *vo, int r)
+#else
 inline int int_locate_endpoint_a(ipoint_t *v, ipoint_t *vo, int r)
+#endif
+
 {
       register int root;
 


### PR DESCRIPTION
These changes allow OpenCPN to build a 32 bit version out of the box on Snow Leopard.
