### PR TITLE
Add dynamic menu for AIS targets to show/hide CPA line

### DIFF
--- a/include/ais.h
+++ b/include/ais.h
@@ -227,6 +227,7 @@ public:
     wxString GetRolloverString(void);
     wxString Get_vessel_type_string(bool b_short = false);
     wxString Get_class_string(bool b_short = false);
+	void Toggle_AIS_CPA(void); //TR 2012.06.28: Show AIS-CPA
 
 
     int                       MID;
@@ -299,6 +300,8 @@ public:
     bool                      bCPA_Valid;
     double                    TCPA;                     // Minutes
     double                    CPA;                      // Nautical Miles
+
+	bool                      b_show_AIS_CPA;           //TR 2012.06.28: Show AIS-CPA
 
     AISTargetTrackList        *m_ptrack;
 

--- a/src/ais.cpp
+++ b/src/ais.cpp
@@ -527,6 +527,7 @@ AIS_Target_Data::AIS_Target_Data()
     strncpy(CallSign, "       ", 8);
     strncpy(Destination, "                    ", 21);
     ShipNameExtension[0] = 0;
+	b_show_AIS_CPA = false;             //TR 2012.06.28: Show AIS-CPA
 
     SOG = 555.;
     COG = 666.;
@@ -1224,7 +1225,10 @@ wxString AIS_Target_Data::Get_class_string(bool b_short)
             return b_short ? _("Unk") : _("Unknown");
       }
 }
-
+void AIS_Target_Data::Toggle_AIS_CPA(void) //TR 2012.06.28: Show AIS-CPA
+{
+	b_show_AIS_CPA=!b_show_AIS_CPA?true:false; //TR 2012.06.28: Show AIS-CPA :simply toggle b_show_AIS_CPA 
+}
 
 //---------------------------------------------------------------------------------
 //

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -313,6 +313,7 @@ enum
         ID_RC_MENU_ZOOM_OUT,
         ID_RC_MENU_FINISH,
         ID_DEF_MENU_AIS_QUERY,
+		ID_DEF_MENU_AIS_CPA, //TR 2012.06.28: Show AIS-CPA
         ID_DEF_MENU_ACTIVATE_MEASURE,
         ID_DEF_MENU_DEACTIVATE_MEASURE,
 
@@ -3179,6 +3180,7 @@ EVT_MENU ( ID_RC_MENU_ZOOM_IN,      ChartCanvas::PopupMenuHandler )
 EVT_MENU ( ID_RC_MENU_ZOOM_OUT,     ChartCanvas::PopupMenuHandler )
 EVT_MENU ( ID_RC_MENU_FINISH,       ChartCanvas::PopupMenuHandler )
 EVT_MENU ( ID_DEF_MENU_AIS_QUERY,   ChartCanvas::PopupMenuHandler )
+EVT_MENU ( ID_DEF_MENU_AIS_CPA,   ChartCanvas::PopupMenuHandler ) //TR 2012.06.28: Show AIS-CPA 
 
 EVT_MENU ( ID_DEF_MENU_ACTIVATE_MEASURE,   ChartCanvas::PopupMenuHandler )
 EVT_MENU ( ID_DEF_MENU_DEACTIVATE_MEASURE, ChartCanvas::PopupMenuHandler )
@@ -6062,7 +6064,8 @@ void ChartCanvas::AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
         if( td->b_positionDoubtful ) target_brush = wxBrush( GetGlobalColor( _T ( "UINFF" ) ) );
 
 //    Check for alarms here, maintained by AIS class timer tick
-        if( ( td->n_alarm_state == AIS_ALARM_SET ) && ( td->bCPA_Valid ) ) {
+//TR original code:           if( ( td->n_alarm_state == AIS_ALARM_SET ) && ( td->bCPA_Valid ) ) {
+        if( ((td->n_alarm_state == AIS_ALARM_SET) && (td->bCPA_Valid)) || (td->b_show_AIS_CPA && (td->bCPA_Valid))) { //TR 2012.06.28: Show AIS-CPA;  show CPA when b_show_AIS_CPA is true
             //  Calculate the point of CPA for target
             double tcpa_lat, tcpa_lon;
             ll_gc_ll( td->Lat, td->Lon, td->COG, target_sog * td->TCPA / 60., &tcpa_lat,
@@ -8098,9 +8101,16 @@ void ChartCanvas::CanvasPopupMenu( int x, int y, int seltype )
     pdef_menu->AppendSeparator();
 
     if( g_pAIS ) {
-        if( seltype & SELTYPE_AISTARGET ) pdef_menu->Append( ID_DEF_MENU_AIS_QUERY,
-                _( "AIS Target Query" ) );
-
+        if( seltype & SELTYPE_AISTARGET ) {
+			pdef_menu->Append( ID_DEF_MENU_AIS_QUERY, _( "AIS Target Query" ) );
+			AIS_Target_Data *myptarget = g_pAIS->Get_Target_Data_From_MMSI(m_FoundAIS_MMSI); //TR 2012.06.28: Show AIS-CPA
+			if ( myptarget && myptarget->bCPA_Valid) {                                       //TR 2012.06.28: Show AIS-CPA : show menu-selection only, if we have a valid CPA !
+               if(myptarget->b_show_AIS_CPA )                                                //TR 2012.06.28: Hide AIS-CPA
+				   pdef_menu->Append ( ID_DEF_MENU_AIS_CPA,  _( "Hide AIS Target CPA" ) );   //TR 2012.06.28: Hide AIS-CPA
+			   else                                                                          //TR 2012.06.28: Hide AIS-CPA
+                   pdef_menu->Append ( ID_DEF_MENU_AIS_CPA,  _( "Show AIS Target CPA" ) );   //TR 2012.06.28: Show AIS-CPA
+		     }
+		}
         pdef_menu->Append( ID_DEF_MENU_AISTARGETLIST, _("AIS target list") );
         pdef_menu->AppendSeparator();
     }
@@ -8547,6 +8557,13 @@ void ChartCanvas::PopupMenuHandler( wxCommandEvent& event )
             wxWindow *pwin = wxDynamicCast(this, wxWindow);
             ShowAISTargetQueryDialog( pwin, m_FoundAIS_MMSI );
             break;
+        }
+
+        case ID_DEF_MENU_AIS_CPA: {             //TR 2012.06.28: Show AIS-CPA     
+            AIS_Target_Data *myptarget = g_pAIS->Get_Target_Data_From_MMSI(m_FoundAIS_MMSI); //TR 2012.06.28: Show AIS-CPA
+            if ( myptarget )                    //TR 2012.06.28: Show AIS-CPA
+               myptarget->Toggle_AIS_CPA();     //TR 2012.06.28: Show AIS-CPA
+            break;                              //TR 2012.06.28: Show AIS-CPA
         }
 
         case ID_DEF_MENU_QUILTREMOVE: {


### PR DESCRIPTION
I used/tested this function already for 2 weeks while sailing. Found it
very usefull to estimate where and how CPA will happen with target (ahead/aft/starboard/port)
It uses the original CPA line which is used in case of an alert, and is updated frequently.
Menu is only shown when we have a valid CPA, and CPA line is only shown as long as CPA is valid.
It works target specific, so it is possible to show the CPA-line for several targets in parallel
