### PR TITLE
Adding the "routeplanning": printing a route as a table with list of waypoints and their description

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -310,6 +310,8 @@ SET(HDRS
 		include/routeman.h
 		include/routemanagerdialog.h
 		include/routeprop.h
+		include/routeprintout.h
+		include/printtable.h		
 		include/statwin.h
 		include/tcmgr.h
 		include/thumbwin.h
@@ -349,6 +351,8 @@ SET(SRCS
 		src/routeman.cpp
 		src/routemanagerdialog.cpp
 		src/routeprop.cpp
+		src/routeprintout.cpp
+		src/printtable.cpp
 		src/statwin.cpp
 		src/tcmgr.cpp
 		src/thumbwin.cpp

--- a/include/chart1.h
+++ b/include/chart1.h
@@ -393,13 +393,21 @@ void *x_malloc(size_t t);
 class MyPrintout: public wxPrintout
 {
  public:
-  MyPrintout(const wxChar *title = _T("My printout")):wxPrintout(title) {}
+  MyPrintout(const wxChar *title = _T("My printout")):wxPrintout(title){}
+  virtual
   bool OnPrintPage(int page);
+  virtual
   bool HasPage(int page);
+  virtual
   bool OnBeginDocument(int startPage, int endPage);
+  virtual
   void GetPageInfo(int *minPage, int *maxPage, int *selPageFrom, int *selPageTo);
 
   void DrawPageOne(wxDC *dc);
+  
+
+  
+  
 };
 
 

--- a/include/navutil.h
+++ b/include/navutil.h
@@ -102,6 +102,8 @@ public:
       void SetPropFromString(const wxString &prop_string);
 
       void SetPosition(double lat, double lon);
+      double GetLatitude()  { return m_lat; };
+      double GetLongitude() { return m_lon; };      
       void CalculateDCRect(wxDC& dc, wxRect *prect);
 
       bool IsSame(RoutePoint *pOtherRP);        // toh, 2009.02.11
@@ -112,10 +114,17 @@ public:
       void SetListed(bool viz = true){ m_bIsListed = viz; }
       void SetNameShown(bool viz = true) { m_bShowName = viz; }
       wxString GetName(void){ return m_MarkName; }
+      wxString GetDescription(void) { return m_MarkDescription; }
 
       void SetName(wxString name);
       void CalculateNameExtents(void);
 
+      void SetCourse( double course) { m_course = course; }; 
+      double GetCourse() { return m_course; };      
+      void SetDistance( double distance) { m_distance = distance; }; 
+      double GetDistance() { return m_distance; };         
+
+      
       bool SendToGPS ( wxString& com_name, wxGauge *pProgress );
 
 
@@ -163,6 +172,9 @@ public:
       int               m_GPXTrkSegNo;
       bool              m_bIsInLayer;
       int               m_LayerID;
+      
+      double            m_course;		// course from this waypoint to the next waypoint in the route. It is set when the route property dialog created.
+      double            m_distance;		// distance from this waypoint to the next waypoint in the route. It is set when the route property dialog created.
 
       HyperlinkList     *m_HyperlinkList;
 

--- a/include/printtable.h
+++ b/include/printtable.h
@@ -1,0 +1,225 @@
+/******************************************************************************
+ *
+ * Project:  OpenCP
+ * Purpose:  OpenCP Main wxWidgets Program
+ * Author:   Pavel Saviankou
+ *
+ ***************************************************************************
+ *   Copyright (C) 2010 by Pavel Saviankou                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ *
+ *
+ */
+#include <iostream>
+#include <vector>
+using namespace std;
+
+
+#ifndef __PRINTTABLE_H__
+#define __PRINTTABLE_H__
+
+#include <wx/print.h>
+#include <wx/datetime.h>
+#include <wx/cmdline.h>
+#include <wx/string.h>
+#ifdef __WXMSW__
+#include <wx/msw/private.h>
+#endif
+
+#include "ocpn_types.h"
+#include "navutil.h"
+
+/**
+ * \brief 
+ *  Enumeration is used to notice the state of the table.
+ * 
+ *  Different states are used to signalize different semanic of the data in
+ *  the operator << of the class Table.
+ *  If the state is "setup columns widths" -> then the data is used to store
+ *  the width of the columns.
+ *  If the state is "fill with data" -> then the data is the cell content.  
+ */
+ enum TableState { TABLE_SETUP_WIDTHS=0, TABLE_FILL_DATA, TABLE_FILL_HEADER };
+
+
+/** 
+ *  \brief Represents a NxM simple table with captions.
+ *  
+ *  Input operator is "<<" 
+ *  Number of columns and rows are given dynamically by the input data.
+ *  Captions are given by first input line.
+ *  Every cell is given column by column.
+ *  Next row is given by "<< '\n'" (or << endl)
+ *  
+ *  
+ * 
+ */
+class Table 
+{
+  protected:
+    uint32_t nrows;
+    uint32_t ncols;
+    
+    bool create_next_row;
+    
+    vector< vector < wxString > > data;
+    vector< double > widths;
+    vector< wxString > header;
+    TableState state;
+    
+    void
+    Start();
+    
+    void
+    NewRow();
+    
+  public:
+    Table();
+    ~Table();
+    
+    Table& operator<< (const string&);
+    Table& operator<< (const int&);
+    Table& operator<< (const double&);    
+    vector< vector < wxString > > & GetData() { return data; };
+    
+    void
+    StartFillData() { state  = TABLE_FILL_DATA; };
+    void
+    StartFillHeader() { state  = TABLE_FILL_HEADER; };
+    void
+    StartFillWidths() { state  = TABLE_SETUP_WIDTHS; };    
+    int GetRowHeight( int i) { return widths[i]; };
+};
+
+
+ostream& operator<<(ostream&, Table&);
+
+
+
+/**
+ *  \brief This class takes multilined string and modifies it to fit into given width 
+ *         for given device. If it is too wide for given DC (by class PrintTable )
+ *        it introduces new lines between words 
+ *   
+ */
+
+class PrintCell 
+{
+  protected:
+    /// Copy of printing device
+    wxDC * dc;
+    
+    /// Target width
+    int width;
+    
+    /// Target height
+    int height;
+    
+    /// Cellpadding
+    int cellpadding;
+    
+    /// Content of a cell
+    wxString content;     
+    
+    /// Result of modification
+    wxString  modified_content;   
+    
+    /// Rect for printing of modified string
+    wxRect  rect;
+    
+    /// Stores page, where this cell will be printed
+    int page;
+    
+    /// Stores, if one has to ovveride property "weight" of the font with the value "bold" - used to print header of the table.
+    bool bold_font;
+    
+    
+    /// Adjust text
+    void Adjust();
+
+    
+  public:
+    
+    /// Constructor with content to print and device
+    PrintCell () {};
+
+    /// Constructor with content to print and device
+    void Init (const wxString& _content, wxDC* _dc, int _width, int _cellpadding, bool bold_font = false);
+     
+    /// Returns rect for printing 
+    wxRect GetRect() { return rect; };               
+    
+    /// Returns modified cell content
+    wxString GetText() { return modified_content; };    
+    
+    /// Returns height of the cell
+    int GetHeight() { return height; };
+    
+    /// Returns width of the cell
+    int GetWidth() { return width; };
+    
+    /// sets the page to print 
+    void SetPage( int _page) { page = _page; };
+    
+    /// sets the height 
+    void SetHeight( int _height) { height = _height; };  
+    
+    /// Returns the page, where this element should be painted
+    int GetPage() { return page; };
+};
+
+
+
+/**
+ *  \brief Extension of a class Table with printing into dc.
+ * 
+ *   It takes all elements, takes DC as a printing device, takes  a maximal 
+ *   possible table width,  calculate width of every column. 
+ *   For printing of every cell it modifies its content so, that it fits into cell by inserting 
+ *   new lines. 
+ * 
+ */
+class PrintTable : public Table
+{
+  protected:
+    vector< vector < PrintCell > > contents;
+    vector < PrintCell > header_content;    
+    vector< int > rows_heights;
+    int	header_height;
+    
+    
+    int number_of_pages;		/// stores the number of pages for printing of this table. It is set by AdjustCells(...)
+    
+  public:
+    PrintTable();
+    
+    /// creates internally vector of PrintCell's, to calculate columns widths and row sizes
+    void AdjustCells( wxDC* _dc, int marginX, int marginY); 
+    
+    /// delivers content of the table
+     vector< vector < PrintCell > >& GetContent() { return contents; };
+    /// delivers header  of the table
+    vector < PrintCell > & GetHeader() { return header_content; };     
+    /// returns the total number of needed pages;
+    int GetNumberPages() { return number_of_pages; };
+     
+    /// Returns the height of the header
+    int GetHeaderHeight() { return header_height; }; 
+  
+};
+#endif

--- a/include/routeprintout.h
+++ b/include/routeprintout.h
@@ -1,0 +1,201 @@
+/******************************************************************************
+ *
+ * Project:  OpenCP
+ * Purpose:  OpenCP Main wxWidgets Program
+ * Author:   David Register
+ *
+ ***************************************************************************
+ *   Copyright (C) 2010 by David S. Register   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.             *
+ ***************************************************************************
+ *
+ *
+ */
+#include <iostream>
+using namespace std;
+
+
+#ifndef __ROUTEPRINTOUT_H__
+#define __ROUTEPRINTOUT_H__
+
+#include <wx/print.h>
+#include <wx/datetime.h>
+#include <wx/cmdline.h>
+
+#ifdef __WXMSW__
+#include <wx/msw/private.h>
+#endif
+
+#include "ocpn_types.h"
+#include "navutil.h"
+#include "printtable.h"
+
+class MyRoutePrintout: public MyPrintout
+{
+ public:
+  MyRoutePrintout( std::vector<bool> _toPrintOut, Route * route, const wxChar *title = _T("My Route printout"));
+  virtual
+  bool OnPrintPage(int page);
+  void DrawPage(wxDC *dc);
+  virtual
+  void OnPreparePrinting();
+  
+  virtual 
+  bool HasPage( int num )  {return num > 0 || num <= 1; };
+  
+  virtual
+    void GetPageInfo(int *minPage, int *maxPage, int *selPageFrom, int *selPageTo);
+  
+  protected:
+  wxDC * myDC;
+  PrintTable table;
+  Route * myRoute;
+  std::vector<bool> toPrintOut; // list of fields of bool, if certain element should be print out.
+  static const int pN = 5; // number of fields sofar
+  int	pageToPrint;
+  int   numberOfPages;
+  int marginX;
+  int marginY;
+  
+};
+
+
+// route elements selection dialog
+////@begin control identifiers
+#define ID_ROUTEPRINTSELECTION 9000
+#define SYMBOL_ROUTEPRINT_SELECTION_STYLE wxCAPTION|wxRESIZE_BORDER|wxSYSTEM_MENU|wxCLOSE_BOX
+#define SYMBOL_ROUTEPRINT_SELECTION_TITLE _("Print Route Selection")
+#define SYMBOL_ROUTEPRINT_SELECTION_IDNAME ID_ROUTEPRINTSELECTION
+#define SYMBOL_ROUTEPRINT_SELECTION_SIZE wxSize(750, 300)
+#define SYMBOL_ROUTEPRINT_SELECTION_POSITION wxDefaultPosition
+
+#define ID_ROUTEPRINT_SELECTION_OK 9001
+#define ID_ROUTEPRINT_SELECTION_CANCEL 9002
+
+
+class RoutePrintSelection: public wxDialog
+{
+    DECLARE_DYNAMIC_CLASS( RoutePrintSelection )
+    DECLARE_EVENT_TABLE()
+
+public:
+    /// Constructors
+    RoutePrintSelection( );
+    RoutePrintSelection(wxWindow* parent, Route * route, wxWindowID id = SYMBOL_ROUTEPRINT_SELECTION_IDNAME,
+        const wxString& caption = SYMBOL_ROUTEPRINT_SELECTION_TITLE,
+        const wxPoint& pos = SYMBOL_ROUTEPRINT_SELECTION_POSITION,
+        const wxSize& size = SYMBOL_ROUTEPRINT_SELECTION_SIZE,
+        long style = SYMBOL_ROUTEPRINT_SELECTION_STYLE );
+    ~RoutePrintSelection( );
+
+    /// Creation
+    bool Create( wxWindow* parent, wxWindowID id = SYMBOL_ROUTEPRINT_SELECTION_IDNAME,
+                 const wxString& caption = SYMBOL_ROUTEPRINT_SELECTION_TITLE,
+                 const wxPoint& pos = SYMBOL_ROUTEPRINT_SELECTION_POSITION,
+                 const wxSize& size = SYMBOL_ROUTEPRINT_SELECTION_SIZE,
+                 long style = SYMBOL_ROUTEPRINT_SELECTION_STYLE );
+
+    void CreateControls();
+
+    void SetColorScheme(ColorScheme cs);
+    void SetDialogTitle(wxString title);
+    void OnRoutepropCancelClick( wxCommandEvent& event );
+    void OnRoutepropOkClick( wxCommandEvent& event );
+//     void OnPlanSpeedCtlUpdated( wxCommandEvent& event );
+//     void OnStartTimeCtlUpdated( wxCommandEvent& event );
+//     void OnTimeZoneSelected( wxCommandEvent& event );
+//     void OnRoutepropListClick( wxListEvent& event );
+//     void OnRoutepropSplitClick( wxCommandEvent& event );
+//     void OnRoutepropExtendClick( wxCommandEvent& event );
+//     void OnRoutepropPrintClick( wxCommandEvent& event );
+//     void OnRoutepropCopyTxtClick( wxCommandEvent& event );
+//     void OnRoutePropRightClick( wxListEvent &event );
+//     void OnRoutePropMenuSelected( wxCommandEvent &event );
+//     bool IsThisRouteExtendable();
+//     bool IsThisTrackExtendable();
+//     void OnEvtColDragEnd(wxListEvent& event);
+//     void InitializeList();
+
+
+    /// Should we show tooltips?
+    static bool ShowToolTips();
+
+//     void SetRouteAndUpdate(Route *pR);
+//     Route *GetRoute(void){return m_pRoute;}
+
+//     bool UpdateProperties(void);
+//     wxString MakeTideInfo(int jx, time_t tm, int tz_selection, long LMT_Offset);
+//     bool SaveChanges(void);
+/*
+    wxTextCtrl  *m_TotalDistCtl;
+    wxTextCtrl  *m_PlanSpeedCtl;
+    wxTextCtrl	*m_StartTimeCtl;
+    wxTextCtrl  *m_TimeEnrouteCtl;
+
+    wxStaticText *m_PlanSpeedLabel;
+    wxStaticText *m_StartTimeLabel;
+
+    wxTextCtrl  *m_RouteNameCtl;
+    wxTextCtrl  *m_RouteStartCtl;
+    wxTextCtrl  *m_RouteDestCtl;
+
+    wxListCtrl        *m_wpList;
+    OCPNTrackListCtrl *m_wpTrackList;*/
+
+    wxButton*     m_CancelButton;
+    wxButton*     m_OKButton;
+    
+    wxCheckBox * m_checkBoxWPName;
+    wxCheckBox * m_checkBoxWPPosition;   
+    wxCheckBox * m_checkBoxWPCourse;
+    wxCheckBox * m_checkBoxWPDistanceToNext;
+    wxCheckBox * m_checkBoxWPDescription;
+    
+    Route *       route;
+    
+//     wxButton*     m_CopyTxtButton;
+//     wxButton*     m_PrintButton;    
+//     wxButton*     m_ExtendButton;
+//     wxButton*     m_SplitButton;
+
+//     Route       *m_pRoute;
+//     Route       *m_pHead; // for route splitting
+//     Route       *m_pTail;
+//     RoutePoint *m_pExtendPoint;
+//     Route *m_pExtendRoute;
+//     RoutePoint    *m_pEnroutePoint;
+//     bool          m_bStartNow;
+// 
+//     double      m_planspeed;
+//     double      m_avgspeed;
+// 
+//     int         m_nSelected; // index of point selected in Properties dialog row
+//     int         m_tz_selection;
+// 
+//     wxDateTime	 m_starttime; // kept as UTC
+//     wxRadioBox	*pDispTz;
+//     wxStaticText  *m_staticText1;
+//     wxStaticText  *m_staticText2;
+//     wxStaticText  *m_staticText3;
+//     wxChoice      *m_chColor;
+//     wxChoice      *m_chStyle;
+//     wxChoice      *m_chWidth;
+// 
+//     wxStaticBoxSizer* m_pListSizer;
+};
+
+#endif

--- a/include/routeprop.h
+++ b/include/routeprop.h
@@ -80,6 +80,7 @@ class   HyperlinkList;
 #define ID_ROUTEPROP_SPLIT     7107
 #define ID_ROUTEPROP_EXTEND    7207
 #define ID_ROUTEPROP_COPYTXT   7307
+#define ID_ROUTEPROP_PRINT     7407
 #define ID_PLANSPEEDCTL        7008
 #define ID_TEXTCTRL4           7009
 #define ID_TEXTCTRLDESC        7010
@@ -159,6 +160,7 @@ public:
     void OnRoutepropListClick( wxListEvent& event );
     void OnRoutepropSplitClick( wxCommandEvent& event );
     void OnRoutepropExtendClick( wxCommandEvent& event );
+    void OnRoutepropPrintClick( wxCommandEvent& event );
     void OnRoutepropCopyTxtClick( wxCommandEvent& event );
     void OnRoutePropRightClick( wxListEvent &event );
     void OnRoutePropMenuSelected( wxCommandEvent &event );
@@ -196,6 +198,7 @@ public:
     wxButton*     m_CancelButton;
     wxButton*     m_OKButton;
     wxButton*     m_CopyTxtButton;
+    wxButton*     m_PrintButton;    
     wxButton*     m_ExtendButton;
     wxButton*     m_SplitButton;
 

--- a/src/about.cpp
+++ b/src/about.cpp
@@ -44,6 +44,8 @@
 #include "chart1.h"
 #include "chcanv.h"
 #include "styles.h"
+#include "version.h"
+
 
 wxString str_version_start = wxT("\n      Version ");
 wxString str_version_major = wxString::Format(wxT("%i"),VERSION_MAJOR);

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -40,9 +40,11 @@
 #include <wx/intl.h>
 #include <wx/listctrl.h>
 #include <wx/aui/aui.h>
-#include <version.h> //Gunther
 #include <wx/dialog.h>
 #include <wx/progdlg.h>
+#include <wx/brush.h>
+#include <wx/colour.h>
+
 
 #if wxCHECK_VERSION(2, 9, 0)
 #include <wx/dialog.h>
@@ -82,7 +84,7 @@
 #include "routeprop.h"
 #include "toolbar.h"
 #include "compasswin.h"
-
+#include "version.h" //Gunther
 #include "cutil.h"
 #include "routemanagerdialog.h"
 #include "pluginmanager.h"
@@ -6177,32 +6179,32 @@ bool GetMemoryStatus( int *mem_total, int *mem_used )
 
 void MyFrame::DoPrint( void )
 {
-    if( NULL == g_printData ) {
-        g_printData = new wxPrintData;
-        g_printData->SetOrientation( wxLANDSCAPE );
-        g_pageSetupData = new wxPageSetupDialogData;
-    }
-
-    wxPrintDialogData printDialogData( *g_printData );
-    printDialogData.EnablePageNumbers( false );
-
-    wxPrinter printer( &printDialogData );
-
-    MyPrintout printout( _("Chart Print") );
-    if( !printer.Print( this, &printout, true ) ) {
-        if( wxPrinter::GetLastError() == wxPRINTER_ERROR ) OCPNMessageBox(
-                _("There was a problem printing.\nPerhaps your current printer is not set correctly?"),
-                _T("OpenCPN"), wxOK );
-//        else
-//            OCPNMessageBox(_T("Print Cancelled"), _T("OpenCPN"), wxOK);
-    } else {
-        ( *g_printData ) = printer.GetPrintDialogData().GetPrintData();
-    }
+//     if( NULL == g_printData ) {
+//         g_printData = new wxPrintData;
+//         g_printData->SetOrientation( wxLANDSCAPE );
+//         g_pageSetupData = new wxPageSetupDialogData;
+//     }
+// 
+//     wxPrintDialogData printDialogData( *g_printData );
+//     printDialogData.EnablePageNumbers( false );
+// 
+//     wxPrinter printer( &printDialogData );
+// 
+//     MyPrintout printout( _("Chart Print") );
+//     if( !printer.Print( this, &printout, true ) ) {
+//         if( wxPrinter::GetLastError() == wxPRINTER_ERROR ) OCPNMessageBox(
+//                 _("There was a problem printing.\nPerhaps your current printer is not set correctly?"),
+//                 _T("OpenCPN"), wxOK );
+// //        else
+// //            OCPNMessageBox(_T("Print Cancelled"), _T("OpenCPN"), wxOK);
+//     } else {
+//         ( *g_printData ) = printer.GetPrintDialogData().GetPrintData();
+//     }
 
 // Pass two printout objects: for preview, and possible printing.
-    /*
-     wxPrintDialogData printDialogData(* g_printData);
-     wxPrintPreview *preview = new wxPrintPreview(new MyPrintout, new MyPrintout, & printDialogData);
+    
+//      wxPrintDialogData printDialogData(* g_printData);
+     wxPrintPreview *preview = new wxPrintPreview(new MyPrintout, new MyPrintout);
      if (!preview->Ok())
      {
      delete preview;
@@ -6210,11 +6212,11 @@ void MyFrame::DoPrint( void )
      return;
      }
 
-     wxPreviewFrame *frame = new wxPreviewFrame(preview, this, _T("Demo Print Preview"), wxPoint(100, 100), wxSize(600, 650));
+     wxPreviewFrame *frame = new wxPreviewFrame(preview, this, _T("Chart Print Preview"), wxPoint(100, 100), wxSize(600, 650));
      frame->Centre(wxBOTH);
      frame->Initialize();
      frame->Show();
-     */
+     
 
 }
 
@@ -7138,6 +7140,8 @@ void MyPrintout::DrawPageOne( wxDC *dc )
     }
 
 }
+
+
 
 //---------------------------------------------------------------------------------------
 //

--- a/src/printtable.cpp
+++ b/src/printtable.cpp
@@ -1,0 +1,357 @@
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  OpenCPN Main wxWidgets Program
+ * Author:   Pavel Saviankou
+ *
+ ***************************************************************************
+ *   Copyright (C) 2012 by Pavel Saviankou                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ *
+ */
+#include <iostream>
+#include <sstream>
+#include <vector>
+using namespace std;
+
+#include "wx/wxprec.h"
+
+#ifndef  WX_PRECOMP
+#include "wx/wx.h"
+#endif //precompiled headers
+#ifdef __WXMSW__
+//#include "c:\\Program Files\\visual leak detector\\include\\vld.h"
+#endif
+
+#include "wx/print.h"
+#include "wx/printdlg.h"
+#include "wx/artprov.h"
+#include "wx/stdpaths.h"
+#include <wx/intl.h>
+#include <wx/listctrl.h>
+#include <wx/aui/aui.h>
+// #include <wx/version.h> //Gunther
+#include <wx/dialog.h>
+#include <wx/progdlg.h>
+#include <wx/brush.h>
+#include <wx/colour.h>
+#include <wx/tokenzr.h>
+
+#if wxCHECK_VERSION(2, 9, 0)
+#include <wx/dialog.h>
+#else
+//  #include "scrollingdialog.h"
+#endif
+
+#include "dychart.h"
+
+#ifdef __WXMSW__
+#include <stdlib.h>
+#include <math.h>
+#include <time.h>
+#include <psapi.h>
+#endif
+
+#ifndef __WXMSW__
+#include <signal.h>
+#include <setjmp.h>
+#endif
+
+#include "printtable.h"
+
+void
+PrintCell::Init (const wxString& _content, wxDC* _dc, int _width, int _cellpadding, bool _bold_font)
+{ 
+  bold_font = _bold_font;
+  dc= _dc;
+  width = _width;
+  cellpadding = _cellpadding;
+  content = _content;
+  page = 1;
+  Adjust(); 
+};                                  
+
+
+
+void
+PrintCell::Adjust()
+{
+    wxFont orig_font = dc->GetFont();
+    wxFont _font = orig_font;
+    if (bold_font)
+      _font.SetWeight( wxFONTWEIGHT_BOLD );
+    dc->SetFont(_font);
+    vector<wxString>  list;
+    list.push_back(wxString());
+    wxString separator = wxT(" ");
+    wxStringTokenizer tokenizer(content, separator, wxTOKEN_RET_DELIMS );
+    int words_number = 0;
+    while ( tokenizer.HasMoreTokens() )
+    {
+        wxString token = tokenizer.GetNextToken();
+	wxCoord h=0;
+	wxCoord w=0;
+	wxString tmp = list[ list.size() - 1 ];
+	wxString tmp2 = tmp + token;
+	words_number ++;
+	dc->GetMultiLineTextExtent( tmp2, &w, &h ); 
+	if ( ( w < width-2*cellpadding ) || words_number == 1 )
+	  list[ list.size() - 1 ] = tmp2;
+	else
+	  list.push_back(wxString());
+    }
+    
+    for (size_t i = 0; i < list.size()-1; i++)
+    {
+      modified_content = modified_content + list[i] + '\n';
+    }
+    // now add last element without new line
+    modified_content = modified_content + list[list.size()-1];
+
+    
+    wxCoord h=0;
+    wxCoord w=0;
+    dc->GetMultiLineTextExtent( modified_content, &w, &h );
+    SetHeight(h);
+    
+    dc->SetFont( orig_font);
+}
+
+
+
+
+
+
+
+
+
+
+
+Table::Table()
+{
+  nrows=0;
+  ncols=0;
+  data.clear();
+  state = TABLE_SETUP_WIDTHS;
+  create_next_row = true;
+}
+
+Table::~Table()
+{
+  for (vector < vector < wxString > >::iterator iter=data.begin(); iter!= data.end(); iter++)
+  {
+    (*iter).clear();
+  }
+  data.clear();
+}
+
+
+void
+Table::Start()
+{
+  if ( create_next_row )
+  {
+    NewRow();
+    create_next_row = false;
+  }
+}
+
+void
+Table::NewRow()
+{
+    vector<wxString> empty_row;
+    data.push_back( empty_row );
+}
+
+Table&
+Table::operator<<(const double& cellcontent)
+{
+  if (state == TABLE_SETUP_WIDTHS)
+  {
+    widths.push_back( cellcontent );
+    return *this;
+  }
+  if ( state == TABLE_FILL_DATA)
+  {
+    stringstream sstr;
+    sstr << cellcontent;
+    string _cellcontent = sstr.str();
+    Start();
+    wxString _str(_cellcontent.c_str(), wxConvUTF8);
+    data[ data.size() - 1].push_back( _str );
+  }
+  return *this;
+}
+
+
+Table&
+Table::operator<<(const string& cellcontent)
+{
+  Start();
+  if ( state == TABLE_FILL_HEADER )  // if we start to fill with string data, we change state automatically.
+  {
+    wxString _str(cellcontent.c_str(), wxConvUTF8);
+    header.push_back( _str );
+    return *this;
+  }
+  if ( state == TABLE_SETUP_WIDTHS )  // if we start to fill with string data, we change state automatically.
+  {
+    state = TABLE_FILL_DATA;
+  }
+
+  if ( ( cellcontent.compare("\n") == 0) )
+  {
+    create_next_row = true;
+    return *this;
+  }
+  wxString _str(cellcontent.c_str(), wxConvUTF8);
+  data[ data.size() - 1].push_back( _str );
+  return *this;
+}
+
+Table&
+Table::operator<<(const int& cellcontent)
+{
+  if (state == TABLE_SETUP_WIDTHS)
+  {
+    widths.push_back( (double)cellcontent );
+    return *this;
+  }
+  if ( state == TABLE_FILL_DATA)
+  {
+    stringstream sstr;
+    sstr << cellcontent;
+    string _cellcontent = sstr.str();
+    Start();
+    wxString _str(_cellcontent.c_str(), wxConvUTF8);
+    data[ data.size() - 1].push_back( _str );
+  }
+  return *this;
+}
+
+
+
+
+ostream&
+operator<<(ostream& out, Table& table)
+{
+  vector< vector < wxString > > & data= table.GetData();
+  
+  for (vector < vector < wxString > >::iterator iter=data.begin(); iter!= data.end(); iter++)
+  {
+    vector< wxString > row = (*iter);
+    for ( vector < wxString >::iterator rowiter=row.begin(); rowiter!= row.end(); rowiter++)
+    {
+      out << (*rowiter).fn_str() << " ";
+    }
+    out << endl;
+  }
+  return out;
+}
+
+
+PrintTable::PrintTable():Table()
+{
+  rows_heights.clear();
+}
+
+
+
+void
+PrintTable::AdjustCells( wxDC * dc, int marginX, int marginY)
+{
+  
+  
+    
+  number_of_pages = -1;
+  contents.clear();
+  int sum=0;
+  for ( size_t j=0; j< widths.size(); j++)
+  {
+    sum+= widths[j];
+  }
+  
+  int w, h;
+  dc->GetSize( &w, &h );
+  int width = w - 4*marginX;
+  header_height = -1;
+  for ( size_t j=0; j< header.size(); j++)
+  {
+    int cell_width = (int)( (double) width* widths[j]/sum );
+    PrintCell cell_content;
+    cell_content.Init( header[j] , dc, cell_width, 10, true );
+    header_content.push_back(cell_content);
+    header_height = std::max ( header_height, cell_content.GetHeight()); 
+  }
+
+
+  
+  
+  
+
+
+
+
+  for (size_t i=0; i< data.size(); i++)
+  {
+    vector< wxString > row = data[i];
+    vector<PrintCell> contents_row;
+    int max_height = -1;
+    for ( size_t j=0; j< row.size(); j++)
+    {
+      int cell_width = (int)( (double) width* widths[j]/sum );
+      PrintCell cell_content;
+      cell_content.Init( row[j] , dc, cell_width, 10 );
+      contents_row.push_back(cell_content);
+      max_height = std::max ( max_height, cell_content.GetHeight()); 
+    }
+    rows_heights.push_back( max_height );
+    contents.push_back(contents_row);
+  }
+  
+  int stripped_page = h - 4* marginY - header_height;
+  int current_page = 1;
+  int current_y = 0;
+  for(size_t i=0; i< data.size(); i++)
+  {
+    int row_height = rows_heights[i];
+    if ( row_height + current_y > stripped_page)
+    {
+      current_page++;
+      current_y = row_height;
+    }else
+    {
+      current_y += row_height;
+    }
+    int row_page = current_page;
+    vector<PrintCell> & contents_row = contents[i];
+    for ( size_t j=0; j< contents_row.size(); j++)
+    {
+      contents_row[j].SetPage(row_page);
+      contents_row[j].SetHeight(row_height);
+    }
+    number_of_pages = std::max ( row_page, number_of_pages);
+  }
+  
+  
+  
+  
+  
+  
+  
+}

--- a/src/routeprintout.cpp
+++ b/src/routeprintout.cpp
@@ -1,0 +1,577 @@
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  OpenCPN Main wxWidgets Program
+ * Author:   Pavel Saviankou
+ *
+ ***************************************************************************
+ *   Copyright (C) 2012 by Pavel Saviankou                                 *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ *
+ */
+#include <iostream>
+using namespace std;
+
+#include "wx/wxprec.h"
+
+#ifndef  WX_PRECOMP
+#include "wx/wx.h"
+#endif //precompiled headers
+#ifdef __WXMSW__
+//#include "c:\\Program Files\\visual leak detector\\include\\vld.h"
+#endif
+
+#include "wx/print.h"
+#include "wx/printdlg.h"
+#include "wx/artprov.h"
+#include "wx/stdpaths.h"
+#include <wx/intl.h>
+#include <wx/listctrl.h>
+#include <wx/aui/aui.h>
+// #include <wx/version.h> //Gunther
+#include <wx/dialog.h>
+#include <wx/progdlg.h>
+#include <wx/brush.h>
+#include <wx/colour.h>
+
+
+#if wxCHECK_VERSION(2, 9, 0)
+#include <wx/dialog.h>
+#else
+//  #include "scrollingdialog.h"
+#endif
+
+#include "dychart.h"
+
+#ifdef __WXMSW__
+#include <stdlib.h>
+#include <math.h>
+#include <time.h>
+#include <psapi.h>
+#endif
+
+#ifndef __WXMSW__
+#include <signal.h>
+#include <setjmp.h>
+#endif
+
+#include "routeprintout.h"
+#include "printtable.h"
+
+#define PRINT_WP_NAME 0
+#define PRINT_WP_POSITION 1
+#define PRINT_WP_COURSE 2
+#define PRINT_WP_DISTANCE 3
+#define PRINT_WP_DESCRIPTION 4
+
+// Global print data, to remember settings during the session
+extern wxPrintData               *g_printData;
+// Global page setup data
+extern wxPageSetupData           *g_pageSetupData;
+MyRoutePrintout::MyRoutePrintout(std::vector<bool> _toPrintOut, 
+				  Route * route, 
+				  const wxChar *title
+				):MyPrintout(title), 
+				  myRoute(route), 
+				  toPrintOut(_toPrintOut)
+{
+    // Let's have at least some device units margin
+  marginX = 5;
+  marginY = 5;
+ 
+  
+      table.StartFillHeader();
+    // setup widths for columns
+      if (toPrintOut[PRINT_WP_NAME])
+      {
+	table << "Name";
+      }
+      if (toPrintOut[PRINT_WP_POSITION])
+      {
+	table << "Pos";
+      }
+      if (toPrintOut[PRINT_WP_COURSE])
+      {
+	table << "Course";
+      }
+      if (toPrintOut[PRINT_WP_DISTANCE])
+      {
+	table << "Dist";
+      }
+      if (toPrintOut[PRINT_WP_DESCRIPTION])
+      {
+	table << "Description";
+      }
+  
+      table.StartFillWidths();
+  // setup widths for columns
+      if (toPrintOut[PRINT_WP_NAME])
+      {
+	table << 23;
+      }
+      if (toPrintOut[PRINT_WP_POSITION])
+      {
+	table << 40;
+      }
+      if (toPrintOut[PRINT_WP_COURSE])
+      {
+	table << 30;
+      }
+      if (toPrintOut[PRINT_WP_DISTANCE])
+      {
+	table << 38;
+      }
+      if (toPrintOut[PRINT_WP_DESCRIPTION])
+      {
+	table << 100;
+      }
+  
+      table.StartFillData();
+  
+  
+    for (int n=1; n<= myRoute->GetnPoints(); n++)
+    {
+      RoutePoint * point = myRoute->GetPoint( n );
+
+      if (toPrintOut[PRINT_WP_NAME])
+      {
+// 	dc->DrawText(point->GetName(), marginX , marginY + 10*n ); 
+	string cell(point->GetName().fn_str());
+	table << cell;
+      }
+      if (toPrintOut[PRINT_WP_POSITION])
+      {
+// 	dc->DrawText(_("POS"), marginX + 50, marginY + 10*n   ); 
+	wxString point_position = toSDMM( 1, point->m_lat, point->m_bIsInTrack ) + _T("\n") + toSDMM( 2, point->m_lon, point->m_bIsInTrack );
+// 	point_position.Printf(_T("%03.0f Deg. T \n %03.0f Deg. T"), point->GetLatitude(), point->GetLongitude());;
+
+	string cell(point_position.fn_str());
+	table << cell;
+      }
+      if (toPrintOut[PRINT_WP_COURSE])
+      {
+	wxString point_course; 
+	point_course.Printf(_T("%03.0f Deg"), point->GetCourse());
+	string cell(point_course.fn_str());
+	table << cell;
+      }
+      if (toPrintOut[PRINT_WP_DISTANCE])
+      {
+	wxString point_distance; 
+	point_distance.Printf(_T("%6.2f NM"), point->GetDistance());
+	string cell(point_distance.fn_str());
+	table << cell;
+
+      }
+      if (toPrintOut[PRINT_WP_DESCRIPTION])
+      {
+// 	dc->DrawText(point->GetDescription(), marginX + 200, marginY + 10*n   );
+	string cell(point->GetDescription().fn_str());
+	table << cell;
+      }
+      table << "\n";
+    }
+    
+
+    
+}
+
+
+void MyRoutePrintout::GetPageInfo( int *minPage, int *maxPage, int *selPageFrom, int *selPageTo )
+{
+    *minPage = 1;
+    *maxPage = numberOfPages;
+    *selPageFrom = 1;
+    *selPageTo = numberOfPages;
+}
+
+
+void MyRoutePrintout::OnPreparePrinting()
+{
+  pageToPrint = 1;
+  wxDC *dc = GetDC();
+  wxFont routePrintFont(10, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
+  dc->SetFont(routePrintFont);
+    
+  table.AdjustCells(dc, marginX, marginY);
+  numberOfPages = table.GetNumberPages();
+}
+
+
+bool MyRoutePrintout::OnPrintPage( int page )
+{
+  wxDC *dc = GetDC();
+  pageToPrint = page;
+  DrawPage( dc );
+  return true;
+}
+
+void MyRoutePrintout::DrawPage( wxDC *dc )
+{
+
+
+  
+    // Get the Size of the Chart Canvas
+//     int sx, sy;
+//     dc->GetClientSize( &sx, &sy );                       // of the canvas
+
+//     float maxX = sx;
+//     float maxY = sy;
+
+
+
+    // Add the margin to the graphic size
+//     maxX += ( 2 * marginX );
+//     maxY += ( 2 * marginY );
+
+    // Get the size of the DC in pixels
+    int w, h;
+    dc->GetSize( &w, &h );
+    
+    int maxX = w;
+    int maxY = h;
+    
+    // Calculate a suitable scaling factor
+    float scaleX = (float) ( w / maxX );
+    float scaleY = (float) ( h / maxY );
+
+    // Use x or y scaling factor, whichever fits on the DC
+    float actualScale = wxMin(scaleX,scaleY);
+
+    // Calculate the position on the DC for centring the graphic
+    float posX = (float) ( ( w - ( maxX * actualScale ) ) / 2.0 );
+    float posY = (float) ( ( h - ( maxY * actualScale ) ) / 2.0 );
+
+    posX = wxMax(posX, marginX);
+    posY = wxMax(posY, marginY);
+
+    // Set the scale and origin
+    dc->SetUserScale( actualScale, actualScale );
+    dc->SetDeviceOrigin( (long) posX, (long) posY );
+//     wxFont routePrintFont(10, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
+//     dc->SetFont(routePrintFont);
+    
+        
+    wxFont routePrintFont_bold(10, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD);
+    dc->SetFont(routePrintFont_bold);
+
+    
+    int currentX = marginX;
+    int currentY = marginY;
+    vector< PrintCell >& header_content = table.GetHeader();
+    for (size_t j=0; j< header_content.size(); j++)
+    {
+      PrintCell& cell = header_content[j];
+      dc->DrawRectangle(currentX, currentY, cell.GetWidth(), cell.GetHeight());
+      dc->DrawText(cell.GetText(),  currentX, currentY);
+      currentX += cell.GetWidth();
+    }
+
+
+    
+    wxFont routePrintFont_normal(10, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
+    dc->SetFont(routePrintFont_normal);    
+    wxBrush brush( wxNullColour,  wxTRANSPARENT );
+    dc->SetBrush(brush);
+//     dc->DrawRectangle(marginX, marginY, maxX-4*marginX, maxY-4*marginY);
+    
+    vector< vector < PrintCell > > & cells = table.GetContent();
+    currentY = marginY + table.GetHeaderHeight();
+    int currentHeight = 0;
+    for (size_t i=0; i< cells.size(); i++)
+    {
+      vector< PrintCell >& content_row = cells [i]; 
+      currentX = marginX;
+      for (size_t j=0; j< content_row.size(); j++)
+      {
+	PrintCell& cell = content_row[j];
+	if (cell.GetPage() == pageToPrint)
+	{
+	  dc->DrawRectangle(currentX, currentY, cell.GetWidth(), cell.GetHeight());
+	  dc->DrawText(cell.GetText(),  currentX, currentY);
+	  currentX += cell.GetWidth();
+	  currentHeight = cell.GetHeight();
+
+	}
+      }
+      currentY += currentHeight;
+    }
+    
+    
+    
+
+}
+
+// WP # , Position , Course , Remarks
+
+
+
+
+
+// ---------- RoutePrintSelection dialof implementation
+
+/*!
+ * RoutePrintSelection type definition
+ */
+
+/* global instance of RoutePrintSelection
+ */
+RoutePrintSelection * pRoutePrintSelection;
+
+
+IMPLEMENT_DYNAMIC_CLASS( RoutePrintSelection, wxDialog )
+/*!
+ * RouteProp event table definition
+ */
+
+BEGIN_EVENT_TABLE( RoutePrintSelection, wxDialog )
+    EVT_BUTTON( ID_ROUTEPRINT_SELECTION_CANCEL, RoutePrintSelection::OnRoutepropCancelClick )
+    EVT_BUTTON( ID_ROUTEPRINT_SELECTION_OK, RoutePrintSelection::OnRoutepropOkClick )
+END_EVENT_TABLE()
+
+/*!
+ * RouteProp constructors
+ */
+
+RoutePrintSelection::RoutePrintSelection()
+{
+}
+
+RoutePrintSelection::RoutePrintSelection( wxWindow* parent, Route * _route,  wxWindowID id, const wxString& caption, const wxPoint& pos,
+        const wxSize& size, long style )
+{
+       route = _route;  
+
+
+    long wstyle = style;
+// #ifdef __WXOSX__
+//     wstyle |= wxSTAY_ON_TOP;
+// #endif
+
+    Create( parent, id, caption, pos, size, wstyle );
+//     GetSizer()->SetSizeHints( this );
+    Centre();
+}
+
+RoutePrintSelection::~RoutePrintSelection()
+{}
+
+/*!
+ * RouteProp creator
+ */
+
+bool RoutePrintSelection::Create( wxWindow* parent, wxWindowID id, const wxString& caption,
+        const wxPoint& pos, const wxSize& size, long style )
+{
+
+    SetExtraStyle( GetExtraStyle() | wxWS_EX_BLOCK_EVENTS );
+    wxDialog::Create( parent, id, caption, pos, size, style );
+
+    CreateControls();
+
+    return TRUE;
+}
+
+/*!
+ * Control creation for RouteProp
+ */
+
+void RoutePrintSelection::CreateControls()
+{
+    ////@begin RouteProp content construction
+    
+    
+    
+    RoutePrintSelection* itemDialog1 = this;
+    
+     wxStaticBox* itemStaticBoxSizer3Static = new wxStaticBox( itemDialog1, wxID_ANY,
+            _("Elements to print...") );
+    
+    
+    wxStaticBoxSizer* itemBoxSizer1 = new wxStaticBoxSizer(itemStaticBoxSizer3Static,  wxVERTICAL );
+    itemDialog1->SetSizer( itemBoxSizer1 );
+    
+    
+    wxBoxSizer* bSizer2;
+    bSizer2 = new wxBoxSizer( wxVERTICAL );
+    
+    
+    
+
+    
+    wxBoxSizer* bSizer00;
+    bSizer00 = new wxBoxSizer( wxHORIZONTAL );        
+    m_checkBoxWPName = new wxCheckBox( itemDialog1, wxID_ANY, _("WP Name"),
+            wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT );
+    m_checkBoxWPName->SetValue(true);
+    bSizer00->Add( m_checkBoxWPName, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5 );
+    
+    wxStaticText* label1 = new  wxStaticText(itemDialog1, wxID_ANY, _("With selecting this element name of the WP will be present int the route printout."), wxDefaultPosition, wxDefaultSize);
+    bSizer00->Add( label1, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5 );
+    bSizer2->Add(bSizer00, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5 )  ; 
+    
+        
+    wxBoxSizer* bSizer10;
+    bSizer10 = new wxBoxSizer( wxHORIZONTAL );   
+    m_checkBoxWPPosition = new wxCheckBox( itemDialog1, wxID_ANY, _("Position"),
+            wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT );
+    m_checkBoxWPPosition->SetValue(true);
+    bSizer10->Add( m_checkBoxWPPosition, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5 );
+    wxStaticText* label2 = new  wxStaticText(itemDialog1, wxID_ANY, _("GPS Position of the WP is printed as well."), wxDefaultPosition, wxDefaultSize);
+    bSizer10->Add( label2, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5 );
+    bSizer2->Add(bSizer10, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5 )  ; 
+        
+
+    
+    wxBoxSizer* bSizer20;
+    bSizer20 = new wxBoxSizer( wxHORIZONTAL );    
+    m_checkBoxWPCourse = new wxCheckBox( itemDialog1, wxID_ANY, _("Course"),
+            wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT );
+    m_checkBoxWPCourse->SetValue(true);
+    bSizer20->Add( m_checkBoxWPCourse, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5 );
+    wxStaticText* label3 = new  wxStaticText(itemDialog1, wxID_ANY, _("Indicates the course from the WP tp the next one. "), wxDefaultPosition, wxDefaultSize);
+    bSizer20->Add( label3, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5 );
+    bSizer2->Add(bSizer20, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5 )  ; 
+        
+    
+    
+    wxBoxSizer* bSizer30;
+    bSizer30 = new wxBoxSizer( wxHORIZONTAL );    
+    m_checkBoxWPDistanceToNext = new wxCheckBox( itemDialog1, wxID_ANY, _("Distance to next WP"),
+            wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT );
+    m_checkBoxWPDistanceToNext->SetValue(true);
+    bSizer30->Add( m_checkBoxWPDistanceToNext, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5 );
+    wxStaticText* label4 = new  wxStaticText(itemDialog1, wxID_ANY, _("Distance from the current WP to the next WP."), wxDefaultPosition, wxDefaultSize);    
+    bSizer30->Add( label4, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5 );
+    bSizer2->Add(bSizer30, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5 )  ; 
+        
+    
+    wxBoxSizer* bSizer40;
+    bSizer40 = new wxBoxSizer( wxHORIZONTAL );    
+    m_checkBoxWPDescription = new wxCheckBox( itemDialog1, wxID_ANY, _("Description"),
+            wxDefaultPosition, wxDefaultSize, wxALIGN_LEFT );
+    m_checkBoxWPDescription->SetValue(true);
+    bSizer40->Add( m_checkBoxWPDescription, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5 );
+    wxStaticText* label5 = new  wxStaticText(itemDialog1, wxID_ANY, _("Include the description of the WP for print out. It is probably most valuable field."), wxDefaultPosition, wxDefaultSize);       
+    bSizer40->Add( label5, 1, wxALL | wxALIGN_CENTER_VERTICAL, 5 );
+    bSizer2->Add(bSizer40, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5 )  ; 
+                
+    itemBoxSizer1->Add( bSizer2, 5, wxEXPAND, 5 );
+
+    
+    wxBoxSizer* itemBoxSizer16 = new wxBoxSizer( wxHORIZONTAL );
+    itemBoxSizer1->Add( itemBoxSizer16, 0, wxALIGN_RIGHT | wxALL, 5 );
+    
+    m_CancelButton = new wxButton( itemDialog1, ID_ROUTEPRINT_SELECTION_CANCEL, _("Cancel"), wxDefaultPosition,
+            wxDefaultSize, 0 );
+    itemBoxSizer16->Add( m_CancelButton, 0, wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL | wxALL, 5 );
+
+    m_OKButton = new wxButton( itemDialog1, ID_ROUTEPRINT_SELECTION_OK, _("OK"), wxDefaultPosition,
+            wxDefaultSize, 0 );
+    itemBoxSizer16->Add( m_OKButton, 0, wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL | wxALL, 5 );
+    m_OKButton->SetDefault();
+
+    SetColorScheme( (ColorScheme) 0 );
+
+}
+
+
+void RoutePrintSelection::SetColorScheme( ColorScheme cs )
+{
+    DimeControl( this );
+}
+
+/*
+ * Should we show tooltips?
+ */
+
+bool RoutePrintSelection::ShowToolTips()
+{
+    return TRUE;
+}
+
+void RoutePrintSelection::SetDialogTitle( wxString title )
+{
+    SetTitle( title );
+}
+
+
+void RoutePrintSelection::OnRoutepropCancelClick( wxCommandEvent& event )
+{
+    Hide();
+    event.Skip();
+}
+
+void RoutePrintSelection::OnRoutepropOkClick( wxCommandEvent& event )
+{
+  std::vector<bool> toPrintOut;
+  toPrintOut.push_back(m_checkBoxWPName->GetValue()); 
+  toPrintOut.push_back(m_checkBoxWPPosition->GetValue()); 
+  toPrintOut.push_back(m_checkBoxWPCourse->GetValue()); 
+  toPrintOut.push_back(m_checkBoxWPDistanceToNext->GetValue()); 
+  toPrintOut.push_back(m_checkBoxWPDescription->GetValue());   
+  
+    if( NULL == g_printData ) 
+    {
+        g_printData = new wxPrintData;
+        g_printData->SetOrientation( wxLANDSCAPE );
+        g_pageSetupData = new wxPageSetupDialogData;
+    }
+  
+  MyRoutePrintout * myrouteprintout1 = new MyRoutePrintout(toPrintOut, route,  _("Route Print"));
+  
+  wxPrintDialogData printDialogData( *g_printData );
+  printDialogData.EnablePageNumbers( true );
+
+  wxPrinter printer( &printDialogData );
+  if( !printer.Print( this, myrouteprintout1, true ) ) 
+  {
+    if( wxPrinter::GetLastError() == wxPRINTER_ERROR ) OCPNMessageBox(
+	    _("There was a problem printing.\nPerhaps your current printer is not set correctly?"),
+	    _T("OpenCPN"), wxOK );
+//        else
+//            OCPNMessageBox(_T("Print Cancelled"), _T("OpenCPN"), wxOK);
+    } 
+
+  
+/*
+    MyRoutePrintout * myrouteprintout1 = new MyRoutePrintout(toPrintOut, route,  _("Route Print"));
+    MyRoutePrintout * myrouteprintout2 = new MyRoutePrintout(toPrintOut, route,  _("Route Print"));
+    wxPrintPreview *preview = new wxPrintPreview(myrouteprintout1, myrouteprintout2);
+    
+    
+    
+    wxPreviewFrame *frame = new wxPreviewFrame(preview, this,
+                                               _T("Route Print Preview"),
+                                               wxPoint(100, 100),
+                                               wxSize(600, 650));
+    frame->Centre(wxBOTH);
+    frame->Initialize();
+    frame->Show(true);
+ 
+    */
+    
+    
+    
+    
+//     cc1->Refresh( false );
+    Hide();
+    event.Skip();
+}
+
+

--- a/src/routeprop.cpp
+++ b/src/routeprop.cpp
@@ -34,6 +34,9 @@
 
 #include <wx/datetime.h>
 #include <wx/clipbrd.h>
+#include <wx/print.h>
+#include <wx/printdlg.h>
+#include <wx/stattext.h>
 
 #include "styles.h"
 #include "routeprop.h"
@@ -42,6 +45,7 @@
 #include "chart1.h"
 #include "routeman.h"
 #include "routemanagerdialog.h"
+#include "routeprintout.h"
 #include "chcanv.h"
 #include "tcmgr.h"		// pjotrc 2011.03.02
 
@@ -62,6 +66,15 @@ extern Track              *g_pActiveTrack;
 extern RouteList          *pRouteList;
 
 extern MyFrame            *gFrame;
+
+// Global print data, to remember settings during the session
+extern wxPrintData               *g_printData;
+
+// Global page setup data
+extern wxPageSetupData*          g_pageSetupData;
+
+// Global print route selection dialog
+extern RoutePrintSelection * pRoutePrintSelection;
 
 /*!
 * Helper stuff for calculating Route Plans
@@ -459,6 +472,7 @@ BEGIN_EVENT_TABLE( RouteProp, wxDialog )
     EVT_LIST_ITEM_SELECTED( ID_TRACKLISTCTRL, RouteProp::OnRoutepropListClick )
     EVT_BUTTON( ID_ROUTEPROP_SPLIT, RouteProp::OnRoutepropSplitClick )
     EVT_BUTTON( ID_ROUTEPROP_EXTEND, RouteProp::OnRoutepropExtendClick )
+    EVT_BUTTON( ID_ROUTEPROP_PRINT, RouteProp::OnRoutepropPrintClick )
 END_EVENT_TABLE()
 
 /*!
@@ -576,6 +590,17 @@ void RouteProp::OnRoutepropSplitClick( wxCommandEvent& event )
                 pRouteManagerDialog->UpdateTrkListCtrl();
         }
     }
+}
+
+void RouteProp::OnRoutepropPrintClick( wxCommandEvent& event )
+{
+  
+  if (pRoutePrintSelection == NULL)
+    pRoutePrintSelection = new RoutePrintSelection( GetParent(), m_pRoute );
+
+  if( !pRoutePrintSelection->IsShown() ) pRoutePrintSelection->ShowModal();
+    delete pRoutePrintSelection;
+  pRoutePrintSelection=NULL;
 }
 
 void RouteProp::OnRoutepropExtendClick( wxCommandEvent& event )
@@ -780,6 +805,9 @@ RouteProp::~RouteProp()
     //	delete pDispTz;
 
     delete m_wpList;
+    
+    // delete global print route selection dialog
+    delete pRoutePrintSelection;
 }
 
 /*!
@@ -957,6 +985,12 @@ void RouteProp::CreateControls()
     wxBoxSizer* itemBoxSizer16 = new wxBoxSizer( wxHORIZONTAL );
     itemBoxSizer2->Add( itemBoxSizer16, 0, wxALIGN_RIGHT | wxALL, 5 );
 
+     m_PrintButton = new wxButton( itemDialog1, ID_ROUTEPROP_PRINT, _("Print Route"),
+            wxDefaultPosition, wxDefaultSize, 0 );
+    itemBoxSizer16->Add( m_PrintButton, 0, wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL | wxALL, 5 );
+    m_PrintButton->Enable( true );   
+    
+    
     m_ExtendButton = new wxButton( itemDialog1, ID_ROUTEPROP_EXTEND, _("Extend Route"),
             wxDefaultPosition, wxDefaultSize, 0 );
     itemBoxSizer16->Add( m_ExtendButton, 0, wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL | wxALL, 5 );
@@ -1000,6 +1034,8 @@ void RouteProp::CreateControls()
     m_wpList->InsertColumn( 6, _("ETE/ETD"), wxLIST_FORMAT_LEFT, 135 );
     m_wpList->InsertColumn( 7, _("Speed (Kts)"), wxLIST_FORMAT_CENTER, 72 );
     m_wpList->InsertColumn( 8, _("Next tide event"), wxLIST_FORMAT_LEFT, 90 );
+    m_wpList->InsertColumn( 9, _("Description"), wxLIST_FORMAT_LEFT, 90 );  
+    m_wpList->InsertColumn( 10, _("Course"), wxLIST_FORMAT_LEFT, 70 );    
     m_wpList->Hide();
 
     m_wpTrackList = new OCPNTrackListCtrl( itemDialog1, ID_TRACKLISTCTRL, wxDefaultPosition,
@@ -1013,7 +1049,10 @@ void RouteProp::CreateControls()
     m_wpTrackList->InsertColumn( 4, _("Latitude"), wxLIST_FORMAT_LEFT, 85 );
     m_wpTrackList->InsertColumn( 5, _("Longitude"), wxLIST_FORMAT_LEFT, 90 );
     m_wpTrackList->InsertColumn( 6, _("Timestamp"), wxLIST_FORMAT_LEFT, 135 );
-    m_wpTrackList->InsertColumn( 7, _("Speed (Kts)"), wxLIST_FORMAT_CENTER, 100 );
+    m_wpTrackList->InsertColumn( 7, _("Speed (Kts)"), wxLIST_FORMAT_CENTER, 100 ); 
+    m_wpTrackList->InsertColumn( 8, _("Next tide event"), wxLIST_FORMAT_LEFT, 100 );
+    m_wpTrackList->InsertColumn( 9, _("Description"), wxLIST_FORMAT_CENTER, 100 );     
+    m_wpTrackList->InsertColumn( 10, _("Course"), wxLIST_FORMAT_CENTER, 70 );       
     m_wpTrackList->Hide();
 
     Connect( wxEVT_COMMAND_LIST_ITEM_RIGHT_CLICK,
@@ -1453,7 +1492,9 @@ bool RouteProp::UpdateProperties()
 
             //  Mark Name
             if( arrival ) m_wpList->SetItem( item_line_index, 1, prp->GetName() );
-
+	    // Store Dewcription
+            if( arrival ) m_wpList->SetItem( item_line_index, 9, prp->GetDescription() );
+	    
             //  Distance
             //  Note that Distance/Bearing for Leg 000 is as from current position
 
@@ -1484,14 +1525,42 @@ bool RouteProp::UpdateProperties()
 
             DistanceBearingMercator( prp->m_lat, prp->m_lon, slat, slon, &brg, &leg_dist );
 
+	    // calculation of course at current WayPoint.
+	    double course=10, tmp_leg_dist=23;
+	    wxRoutePointListNode *next_node = node->GetNext(); 
+	    RoutePoint * _next_prp = (next_node)? next_node->GetData(): NULL;
+	    if (_next_prp )
+	    {
+		DistanceBearingMercator( _next_prp->m_lat, _next_prp->m_lon, prp->m_lat, prp->m_lon, &course, &tmp_leg_dist );
+	    }else
+	    {
+	      course = 0.0;
+	      tmp_leg_dist = 0.0;
+	    }
+	    
+	    prp->SetCourse(course); // save the course to the next waypoint for printing.
+	    // end of calculation
+	    
+	    
             t.Printf( _T("%6.2f NM"), leg_dist );
             if( arrival ) m_wpList->SetItem( item_line_index, 2, t );
             if( !enroute ) m_wpList->SetItem( item_line_index, 2, nullify );
+	    prp->SetDistance(leg_dist); // save the course to the next waypoint for printing.
 
             //  Bearing
             t.Printf( _T("%03.0f Deg. T"), brg );
             if( arrival ) m_wpList->SetItem( item_line_index, 3, t );
             if( !enroute ) m_wpList->SetItem( item_line_index, 3, nullify );
+	    
+	    // Course (bearing of next )
+	    if (_next_prp)
+	    {
+		t.Printf( _T("%03.0f Deg. T"), course );
+		if( arrival ) m_wpList->SetItem( item_line_index, 10, t );
+	    }else
+	    {
+	      m_wpList->SetItem( item_line_index, 10, nullify );
+	    }
 
             //  Lat/Lon
             wxString tlat = toSDMM( 1, prp->m_lat, prp->m_bIsInTrack );  // low precision for routes
@@ -1500,6 +1569,7 @@ bool RouteProp::UpdateProperties()
             wxString tlon = toSDMM( 2, prp->m_lon, prp->m_bIsInTrack );
             if( arrival ) m_wpList->SetItem( item_line_index, 5, tlon );
 
+	    
             tide_form = _T("");
 
             LMT_Offset = long( ( prp->m_lon ) * 3600. / 15. );

--- a/src/undo.cpp
+++ b/src/undo.cpp
@@ -88,6 +88,9 @@ wxString UndoAction::Description()
         case Undo_AppendWaypoint:
             descr = _("Append Waypoint");
             break;
+	default:
+            descr = _("");
+	    break;
     }
     return descr;
 }
@@ -400,6 +403,7 @@ UndoAction::~UndoAction()
                         break;
                     case Undo_DeleteWaypoint: break;
                     case Undo_CreateWaypoint: break;
+		     case Undo_AppendWaypoint: break;
                 }
                 break;
             }


### PR DESCRIPTION
Added button in route property dialog to print out the route as a table, where the  waypoints, courses, distances and additional notes (as a discription of a way point) are listed. 
