### PR TITLE
Implement a possibility to completely turn off OpenGL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1010,7 +1010,7 @@ IF(WIN32 AND NOT UNIX)
 
   SET(CPACK_NSIS_INSTALLED_ICON_NAME "opencpn.exe")
   SET(CPACK_NSIS_PACKAGE_NAME_LC "opencpn")
-
+ 
 #  These lines set the name of the Windows Start Menu shortcut and the icon that goes with it
   SET(CPACK_NSIS_DISPLAY_NAME "${CPACK_PACKAGE_NAME} ${PACKAGE_VERSION}")
   SET(CPACK_PACKAGE_ICON "${CMAKE_SOURCE_DIR}/src/bitmaps\\\\opencpn.ico")

--- a/NSIS.template.in
+++ b/NSIS.template.in
@@ -784,6 +784,7 @@ SectionGroup /e "!Shortcuts Section Group" SecGrpShortcuts
 			;# Create shortcuts
 			CreateDirectory "$SMPROGRAMS\$STARTMENU_FOLDER"
 			CreateShortCut "$SMPROGRAMS\$STARTMENU_FOLDER\OpenCPN @CPACK_PACKAGE_VERSION@.lnk" "$INSTDIR\opencpn.exe"
+			CreateShortCut "$SMPROGRAMS\$STARTMENU_FOLDER\OpenCPN @CPACK_PACKAGE_VERSION@ - No OpenGL.lnk" "$INSTDIR\opencpn.exe" "/no_opengl"
 			CreateDirectory "$SMPROGRAMS\$STARTMENU_FOLDER\$(Uninstall_Folder_Name)"
 			CreateShortCut "$SMPROGRAMS\$STARTMENU_FOLDER\$(Uninstall_Folder_Name)\$(Uninstall_Link).lnk" "$INSTDIR\Uninstall @CPACK_PACKAGE_VERSION@.exe"
 		!insertmacro MUI_STARTMENU_WRITE_END

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -406,6 +406,8 @@ bool                      g_bQuiltStart;
 
 bool                      g_bportable;
 
+bool                      g_bdisable_opengl;
+
 ChartGroupArray           *g_pGroupArray;
 int                       g_GroupIndex;
 
@@ -726,12 +728,15 @@ void MyApp::OnInitCmdLine( wxCmdLineParser& parser )
     parser.AddSwitch( _T("unit_test_1") );
 
     parser.AddSwitch( _T("p") );
+
+    parser.AddSwitch( _T("no_opengl") );
 }
 
 bool MyApp::OnCmdLineParsed( wxCmdLineParser& parser )
 {
     g_unit_test_1 = parser.Found( _T("unit_test_1") );
     g_bportable = parser.Found( _T("p") );
+    g_bdisable_opengl = parser.Found( _T("no_opengl") );
 
     return true;
 }
@@ -1959,12 +1964,16 @@ if( 0 == g_memCacheLimit )
     //  We need a deferred resize to get glDrawPixels() to work right.
     //  So we set a trigger to generate a resize after 5 seconds....
     //  See the "UniChrome" hack elsewhere
-    glChartCanvas *pgl = (glChartCanvas *) cc1->GetglCanvas();
-    if( pgl && ( pgl->GetRendererString().Find( _T("UniChrome") ) != wxNOT_FOUND ) ) {
-        gFrame->m_defer_size = gFrame->GetSize();
-        gFrame->SetSize( gFrame->m_defer_size.x - 10, gFrame->m_defer_size.y );
-        g_pauimgr->Update();
-        gFrame->m_bdefer_resize = true;
+    if ( !g_bdisable_opengl )
+    {
+        glChartCanvas *pgl = (glChartCanvas *) cc1->GetglCanvas();
+        if( pgl && ( pgl->GetRendererString().Find( _T("UniChrome") ) != wxNOT_FOUND ) )
+        {
+            gFrame->m_defer_size = gFrame->GetSize();
+            gFrame->SetSize( gFrame->m_defer_size.x - 10, gFrame->m_defer_size.y );
+            g_pauimgr->Update();
+            gFrame->m_bdefer_resize = true;
+        }
     }
     return TRUE;
 }

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -124,6 +124,7 @@ extern bool             g_bShowDepthUnits;
 extern bool             g_bAutoAnchorMark;
 extern bool             g_bskew_comp;
 extern bool             g_bopengl;
+extern bool             g_bdisable_opengl;
 extern bool             g_bsmoothpanzoom;
 
 extern bool             g_bShowOutlines;
@@ -2202,13 +2203,13 @@ void Route::RenameRoutePoints( void )
 bool Route::SendToGPS( wxString& com_name, bool bsend_waypoints, wxGauge *pProgress )
 {
     bool result = false;
-    
+
     if( g_pMUX ) {
         ::wxBeginBusyCursor();
          result = g_pMUX->SendRouteToGPS( this, com_name, bsend_waypoints, pProgress );
         ::wxEndBusyCursor();
     }
-    
+
     wxString msg;
     if( result ) msg = _("Route Uploaded successfully.");
     else
@@ -2554,21 +2555,21 @@ void Track::Draw( ocpnDC& dc, ViewPort &VP )
 
     wxRoutePointListNode *node = pRoutePointList->GetFirst();
     RoutePoint *prp = node->GetData();
-    
+
     //  Establish basic colour
     wxColour basic_colour;
-    if( m_bRunning || prp->m_IconName.StartsWith( _T("xmred") ) ) {     
+    if( m_bRunning || prp->m_IconName.StartsWith( _T("xmred") ) ) {
             basic_colour = GetGlobalColor( _T ( "URED" ) );
     } else
-        if( prp->m_IconName.StartsWith( _T("xmblue") ) ) {            
+        if( prp->m_IconName.StartsWith( _T("xmblue") ) ) {
                 basic_colour = GetGlobalColor( _T ( "BLUE3" ) );
         } else
-            if( prp->m_IconName.StartsWith( _T("xmgreen") ) ) {        
+            if( prp->m_IconName.StartsWith( _T("xmgreen") ) ) {
                     basic_colour = GetGlobalColor( _T ( "UGREN" ) );
-            } else {                                                   
+            } else {
                     basic_colour = GetGlobalColor( _T ( "CHMGD" ) );
             }
-            
+
     int style = wxSOLID;
     int width = g_route_line_width;
     wxColour col;
@@ -2592,13 +2593,13 @@ void Track::Draw( ocpnDC& dc, ViewPort &VP )
     //  Draw the first point
     wxPoint rpt, rptn;
     DrawPointWhich( dc, 1, &rpt );
-    
+
     node = node->GetNext();
     while( node ) {
         RoutePoint *prp = node->GetData();
         unsigned short int ToSegNo = prp->m_GPXTrkSegNo;
 
-/*        
+/*
         if( m_bRunning || prp->m_IconName.StartsWith( _T("xmred") ) ) {         // pjotrc 2010.02.26
             dc.SetBrush( wxBrush( GetGlobalColor( _T ( "URED" ) ) ) );
             wxPen dPen( GetGlobalColor( _T ( "URED" ) ), g_track_line_width );
@@ -2618,17 +2619,17 @@ void Track::Draw( ocpnDC& dc, ViewPort &VP )
                     wxPen dPen( GetGlobalColor( _T ( "CHMGD" ) ), g_track_line_width );
                     dc.SetPen( dPen );
                 }
-*/                
+*/
 
         prp->Draw( dc, &rptn );
 
-        if( ToSegNo == FromSegNo )                  
+        if( ToSegNo == FromSegNo )
             RenderSegment( dc, rpt.x, rpt.y, rptn.x, rptn.y, VP, false, (int) radius ); // no arrows, with hilite
 
         rpt = rptn;
 
         node = node->GetNext();
-        FromSegNo = ToSegNo;          
+        FromSegNo = ToSegNo;
 
     }
 
@@ -2842,7 +2843,7 @@ int Track::Simplify( double maxDelta ) {
 
     SetnPoints();
     pSelect->AddAllSelectableTrackSegments( this );
-    
+
     UpdateSegmentDistances();
     ::wxEndBusyCursor();
     return reduction;
@@ -3031,7 +3032,7 @@ int MyConfig::LoadMyConfig( int iteration )
 
     Read( _T ( "GPSIdent" ), &g_GPS_Ident, wxT("Generic") );
     Read( _T ( "UseGarminHostUpload" ),  &g_bGarminHostUpload, 0 );
-    
+
     Read( _T ( "UseNMEA_RMC" ), &g_bUseRMC, 1 );
     Read( _T ( "UseNMEA_GLL" ), &g_bUseGLL, 1 );
     Read( _T ( "UseBigRedX" ), &g_bbigred, 0 );
@@ -3062,6 +3063,8 @@ int MyConfig::LoadMyConfig( int iteration )
     Read( _T ( "LookAheadMode" ), &g_bLookAhead, 0 );
     Read( _T ( "SkewToNorthUp" ), &g_bskew_comp, 0 );
     Read( _T ( "OpenGL" ), &g_bopengl, 0 );
+    if (g_bdisable_opengl)
+        g_bopengl = false;
 
 //#ifdef __WXMAC__
 //      g_bopengl = 0;
@@ -3116,7 +3119,7 @@ int MyConfig::LoadMyConfig( int iteration )
     Read( _T ( "ShowChartOutlines" ), &g_bShowOutlines, 0 );
     Read( _T ( "ShowActiveRouteHighway" ), &g_bShowActiveRouteHighway, 1 );
     Read( _T ( "MostRecentGPSUploadConnection" ), &g_uploadConnection, _T("") );
-    
+
     Read( _T ( "SDMMFormat" ), &g_iSDMMFormat, 0 ); //0 = "Degrees, Decimal minutes"), 1 = "Decimal degrees", 2 = "Degrees,Minutes, Seconds"
 
     Read( _T ( "OwnshipCOGPredictorMinutes" ), &g_ownship_predictor_minutes, 5 );
@@ -3127,7 +3130,7 @@ int MyConfig::LoadMyConfig( int iteration )
     Read( _T ( "OwnShipGPSOffsetY" ), &g_n_gps_antenna_offset_y, 0 );
     Read( _T ( "OwnShipMinSize" ), &g_n_ownship_min_mm, 1 );
     g_n_ownship_min_mm = wxMax(g_n_ownship_min_mm, 1);
-    
+
     Read( _T ( "FullScreenQuilt" ), &g_bFullScreenQuilt, 1 );
 
     Read( _T ( "StartWithTrackActive" ), &g_bTrackCarryOver, 0 );
@@ -3157,10 +3160,10 @@ int MyConfig::LoadMyConfig( int iteration )
     g_NMEALogWindow_sy = Read( _T ( "NMEALogWindowSizeY" ), 400L );
     g_NMEALogWindow_x = Read( _T ( "NMEALogWindowPosX" ), 10L );
     g_NMEALogWindow_y = Read( _T ( "NMEALogWindowPosY" ), 10L );
-    
+
     if( ( g_NMEALogWindow_x < 0 ) || ( g_NMEALogWindow_x > display_width ) ) g_NMEALogWindow_x = 5;
     if( ( g_NMEALogWindow_y < 0 ) || ( g_NMEALogWindow_y > display_height ) ) g_NMEALogWindow_y = 5;
-                              
+
     SetPath( _T ( "/Settings/GlobalState" ) );
     Read( _T ( "bFollow" ), &st_bFollow );
 
@@ -3379,7 +3382,7 @@ int MyConfig::LoadMyConfig( int iteration )
     global_color_scheme = (ColorScheme) read_int;
 
     SetPath( _T ( "/Settings/NMEADataSource" ) );
-    
+
     wxString connectionconfigs;
     Read ( _T( "DataConnections" ),  &connectionconfigs, wxEmptyString );
     wxArrayString confs = wxStringTokenize(connectionconfigs, _T("|"));
@@ -3408,10 +3411,10 @@ int MyConfig::LoadMyConfig( int iteration )
             port = xSource.Mid(7);
         else
             port = _T("");
-        
+
         if( port.Len() && (port != _T("None")) && (port != _T("AIS Port (Shared)")) ) {
         //  Look in the ConnectionParams array to see if this port has been defined in the newer style
-            bool bfound = false;    
+            bool bfound = false;
             for ( size_t i = 0; i < g_pConnectionParams->Count(); i++ )
             {
                 ConnectionParams *cp = g_pConnectionParams->Item(i);
@@ -3420,24 +3423,24 @@ int MyConfig::LoadMyConfig( int iteration )
                     break;
                 }
             }
-            
+
             if(!bfound) {
                 ConnectionParams * prm = new ConnectionParams();
                 prm->Baudrate = wxAtoi(xRate);
                 prm->Port = port;
                 prm->Garmin = (b_garmin_host == 1);
-                
+
                 g_pConnectionParams->Add(prm);
-                
+
                 g_bGarminHostUpload = b_garmin_host;
             }
         }
         if( iteration == 1 ) {
             Write ( _T ( "Source" ), _T("") );          // clear the old tag
-            Write ( _T ( "BaudRate" ), _T("") ); 
+            Write ( _T ( "BaudRate" ), _T("") );
         }
     }
-             
+
    //  Is there an existing AISPort definition?
     SetPath( _T ( "/Settings/AISPort" ) );
     wxString aSource;
@@ -3450,10 +3453,10 @@ int MyConfig::LoadMyConfig( int iteration )
             port = aSource.Mid(7);
         else
             port = _T("");
-        
+
         if(port.Len() && port != _T("None") ) {
             //  Look in the ConnectionParams array to see if this port has been defined in the newer style
-            bool bfound = false;    
+            bool bfound = false;
             for ( size_t i = 0; i < g_pConnectionParams->Count(); i++ )
             {
                 ConnectionParams *cp = g_pConnectionParams->Item(i);
@@ -3462,7 +3465,7 @@ int MyConfig::LoadMyConfig( int iteration )
                     break;
                 }
             }
-            
+
             if(!bfound) {
                 ConnectionParams * prm = new ConnectionParams();
                 if( aRate.Len() )
@@ -3470,17 +3473,17 @@ int MyConfig::LoadMyConfig( int iteration )
                 else
                     prm->Baudrate = 38400;              // default for most AIS receivers
                 prm->Port = port;
-                
+
                 g_pConnectionParams->Add(prm);
             }
         }
 
         if( iteration == 1 ) {
             Write ( _T ( "Port" ), _T("") );          // clear the old tag
-            Write ( _T ( "BaudRate" ), _T("") ); 
+            Write ( _T ( "BaudRate" ), _T("") );
         }
     }
-             
+
     //  Is there an existing NMEAAutoPilotPort definition?
     SetPath( _T ( "/Settings/NMEAAutoPilotPort" ) );
     Read ( _T ( "Port" ), &xSource );
@@ -3490,7 +3493,7 @@ int MyConfig::LoadMyConfig( int iteration )
             port = xSource.Mid(7);
         else
             port = _T("");
-        
+
         if(port.Len() && port != _T("None") ) {
             //  Look in the ConnectionParams array to see if this port has been defined in the newer style
             bool bfound = false;
@@ -3503,14 +3506,14 @@ int MyConfig::LoadMyConfig( int iteration )
                     break;
                 }
             }
-            
+
             if(!bfound) {
                 ConnectionParams * prm = new ConnectionParams();
                 prm->Port = port;
                 prm->OutputSentenceListType = WHITELIST;
                 prm->OutputSentenceList.Add( _T("RMB") );
                 prm->Output = true;
-                
+
                 g_pConnectionParams->Add(prm);
             }
             else {                                  // port was found, so make sure it is set for output
@@ -3519,11 +3522,11 @@ int MyConfig::LoadMyConfig( int iteration )
                 cp->OutputSentenceList.Add( _T("RMB") );
             }
         }
-        
+
         if( iteration == 1 )
             Write ( _T ( "Port" ), _T("") );          // clear the old tag
     }
-             
+
 //    Reasonable starting point
     vLat = START_LAT;                   // display viewpoint
     vLon = START_LON;
@@ -4055,13 +4058,13 @@ int MyConfig::LoadMyConfig( int iteration )
     Read( _T ( "RadarRingsStepUnits" ), &g_pNavAidRadarRingsStepUnits );
 
     //  Support Version 3.0 and prior config setting for Radar Rings
-    bool b300RadarRings= true;   
+    bool b300RadarRings= true;
     Read ( _T ( "ShowRadarRings" ), &b300RadarRings );
     if(!b300RadarRings)
         g_iNavAidRadarRingsNumberVisible = 0;
-        
+
     Read( _T ( "ConfirmObjectDeletion" ), &g_bConfirmObjectDelete, true );
-    
+
     // Waypoint dragging with mouse
     g_bWayPointPreventDragging = false;
     Read( _T ( "WaypointPreventDragging" ), &g_bWayPointPreventDragging );
@@ -4464,7 +4467,7 @@ void MyConfig::UpdateSettings()
     Write( _T ( "ShowActiveRouteHighway" ), g_bShowActiveRouteHighway );
     Write( _T ( "SDMMFormat" ), g_iSDMMFormat );
     Write( _T ( "MostRecentGPSUploadConnection" ), g_uploadConnection );
-    
+
     Write( _T ( "FilterNMEA_Avg" ), g_bfilter_cogsog );
     Write( _T ( "FilterNMEA_Sec" ), g_COGFilterSec );
 
@@ -4524,7 +4527,7 @@ void MyConfig::UpdateSettings()
 
     Write( _T ( "GPSIdent" ), g_GPS_Ident );
     Write( _T ( "UseGarminHostUpload" ), g_bGarminHostUpload );
-    
+
     wxString st0;
     st0.Printf( _T ( "%g" ), g_PlanSpeed );
     Write( _T ( "PlanSpeed" ), st0 );
@@ -4625,7 +4628,7 @@ void MyConfig::UpdateSettings()
     Write( _T ( "bAISAlertSuppressMoored" ), g_bAIS_CPA_Alert_Suppress_Moored );
     Write( _T ( "bShowAreaNotices" ), g_bShowAreaNotices );
     Write( _T ( "bDrawAISSize" ), g_bDrawAISSize );
-    
+
     Write( _T ( "AlertDialogSizeX" ), g_ais_alert_dialog_sx );
     Write( _T ( "AlertDialogSizeY" ), g_ais_alert_dialog_sy );
     Write( _T ( "AlertDialogPosX" ), g_ais_alert_dialog_x );
@@ -4739,7 +4742,7 @@ void MyConfig::UpdateSettings()
     Write( _T ( "RadarRingsStepUnits" ), g_pNavAidRadarRingsStepUnits );
 
     Write( _T ( "ConfirmObjectDeletion" ), g_bConfirmObjectDelete );
-    
+
     // Waypoint dragging with mouse; toh, 2009.02.24
     Write( _T ( "WaypointPreventDragging" ), g_bWayPointPreventDragging );
 
@@ -4887,16 +4890,16 @@ void MyConfig::ExportGPX( wxWindow* parent, bool bviz_only, bool blayer )
         wxProgressDialog *pprog = NULL;
         int count = pWayPointMan->m_pWayPointList->GetCount();
         if( count > 200) {
-            pprog = new wxProgressDialog( _("Export GPX file"), _T("0/0"), count, NULL, 
+            pprog = new wxProgressDialog( _("Export GPX file"), _T("0/0"), count, NULL,
                                           wxPD_APP_MODAL | wxPD_SMOOTH |
                                           wxPD_ELAPSED_TIME | wxPD_ESTIMATED_TIME | wxPD_REMAINING_TIME );
             pprog->SetSize( 400, wxDefaultCoord );
             pprog->Centre();
         }
-        
+
         //WPTs
         int ic = 0;
-        
+
         wxRoutePointListNode *node = pWayPointMan->m_pWayPointList->GetFirst();
         RoutePoint *pr;
         while( node ) {
@@ -4906,14 +4909,14 @@ void MyConfig::ExportGPX( wxWindow* parent, bool bviz_only, bool blayer )
                 pprog->Update( ic, msg );
                 ic++;
             }
-            
+
             pr = node->GetData();
 
             bool b_add = true;
 
             if( bviz_only && !pr->m_bIsVisible )
                 b_add = false;
-            
+
             if( pr->m_bIsInLayer && !blayer )
                 b_add = false;
             if( b_add) {
@@ -4927,17 +4930,17 @@ void MyConfig::ExportGPX( wxWindow* parent, bool bviz_only, bool blayer )
         wxRouteListNode *node1 = pRouteList->GetFirst();
         while( node1 ) {
             Route *pRoute = node1->GetData();
-            
+
             bool b_add = true;
-            
+
             if( bviz_only && !pRoute->IsVisible() )
                 b_add = false;
-            
-            if(  pRoute->m_bIsInLayer && !blayer ) 
+
+            if(  pRoute->m_bIsInLayer && !blayer )
                 b_add = false;
-                
+
             if( b_add ) {
-                if( !pRoute->m_bIsTrack ) 
+                if( !pRoute->m_bIsTrack )
                     gpxroot->AddRoute( CreateGPXRte( pRoute ) );
                 else
                     gpxroot->AddTrack( CreateGPXTrk( pRoute ) );
@@ -4948,12 +4951,12 @@ void MyConfig::ExportGPX( wxWindow* parent, bool bviz_only, bool blayer )
         gpx->SaveFile( fn.GetFullPath() );
         gpx->Clear();
         delete gpx;
-        
+
         ::wxEndBusyCursor();
-        
+
         if( pprog)
             delete pprog;
-        
+
     }
 }
 
@@ -8005,22 +8008,22 @@ TTYWindow::TTYWindow()
 TTYWindow::TTYWindow(wxWindow *parent, int n_lines)
 {
     wxDialog::Create( parent, -1, _T("Title"), wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER );
-    
+
     wxBoxSizer* bSizerOuterContainer = new wxBoxSizer( wxVERTICAL );
     SetSizer( bSizerOuterContainer );
-    
+
     m_pScroll = new TTYScroll(this, n_lines);
     m_pScroll->Scroll(-1, 1000);        // start with full scroll down
-    
+
     bSizerOuterContainer->Add( m_pScroll, 1, wxEXPAND, 5 );
 
     wxBoxSizer* bSizerBottomContainer = new wxBoxSizer( wxHORIZONTAL );
     bSizerOuterContainer->Add( bSizerBottomContainer, 0, wxEXPAND, 5 );
-    
- 
+
+
     wxStaticBox *psb = new wxStaticBox( this,  wxID_ANY, _("Legend")) ;
     wxStaticBoxSizer* sbSizer1 = new wxStaticBoxSizer( psb , wxVERTICAL );
-    
+
     CreateLegendBitmap();
     wxBitmapButton *bb = new wxBitmapButton(this, wxID_ANY, m_bm_legend);
     sbSizer1->Add( bb, 1, wxALL|wxEXPAND, 5 );
@@ -8028,9 +8031,9 @@ TTYWindow::TTYWindow(wxWindow *parent, int n_lines)
 
     m_buttonPause = new wxButton( this, wxID_ANY, _("Pause"), wxDefaultPosition, wxDefaultSize, 0 );
     bSizerBottomContainer->Add( m_buttonPause, 0, wxALIGN_RIGHT | wxALL, 5 );
-    
+
     m_buttonPause->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( TTYWindow::OnPauseClick ), NULL, this );
-   
+
     bpause = false;
 }
 
@@ -8046,42 +8049,42 @@ void TTYWindow::CreateLegendBitmap()
     wxMemoryDC dc;
     dc.SelectObject( m_bm_legend );
     if( m_bm_legend.IsOk()) {
-        
+
         dc.SetBackground( wxBrush(GetGlobalColor(_T("DILG1"))) );
         dc.Clear();
-        
+
         wxFont f(8, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL);
         dc.SetFont(f);
-        
+
         int yp = 25;
         int y = 5;
-        
+
         wxBrush b1(wxColour( _T("DARK GREEN")) );
         dc.SetBrush(b1);
         dc.DrawRectangle( 5, y, 20, 20 );
         dc.SetTextForeground( wxColour(_T("DARK GREEN")) );
         dc.DrawText(  _("Message accepted"), 30, y );
-        
+
         y += yp;
         wxBrush b2(wxColour( _T("#a0832a")) );
         dc.SetBrush(b2);
         dc.DrawRectangle( 5, y, 20, 20 );
         dc.SetTextForeground( wxColour(_T("#a0832a")) );
         dc.DrawText(  _("Message filtered and dropped"), 30, y );
-        
+
         y += yp;
         wxBrush b3(wxColour( _T("BLUE")) );
         dc.SetBrush(b3);
         dc.DrawRectangle( 5, y, 20, 20 );
         dc.SetTextForeground( wxColour(_T("BLUE")) );
         dc.DrawText(  _("Output Message"), 30, y );
-        
-        
-        
+
+
+
     }
-        
+
     dc.SelectObject( wxNullBitmap );
-        
+
 }
 
 
@@ -8092,13 +8095,13 @@ void TTYWindow::OnPauseClick( wxCommandEvent& event )
     if(!bpause) {
         bpause = true;
         m_pScroll->Pause( true );
-        
+
         m_buttonPause->SetLabel( _("Resume") );
     }
     else {
         bpause = false;
         m_pScroll->Pause( false );
-        
+
         m_buttonPause->SetLabel( _("Pause") );
     }
 }
@@ -8136,7 +8139,7 @@ void TTYScroll::Add( wxString &line )
         if( m_plineArray->GetCount() > m_nLines - 1 ) {                       // shuffle the arraystring
             wxArrayString *p_newArray = new wxArrayString;
 
-            for( unsigned int i = 1; i < m_plineArray->GetCount(); i++ ) 
+            for( unsigned int i = 1; i < m_plineArray->GetCount(); i++ )
                 p_newArray->Add( m_plineArray->Item( i ) );
 
             delete m_plineArray;
@@ -8177,12 +8180,12 @@ void TTYScroll::OnDraw( wxDC& dc )
                 dc.SetTextForeground( wxColour(_T("BLUE")) );
                 lss = ls.Mid(6);
         }
-        
+
         else if(ls.Mid(0, 5) == _T("<RED>") ){
             dc.SetTextForeground( wxColour(_T("RED")) );
             lss = ls.Mid(5);
         }
-        
+
         dc.DrawText( lss, 0, y );
        y += m_hLine;
     }
@@ -8229,13 +8232,13 @@ static int OCPNSoundCallback( const void *inputBuffer, void *outputBuffer,
         *out = data[sindex];
         out++;
         sindex++;
-        
+
         if( sindex >= smax_samples ) {
             bdone = true;
             break;
         }
     }
-    
+
     if(bdone)
         return paComplete;
     else
@@ -8257,19 +8260,19 @@ OCPN_Sound::OCPN_Sound()
         }
         portaudio_initialized = true;
     }
-        
+
     m_osdata = NULL;
     m_OK = false;
     m_stream = NULL;
-    
+
 }
- 
+
 OCPN_Sound::~OCPN_Sound()
 {
     if( m_stream ) {
         Pa_CloseStream( m_stream );
     }
-    
+
     FreeMem();
 }
 
@@ -8281,19 +8284,19 @@ bool OCPN_Sound::IsOk() const
 bool OCPN_Sound::Create(const wxString& fileName, bool isResource)
 {
     m_OK = false;
-    
+
     FreeMem();
-    
+
     wxFile fileWave;
     if (!fileWave.Open(fileName, wxFile::read))
     {
         return false;
     }
-    
+
     wxFileOffset lenOrig = fileWave.Length();
     if ( lenOrig == wxInvalidOffset )
         return false;
-    
+
     size_t len = wx_truncate_cast(size_t, lenOrig);
     wxUint8 *data = new wxUint8[len];
     if ( fileWave.Read(data, len) != lenOrig )
@@ -8302,7 +8305,7 @@ bool OCPN_Sound::Create(const wxString& fileName, bool isResource)
         wxLogError(_("Couldn't load sound data from '%s'."), fileName.c_str());
         return false;
     }
-    
+
     if (!LoadWAV(data, len, true))
     {
         delete [] data;
@@ -8310,19 +8313,19 @@ bool OCPN_Sound::Create(const wxString& fileName, bool isResource)
                    fileName.c_str());
         return false;
     }
-    
+
     sdata = m_osdata->m_data;           //The raw sound data
     sindex = 0;
     smax_samples = m_osdata->m_samples;
- 
+
     PaError err;
     m_stream = NULL;
-    
+
     /* Open an audio I/O stream. */
     err = Pa_OpenDefaultStream( &m_stream,
                                 0, /* no input channels */
-                                m_osdata->m_channels, 
-                                paInt16, 
+                                m_osdata->m_channels,
+                                paInt16,
                                 m_osdata->m_samplingRate,
                                 256, /* frames per buffer, i.e. the number
                                 of sample frames that PortAudio will
@@ -8337,12 +8340,12 @@ bool OCPN_Sound::Create(const wxString& fileName, bool isResource)
     if( err != paNoError )
         printf( "PortAudio Create() error: %s\n", Pa_GetErrorText( err ) );
 
-    err = Pa_SetStreamFinishedCallback( m_stream, OCPNSoundFinishedCallback ); 
+    err = Pa_SetStreamFinishedCallback( m_stream, OCPNSoundFinishedCallback );
     if( err != paNoError )
         printf( "PortAudio SetStreamFinishedCallback() error: %s\n", Pa_GetErrorText( err ) );
-    
+
     m_OK = true;
-    
+
     return true;
 }
 
@@ -8350,13 +8353,13 @@ bool OCPN_Sound::Play(unsigned flags) const
 {
     if(m_stream) {
         Pa_StopStream( m_stream );
-    
+
         if( !splaying ) {
             sdata = m_osdata->m_data;           //The raw sound data
             sindex = 0;
             smax_samples = m_osdata->m_samples;
             stream = m_stream;
-    
+
             PaError err = Pa_StartStream( stream );
             if( err != paNoError ) {
                 printf( "PortAudio Play() error: %s\n", Pa_GetErrorText( err ) );
@@ -8366,7 +8369,7 @@ bool OCPN_Sound::Play(unsigned flags) const
                 splaying = true;
                 return true;
             }
-        
+
         }
         else
             return false;
@@ -8383,7 +8386,7 @@ void OCPN_Sound::Stop()
 {
     Pa_StopStream( m_stream );
     splaying = false;
-    
+
 }
 
 typedef struct
@@ -8425,7 +8428,7 @@ bool OCPN_Sound::LoadWAV(const wxUint8 *data, size_t length, bool copyData)
     // so check that we have at least as much
     if ( length < 44 )
         return false;
-    
+
     WAVEFORMAT waveformat;
     memcpy(&waveformat, &data[FMT_INDEX + 4], sizeof(WAVEFORMAT));
     waveformat.uiSize = wxUINT32_SWAP_ON_BE(waveformat.uiSize);
@@ -8435,15 +8438,15 @@ bool OCPN_Sound::LoadWAV(const wxUint8 *data, size_t length, bool copyData)
     waveformat.ulAvgBytesPerSec = wxUINT32_SWAP_ON_BE(waveformat.ulAvgBytesPerSec);
     waveformat.uiBlockAlign = wxUINT16_SWAP_ON_BE(waveformat.uiBlockAlign);
     waveformat.uiBitsPerSample = wxUINT16_SWAP_ON_BE(waveformat.uiBitsPerSample);
-    
+
     // get the sound data size
     wxUint32 ul;
     memcpy(&ul, &data[FMT_INDEX + waveformat.uiSize + 12], 4);
     ul = wxUINT32_SWAP_ON_BE(ul);
-    
+
     if ( length < ul + FMT_INDEX + waveformat.uiSize + 16 )
         return false;
-    
+
     if (memcmp(data, "RIFF", 4) != 0)
         return false;
     if (memcmp(&data[WAVE_INDEX], "WAVE", 4) != 0)
@@ -8452,14 +8455,14 @@ bool OCPN_Sound::LoadWAV(const wxUint8 *data, size_t length, bool copyData)
         return false;
     if (memcmp(&data[FMT_INDEX + waveformat.uiSize + 8], "data", 4) != 0)
         return false;
-    
+
     if (waveformat.uiFormatTag != WAVE_FORMAT_PCM)
         return false;
-    
+
     if (waveformat.ulSamplesPerSec !=
         waveformat.ulAvgBytesPerSec / waveformat.uiBlockAlign)
         return false;
-    
+
     m_osdata = new OCPNSoundData;
     m_osdata->m_dataWithHeader = NULL;
     m_osdata->m_channels = waveformat.uiChannels;
@@ -8467,7 +8470,7 @@ bool OCPN_Sound::LoadWAV(const wxUint8 *data, size_t length, bool copyData)
     m_osdata->m_bitsPerSample = waveformat.uiBitsPerSample;
     m_osdata->m_samples = ul / (m_osdata->m_channels * m_osdata->m_bitsPerSample / 8);
     m_osdata->m_dataBytes = ul;
-    
+
     if (copyData)
     {
         m_osdata->m_dataWithHeader = new wxUint8[length];
@@ -8475,10 +8478,10 @@ bool OCPN_Sound::LoadWAV(const wxUint8 *data, size_t length, bool copyData)
     }
     else
         m_osdata->m_dataWithHeader = (wxUint8*)data;
-    
+
     m_osdata->m_data =
     (&m_osdata->m_dataWithHeader[FMT_INDEX + waveformat.uiSize + 8]);
-    
+
     return true;
 }
 
@@ -8488,7 +8491,7 @@ void OCPN_Sound::FreeMem(void)
         if( m_osdata->m_dataWithHeader )
             delete [] m_osdata->m_dataWithHeader;
         delete m_osdata;
-        
+
         m_osdata = NULL;
     }
 }
@@ -8520,11 +8523,11 @@ bool OCPN_Sound::Play(unsigned flags) const
 
 bool OCPN_Sound::IsPlaying() const
 {
-#ifndef __WXMSW__    
+#ifndef __WXMSW__
     return wxSound::IsPlaying();
 #else
     return false;
-#endif    
+#endif
 }
 
 void OCPN_Sound::Stop()

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -170,6 +170,7 @@ extern s52plib          *ps52plib;
 
 extern wxString         g_locale;
 extern bool             g_bportable;
+extern bool             g_bdisable_opengl;
 extern wxString         *pHome_Locn;
 
 extern ChartGroupArray  *g_pGroupArray;
@@ -199,24 +200,24 @@ int wxCALLBACK SortConnectionOnPriority(long item1, long item2, long list)
 
 {
     wxListCtrl *lc = (wxListCtrl*)list;
-    
+
     wxListItem it1, it2;
     it1.SetId(lc->FindItem(-1, item1));
     it1.SetColumn(3);
     it1.SetMask(it1.GetMask() | wxLIST_MASK_TEXT);
-    
+
     it2.SetId(lc->FindItem(-1, item2));
     it2.SetColumn(3);
     it2.SetMask(it2.GetMask() | wxLIST_MASK_TEXT);
-    
+
     lc->GetItem(it1);
     lc->GetItem(it2);
-    
+
 #ifdef __WXOSX__
     return it1.GetText().CmpNoCase(it2.GetText());
 #else
     return it2.GetText().CmpNoCase(it1.GetText());
-#endif    
+#endif
 }
 
 
@@ -511,11 +512,11 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     m_cbFurunoGP3X = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Format uploads for Furuno GP3X"), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbFurunoGP3X->SetValue(g_GPS_Ident == _T("FurunoGP3X"));
     bSizer161->Add( m_cbFurunoGP3X, 0, wxALL, 3 );
-    
+
     m_cbGarminUploadHost = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Use Garmin GRMN (Host) mode for uploads"), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbGarminUploadHost->SetValue(g_bGarminHostUpload);
     bSizer161->Add( m_cbGarminUploadHost, 0, wxALL, 3 );
-    
+
     bSizer151->Add( bSizer161, 1, wxEXPAND, 5 );
     sbSizerGeneral->Add( bSizer151, 1, wxEXPAND, 5 );
     bSizerOuterContainer->Add( sbSizerGeneral, 0, wxALL|wxEXPAND, 5 );
@@ -770,12 +771,12 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     m_tFilterSec->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
 
     m_lcSources->Connect( wxEVT_LEFT_DOWN, wxMouseEventHandler(options::OnConnectionToggleEnable), NULL, this );
-    
+
     wxListItem col0;
     col0.SetId(0);
     col0.SetText( _("Enable") );
     m_lcSources->InsertColumn(0, col0);
-    
+
     wxListItem col1;
     col1.SetId(1);
     col1.SetText( _("Type") );
@@ -800,36 +801,36 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     col5.SetId(5);
     col5.SetText( _("Output") );
     m_lcSources->InsertColumn(5, col5);
-    
+
     wxListItem col6;
     col6.SetId(6);
     col6.SetText( _("Filters") );
     m_lcSources->InsertColumn(6, col6);
-    
+
     //  Build the image list
     wxBitmap unchecked_bmp(16, 16), checked_bmp(16, 16);
-    
+
     {
         wxMemoryDC renderer_dc;
-        
+
         // Unchecked
         renderer_dc.SelectObject(unchecked_bmp);
         renderer_dc.SetBackground(*wxTheBrushList->FindOrCreateBrush(GetBackgroundColour(), wxSOLID));
         renderer_dc.Clear();
         wxRendererNative::Get().DrawCheckBox(this, renderer_dc, wxRect(0, 0, 16, 16), 0);
-        
+
         // Checked
         renderer_dc.SelectObject(checked_bmp);
         renderer_dc.SetBackground(*wxTheBrushList->FindOrCreateBrush(GetBackgroundColour(), wxSOLID));
         renderer_dc.Clear();
         wxRendererNative::Get().DrawCheckBox(this, renderer_dc, wxRect(0, 0, 16, 16), wxCONTROL_CHECKED);
     }
- 
+
     wxImageList *imglist = new wxImageList( 16, 16, true, 1 );
     imglist->Add( unchecked_bmp );
     imglist->Add( checked_bmp );
     m_lcSources->AssignImageList( imglist, wxIMAGE_LIST_SMALL );
- 
+
     m_lcSources->Refresh();
 
     m_stcdialog_in = new SentenceListDlg(FILTER_INPUT, this);
@@ -852,7 +853,7 @@ void options::OnConnectionToggleEnable( wxMouseEvent &event )
     wxPoint pos = event.GetPosition();
     int flags = 0;
     long clicked_index = m_lcSources->HitTest( pos, flags );
-    
+
     //    Clicking Enable Checkbox (full column)?
     if( clicked_index > -1 && event.GetX() < m_lcSources->GetColumnWidth( 0 ) ) {
         // Process the clicked item
@@ -860,7 +861,7 @@ void options::OnConnectionToggleEnable( wxMouseEvent &event )
         conn->bEnabled = !conn->bEnabled;
         m_connection_enabled = conn->bEnabled;
         m_lcSources->SetItemImage( clicked_index, conn->bEnabled ? 1 : 0 );
-        
+
         cc1->Refresh();
     }
     else if( clicked_index == -1 ) {
@@ -1206,7 +1207,7 @@ void options::CreatePanel_TidesCurrents( size_t parent, int border_size, int gro
 
     btnSizer->Add( insertButton, 1, wxALL | wxEXPAND, group_item_spacing );
     btnSizer->Add( removeButton, 1, wxALL | wxEXPAND, group_item_spacing );
-    
+
 }
 
 void options::CreatePanel_ChartGroups( size_t parent, int border_size, int group_item_spacing,
@@ -1364,6 +1365,7 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
     //  OpenGL Render checkbox
     pOpenGL = new wxCheckBox( itemPanelUI, ID_OPENGLBOX, _("Use Accelerated Graphics (OpenGL)") );
     itemStaticBoxSizerCDO->Add( pOpenGL, 1, wxALL, border_size );
+    pOpenGL->Enable(!g_bdisable_opengl);
 
     //  Smooth Pan/Zoom checkbox
     pSmoothPanZoom = new wxCheckBox( itemPanelUI, ID_SMOOTHPANZOOMBOX,
@@ -1667,8 +1669,8 @@ void options::CreatePanel_UI( size_t parent, int border_size, int group_item_spa
                                                _("Confirm deletion of tracks and routes") );
     pConfirmObjectDeletion->SetValue( FALSE );
     miscOptions->Add( pConfirmObjectDeletion, 0, wxALL, border_size );
-                                               
-                                               
+
+
 }
 
 void options::CreateControls()
@@ -1903,7 +1905,7 @@ void options::SetInitialSettings()
 
     pWayPointPreventDragging->SetValue( g_bWayPointPreventDragging );
     pConfirmObjectDeletion->SetValue( g_bConfirmObjectDelete );
-    
+
     pEnableZoomToCursor->SetValue( g_bEnableZoomToCursor );
     if( pEnableZoomToCursor->GetValue() ) {
         pSmoothPanZoom->Disable();
@@ -2094,7 +2096,7 @@ void options::OnShowGpsWindowCheckboxClick( wxCommandEvent& event )
         g_NMEALogWindow->SetSize( g_NMEALogWindow_x, g_NMEALogWindow_y, g_NMEALogWindow_sx,
                 g_NMEALogWindow_sy );
         g_NMEALogWindow->Show();
-        
+
         Raise();
     }
 }
@@ -2271,7 +2273,7 @@ ConnectionParams * options::SaveConnectionParams()
     //  Special encoding for deleted connection
     if ( m_rbTypeSerial->GetValue() && m_comboPort->GetValue() == _T("Deleted" ))
         return NULL;
-        
+
     if ( m_rbTypeSerial->GetValue() && m_comboPort->GetValue() == wxEmptyString )
     {
         wxMessageBox( _("You must select or enter the port..."), _("Error!") );
@@ -2289,7 +2291,7 @@ ConnectionParams * options::SaveConnectionParams()
     }
 
     ConnectionParams * m_pConnectionParams = new ConnectionParams();
-    
+
     m_pConnectionParams->Valid = true;
     if ( m_rbTypeSerial->GetValue() )
         m_pConnectionParams->Type = SERIAL;
@@ -2321,7 +2323,7 @@ ConnectionParams * options::SaveConnectionParams()
         m_pConnectionParams->OutputSentenceListType = BLACKLIST;
     m_pConnectionParams->Port = m_comboPort->GetValue();
     m_pConnectionParams->Protocol = PROTO_NMEA0183;
-    
+
     m_pConnectionParams->bEnabled = m_connection_enabled;
     return m_pConnectionParams;
 }
@@ -2387,7 +2389,7 @@ void options::OnApplyClick( wxCommandEvent& event )
     }
     groupsPanel->SetDBDirs( *m_pWorkDirList );          // update the Groups tab
     groupsPanel->m_treespopulated = false;
-    
+
     int k_force = FORCE_UPDATE;
     if( pUpdateCheckBox ) {
         if( !pUpdateCheckBox->GetValue() ) k_force = 0;
@@ -2458,7 +2460,7 @@ void options::OnApplyClick( wxCommandEvent& event )
     g_pNavAidRadarRingsStepUnits = m_itemRadarRingsUnits->GetSelection();
     g_bWayPointPreventDragging = pWayPointPreventDragging->GetValue();
     g_bConfirmObjectDelete = pConfirmObjectDeletion->GetValue();
-    
+
     g_bPreserveScaleOnX = pPreserveScale->GetValue();
 
     g_bPlayShipsBells = pPlayShipsBells->GetValue();
@@ -2500,7 +2502,7 @@ void options::OnApplyClick( wxCommandEvent& event )
 
     g_bShowAreaNotices = m_pCheck_Show_Area_Notices->GetValue();
     g_bDrawAISSize = m_pCheck_Draw_Target_Size->GetValue();
-    
+
     //      Alert
     g_bAIS_CPA_Alert = m_pCheck_AlertDialog->GetValue();
     g_bAIS_CPA_Alert_Audio = m_pCheck_AlertAudio->GetValue();
@@ -2563,18 +2565,18 @@ void options::OnApplyClick( wxCommandEvent& event )
             dstr->SetOutputFilter(cp->OutputSentenceList);
             dstr->SetOutputFilterType(cp->OutputSentenceListType);
             dstr->SetChecksumCheck(cp->ChecksumCheck);
-        
+
             g_pMUX->AddStream(dstr);
         }
     }
-    
+
     g_bGarminHostUpload = m_cbGarminUploadHost->GetValue();
     if( m_cbFurunoGP3X->GetValue() )
         g_GPS_Ident = _T("FurunoGP3X");
     else
         g_GPS_Ident = _T("Generic");
-    
-    
+
+
 #ifdef USE_S57
     //    Handle Vector Charts Tab
 
@@ -2745,17 +2747,17 @@ void options::OnXidOkClick( wxCommandEvent& event )
     for (size_t i = 0; i < m_pListbook->GetPageCount(); i++)
     {
         wxNotebookPage* pg = m_pListbook->GetPage( i );
-            
+
         if( pg->IsKindOf( CLASSINFO(wxNotebook))) {
                 wxNotebook *nb = ((wxNotebook *)pg);
                 nb->ChangeSelection(0);
         }
     }
-                            
+
     delete pActiveChartsList;
     delete ps57CtlListBox;
     delete tcDataSelected;
-    
+
     lastWindowPos = GetPosition();
     lastWindowSize = GetSize();
     EndModal( m_returnChanges );
@@ -2790,7 +2792,7 @@ void options::OnButtondeleteClick( wxCommandEvent& event )
     k_charts |= CHANGE_CHARTS;
 
     pScanCheckBox->Disable();
-    
+
     event.Skip();
 }
 
@@ -3239,12 +3241,12 @@ void ChartGroupsUI::PopulateTrees()
         wxString dirname = m_db_dirs.Item( i ).fullpath;
         if( !dirname.IsEmpty() ) dir_array.Add( dirname );
     }
-    
-    
+
+
     PopulateTreeCtrl( allAvailableCtl->GetTreeCtrl(), dir_array, wxColour( 0, 0, 0 ) );
     m_pActiveChartsTree = allAvailableCtl->GetTreeCtrl();
-    
-    
+
+
     //    Fill in the Page 0 tree control
     //    from the options dialog "Active Chart Directories" list
     wxArrayString dir_array0;
@@ -3255,7 +3257,7 @@ void ChartGroupsUI::PopulateTrees()
     }
     PopulateTreeCtrl( defaultAllCtl->GetTreeCtrl(), dir_array0, wxColour( 128, 128, 128 ),
                       iFont );
-    
+
 }
 
 
@@ -3292,7 +3294,7 @@ void ChartGroupsUI::PopulateTreeCtrl( wxTreeCtrl *ptc, const wxArrayString &dir_
         if( !dirname.IsEmpty() ) {
             wxDirItemData *dir_item = new wxDirItemData( dirname, dirname, true );
             wxTreeItemId id = ptc->AppendItem( m_rootId, dirname, 0, -1, dir_item );
-            
+
             //wxWidgets bug workaraound (Ticket #10085)
             ptc->SetItemText(id, dirname);
             if( pFont ) ptc->SetItemFont( id, *pFont );
@@ -3691,7 +3693,7 @@ void options::ShowNMEACommon(bool visible)
         sbSizerInFilter->SetDimension(0,0,0,0);
         sbSizerConnectionProps->SetDimension(0,0,0,0);
     }
-    
+
     m_bNMEAParams_shown = visible;
 }
 
@@ -3781,7 +3783,7 @@ void options::ClearNMEAForm()
     Fit();
     Layout();
 }
-    
+
 wxString StringArrayToString(wxArrayString arr)
 {
     wxString ret = wxEmptyString;
@@ -3846,19 +3848,19 @@ void options::SetConnectionParams(ConnectionParams *cp)
     m_choicePriority->Select(m_choicePriority->FindString(wxString::Format(_T("%d"),cp->Priority)));
 
     m_tNetAddress->SetValue(cp->NetworkAddress);
-    
+
     if( cp->NetworkPort == 0)
         m_tNetPort->SetValue(_T(""));
     else
         m_tNetPort->SetValue(wxString::Format(wxT("%i"), cp->NetworkPort));
-    
+
     if(cp->NetProtocol == TCP)
         m_rbNetProtoTCP->SetValue(true);
     else if (cp->NetProtocol == UDP)
         m_rbNetProtoUDP->SetValue(true);
-    else 
+    else
         m_rbNetProtoGPSD->SetValue(true);
-    
+
     if ( cp->Type == SERIAL )
     {
         m_rbTypeSerial->SetValue( true );
@@ -3869,9 +3871,9 @@ void options::SetConnectionParams(ConnectionParams *cp)
         m_rbTypeNet->SetValue( true );
         SetNMEAFormToNet();
     }
-    
+
     m_connection_enabled = cp->bEnabled;
-    
+
 }
 
 void options::OnAddDatasourceClick( wxCommandEvent& event )
@@ -3899,19 +3901,19 @@ void options::FillSourceList()
     m_lcSources->DeleteAllItems();
     for (size_t i = 0; i < g_pConnectionParams->Count(); i++)
     {
- 
+
         wxListItem li;
         li.SetId( i );
         li.SetImage( g_pConnectionParams->Item(i)->bEnabled ? 1 : 0  );
         li.SetData( i );
         li.SetText( _T("") );
-        
+
         long itemIndex = m_lcSources->InsertItem( li );
-        
+
         m_lcSources->SetItem(itemIndex, 1, g_pConnectionParams->Item(i)->GetSourceTypeStr());
         m_lcSources->SetItem(itemIndex, 2, g_pConnectionParams->Item(i)->GetAddressStr());
         wxString prio_str;
-        prio_str.Printf(_T("%d"), g_pConnectionParams->Item(i)->Priority ); 
+        prio_str.Printf(_T("%d"), g_pConnectionParams->Item(i)->Priority );
         m_lcSources->SetItem(itemIndex, 3, prio_str);
         m_lcSources->SetItem(itemIndex, 4, g_pConnectionParams->Item(i)->GetParametersStr());
         m_lcSources->SetItem(itemIndex, 5, g_pConnectionParams->Item(i)->GetOutputValueStr());
@@ -3937,7 +3939,7 @@ void options::FillSourceList()
 #endif
 
     m_lcSources->SortItems( SortConnectionOnPriority, (long) m_lcSources );
-    
+
 }
 
 void options::OnRemoveDatasourceClick( wxCommandEvent& event )
@@ -3948,12 +3950,12 @@ void options::OnRemoveDatasourceClick( wxCommandEvent& event )
         itemIndex = m_lcSources->GetNextItem( itemIndex, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED );
         if ( itemIndex == -1 )
             break;
-        
+
         int params_index = m_lcSources->GetItemData(itemIndex);
         if( params_index != -1 )
             g_pConnectionParams->RemoveAt( params_index );
 
-        //  Mark connection deleted  
+        //  Mark connection deleted
         m_rbTypeSerial->SetValue(true);
         m_comboPort->SetValue( _T("Deleted") );
     }
@@ -4002,8 +4004,8 @@ void options::OnNetProtocolSelected( wxCommandEvent& event )
         if (m_tNetPort->GetValue() == wxEmptyString)
             m_tNetPort->SetValue(_T("10110"));
     }
-    
-    
+
+
     SetDSFormRWStates();
     OnConnValChange(event);
 }
@@ -4042,12 +4044,12 @@ SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent, wxWindo
         standard_sentences.Add(_T("ECRMC"));
         standard_sentences.Add(_T("ECAPB"));
     }
-    
+
     standard_sentences.Add(_T("AIVDM"));
     standard_sentences.Add(_T("AIVDO"));
     standard_sentences.Add(_T("FRPOS"));
     standard_sentences.Add(_T("CD"));
-    
+
     m_pclbBox = new wxStaticBox( this,  wxID_ANY, _T("")) ;
 
     wxStaticBoxSizer* sbSizerclb;


### PR DESCRIPTION
We get silently killed in glChartCanvas constructor on some 64bit W7 systems. This is the least impact way to give those people a chance to use OpenCPN I could think of:
Do not construct anything OpenGL related and disable the posibility to use OpenGL in Toolbox.
