### PR TITLE
Improve grib data panel ( Add unit symbols and use all available space for data )

### DIFF
--- a/plugins/grib_pi/src/GribSettingsDialog.cpp
+++ b/plugins/grib_pi/src/GribSettingsDialog.cpp
@@ -149,7 +149,7 @@ double GribOverlaySettings::CalibrationFactor(int settings)
         } break;
     case 1: switch(Settings[settings].m_Units) {
         case MILLIBARS: return 1 / 100.;
-        case MMHG: return 1 / 100. * 1.33;
+        case MMHG: return 1 / (100. * 1.33);
         } break;
     case 2: switch(Settings[settings].m_Units) {
         case METERS: return 1;
@@ -167,6 +167,38 @@ double GribOverlaySettings::CalibrationFactor(int settings)
     }
         
     return 1;
+}
+
+wxString GribOverlaySettings::GetUnitSymbol(int settings)
+{
+    switch(unittype[settings]) {
+        case 0: switch(Settings[settings].m_Units) {
+            case KNOTS:  return _T("kt");
+            case M_S:    return _T("m/s");
+            case MPH:    return _T("mph");
+            case KPH:    return _T("kmh");
+        } break;
+        case 1: switch(Settings[settings].m_Units) {
+            case MILLIBARS: return _T("hPa");
+            case MMHG: return _T("mmHg");
+        } break;
+        case 2: switch(Settings[settings].m_Units) {
+            case METERS: return _T("m");
+            case FEET:   return _T("ft");
+        } break;
+        case 3: switch(Settings[settings].m_Units) {
+            case CELCIUS:     return _T("\u00B0C");
+            case FAHRENHEIT: return _T("\u00B0F");
+        } break;
+        case 4: switch(Settings[settings].m_Units) {
+            case MILLIMETERS: return _T("mm");
+            case INCHES:      return _T("in");
+        } break;
+        case 5: switch(Settings[settings].m_Units) {
+            case PERCENTAGE:  return _T("%");
+        } break;
+    }
+    return _T("");
 }
 
 double GribOverlaySettings::GetMin(int settings)

--- a/plugins/grib_pi/src/GribSettingsDialog.h
+++ b/plugins/grib_pi/src/GribSettingsDialog.h
@@ -44,6 +44,7 @@ struct GribOverlaySettings
     double CalibrationFactor(int settings);
     double CalibrateValue(int settings, double input)
         { return (input+CalibrationOffset(settings))*CalibrationFactor(settings); }
+    wxString GetUnitSymbol(int settings);
     double GetMin(int settings);
     double GetMax(int settings);
     // settings options

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -312,7 +312,7 @@ GRIBUIDialog::GRIBUIDialog(wxWindow *parent, grib_pi *ppi)
     DimeWindow( this );
 
     m_pTimelineSet = NULL;
-    PopulateTrackingControls();
+    m_fgTrackingControls->Clear();
 
     Fit();
     SetMinSize( GetBestSize() );
@@ -403,8 +403,7 @@ void GRIBUIDialog::PopulateTrackingControls( void )
     }
 
     m_fgTrackingControls->Clear();
-    int cols = (GetSize().x / 180) * 3;
-    m_fgTrackingControls->SetCols(cols);
+    m_fgTrackingControls->SetCols(9);
 
     GribRecord **RecordArray;
     if( m_pTimelineSet )
@@ -471,12 +470,12 @@ void GRIBUIDialog::UpdateTrackingControls( void )
             vy = m_OverlaySettings.CalibrateValue(GribOverlaySettings::WIND, vy);
             
             double vkn = sqrt( vx * vx + vy * vy );
-            m_tcWindSpeed->SetValue( wxString::Format( _T("%2d"), (int) vkn ));
+            m_tcWindSpeed->SetValue( wxString::Format( _T("%2d ") + m_OverlaySettings.GetUnitSymbol(GribOverlaySettings::WIND) , (int) vkn ) );
             
             double ang = 90. + ( atan2( vy, -vx ) * 180. / PI );
             if( ang > 360. ) ang -= 360.;
             if( ang < 0. ) ang += 360.;
-            m_tcWindDirection->SetValue( wxString::Format( _T("%03d"), (int) ( ang ) ));
+            m_tcWindDirection->SetValue( wxString::Format( _T("%03d\u00B0"), (int) ( ang ) ));
         } else {
             m_tcWindSpeed->SetValue( _("N/A") );
             m_tcWindDirection->SetValue(  _("N/A") );
@@ -495,12 +494,12 @@ void GRIBUIDialog::UpdateTrackingControls( void )
             vy = m_OverlaySettings.CalibrateValue(GribOverlaySettings::WIND, vy);
             
             double vkn = sqrt( vx * vx + vy * vy );
-            m_tcWindScatSpeed->SetValue( wxString::Format( _T("%2d"), (int) vkn ) );
+            m_tcWindScatSpeed->SetValue( wxString::Format( _T("%2d ") + m_OverlaySettings.GetUnitSymbol(GribOverlaySettings::WIND), (int) vkn ) );
             
             double ang = 90. + ( atan2( vy, -vx ) * 180. / PI );
             if( ang > 360. ) ang -= 360.;
             if( ang < 0. ) ang += 360.;
-            m_tcWindScatDirection->SetValue( wxString::Format( _T("%03d"), (int) ( ang ) ) );
+            m_tcWindScatDirection->SetValue( wxString::Format( _T("%03d\u00B0"), (int) ( ang ) ) );
         } else {
             m_tcWindScatSpeed->SetValue( _("N/A") );
             m_tcWindScatDirection->SetValue( _("N/A") );
@@ -514,7 +513,7 @@ void GRIBUIDialog::UpdateTrackingControls( void )
         
         if( vkn != GRIB_NOTDEF ) {
             vkn = m_OverlaySettings.CalibrateValue(GribOverlaySettings::WIND_GUST, vkn);
-            m_tcWindGust->SetValue( wxString::Format(_T("%2d"), (int) ( vkn )) );
+            m_tcWindGust->SetValue( wxString::Format(_T("%2d ") + m_OverlaySettings.GetUnitSymbol(GribOverlaySettings::WIND_GUST), (int) ( vkn )) );
         } else
             m_tcWindGust->SetValue( _("N/A") );
     }
@@ -526,7 +525,7 @@ void GRIBUIDialog::UpdateTrackingControls( void )
         
         if( press != GRIB_NOTDEF ) {
             press = m_OverlaySettings.CalibrateValue(GribOverlaySettings::PRESSURE, press);
-            m_tcPressure->SetValue( wxString::Format(_T("%2d"), (int) ( press )) );
+            m_tcPressure->SetValue( wxString::Format(_T("%2d ") + m_OverlaySettings.GetUnitSymbol(GribOverlaySettings::PRESSURE), (int) ( press )) );
         } else
             m_tcPressure->SetValue( _("N/A") );
     }
@@ -538,7 +537,7 @@ void GRIBUIDialog::UpdateTrackingControls( void )
         
         if( height != GRIB_NOTDEF ) {
             height = m_OverlaySettings.CalibrateValue(GribOverlaySettings::WAVE, height);
-            m_tcWaveHeight->SetValue( wxString::Format( _T("%4.1f"), height ));
+            m_tcWaveHeight->SetValue( wxString::Format( _T("%4.1f ") + m_OverlaySettings.GetUnitSymbol(GribOverlaySettings::WAVE), height ));
         } else
             m_tcWaveHeight->SetValue( _("N/A") );
     }
@@ -548,7 +547,7 @@ void GRIBUIDialog::UpdateTrackingControls( void )
         double direction = RecordArray[Idx_WVDIR]->
             getInterpolatedValue(m_cursor_lon, m_cursor_lat, true );
         if( direction != GRIB_NOTDEF )
-            m_tcWaveDirection->SetValue( wxString::Format( _T("%03d"), (int)direction ));
+            m_tcWaveDirection->SetValue( wxString::Format( _T("%03d\u00B0"), (int)direction ));
         else
             m_tcWaveDirection->SetValue( _("N/A") );
     }
@@ -566,12 +565,12 @@ void GRIBUIDialog::UpdateTrackingControls( void )
             vy = m_OverlaySettings.CalibrateValue(GribOverlaySettings::CURRENT, vy);
             
             double vkn = sqrt( vx * vx + vy * vy );
-            m_tcCurrentVelocity->SetValue( wxString::Format( _T("%5.2f"), vkn ) );
+            m_tcCurrentVelocity->SetValue( wxString::Format( _T("%4.1f ") + m_OverlaySettings.GetUnitSymbol(GribOverlaySettings::CURRENT), vkn ) );
             
             double ang = 90. + ( atan2( -vy, vx ) * 180. / PI );
             if( ang > 360. ) ang -= 360.;
             if( ang < 0. ) ang += 360.;
-            m_tcCurrentDirection->SetValue( wxString::Format( _T("%03d"), (int) ( ang ) ) );            
+            m_tcCurrentDirection->SetValue( wxString::Format( _T("%03d\u00B0"), (int) ( ang ) ) );            
         } else {
             m_tcCurrentVelocity->SetValue( _("N/A") );
             m_tcCurrentDirection->SetValue( _("N/A") );
@@ -585,7 +584,7 @@ void GRIBUIDialog::UpdateTrackingControls( void )
         
         if( precip != GRIB_NOTDEF ) {
             precip = m_OverlaySettings.CalibrateValue(GribOverlaySettings::PRECIPITATION, precip);
-            m_tcPrecipitation->SetValue( wxString::Format( _T("%6.2f"), precip ) );
+            m_tcPrecipitation->SetValue( wxString::Format( _T("%6.2f ") + m_OverlaySettings.GetUnitSymbol(GribOverlaySettings::PRECIPITATION), precip ) );
         } else
             m_tcPrecipitation->SetValue( _("N/A") );
     }
@@ -597,7 +596,8 @@ void GRIBUIDialog::UpdateTrackingControls( void )
         
         if( cloud != GRIB_NOTDEF ) {
             cloud = m_OverlaySettings.CalibrateValue(GribOverlaySettings::CLOUD, cloud);
-            m_tcCloud->SetValue( wxString::Format( _T("%6.2f"), cloud ) );
+            wxString val( wxString::Format( _T("%5.1f "), cloud ) );
+            m_tcCloud->SetValue( val + m_OverlaySettings.GetUnitSymbol(GribOverlaySettings::CLOUD) );
         } else
             m_tcCloud->SetValue( _("N/A") );
     }
@@ -609,7 +609,7 @@ void GRIBUIDialog::UpdateTrackingControls( void )
         
         if( temp != GRIB_NOTDEF ) {
             temp = m_OverlaySettings.CalibrateValue(GribOverlaySettings::AIR_TEMPERATURE, temp);
-            m_tcAirTemperature->SetValue( wxString::Format( _T("%6.2f"), temp ) );
+            m_tcAirTemperature->SetValue( wxString::Format( _T("%5.1f ") + m_OverlaySettings.GetUnitSymbol(GribOverlaySettings::AIR_TEMPERATURE), temp ) );
         } else
             m_tcAirTemperature->SetValue( _("N/A") );
     }
@@ -621,7 +621,7 @@ void GRIBUIDialog::UpdateTrackingControls( void )
         
         if( temp != GRIB_NOTDEF ) {
             temp = m_OverlaySettings.CalibrateValue(GribOverlaySettings::SEA_TEMPERATURE, temp);
-            m_tcSeaTemperature->SetValue( wxString::Format( _T("%6.2f"), temp ) );
+            m_tcSeaTemperature->SetValue( wxString::Format( _T("%5.1f ") + m_OverlaySettings.GetUnitSymbol(GribOverlaySettings::SEA_TEMPERATURE), temp ) );
         } else
             m_tcSeaTemperature->SetValue( _("N/A") );
     }
@@ -650,8 +650,6 @@ void GRIBUIDialog::OnSize( wxSizeEvent& event )
     wxSize p = event.GetSize();
     pPlugIn->SetGribDialogSizeX( p.x );
     pPlugIn->SetGribDialogSizeY( p.y );
-
-    PopulateTrackingControls();
 
     event.Skip();
 }


### PR DESCRIPTION
1)  unit symbols : better user information
2) use all available space for data
    The columns number calculation has almost always a result of 6 ( 2 groups of 3 ) thus a part of the space is lost and 1 line more is used
    There is very little possibility to have really 3 \* 3 data to display on the same line as only wind , waves and currents have 3 data . So I choose to set arbitrary , the column number at 9 ( 3 groups of 3 ) . All the space is always used and only in few cases the panel is a little longer (see shots "before" and "after" attached
3) correct a little bug in mmHg calculation.
Jean Pierre
![after](https://f.cloud.github.com/assets/2202442/567077/8bc89aae-c6a8-11e2-8097-a973830c546e.jpg)
![before](https://f.cloud.github.com/assets/2202442/567076/81b0ce6a-c6a8-11e2-8312-10e673b458f0.jpg)
