### PR TITLE
use feet for short distances if selected unit is miles

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -8818,7 +8818,7 @@ wxString ChartCanvas::FormatDistanceAdaptive( double distance ) {
     int unit = g_iDistanceFormat;
     double usrDistance = toUsrDistance( distance, unit );
     if( usrDistance < 0.1 &&  ( unit == DISTANCE_KM || unit == DISTANCE_MI || unit == DISTANCE_NMI ) ) {
-	unit = ( unit == DISTANCE_KM ) ? DISTANCE_M : DISTANCE_FT;
+	unit = ( unit == DISTANCE_MI ) ? DISTANCE_FT : DISTANCE_M;
 	usrDistance = toUsrDistance( distance, unit );
     }
     wxString format;


### PR DESCRIPTION
Original code has hard-coded nmi->m conversion and unit. In addition, most users that choose nautical miles or statue miles as their distance unit would like to see short distances measures in feet instead of meters.
