### PR TITLE
Added multicast support

### DIFF
--- a/include/datastream.h
+++ b/include/datastream.h
@@ -56,6 +56,7 @@
 
 #ifndef __WXMSW__
 #include <sys/socket.h>                 // needed for (some) Mac builds
+#include <netinet/in.h>
 #endif
 
 #ifdef __WXMSW__
@@ -65,7 +66,6 @@
 #include <winioctl.h>
 #include <initguid.h>
 #endif
-
 #include <string>
 #include "ConnectionParams.h"
 #include "dsPortType.h"
@@ -224,6 +224,8 @@ private:
     wxIPV4address       m_addr;
     wxSocketBase        *m_sock;
     wxSocketBase        *m_tsock;
+    bool                m_is_multicast;
+    struct ip_mreq      m_mrq;      // mreq rather than mreqn for windows
 
     //  TCP Server support
     void OnServerSocketEvent(wxSocketEvent& event);             // The listener


### PR DESCRIPTION
Hello,

this is my first experience with github so please go easy on me :-)

This patch is really simple and was originally submitted to flyspray as FS#1063.  All it does is to check whether the address a user inputs for a UDP data connection is an IPv4 multicast address. If it is it adds membership of that group on the default multicast interface.  Code is also added to the datastream destructor to remove group membership when the datastream is destroyed.

This patch should have no impact on anything without a UDP multicast address.

Currently if a user requests a datastream with a multicast address he/she will not receive anything as group membership won't be added to the interface.  

NOTE!! I only have a linux development platform.  This compiles fine on linux. It _should_ compile on MacOS.  For Windows I checked technet to ensure that I wasn't doing anything not in windows APIs but you may need to tweak included header files for different versions of windows: I have no facilities for windows development.  It _should_ only be header files which need adding though.
