### PR TITLE
Disable Nagle Algorithm on outgoing TCP connections

### DIFF
--- a/src/datastream.cpp
+++ b/src/datastream.cpp
@@ -44,6 +44,7 @@
 
 #ifndef __WXMSW__
 #include <arpa/inet.h>
+#include <netinet/tcp.h>
 #endif
 
 #include "dychart.h"
@@ -238,6 +239,14 @@ void DataStream::Open(void)
                         //  TCP Datastreams can be either input or output, but not both...
                     if((m_io_select == DS_TYPE_INPUT_OUTPUT) || (m_io_select == DS_TYPE_OUTPUT)) {
                         m_socket_server = new wxSocketServer(m_addr, wxSOCKET_REUSEADDR );
+                        // Disable nagle algorithm on outgoing connection
+                        // Doing this here rather than after the accept() is
+                        // pointless  on platforms where TCP_NODELAY is
+                        // not inherited.  However, none of OpenCPN's currently
+                        // supported platforms fall into that category.
+
+                        int nagleDisable=1;
+                        m_socket_server->SetOption(IPPROTO_TCP,TCP_NODELAY,&nagleDisable, sizeof(nagleDisable));
                         m_socket_server->SetEventHandler(*this, DS_SERVERSOCKET_ID);
                         m_socket_server->SetNotify( wxSOCKET_CONNECTION_FLAG );
                         m_socket_server->Notify(TRUE);


### PR DESCRIPTION
The Nagle algorithm is a method of conserving bandwidth for small network writes by buffering them while there is unacknowledged data and not enough that the algorithm thinks is worth sending yet.  Unfortunately receivers also try to conserve bandwidth by not acknowledging every packet but with small packets only sending one every N ms.  How much this buffering delays transmission can depend on the size of N. Traditionally this was half a second.  Some investigation shows a default of 200ms for windows and freebsd (the latter I can confirm), 50ms for MacOs, 40ms for linux. 

For an application such as writing out NMEA-0183 over tcp, we want to disable this buffering. That's what this patch does. Testing has shown that where the receiving systems delayed ack timer is less than or equal to the inter-sentence period, there is no observable difference.  Where sentences were available every 50ms, a freebsd (and presumably windows) application was seeing sentences transmitted from opencpn "bunched up" into groups of 3 or 4 (the first in the group  being delayed ~200ms).  The patch smoothed out transmission.

This has no impact on anything other than OUTBOUND tcp connections.  Do not worry about negative network impact from disabling nagle: Additional overhead is insignificant in this application.

NOTE!! As with my previous submission I have not been able to compile against windows.  The code should work but a different header file may be needed (WinSock2.h?).

Note also: I've sacrificed some portability for minimal code addition.  Traditionally you would set the TCP_NODELAY option on the accept()-ed socket.  All modern OSes (incl windows, linux and macos) seem to support inheritance of this option from the listening socket.  I've set it on the listening socket rather than doing it each time we get a connect.

Happy to answer any questions on this
