### PR TITLE
Add LateInit() as optional plugin functionality

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -79,6 +79,7 @@ class       wxAuiManager;
 #define     WANTS_PLUGIN_MESSAGING                    0x00004000
 #define     WANTS_OPENGL_OVERLAY_CALLBACK             0x00008000
 #define     WANTS_DYNAMIC_OPENGL_OVERLAY_CALLBACK     0x00010000
+#define     WANTS_LATE_INIT                           0x40000000
 
 //----------------------------------------------------------------------------------------------------------
 //    Some PlugIn API interface object class definitions
@@ -408,6 +409,7 @@ public:
 
       virtual wxArrayString GetDynamicChartClassNameArray(void);
 
+      virtual void LateInit(void); // If WANTS_LATE_INIT is returned by Init()
  };
 
 

--- a/include/pluginmanager.h
+++ b/include/pluginmanager.h
@@ -242,6 +242,7 @@ public:
       void SendResizeEventToAllPlugIns(int x, int y);
       void SetColorSchemeForAllPlugIns(ColorScheme cs);
       void NotifyAuiPlugIns(void);
+      bool CallLateInit(void);
 
       wxArrayString GetPlugInChartClassNameArray(void);
 

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -2090,6 +2090,9 @@ if( 0 == g_memCacheLimit )
             gFrame->m_bdefer_resize = true;
         }
     }
+
+    g_pi_manager->CallLateInit();
+
     return TRUE;
 }
 

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -281,6 +281,27 @@ bool PlugInManager::LoadAllPlugIns(const wxString &plugin_dir)
         return false;
 }
 
+bool PlugInManager::CallLateInit(void)
+{
+    bool bret = true;
+
+    for(unsigned int i = 0 ; i < plugin_array.GetCount() ; i++)
+    {
+        PlugInContainer *pic = plugin_array.Item(i);
+
+        if(pic->m_cap_flag & WANTS_LATE_INIT)
+        {
+            wxString msg(_T("PlugInManager: Calling LateInit PlugIn: "));
+            msg += pic->m_plugin_file;
+            wxLogMessage(msg);
+
+            pic->m_pplugin->LateInit();
+        }
+    }
+
+    return bret;
+}
+
 bool PlugInManager::UpdatePlugIns()
 {
     bool bret = false;
@@ -2302,6 +2323,9 @@ void opencpn_plugin::SetColorScheme(PI_ColorScheme cs)
 {}
 
 void opencpn_plugin::UpdateAuiStatus(void)
+{}
+
+void opencpn_plugin::LateInit(void)
 {}
 
 


### PR DESCRIPTION
LateInit() is called if a plugin returns WANTS_LATE_INIT of its Init()
call.

LateInit() is called when all other initialization and setup has been
done, including first graphical update of the application. This enables a
plugin to place itself on top and gain focus if needed.

Signed-off-by: Per-Ola Robertsson per-ola.robertsson@symbio.com
