### PR TITLE
needed for plugin sound support to play on non-msw

### DIFF
--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -1784,7 +1784,7 @@ void PlugInPlaySound( wxString &sound_file )
         
 #ifndef __WXMSW__
     if(sound.IsOk() && !sound.IsPlaying())
-        sound.Play();
+        sound.Play(wxSOUND_SYNC);
 #else
     if( sound.IsOk() ) sound.Play();
 #endif


### PR DESCRIPTION
when leaving scope (PlugInPlaySound returns) calls destructor for ocpn_sound which occurs before the sound is heard
when playing asyncronously.. so either play syncronously, or change destructor of ocpn_sound to not call stop
