### PR TITLE
Reinstall the possibility to manage mail parameters

### DIFF
--- a/plugins/grib_pi/src/GribSettingsDialog.cpp
+++ b/plugins/grib_pi/src/GribSettingsDialog.cpp
@@ -36,10 +36,10 @@ static const wxString units5_names[] = {_("Percentage"), wxEmptyString};
 static const wxString *unit_names[] = {units0_names, units1_names, units2_names,
                                        units3_names, units4_names, units5_names};
 
-static const wxString name_from_index[] = {_T("Wind"), _T("WindGust"), _T("Pressure"),
-                                           _T("Wave"), _T("Current"),
-                                           _T("Precipitation"), _T("CloudCover"),
-                                           _T("AirTemperature"), _T("SeaTemperature")};
+static const wxString name_from_index[] = {_("Wind"), _("WindGust"), _("Pressure"),
+                                           _("Wave"), _("Current"),
+                                           _("Precipitation"), _("CloudCover"),
+                                           _("AirTemperature"), _("SeaTemperature")};
 static const wxString tname_from_index[] = {_("Wind"), _("Wind Gust"),  _("Pressure"),
                                             _("Wave"), _("Current"),
                                             _("Precipitation"), _("Cloud Cover"),

--- a/plugins/grib_pi/src/GribUIDialog.h
+++ b/plugins/grib_pi/src/GribUIDialog.h
@@ -127,8 +127,6 @@ private:
     void OnTimeline( wxScrollEvent& event );
     void OnCBAny( wxCommandEvent& event );
 
-    void ShowSendRequest( wxString r_zone );
-
     //    Data
     wxWindow *pParent;
     grib_pi *pPlugIn;
@@ -184,18 +182,23 @@ private:
     int m_nGribRecords;
 };
 
-class GribPofileDisplay : public GribPofileDisplayBase
+class GribRequestSetting : public GribRequestSettingBase
 {
 public:
-      GribPofileDisplay( wxWindow *parent, wxString profile )
-          : GribPofileDisplayBase(parent)
-    {    m_stProfile->SetLabel( profile ); }
+      GribRequestSetting( wxWindow *parent, wxString config, wxString zone, wxString adress )
+          : GribRequestSettingBase(parent)
+      {m_RequestConfigBase = config; m_RequestZoneBase = zone; m_MailAdressBase = adress; InitRequestConfig();}
 
-      ~GribPofileDisplay() {}
+      ~GribRequestSetting() {}
       
 private:
-      void OnSend(wxCommandEvent &event) { EndModal( wxID_OK ); }
-      void OnModify(wxCommandEvent &event) { EndModal( wxID_SAVE ); }
+      void InitRequestConfig();
+      void ApplyRequestConfig( int sel1, int sel2 );
+      wxString WriteMail();
+
+      void OnModelChange(wxCommandEvent &event);
+      void OnAnyChange( wxCommandEvent& event );
+      void OnSendMaiL( wxCommandEvent& event );
 };
 
 

--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -464,47 +464,150 @@ GribPreferencesDialogBase::~GribPreferencesDialogBase()
 {
 }
 
-GribPofileDisplayBase::GribPofileDisplayBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
-{
-	this->SetSizeHints( wxDefaultSize, wxDefaultSize );
-	
-	wxFlexGridSizer* fgSizer8;
-	fgSizer8 = new wxFlexGridSizer( 0, 2, 0, 0 );
-	fgSizer8->SetFlexibleDirection( wxBOTH );
-	fgSizer8->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-	
-	m_staticText10 = new wxStaticText( this, wxID_ANY, _("Model"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticText10->Wrap( -1 );
-	fgSizer8->Add( m_staticText10, 0, wxALL, 5 );
-	
-	m_stProfile = new wxStaticText( this, wxID_ANY, _("MyLabel"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_stProfile->Wrap( -1 );
-	fgSizer8->Add( m_stProfile, 0, wxALL, 5 );
-	
-	m_bSend = new wxButton( this, wxID_ANY, _("Send"), wxDefaultPosition, wxDefaultSize, 0 );
-	fgSizer8->Add( m_bSend, 0, wxALL, 5 );
-	
-	m_sdbSizer3 = new wxStdDialogButtonSizer();
-	m_sdbSizer3Cancel = new wxButton( this, wxID_CANCEL );
-	m_sdbSizer3->AddButton( m_sdbSizer3Cancel );
-	m_sdbSizer3->Realize();
-	
-	fgSizer8->Add( m_sdbSizer3, 1, wxEXPAND, 5 );
-	
-	
-	this->SetSizer( fgSizer8 );
-	this->Layout();
-	fgSizer8->Fit( this );
-	
-	this->Centre( wxBOTH );
-	
-	// Connect Events
-	m_bSend->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GribPofileDisplayBase::OnSend ), NULL, this );
-}
 
-GribPofileDisplayBase::~GribPofileDisplayBase()
+//-------------------------------------------------------------------------------------------------------
+//Request Preferences Dialog implementation
+//---------------------------------------------------------------------------------------------------------
+GribRequestSettingBase::GribRequestSettingBase( wxWindow* parent, wxWindowID id,
+    const wxString& title, const wxPoint& pos, const wxSize& size, long style) 
+    : wxDialog( parent, id, title, pos, size, style)
+{
+    int border_size = 5;
+
+    wxBoxSizer* bsRequest1 = new wxBoxSizer(wxVERTICAL);
+    this->SetSizer(bsRequest1);
+
+     // head request Setting
+    wxStaticBoxSizer* sbsRequest1;
+	sbsRequest1 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, wxT("Profil") ), wxVERTICAL );
+	bsRequest1->Add( sbsRequest1, 0, wxGROW|wxALL, border_size );
+
+    wxFlexGridSizer *m_pTopSizer = new wxFlexGridSizer(4);
+    sbsRequest1->Add( m_pTopSizer, 0, wxALL | wxEXPAND, border_size );
+
+    wxStaticText* m_mailto_text = new wxStaticText( this, wxID_ANY, _("Mail To "), wxDefaultPosition, wxSize(-1, -1) );
+    m_pTopSizer->Add( m_mailto_text, 0, wxALIGN_LEFT | wxALL | wxALIGN_CENTER_VERTICAL | wxEXPAND, border_size );
+
+    const wxString dest[] = { _T("Saildocs") };
+    m_pMailTo = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 1, dest, wxALIGN_LEFT );
+    m_pTopSizer->Add( m_pMailTo, 0, wxTOP, border_size );
+    m_pMailTo->SetSelection( 0 );
+
+    m_pTopSizer->Add( 0, 0, 0, 0 );
+    m_pTopSizer->Add( 0, 0, 0, 0 );
+
+    wxStaticText* m_model_text = new wxStaticText( this, wxID_ANY, _("Forecast Model "), wxDefaultPosition, wxSize(-1, -1) );
+    m_pTopSizer->Add( m_model_text, 0, wxALIGN_LEFT | wxALL | wxALIGN_CENTER_VERTICAL | wxEXPAND, border_size );
+
+    const wxString model[] = { wxT("NOAA_GFS"), wxT("NOAA_COAMPS") ,wxT("NOAA_RTOFS") };
+    m_pModel = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 3, model, wxALIGN_LEFT );
+    m_pTopSizer->Add( m_pModel, 0, wxTOP, border_size );
+  
+    wxStaticText* m_Resolution_text = new wxStaticText( this, wxID_ANY, _("Resolution"), wxDefaultPosition, wxSize(-1, -1) );
+    m_pTopSizer->Add( m_Resolution_text, 0, wxALIGN_LEFT | wxALL | wxALIGN_CENTER_VERTICAL | wxEXPAND, border_size );
+
+    m_pResolution = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 4, resolution0, wxALIGN_LEFT );
+ 
+    m_pTopSizer->Add( m_pResolution , 0, wxTOP, border_size );
+
+    wxStaticText* m_Interval_text = new wxStaticText( this, wxID_ANY, _("Interval"), wxDefaultPosition, wxSize(-1, -1) );
+    m_pTopSizer->Add( m_Interval_text, 0, wxALIGN_LEFT | wxALL | wxALIGN_CENTER_VERTICAL | wxEXPAND, border_size );
+
+    const wxString interval[] = { _("3 h"), _("6 h"), _("12 h") };
+    m_pInterval = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 3, interval, wxALIGN_LEFT );
+    m_pTopSizer->Add( m_pInterval, 0, wxTOP, border_size );
+
+    wxStaticText* m_Range_text = new wxStaticText( this, wxID_ANY, _T("Time Range"), wxDefaultPosition, wxSize(-1, -1) );
+    m_pTopSizer->Add( m_Range_text, 0, wxALIGN_LEFT | wxALL | wxALIGN_CENTER_VERTICAL | wxEXPAND, border_size );
+
+    const wxString range[] = { _("4 days"), _("6 days"), _("8 days") };
+    m_pTimeRange = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 3, range, wxALIGN_LEFT );
+    m_pTopSizer->Add( m_pTimeRange, 0, wxTOP, border_size );
+  
+    // data request Setting
+    wxStaticBoxSizer* sbsRequest2;
+	sbsRequest2 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, wxT("Data available in the selected forecast model") ), wxVERTICAL );
+	bsRequest1->Add( sbsRequest2, 0, wxGROW|wxALL, border_size );
+
+    wxFlexGridSizer *pTopSizer2 = new wxFlexGridSizer( 2 );
+    sbsRequest2->Add( pTopSizer2, 0, wxALL | wxEXPAND, border_size );
+
+    m_pWind = new wxCheckBox( this, -1, _("Wind"));
+    pTopSizer2->Add( m_pWind, 1, wxALIGN_LEFT|wxALL, border_size );
+
+    m_pPress = new wxCheckBox( this, -1, _("Pressure"));
+    pTopSizer2->Add( m_pPress, 1, wxALIGN_LEFT|wxALL, border_size );
+  
+    m_pWaves = new wxCheckBox( this, -1, _("Waves"));
+    pTopSizer2->Add( m_pWaves, 1, wxALIGN_LEFT|wxALL, border_size );
+    
+    m_pRainfall = new wxCheckBox( this, -1, _("Rainfall"));
+    pTopSizer2->Add( m_pRainfall, 1, wxALIGN_LEFT|wxALL, border_size );
+   
+    m_pCloudCover = new wxCheckBox( this, -1, _("Clouds Cover"));
+    pTopSizer2->Add( m_pCloudCover, 1, wxALIGN_LEFT|wxALL, border_size );
+    
+    m_pAirTemp = new wxCheckBox( this, -1, _("Air Temperature(2m)"));
+    pTopSizer2->Add( m_pAirTemp, 1, wxALIGN_LEFT|wxALL, border_size );
+    
+    m_pSeaTemp = new wxCheckBox( this, -1, _("Sea Temperature(surf.)"));
+    pTopSizer2->Add( m_pSeaTemp, 1, wxALIGN_LEFT|wxALL, border_size );
+
+    m_pCurrent = new wxCheckBox( this, -1, _("Current(Surf.)"));
+    pTopSizer2->Add( m_pCurrent, 1, wxALIGN_LEFT|wxALL, border_size );
+   
+    wxStaticBoxSizer* sbsRequest3;
+	sbsRequest3 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, wxT("Mail") ), wxVERTICAL );
+	bsRequest1->Add( sbsRequest3, 0, wxGROW|wxALL, border_size );
+
+    m_MailImage = new wxStaticText( this, wxID_ANY, _(""), wxDefaultPosition, wxSize(-1, -1) );
+    sbsRequest3->Add( m_MailImage, 0, wxALIGN_LEFT | wxALL | wxALIGN_CENTER_VERTICAL | wxEXPAND, border_size );
+
+    wxStdDialogButtonSizer* DialogButtonSizer = new wxStdDialogButtonSizer();
+    m_bSave = new wxButton( this, wxID_ANY, _("Save") );
+    DialogButtonSizer->SetNegativeButton( m_bSave );
+    m_bSend = new wxButton( this, wxID_ANY, _("Send") );
+    DialogButtonSizer->SetAffirmativeButton( m_bSend );
+    wxButton *m_Cancel = new wxButton( this, wxID_CANCEL );
+    DialogButtonSizer->AddButton( m_Cancel );
+    DialogButtonSizer->Realize();
+
+    bsRequest1->Add(DialogButtonSizer, 0, wxALIGN_RIGHT|wxALL, border_size);
+
+    Fit();
+
+    // Connect Events
+    m_pModel->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(GribRequestSettingBase::OnModelChange), NULL, this );
+    m_pResolution->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pInterval->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pTimeRange->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pWind->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pPress->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pWaves->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pRainfall->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pCloudCover->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pAirTemp->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pSeaTemp->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pCurrent->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_bSend->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnSendMaiL), NULL, this );
+    m_bSave->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnSaveRequest), NULL, this );
+ }
+
+GribRequestSettingBase::~GribRequestSettingBase()
 {
 	// Disconnect Events
-	m_bSend->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GribPofileDisplayBase::OnSend ), NULL, this );
-	
+	m_pModel->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(GribRequestSettingBase::OnModelChange), NULL, this );
+	m_pResolution->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pInterval->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pTimeRange->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pWind->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pPress->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pWaves->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pRainfall->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pCloudCover->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pAirTemp->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pSeaTemp->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_pCurrent->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this );
+    m_bSend->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnSendMaiL), NULL, this );
+    m_bSave->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(GribRequestSettingBase::OnSaveRequest), NULL, this );
 }

--- a/plugins/grib_pi/src/GribUIDialogBase.h
+++ b/plugins/grib_pi/src/GribUIDialogBase.h
@@ -44,6 +44,9 @@
 #define ID_CB_PRESSURE 1005
 #define ID_CB_SEA_TEMPERATURE 1006
 
+const wxString resolution0[] = { _("0.5 Deg"), _("1.0 Deg"), _("1.5 Deg"), _("2.0 Deg") };
+const wxString resolution1[] = { _("0.2 Deg"), _("0.6 Deg"), _("1.2 Deg"), _("2.0 Deg") };
+
 ///////////////////////////////////////////////////////////////////////////////
 /// Class GRIBUIDialogBase
 ///////////////////////////////////////////////////////////////////////////////
@@ -188,28 +191,44 @@ class GribPreferencesDialogBase : public wxDialog
 };
 
 ///////////////////////////////////////////////////////////////////////////////
-/// Class GribPofileDisplayBase
+/// Class GribRequestSettingBas
 ///////////////////////////////////////////////////////////////////////////////
-class GribPofileDisplayBase : public wxDialog 
+class GribRequestSettingBase : public wxDialog 
 {
-	private:
-	
-	protected:
-		wxStaticText* m_staticText10;
-		wxStaticText* m_stProfile;
-		wxButton* m_bSend;
-		wxStdDialogButtonSizer* m_sdbSizer3;
-		wxButton* m_sdbSizer3Cancel;
-		
-		// Virtual event handlers, overide them in your derived class
-		virtual void OnSend( wxCommandEvent& event ) { event.Skip(); }
-		
-	
-	public:
-		
-		GribPofileDisplayBase( wxWindow* parent, wxWindowID id = wxID_ANY, const wxString& title = _("Request Pofile"), const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_DIALOG_STYLE ); 
-		~GribPofileDisplayBase();
-	
+    private:
+        void OnSaveRequest( wxCommandEvent& event ) { EndModal( wxID_SAVE ); }
+    protected:
+        virtual void OnModelChange( wxCommandEvent& event ) { event.Skip(); }
+        virtual void OnAnyChange( wxCommandEvent& event ) { event.Skip(); }
+        virtual void OnSendMaiL( wxCommandEvent& event ) { event.Skip(); }
+    public:
+        wxString m_RequestConfigBase;
+        wxString m_MailAdressBase;
+        wxString m_RequestZoneBase;
+        wxChoice *m_pMailTo;
+        wxChoice *m_pModel;
+        wxChoice *m_pResolution;
+        wxChoice *m_pInterval;
+        wxChoice *m_pTimeRange;
+
+        wxStaticText* m_MailImage;
+
+        wxCheckBox *m_pWind;
+        wxCheckBox *m_pPress;
+        wxCheckBox *m_pWaves;
+        wxCheckBox *m_pRainfall;
+        wxCheckBox *m_pCloudCover;
+        wxCheckBox *m_pAirTemp;
+        wxCheckBox *m_pSeaTemp;
+        wxCheckBox *m_pCurrent;
+
+        wxButton   *m_bSend;
+        wxButton   *m_bSave;
+
+        GribRequestSettingBase( wxWindow *parent, wxWindowID id = wxID_ANY, const wxString& title = _("Write and Send GRIB Request eMails"),
+            const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = wxDEFAULT_DIALOG_STYLE);
+        ~GribRequestSettingBase();
+
 };
 
 #endif //__GRIBUIDIALOGBASE_H__

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -431,14 +431,13 @@ bool grib_pi::LoadConfig(void)
     pConf->Read ( _T( "GRIBTimeZone" ), &m_bTimeZone, 1 );
     pConf->Read ( _T( "CopyFirstCumulativeRecord" ), &m_bCopyFirstCumRec, 1 );
     pConf->Read ( _T( "CopyMissingWaveRecord" ), &m_bCopyMissWaveRec, 1 );
-    pConf->Read ( _T( "GRIBdataConfig" ), &m_grib_DataConfig, _T( "0XXXXXXXXXX" ) );
-    pConf->Read ( _T( "MailRequestConfig" ), &m_grib_RequestConfig, _T( "00220XX....." ) );
+    pConf->Read ( _T( "MailRequestConfig" ), &m_RequestConfig, _T( "000220XX......" ) );
     pConf->Read ( _T( "MailRequestAdesse" ), &m_bMailAdresse, _T("query@saildocs.com") );
 
 
     //if GriDataConfig has been corrupted , take the standard one to fix a crash
-    if( m_grib_DataConfig.Len() != wxString (_T( "0XXXXXXXXXX" ) ).Len() )
-        m_grib_DataConfig = _T( "0XXXXXXXXXX" );
+    if( m_RequestConfig.Len() != wxString (_T( "000220XX......" ) ).Len() )
+        m_RequestConfig = _T( "000220XX......" );
 
     m_grib_dialog_sx = pConf->Read ( _T ( "GRIBDialogSizeX" ), 300L );
     m_grib_dialog_sy = pConf->Read ( _T ( "GRIBDialogSizeY" ), 540L );
@@ -463,8 +462,7 @@ bool grib_pi::SaveConfig(void)
     pConf->Write ( _T ( "GRIBTimeZone" ), m_bTimeZone );
     pConf->Write ( _T ( "CopyFirstCumulativeRecord" ), m_bCopyFirstCumRec );
     pConf->Write ( _T ( "CopyMissingWaveRecord" ), m_bCopyMissWaveRec );
-    pConf->Write ( _T ( "GRIBdataConfig" ), m_grib_DataConfig );
-    pConf->Write ( _T ( "MailRequestConfig" ), m_grib_RequestConfig );
+    pConf->Write ( _T ( "MailRequestConfig" ), m_RequestConfig );
     pConf->Write ( _T( "MailRequestAdesse" ), m_bMailAdresse );
 
 

--- a/plugins/grib_pi/src/grib_pi.h
+++ b/plugins/grib_pi/src/grib_pi.h
@@ -94,11 +94,9 @@ public:
 
       void OnGribDialogClose();
 
-      void SetGRIBDataConfig ( wxString conf ){ m_grib_DataConfig = conf; }
-      void SetMailRequestConfig ( wxString conf ){ m_grib_RequestConfig = conf; }
-
-      wxString GetGRIBDataConfig(){ return m_grib_DataConfig; }
-      wxString GetMailRequestConfig(){ return m_grib_RequestConfig; }
+      void SetRequestConfig ( wxString conf ){ m_RequestConfig = conf; }
+      wxString GetRequestConfig(){ return m_RequestConfig; }
+      wxString GetMailAdresse(){ return m_bMailAdresse; }
 
       int  GetTimeZone() { return m_bTimeZone; }
       bool GetCopyFirstCumRec() { return  m_bCopyFirstCumRec; }
@@ -136,9 +134,7 @@ private:
       bool             m_bCopyFirstCumRec;
       bool             m_bCopyMissWaveRec;
 
-      wxString         m_grib_DataConfig;
-      wxString         m_grib_RequestConfig;
-
+      wxString         m_RequestConfig;
       wxString         m_bMailAdresse;
       
       bool             m_bGRIBShowIcon;

--- a/plugins/grib_pi/src/smapi.cpp
+++ b/plugins/grib_pi/src/smapi.cpp
@@ -110,15 +110,13 @@ void wxMapiSession::Initialise()
                 m_data->m_lpfnMAPIResolveName == NULL ||
                 m_data->m_lpfnMAPIFreeBuffer == NULL)
             {
-                wxLogDebug(_T("Failed to get one of the functions pointer in MAPI32.DLL\n"));
+                wxLogMessage(_T("MAIL Error: Failed to get one of the functions pointer in MAPI32.DLL\n"));
                 Deinitialise();
             }
         }
     }
     else {
-        //wxLogDebug(_T("Mapi is not installed on this computer\n"));
-        wxMessageDialog *m = new wxMessageDialog( NULL, _("Mapi is not installed or invalid on this computer"), _("Error"), wxOK );
-        m->ShowModal();
+        wxLogMessage(_("MAIL Error: MAPI32.DLL is not installed or invalid on this computer!"));
     }
 }
 
@@ -194,7 +192,7 @@ bool wxMapiSession::Logon(const wxString& sProfileName, const wxString& sPasswor
     if (nError != SUCCESS_SUCCESS && nError != MAPI_E_USER_ABORT)
     {
         //Failed to create a create mapi session, try to acquire a shared mapi session
-        wxLogDebug(_T("Failed to logon to MAPI using a new session, trying to acquire a shared one\n"));
+        //wxLogDebug(_T("Failed to logon to MAPI using a new session, trying to acquire a shared one\n"));
         nError = m_data->m_lpfnMAPILogon(nUIParam, NULL, NULL, 0, 0, &m_data->m_hSession);
         if (nError == SUCCESS_SUCCESS)
         {
@@ -203,10 +201,7 @@ bool wxMapiSession::Logon(const wxString& sProfileName, const wxString& sPasswor
         }
         else
         {
-            wxMessageDialog *m = new wxMessageDialog( NULL, _("OpenCpn failed to logon! Please verify your eMail environment"),
-                _("eMail error"), wxOK );
-            m->ShowModal();
-            //wxLogDebug(_T("Failed to logon to MAPI using a shared session, Error:%ld\n"), nError);
+            wxLogMessage(_T("MAIL Error: Failed to logon to MAPI using a shared session, Error:%ld\n"), nError);
             m_data->m_nLastError = nError;
         }
     }
@@ -215,6 +210,8 @@ bool wxMapiSession::Logon(const wxString& sProfileName, const wxString& sPasswor
         m_data->m_nLastError = SUCCESS_SUCCESS;
         bSuccess = TRUE;
     }
+
+    if(bSuccess) 
     
     return bSuccess;
 }
@@ -243,7 +240,7 @@ bool wxMapiSession::Logoff()
         ULONG nError = m_data->m_lpfnMAPILogoff(m_data->m_hSession, 0, 0, 0); 
         if (nError != SUCCESS_SUCCESS)
         {
-            wxLogDebug(_T("Failed in call to MapiLogoff, Error:%ld"), nError);
+            wxLogMessage(_T("MAIL Error: Failed in call to MapiLogoff, Error:%ld"), nError);
             m_data->m_nLastError = nError;
             bSuccess = TRUE;
         }
@@ -278,7 +275,7 @@ bool wxMapiSession::Resolve(const wxString& sName, void* lppRecip1)
     ULONG nError = m_data->m_lpfnMAPIResolveName(m_data->m_hSession, 0, lpszAsciiName, 0, 0, lppRecip);
     if (nError != SUCCESS_SUCCESS)
     {
-        wxLogDebug(_T("Failed to resolve the name: %s, Error:%ld\n"),
+        wxLogMessage(_T("MAIL Error: Failed to resolve the name: %s, Error:%ld\n"),
                    sName.c_str(), nError);
         m_data->m_nLastError = nError;
     }
@@ -466,9 +463,7 @@ bool wxMapiSession::Send(wxMailMessage& message)
     }
     else
     {
-        wxMessageDialog *m = new wxMessageDialog( NULL, _("Failed to send mail message"), _("eMail error"), wxOK );
-        m->ShowModal();
-        //wxLogDebug(_T("Failed to send mail message, Error:%ld\n"), nError);
+        wxLogMessage(_T("MAIL Error: Failed to send mail message, Error:%ld\n"), nError);
         m_data->m_nLastError = nError;
     }
     


### PR DESCRIPTION
When clicking on the "mail" button in the main grib dialog, the write/send dialog is open allowing to set the different request parameters.
-Changing the model will enable/disable the different parameters according to this model.
At the bottom the mail is displayed as it will be sent. Each time a parameters is changed the mail is re-written.
There are three buttons 
"cancel" to exit without action off course
"save" to save the setting and exit
"send" to send the mail . we stay in the dialog . the mail is replaced by a message (in red) and the button "send" disappear .
If a parameters is changed , the button  comes back allowing to send a new mail
There are two messages : one if succeed and one if not .
All the error messages coming from the mail functions if there are failures are directed to the log file.

attached two shots
Jean Pierre

![grib1](https://f.cloud.github.com/assets/2202442/462796/8409ab30-b4df-11e2-94d0-5f5a171ada3b.jpg)
![grib2](https://f.cloud.github.com/assets/2202442/462797/8c201804-b4df-11e2-858c-6d278448a95a.jpg)
