### PR TITLE
Adds new instruments to dashboard plugins

### DIFF
--- a/plugins/dashboard_pi/po/dashboard_pi.pot
+++ b/plugins/dashboard_pi/po/dashboard_pi.pot
@@ -6,9 +6,9 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: dashboard_pi 2.6.1718\n"
+"Project-Id-Version: dashboard_pi 3.1.814\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2012-05-22 22:21-0400\n"
+"POT-Creation-Date: 2012-09-01 11:08+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,219 +16,255 @@ msgstr ""
 "Content-Type: text/plain; charset=CHARSET\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: src/compass.cpp:128 src/wind.cpp:85 src/gps.cpp:125 src/dashboard_pi.cpp:564
+#: src/compass.cpp:127 src/wind.cpp:84 src/gps.cpp:124 src/dashboard_pi.cpp:619
 msgid "N"
 msgstr ""
 
-#: src/compass.cpp:128 src/wind.cpp:85
+#: src/compass.cpp:127 src/wind.cpp:84
 msgid "NE"
 msgstr ""
 
-#: src/compass.cpp:128 src/wind.cpp:85 src/gps.cpp:126
+#: src/compass.cpp:127 src/wind.cpp:84 src/gps.cpp:125
 msgid "E"
 msgstr ""
 
-#: src/compass.cpp:128 src/wind.cpp:85
+#: src/compass.cpp:127 src/wind.cpp:84
 msgid "SE"
 msgstr ""
 
-#: src/compass.cpp:128 src/wind.cpp:85 src/gps.cpp:127
+#: src/compass.cpp:127 src/wind.cpp:84 src/gps.cpp:126
 msgid "S"
 msgstr ""
 
-#: src/compass.cpp:128 src/wind.cpp:85
+#: src/compass.cpp:127 src/wind.cpp:84
 msgid "SW"
 msgstr ""
 
-#: src/compass.cpp:128 src/wind.cpp:85 src/gps.cpp:128
+#: src/compass.cpp:127 src/wind.cpp:84 src/gps.cpp:127
 msgid "W"
 msgstr ""
 
-#: src/compass.cpp:128 src/wind.cpp:85
+#: src/compass.cpp:127 src/wind.cpp:84
 msgid "NW"
 msgstr ""
 
-#: src/dashboard_pi.cpp:100
-msgid "Position"
+#: src/instrument.cpp:160
+msgid "true"
 msgstr ""
 
-#: src/dashboard_pi.cpp:102
-msgid "SOG"
-msgstr ""
-
-#: src/dashboard_pi.cpp:104
-msgid "Speedometer"
-msgstr ""
-
-#: src/dashboard_pi.cpp:106
-msgid "COG"
+#: src/instrument.cpp:162
+msgid "mag"
 msgstr ""
 
 #: src/dashboard_pi.cpp:108
-msgid "Compass"
+msgid "Position"
 msgstr ""
 
 #: src/dashboard_pi.cpp:110
-msgid "STW"
+msgid "SOG"
 msgstr ""
 
 #: src/dashboard_pi.cpp:112
-msgid "HDG"
+msgid "Speedometer"
 msgstr ""
 
 #: src/dashboard_pi.cpp:114
-msgid "Apparent wind"
+msgid "COG"
 msgstr ""
 
 #: src/dashboard_pi.cpp:116
-msgid "Wind angle"
+msgid "Compass"
 msgstr ""
 
-#: src/dashboard_pi.cpp:118 src/dashboard_pi.cpp:120
-msgid "Wind speed"
+#: src/dashboard_pi.cpp:118
+msgid "STW"
+msgstr ""
+
+#: src/dashboard_pi.cpp:120
+msgid "true HDG"
 msgstr ""
 
 #: src/dashboard_pi.cpp:122
+msgid "mag HDG"
+msgstr ""
+
+#: src/dashboard_pi.cpp:124
+msgid "Apparent wind"
+msgstr ""
+
+#: src/dashboard_pi.cpp:126
+msgid "Wind angle"
+msgstr ""
+
+#: src/dashboard_pi.cpp:128 src/dashboard_pi.cpp:130
+msgid "Wind speed"
+msgstr ""
+
+#: src/dashboard_pi.cpp:132
 msgid "True wind"
 msgstr ""
 
-#: src/dashboard_pi.cpp:124 src/dashboard_pi.cpp:126
+#: src/dashboard_pi.cpp:134 src/dashboard_pi.cpp:136
 msgid "Depth"
 msgstr ""
 
-#: src/dashboard_pi.cpp:128
-msgid "Temp"
-msgstr ""
-
-#: src/dashboard_pi.cpp:130 src/dashboard_pi.cpp:132
-msgid "VMG"
-msgstr ""
-
-#: src/dashboard_pi.cpp:134 src/dashboard_pi.cpp:136
-msgid "Rudder angle"
-msgstr ""
-
 #: src/dashboard_pi.cpp:138
-msgid "GPS in view"
+msgid "Watertemp"
 msgstr ""
 
 #: src/dashboard_pi.cpp:140
-msgid "GPS status"
+msgid "Airtemp"
 msgstr ""
 
 #: src/dashboard_pi.cpp:142
-msgid "Cursor"
+msgid "App. Wind angle"
 msgstr ""
 
 #: src/dashboard_pi.cpp:144
-msgid "Clock"
+msgid "True Wind angle"
 msgstr ""
 
 #: src/dashboard_pi.cpp:146
-msgid "Sunrise/Sunset"
+msgid "True Wind direction"
 msgstr ""
 
 #: src/dashboard_pi.cpp:148
+msgid "True Wind speed"
+msgstr ""
+
+#: src/dashboard_pi.cpp:150
+msgid "True Wind angle & speed"
+msgstr ""
+
+#: src/dashboard_pi.cpp:152 src/dashboard_pi.cpp:154
+msgid "VMG"
+msgstr ""
+
+#: src/dashboard_pi.cpp:156 src/dashboard_pi.cpp:158
+msgid "Rudder angle"
+msgstr ""
+
+#: src/dashboard_pi.cpp:160
+msgid "GPS in view"
+msgstr ""
+
+#: src/dashboard_pi.cpp:162
+msgid "GPS status"
+msgstr ""
+
+#: src/dashboard_pi.cpp:164
+msgid "Cursor"
+msgstr ""
+
+#: src/dashboard_pi.cpp:166
+msgid "Clock"
+msgstr ""
+
+#: src/dashboard_pi.cpp:168
+msgid "Sunrise/Sunset"
+msgstr ""
+
+#: src/dashboard_pi.cpp:170
 msgid "Moon phase"
 msgstr ""
 
-#: src/dashboard_pi.cpp:247 src/dashboard_pi.cpp:318 src/dashboard_pi.cpp:1059
-#: src/dashboard_pi.cpp:1067 src/dashboard_pi.cpp:1211
-#: src/dashboard_pi.cpp:1246 src/dashboard_pi.cpp:1438
+#: src/dashboard_pi.cpp:276 src/dashboard_pi.cpp:347 src/dashboard_pi.cpp:1115
+#: src/dashboard_pi.cpp:1123 src/dashboard_pi.cpp:1267
+#: src/dashboard_pi.cpp:1302 src/dashboard_pi.cpp:1494
 msgid "Dashboard"
 msgstr ""
 
-#: src/dashboard_pi.cpp:324
+#: src/dashboard_pi.cpp:353
 msgid "Dashboard PlugIn for OpenCPN"
 msgstr ""
 
-#: src/dashboard_pi.cpp:329
+#: src/dashboard_pi.cpp:358
 msgid ""
 "Dashboard PlugIn for OpenCPN\n"
 "Provides navigation instrument display from NMEA source."
 msgstr ""
 
-#: src/dashboard_pi.cpp:1192
+#: src/dashboard_pi.cpp:1248
 msgid "Dashboard preferences"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1253
+#: src/dashboard_pi.cpp:1309
 msgid "show this dashboard"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1258
+#: src/dashboard_pi.cpp:1314
 msgid "Caption:"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1263
+#: src/dashboard_pi.cpp:1319
 msgid "Orientation:"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1266
+#: src/dashboard_pi.cpp:1322
 msgid "Vertical"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1267
+#: src/dashboard_pi.cpp:1323
 msgid "Horizontal"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1270
+#: src/dashboard_pi.cpp:1326
 msgid "Instrument width:"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1279 src/dashboard_pi.cpp:1286
-#: src/dashboard_pi.cpp:1551
+#: src/dashboard_pi.cpp:1335 src/dashboard_pi.cpp:1342
+#: src/dashboard_pi.cpp:1607
 msgid "Instruments"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1294
+#: src/dashboard_pi.cpp:1350
 msgid "Add"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1298
+#: src/dashboard_pi.cpp:1354
 msgid "Edit"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1302
+#: src/dashboard_pi.cpp:1358
 msgid "Delete"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1307
+#: src/dashboard_pi.cpp:1363
 msgid "Up"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1311
+#: src/dashboard_pi.cpp:1367
 msgid "Down"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1319
+#: src/dashboard_pi.cpp:1375
 msgid "Appearance"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1321
+#: src/dashboard_pi.cpp:1377
 msgid "Fonts"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1327
+#: src/dashboard_pi.cpp:1383
 msgid "Title:"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1331
+#: src/dashboard_pi.cpp:1387
 msgid "Data:"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1335
+#: src/dashboard_pi.cpp:1391
 msgid "Label:"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1339
+#: src/dashboard_pi.cpp:1395
 msgid "Small:"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1537
+#: src/dashboard_pi.cpp:1593
 msgid "Add instrument"
 msgstr ""
 
-#: src/dashboard_pi.cpp:1541
+#: src/dashboard_pi.cpp:1597
 msgid "Select instrument to add:"
 msgstr ""

--- a/plugins/dashboard_pi/po/de.po
+++ b/plugins/dashboard_pi/po/de.po
@@ -7,48 +7,68 @@ msgid ""
 msgstr ""
 "Project-Id-Version: opencpn 2.2.1110\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-06-12 12:56-0400\n"
-"PO-Revision-Date: 2011-06-15 16:58+0100\n"
-"Last-Translator: Gunther Pilz <gunther.pilz@gmail.com>\n"
+"POT-Creation-Date: 2012-09-01 10:43+0200\n"
+"PO-Revision-Date: 2012-09-01 11:09+0100\n"
+"Last-Translator: tr\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: \n"
-"X-Poedit-Basepath: F:\\GIT\\opencpn\\plugins\\dashboard_pi\n"
+"X-Poedit-Basepath: C:\\GIT\\opencpn2\\opencpn\\plugins\\dashboard_pi\n"
+
 #
 msgid "Add"
 msgstr "Hinzufügen"
+
 #
 msgid "Add instrument"
 msgstr "Instrument hinzufügen"
+
+#
+msgid "Airtemp"
+msgstr "Lufttemp."
+
+#
+msgid "App. Wind angle"
+msgstr "scheinbarer Wind: Winkel"
+
 #
 msgid "Apparent wind"
-msgstr "Wind - scheinbarer"
+msgstr "scheinbarer Wind"
+
 #
 msgid "Appearance"
 msgstr "Erscheinungsbild"
+
 #
 msgid "COG"
 msgstr "COG"
+
 #
 msgid "Caption:"
 msgstr "Fenstertitel:"
+
 #
 msgid "Clock"
 msgstr "Uhr"
+
 #
 msgid "Compass"
 msgstr "Kompass"
+
 #
 msgid "Cursor"
 msgstr "Cursor Pos."
+
 #
 msgid "Dashboard"
 msgstr "Dashboard"
+
 #
 msgid "Dashboard PlugIn for OpenCPN"
 msgstr "Dashboard Plugin für OpenCPN"
+
 #
 msgid ""
 "Dashboard PlugIn for OpenCPN\n"
@@ -56,126 +76,196 @@ msgid ""
 msgstr ""
 "Dashboard Plugin für OpenCPN\n"
 "ermöglicht Instrumentenanzeigen aus NMEA Quellen."
+
 #
 msgid "Dashboard preferences"
 msgstr "Dashboard Einstellungen"
+
 #
 msgid "Data:"
 msgstr "Daten:"
+
 #
 msgid "Delete"
 msgstr "Löschen"
+
 #
 msgid "Depth"
-msgstr "Echolot"
+msgstr "Tiefe"
+
 #
 msgid "Down"
 msgstr "runter"
+
 #
 msgid "E"
 msgstr "O"
+
 #
 msgid "Edit"
 msgstr "Bearbeiten"
+
 #
 msgid "Fonts"
 msgstr "Schrift"
+
 #
 msgid "GPS in view"
 msgstr "GPS Sat. Anzahl"
+
 #
 msgid "GPS status"
 msgstr "GPS Status"
-#
-msgid "HDG"
-msgstr "HDG"
+
 #
 msgid "Horizontal"
 msgstr "horizontal"
+
 #
 msgid "Instrument width:"
 msgstr "Instrumenten Breite:"
+
 #
 msgid "Instruments"
 msgstr "Instrumente"
+
 #
 msgid "Label:"
 msgstr "Label:"
+
 #
 msgid "Moon phase"
 msgstr "Mondphase"
+
 #
 msgid "N"
 msgstr "N"
+
 #
 msgid "NE"
 msgstr "NO"
+
 #
 msgid "NW"
 msgstr "NW"
+
 #
 msgid "Orientation:"
 msgstr "Ausrichtung:"
+
 #
 msgid "Position"
 msgstr "Position"
+
 #
 msgid "Rudder angle"
 msgstr "Ruderlage"
+
 #
 msgid "S"
 msgstr "S"
+
 #
 msgid "SE"
 msgstr "SO"
+
 #
 msgid "SOG"
 msgstr "SOG"
+
 #
 msgid "STW"
-msgstr "STW"
+msgstr "FdW"
+
 #
 msgid "SW"
 msgstr "SW"
+
 #
 msgid "Select instrument to add:"
 msgstr "Instrument auswählen zum Hinzufügen:"
+
 #
 msgid "Small:"
 msgstr "Klein:"
+
 #
 msgid "Speedometer"
 msgstr "Log"
+
 #
 msgid "Sunrise/Sunset"
 msgstr "Sonnenauf-/ -untergang"
-#
-msgid "Temp"
-msgstr "Thermometer"
+
 #
 msgid "Title:"
 msgstr "Titel:"
+
+#
+msgid "True Wind angle"
+msgstr "wahrer Wind: Winkel"
+
+#
+msgid "True Wind angle & speed"
+msgstr "wahrer Wind: Winkel & Geschw."
+
+#
+msgid "True Wind direction"
+msgstr "wahrer Wind: Richtung "
+
+#
+msgid "True Wind speed"
+msgstr "wahrer Wind: Geschw."
+
 #
 msgid "True wind"
-msgstr "Wind - wahrer"
+msgstr "wahrer Wind"
+
 #
 msgid "Up"
 msgstr "hoch"
+
 #
 msgid "VMG"
 msgstr "VMG"
+
 #
 msgid "Vertical"
 msgstr "vertikal"
+
 #
 msgid "W"
 msgstr "W"
+
+#
+msgid "Watertemp"
+msgstr "Wassertemp."
+
 #
 msgid "Wind angle"
 msgstr "Wind"
+
 #
 msgid "Wind speed"
 msgstr "Windgeschwindigkeit"
+
+#
+msgid "mag"
+msgstr "mag."
+
+#
+msgid "mag HDG"
+msgstr "mag. Kurs"
+
 #
 msgid "show this dashboard"
 msgstr "ausgewähltes Dashboard anzeigen"
+
+#
+msgid "true"
+msgstr "rechtw."
+
+#
+msgid "true HDG"
+msgstr "rechtw. Kurs"
+

--- a/plugins/dashboard_pi/po/it.po
+++ b/plugins/dashboard_pi/po/it.po
@@ -7,54 +7,75 @@ msgid ""
 msgstr ""
 "Project-Id-Version: opencpn 2.2.1110\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-06-11 10:27-0400\n"
-"PO-Revision-Date: 2010-11-25 23:47+0100\n"
-"Last-Translator: Marco Certelli <marco_certelli@yahoo.it>\n"
+"POT-Creation-Date: 2012-09-01 10:43+0200\n"
+"PO-Revision-Date: 2012-09-01 11:11+0100\n"
+"Last-Translator: tr\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Language: \n"
+
 #
 #
 msgid "Add"
 msgstr "Aggiungi"
+
 #
 #
 msgid "Add instrument"
 msgstr "Aggiungi Strumento"
+
+#
+msgid "Airtemp"
+msgstr "Temp. Aria"
+
+#
+#
+msgid "App. Wind angle"
+msgstr "Angolo Vento apparente"
+
 #
 #
 msgid "Apparent wind"
 msgstr "Vento Apparente"
+
 #
 msgid "Appearance"
 msgstr ""
+
 #
 #
 msgid "COG"
 msgstr ""
+
 #
 msgid "Caption:"
 msgstr ""
+
 #
 msgid "Clock"
 msgstr ""
+
 #
 #
 msgid "Compass"
 msgstr "Bussola"
+
 #
 msgid "Cursor"
 msgstr ""
+
 #
 #
 msgid "Dashboard"
 msgstr "Dashboard"
+
 #
 #
 msgid "Dashboard PlugIn for OpenCPN"
 msgstr "Dashboard PlugIn per OpenCPN"
+
 #
 #
 msgid ""
@@ -63,156 +84,227 @@ msgid ""
 msgstr ""
 "Dashboard PlugIn per OpenCPN\n"
 "Mostra strumenti di navigazione dai dati NMEA."
+
 #
 #
 msgid "Dashboard preferences"
 msgstr "Preferenze Dashboard"
+
 #
 msgid "Data:"
 msgstr "Dati:"
+
 #
 #
 msgid "Delete"
 msgstr "Cancella"
+
 #
 #
 msgid "Depth"
 msgstr "Profondità"
+
 #
 #
 msgid "Down"
 msgstr "Giù"
+
 #
 #
 msgid "E"
-msgstr ""
+msgstr "E"
+
 #
 #
 msgid "Edit"
 msgstr "Modifica"
+
 #
 msgid "Fonts"
 msgstr "Caratteri"
+
 #
 #
 msgid "GPS in view"
 msgstr "Satelliti GPS in vista"
+
 #
 #
 msgid "GPS status"
 msgstr "Stato GPS"
-#
-#
-msgid "HDG"
-msgstr ""
+
 #
 msgid "Horizontal"
-msgstr ""
+msgstr "horizontale"
+
 #
 #
 msgid "Instrument width:"
 msgstr "Larghezza Strumenti:"
+
 #
 #
 msgid "Instruments"
 msgstr "Strumenti"
+
 #
 msgid "Label:"
 msgstr "Etichetta:"
+
 #
 msgid "Moon phase"
 msgstr ""
+
 #
 #
 msgid "N"
-msgstr ""
+msgstr "N"
+
 #
 #
 msgid "NE"
-msgstr ""
+msgstr "NE"
+
 #
 #
 msgid "NW"
-msgstr ""
+msgstr "NO"
+
 #
 msgid "Orientation:"
-msgstr ""
+msgstr "Orientazione:"
+
 #
 #
 msgid "Position"
 msgstr "Posizione"
+
 #
 #
 msgid "Rudder angle"
 msgstr "Angolo di barra"
+
 #
 #
 msgid "S"
-msgstr ""
+msgstr "S"
+
 #
 #
 msgid "SE"
-msgstr ""
+msgstr "SE"
+
 #
 #
 msgid "SOG"
 msgstr ""
+
 #
 #
 msgid "STW"
-msgstr ""
+msgstr "Velocità"
+
 #
 #
 msgid "SW"
-msgstr ""
+msgstr "SO"
+
 #
 #
 msgid "Select instrument to add:"
 msgstr "Seleziona strumenti:"
+
 #
 msgid "Small:"
 msgstr "Piccolo:"
+
 #
 #
 msgid "Speedometer"
 msgstr "Velocità"
+
 #
 msgid "Sunrise/Sunset"
 msgstr ""
-#
-#
-msgid "Temp"
-msgstr "Temperatura"
+
 #
 msgid "Title:"
 msgstr "Titolo:"
+
+#
+#
+msgid "True Wind angle"
+msgstr "Angolo Vento reale"
+
+#
+#
+msgid "True Wind angle & speed"
+msgstr "Angolo & Veocità Vento reale"
+
+#
+msgid "True Wind direction"
+msgstr "direz. Vento reale"
+
+#
+#
+msgid "True Wind speed"
+msgstr "Velocità Vento reale"
+
 #
 #
 msgid "True wind"
 msgstr "Vento Reale"
+
 #
 #
 msgid "Up"
 msgstr "Su"
+
 #
 #
 msgid "VMG"
 msgstr ""
+
 #
 msgid "Vertical"
-msgstr ""
+msgstr "verticale"
+
 #
 #
 msgid "W"
-msgstr ""
+msgstr "O"
+
+#
+msgid "Watertemp"
+msgstr "Temp. Aqua"
+
 #
 #
 msgid "Wind angle"
 msgstr "Angolo Vento"
+
 #
 #
 msgid "Wind speed"
 msgstr "Velocità Vento"
+
+#
+msgid "mag"
+msgstr ""
+
+#
+msgid "mag HDG"
+msgstr ""
+
 #
 msgid "show this dashboard"
 msgstr ""
+
+#
+msgid "true"
+msgstr ""
+
+#
+msgid "true HDG"
+msgstr ""
+

--- a/plugins/dashboard_pi/src/instrument.cpp
+++ b/plugins/dashboard_pi/src/instrument.cpp
@@ -150,10 +150,32 @@ void DashboardInstrument_Single::Draw(wxBufferedDC* dc)
 
 void DashboardInstrument_Single::SetData(int st, double data, wxString unit)
 {
-      if (m_cap_flag & st)
-      {
-            if(!wxIsNaN(data))
-                m_data = wxString::Format(m_format, data);
+      if (m_cap_flag & st){
+            if(!wxIsNaN(data)){
+                if (unit == _T("C"))
+                  m_data = wxString::Format(m_format, data)+_T("°C");
+                else if (unit == _T("Deg"))
+                  m_data = wxString::Format(m_format, data)+_T("°");
+                else if (unit == _T("DegT"))
+                  m_data = wxString::Format(m_format, data)+_T("° ") << _("true");
+                else if (unit == _T("DegM"))
+                  m_data = wxString::Format(m_format, data)+_T("° ") << _("mag");
+                else if (unit == _T("DegL"))
+                  m_data = _T(">")+ wxString::Format(m_format, data)+_T("°");
+                else if (unit == _T("DegR"))
+                  m_data = wxString::Format(m_format, data)+_T("°<");
+                else if (unit == _T("N")) //Knots
+                  m_data = wxString::Format(m_format, data)+_T(" Kts");
+/* maybe in the future ...
+                else if (unit == _T("M")) // m/s
+                  m_data = wxString::Format(m_format, data)+_T(" m/s");
+                else if (unit == _T("K")) // km/h
+                  m_data = wxString::Format(m_format, data)+_T(" km/h");
+ ... to be completed
+ */
+                else
+                  m_data = wxString::Format(m_format, data);
+            }
             else
                 m_data = _T("---");
 

--- a/plugins/dashboard_pi/src/instrument.h
+++ b/plugins/dashboard_pi/src/instrument.h
@@ -82,7 +82,11 @@ enum
     OCPN_DBP_STC_PLA = 1 << 19, // Cursor latitude
     OCPN_DBP_STC_PLO = 1 << 20, // Cursor longitude
     OCPN_DBP_STC_CLK = 1 << 21,
-    OCPN_DBP_STC_MON = 1 << 22
+    OCPN_DBP_STC_MON = 1 << 22,
+    OCPN_DBP_STC_ATMP = 1 << 23, //AirTemp
+	OCPN_DBP_STC_MWD = 1 << 24,  //True Wind direction & Speed
+	OCPN_DBP_STC_VWT = 1 << 25,  //True Wind angle & Speed
+	OCPN_DBP_STC_AWA2 = 1 << 26  //App Wind angle, sends unconverted Spd. value
 };
 
 class DashboardInstrument : public wxWindow

--- a/plugins/dashboard_pi/src/nmea0183/mta.cpp
+++ b/plugins/dashboard_pi/src/nmea0183/mta.cpp
@@ -1,0 +1,122 @@
+/***************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  NMEA0183 Support Classes
+ * Author:   Samuel R. Blackburn, David S. Register
+ *
+ ***************************************************************************
+ *   Copyright (C) 2010 by Samuel R. Blackburn, David S Register           *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.             *
+ ***************************************************************************
+ *
+ *   S Blackburn's original source license:                                *
+ *         "You can use it any way you like."                              *
+ *   More recent (2010) license statement:                                 *
+ *         "It is BSD license, do with it what you will"                   *
+ */
+
+#include "nmea0183.h"
+/*
+** Author: Samuel R. Blackburn
+** CI$: 76300,326
+** Internet: sammy@sed.csc.com
+**
+** You can use it any way you like.
+*/
+
+//IMPLEMENT_DYNAMIC( MTA, RESPONSE )
+
+MTA::MTA()
+{
+   Mnemonic = _T("MTA");
+   Empty();
+}
+
+MTA::~MTA()
+{
+   Mnemonic.Empty();
+   Empty();
+}
+
+void MTA::Empty( void )
+{
+//   ASSERT_VALID( this );
+
+   Temperature = 0.0;
+   UnitOfMeasurement.Empty();
+}
+
+bool MTA::Parse( const SENTENCE& sentence )
+{
+//   ASSERT_VALID( this );
+
+   /*
+   ** MTA - Air Temperature
+   **
+   **        1   2 3
+   **        |   | | 
+   ** $--MTA,x.x,C*hh<CR><LF>
+   **
+   ** Field Number: 
+   **  1) Degrees
+   **  2) Unit of Measurement, Celcius
+   **  3) Checksum
+   */
+
+   /*
+   ** First we check the checksum...
+   */
+
+   if ( sentence.IsChecksumBad( 3 ) == TRUE )
+   {
+      SetErrorMessage( _T("Invalid Checksum") );
+      return( FALSE );
+   } 
+
+   Temperature       = sentence.Double( 1 );
+   UnitOfMeasurement = sentence.Field( 2 );
+
+   return( TRUE );
+}
+
+bool MTA::Write( SENTENCE& sentence )
+{
+//   ASSERT_VALID( this );
+
+   /*
+   ** Let the parent do its thing
+   */
+   
+   RESPONSE::Write( sentence );
+
+   sentence += Temperature;
+   sentence += UnitOfMeasurement;
+
+   sentence.Finish();
+
+   return( TRUE );
+}
+
+const MTA& MTA::operator = ( const MTA& source )
+{
+//   ASSERT_VALID( this );
+
+   Temperature       = source.Temperature;
+   UnitOfMeasurement = source.UnitOfMeasurement;
+
+   return( *this );
+}

--- a/plugins/dashboard_pi/src/nmea0183/mta.hpp
+++ b/plugins/dashboard_pi/src/nmea0183/mta.hpp
@@ -1,0 +1,74 @@
+/***************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  NMEA0183 Support Classes
+ * Author:   Samuel R. Blackburn, David S. Register
+ *
+ ***************************************************************************
+ *   Copyright (C) 2010 by Samuel R. Blackburn, David S Register           *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.             *
+ ***************************************************************************
+ *
+ *   S Blackburn's original source license:                                *
+ *         "You can use it any way you like."                              *
+ *   More recent (2010) license statement:                                 *
+ *         "It is BSD license, do with it what you will"                   *
+ */
+
+#if ! defined( MTA_CLASS_HEADER )
+#define MTA_CLASS_HEADER
+
+/*
+** Author: Samuel R. Blackburn
+** CI$: 76300,326
+** Internet: sammy@sed.csc.com
+**
+** You can use it any way you like.
+*/
+
+class MTA : public RESPONSE
+{
+//   DECLARE_DYNAMIC( MTA )
+
+   public:
+
+      MTA();
+     ~MTA();
+
+      /*
+      ** Data
+      */
+
+      double  Temperature;
+      wxString UnitOfMeasurement;
+
+      /*
+      ** Methods
+      */
+
+      virtual void Empty( void );
+      virtual bool Parse( const SENTENCE& sentence );
+      virtual bool Write( SENTENCE& sentence );
+
+      /*
+      ** Operators
+      */
+
+      virtual const MTA& operator = ( const MTA& source );
+};
+
+#endif // MTA_CLASS_HEADER

--- a/plugins/dashboard_pi/src/nmea0183/nmea0183.cpp
+++ b/plugins/dashboard_pi/src/nmea0183/nmea0183.cpp
@@ -84,7 +84,8 @@ NMEA0183::NMEA0183()
    response_table.Append( (RESPONSE *) &Lcd );
 */
    response_table.Append( (RESPONSE *) &Mwd );
-   response_table.Append( (RESPONSE *) &Mtw );
+   response_table.Append( (RESPONSE *) &Mta ); //Air Temperature
+   response_table.Append( (RESPONSE *) &Mtw ); //Water Temperature
    response_table.Append( (RESPONSE *) &Mwv );
 /*
    response_table.Append( (RESPONSE *) &Oln );

--- a/plugins/dashboard_pi/src/nmea0183/nmea0183.hpp
+++ b/plugins/dashboard_pi/src/nmea0183/nmea0183.hpp
@@ -102,7 +102,8 @@
 #include "gga.hpp"
 #include "dbt.hpp"
 #include "dpt.hpp"
-#include "mtw.hpp"
+#include "mta.hpp" //Air temperature
+#include "mtw.hpp" //Water temperature
 #include "mwd.hpp"
 #include "mwv.hpp"
 #include "vhw.hpp"
@@ -195,6 +196,7 @@ class NMEA0183
       HSC Hsc;
       LCD Lcd;
 */
+      MTA Mta; //Air temperature
       MTW Mtw;
       MWD Mwd;
       MWV Mwv;

--- a/plugins/dashboard_pi/src/wind.h
+++ b/plugins/dashboard_pi/src/wind.h
@@ -78,5 +78,22 @@ class DashboardInstrument_WindCompass: public DashboardInstrument_Dial
             void DrawBackground(wxBufferedDC* dc);
 };
 
+class DashboardInstrument_TrueWindAngle: public DashboardInstrument_Dial
+{
+      public:
+            wxString m_unit;
+            DashboardInstrument_TrueWindAngle( wxWindow *parent, wxWindowID id, wxString title, int cap_flag);
+            void SetData(int, double, wxString);
+
+            ~DashboardInstrument_TrueWindAngle(void){}
+
+      private:
+
+      protected:
+            
+            void DrawBackground(wxBufferedDC* dc);
+            void DrawForeground(wxBufferedDC* dc);
+};
+
 #endif // __Wind_H__
 


### PR DESCRIPTION
There are 6 additional "text intruments" :
    \* app.wind angle +-180° on boat axis left/right is shown as > and <, e.g. "> 135°"
    \* true.wind angle +-180° on boat axis left/right is shown as > and <, eg "135° <"
    \* true wind direction
    \* true wind speed
    \* magnetic heading (flyspray #840)
    \* Air Temp (implementing MTA)
 1 graphical (dial) instruments :
    \* true wind angle +-180° on boat axis + speed

 There's a bugfix for true wind direction + speed (#564)
 It also implements a workaround for the Windows bug showing Temp e.g. as "25°ÂC"
It covers a couple of flysray issues #840, parts of #632, #564, #306 (no 1),
