### PR TITLE
 Take file's time steps when "interpolate" option is uncheked and improve timeline scrolling

### DIFF
--- a/plugins/grib_pi/src/GribSettingsDialog.cpp
+++ b/plugins/grib_pi/src/GribSettingsDialog.cpp
@@ -207,6 +207,12 @@ GribSettingsDialog::GribSettingsDialog(GRIBUIDialog &parent, GribOverlaySettings
     m_sSlicesPerUpdate->SetValue(m_Settings.m_SlicesPerUpdate);
     m_sUpdatesPerSecond->SetValue(m_Settings.m_UpdatesPerSecond);
     m_sHourDivider->SetValue(m_Settings.m_HourDivider);
+    if(!m_cInterpolate->IsChecked() ) {              //hide no suiting parameters
+        m_staticText5->Hide();
+        m_sSlicesPerUpdate->Hide();
+        m_staticText9->Hide();
+        m_sHourDivider->Hide();
+    }
 
     for(int i=0; i<GribOverlaySettings::SETTINGS_COUNT; i++)
         m_cDataType->Append(tname_from_index[i]);
@@ -219,7 +225,15 @@ GribSettingsDialog::GribSettingsDialog(GRIBUIDialog &parent, GribOverlaySettings
 /* set settings to the dialog controls */
 void GribSettingsDialog::WriteSettings()
 {
-    m_Settings.m_bInterpolate = m_cInterpolate->GetValue();
+    if(m_Settings.m_bInterpolate != m_cInterpolate->GetValue()) {
+        m_Settings.m_bInterpolate = m_cInterpolate->GetValue();
+        if(m_cInterpolate->IsChecked()) {
+            wxMessageDialog mes(this, _("This file contains data for particular times and you have chosen to display data for different times.\nPlease consider that these values will be interpolated."),
+                _("Warning!"), wxOK);
+            mes.ShowModal();
+        }
+    }
+
     m_Settings.m_bLoopMode = m_cLoopMode->GetValue();
     m_Settings.m_SlicesPerUpdate = m_sSlicesPerUpdate->GetValue();
     m_Settings.m_UpdatesPerSecond = m_sUpdatesPerSecond->GetValue();
@@ -279,5 +293,23 @@ void GribSettingsDialog::OnDataTypeChoice( wxCommandEvent& event )
 void GribSettingsDialog::OnApply( wxCommandEvent& event )
 {
     WriteSettings();
-    m_parent.SetFactoryOptions();
+    m_parent.SetFactoryOptions(true);
+    m_parent.TimelineChanged();
+}
+
+void GribSettingsDialog::OnIntepolateChange( wxCommandEvent& event )
+{
+    if( m_cInterpolate->IsChecked() ) {
+        m_staticText5->Show();
+        m_sSlicesPerUpdate->Show();
+        m_staticText9->Show();
+        m_sHourDivider->Show();
+    } else {                                        //hide no suiting parameters 
+        m_staticText5->Hide();
+        m_sSlicesPerUpdate->Hide();
+        m_staticText9->Hide();
+        m_sHourDivider->Hide();
+    }
+    this->Fit();
+    this->Refresh();
 }

--- a/plugins/grib_pi/src/GribSettingsDialog.h
+++ b/plugins/grib_pi/src/GribSettingsDialog.h
@@ -92,6 +92,7 @@ private:
     void PopulateUnits(int settings);
     void OnDataTypeChoice( wxCommandEvent& event );
     void OnApply( wxCommandEvent& event );
+    void OnIntepolateChange( wxCommandEvent& event );
 
     GRIBUIDialog &m_parent;
 

--- a/plugins/grib_pi/src/GribUIDialog.h
+++ b/plugins/grib_pi/src/GribUIDialog.h
@@ -87,11 +87,11 @@ public:
     void SelectGribRecordSet( GribRecordSet *pGribRecordSet );
     void SetGribTimelineRecordSet(GribTimelineRecordSet *pTimelineSet);
     void SetCursorLatLon( double lat, double lon );
-    void SetFactoryOptions();
+    void SetFactoryOptions( bool set_val = false );
 
     wxDateTime TimelineTime();
     wxDateTime MinTime();
-    wxDateTime MaxTime();
+    //wxDateTime MaxTime();
     GribTimelineRecordSet* GetTimeLineRecordSet(wxDateTime time);
     void TimelineChanged(bool sync=false);
     void CreateActiveFileFromName( wxString filename );

--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -261,39 +261,41 @@ GribSettingsDialogBase::GribSettingsDialogBase( wxWindow* parent, wxWindowID id,
 	wxStaticBoxSizer* sbSizer4;
 	sbSizer4 = new wxStaticBoxSizer( new wxStaticBox( this, wxID_ANY, _("playback") ), wxVERTICAL );
 	
-	wxGridSizer* gSizer2;
-	gSizer2 = new wxGridSizer( 0, 2, 0, 0 );
-	
-	m_cInterpolate = new wxCheckBox( this, wxID_ANY, _("Interpolate between gribs"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_cInterpolate->SetValue(true); 
-	gSizer2->Add( m_cInterpolate, 0, 0, 5 );
-	
+	wxGridSizer* fgSizer41;
+	fgSizer41 = new wxFlexGridSizer( 0, 3, 0, 0 );
+		
 	m_cLoopMode = new wxCheckBox( this, wxID_ANY, _("Loop Mode"), wxDefaultPosition, wxDefaultSize, 0 );
-	gSizer2->Add( m_cLoopMode, 0, 0, 5 );
+	fgSizer41->Add( m_cLoopMode, 0, wxALL, 5 );
+
+    m_staticText4 = new wxStaticText( this, wxID_ANY, _("Updates per Second"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_staticText4->Wrap( -1 );
+	fgSizer41->Add( m_staticText4, 0, wxALL, 5 );
+
+    m_sUpdatesPerSecond = new wxSpinCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 60, 4 );
+	fgSizer41->Add( m_sUpdatesPerSecond, 0, wxALL, 5 );
+
+    m_cInterpolate = new wxCheckBox( this, wxID_ANY, _("Interpolate between gribs"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_cInterpolate->SetValue(true); 
+	fgSizer41->Add( m_cInterpolate, 0, wxALL, 5 );
 	
 	m_staticText5 = new wxStaticText( this, wxID_ANY, _("Slices per Update"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText5->Wrap( -1 );
-	gSizer2->Add( m_staticText5, 0, 0, 5 );
+	fgSizer41->Add( m_staticText5, 0, wxALL, 5 );
 	
 	m_sSlicesPerUpdate = new wxSpinCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 100, 2 );
-	gSizer2->Add( m_sSlicesPerUpdate, 0, wxALL, 5 );
+	fgSizer41->Add( m_sSlicesPerUpdate, 0, wxALL, 5 );
+
+    fgSizer41->Add( 0, 0, wxTOP, 5 );
 	
-	m_staticText9 = new wxStaticText( this, wxID_ANY, _("Updates per Second"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_staticText9 = new wxStaticText( this, wxID_ANY, _("Slices per hour"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_staticText9->Wrap( -1 );
-	gSizer2->Add( m_staticText9, 0, wxALL, 5 );
-	
-	m_sUpdatesPerSecond = new wxSpinCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 60, 4 );
-	gSizer2->Add( m_sUpdatesPerSecond, 0, wxALL, 5 );
-	
-	m_staticText4 = new wxStaticText( this, wxID_ANY, _("Slices per hour"), wxDefaultPosition, wxDefaultSize, 0 );
-	m_staticText4->Wrap( -1 );
-	gSizer2->Add( m_staticText4, 0, wxALL, 5 );
+	fgSizer41->Add( m_staticText9, 0, wxALL, 5 );
 	
 	m_sHourDivider = new wxSpinCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 20, 2 );
-	gSizer2->Add( m_sHourDivider, 0, wxALL, 5 );
+	fgSizer41->Add( m_sHourDivider, 0, wxALL, 5 );
 	
 	
-	sbSizer4->Add( gSizer2, 1, 0, 5 );
+	sbSizer4->Add( fgSizer41, 1, 0, 5 );
 	
 	
 	fgSizer4->Add( sbSizer4, 1, 0, 5 );
@@ -396,6 +398,7 @@ GribSettingsDialogBase::GribSettingsDialogBase( wxWindow* parent, wxWindowID id,
 	this->Centre( wxBOTH );
 	
 	// Connect Events
+    m_cInterpolate->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( GribSettingsDialogBase::OnIntepolateChange ), NULL, this );
 	m_cDataType->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( GribSettingsDialogBase::OnDataTypeChoice ), NULL, this );
 	m_sdbSizer1Apply->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GribSettingsDialogBase::OnApply ), NULL, this );
 }
@@ -403,6 +406,7 @@ GribSettingsDialogBase::GribSettingsDialogBase( wxWindow* parent, wxWindowID id,
 GribSettingsDialogBase::~GribSettingsDialogBase()
 {
 	// Disconnect Events
+    m_cInterpolate->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( GribSettingsDialogBase::OnIntepolateChange ), NULL, this );
 	m_cDataType->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( GribSettingsDialogBase::OnDataTypeChoice ), NULL, this );
 	m_sdbSizer1Apply->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GribSettingsDialogBase::OnApply ), NULL, this );
 	

--- a/plugins/grib_pi/src/GribUIDialogBase.h
+++ b/plugins/grib_pi/src/GribUIDialogBase.h
@@ -154,7 +154,8 @@ class GribSettingsDialogBase : public wxDialog
 		// Virtual event handlers, overide them in your derived class
 		virtual void OnDataTypeChoice( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnApply( wxCommandEvent& event ) { event.Skip(); }
-		
+		virtual void OnIntepolateChange( wxCommandEvent& event ) { event.Skip(); }
+
 	
 	public:
 		wxCheckBox* m_cInterpolate;


### PR DESCRIPTION
1) When the timeline slider scrolling steps are exactly the same as when playing video (previously scrolling step was always 1 hour whatever was the slices choice)
2) when the "interpolate between gribs" option is unchecked , the "slices per update" and "slices per hour" options are hidden (for that the setting dialog is slightly changed) and the file's steps are taken for both scrolling and playing video.
3) the "best forecast for now" is improved
