### PR TITLE
Correct wxWidgets 2.8 Bitmap define to suppress Windows compile warnings

### DIFF
--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -263,10 +263,6 @@ GRIBUIDialog::GRIBUIDialog(wxWindow *parent, grib_pi *ppi)
         pConf->Read ( _T ( "GRIBDirectory" ), &m_grib_dir, spath.GetDocumentsDir()  );
     }
 
-#if !wxCHECK_VERSION(2,9,4) /* to work with wx 2.8 */
-#define SetBitmap SetLabel
-#endif
-
     m_bpPrev->SetBitmap(wxBitmap( prev ));
     m_bpNext->SetBitmap(wxBitmap( next ));
     m_bpNow->SetBitmap(wxBitmap( now ));


### PR DESCRIPTION
This three lines should be cancelled because they have moved to line 123 to be used else where and modified to ovoid warnings .
Jean Pierre 
