### PR TITLE
* Make TCP DataStreams bi-directional

### DIFF
--- a/include/ConnectionParams.h
+++ b/include/ConnectionParams.h
@@ -21,6 +21,10 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 
+#ifndef __DSPORTTYPE_H__
+#include <dsPortType.h>
+#endif
+
 #ifndef __CONNECTIONPARAMS_H__
 #define __CONNECTIONPARAMS_H__
 
@@ -80,7 +84,7 @@ public:
     bool            Garmin;
     bool            GarminUpload;
     bool            FurunoGP3X;
-    bool            Output;
+    dsPortType      IOSelect;
     ListType        InputSentenceListType;
     wxArrayString   InputSentenceList;
     ListType        OutputSentenceListType;
@@ -94,7 +98,7 @@ public:
     wxString GetSourceTypeStr();
     wxString GetAddressStr();
     wxString GetParametersStr();
-    wxString GetOutputValueStr();
+    wxString GetIOTypeValueStr();
     wxString GetFiltersStr();
     wxString GetDSPort();
     wxString GetLastDSPort();

--- a/include/datastream.h
+++ b/include/datastream.h
@@ -230,6 +230,9 @@ private:
     //  TCP Server support
     void OnServerSocketEvent(wxSocketEvent& event);             // The listener
     void OnActiveServerEvent(wxSocketEvent& event);             // The open connection
+    // Setting output parameters
+    bool SetOutputSocketOptions(wxSocketBase* tsock);
+
     wxSocketServer      *m_socket_server;                       //  The listening server
     wxSocketBase        *m_socket_server_active;                //  The active connection
     

--- a/include/dsPortType.h
+++ b/include/dsPortType.h
@@ -28,8 +28,8 @@
 //      Port I/O type
 typedef enum {
     DS_TYPE_INPUT,
-    DS_TYPE_OUTPUT,
-    DS_TYPE_INPUT_OUTPUT
+    DS_TYPE_INPUT_OUTPUT,
+    DS_TYPE_OUTPUT
 } dsPortType;
 
 #endif

--- a/include/options.h
+++ b/include/options.h
@@ -355,6 +355,7 @@ public:
     wxRadioButton* m_rbIIgnore;
     wxTextCtrl* m_tcInputStc;
     wxButton* m_btnInputStcList;
+    wxCheckBox* m_cbInput;
     wxCheckBox* m_cbOutput;
     wxRadioButton* m_rbOAccept;
     wxRadioButton* m_rbOIgnore;
@@ -384,7 +385,8 @@ public:
     void OnRbAcceptInput( wxCommandEvent& event );
     void OnRbIgnoreInput( wxCommandEvent& event );
     void OnBtnIStcs( wxCommandEvent& event );
-    void OnCbOutput( wxCommandEvent& event ) { OnConnValChange(event); }
+    void OnCbInput( wxCommandEvent& event );
+    void OnCbOutput( wxCommandEvent& event );
     void OnRbOutput( wxCommandEvent& event );
     void OnBtnOStcs( wxCommandEvent& event );
     void OnConnValChange( wxCommandEvent& event );

--- a/src/ConnectionParams.cpp
+++ b/src/ConnectionParams.cpp
@@ -48,7 +48,8 @@ void ConnectionParams::Deserialize(const wxString &configStr)
     Port = prms[5];
     Baudrate = wxAtoi(prms[6]);
     ChecksumCheck = !!wxAtoi(prms[7]);
-    Output = !!wxAtoi(prms[8]);
+    int iotval = wxAtoi(prms[8]);
+    IOSelect=((iotval <= 2)?static_cast <dsPortType>(iotval):DS_TYPE_INPUT);
     InputSentenceListType = (ListType)wxAtoi(prms[9]);
     InputSentenceList = wxStringTokenize(prms[10], _T(","));
     OutputSentenceListType = (ListType)wxAtoi(prms[11]);
@@ -88,7 +89,7 @@ wxString ConnectionParams::Serialize()
                                      Port.c_str(),
                                      Baudrate,
                                      ChecksumCheck,
-                                     Output,
+                                     IOSelect,
                                      InputSentenceListType,
                                      istcs.c_str(),
                                      OutputSentenceListType,
@@ -115,7 +116,7 @@ ConnectionParams::ConnectionParams()
     ChecksumCheck = true;
     Garmin = false;
     FurunoGP3X = false;
-    Output = false;
+    IOSelect = DS_TYPE_INPUT;
     InputSentenceListType = WHITELIST;
     OutputSentenceListType = WHITELIST;
     Priority = 0;
@@ -152,12 +153,14 @@ wxString ConnectionParams::GetParametersStr()
             return _("GPSD");
 }
 
-wxString ConnectionParams::GetOutputValueStr()
+wxString ConnectionParams::GetIOTypeValueStr()
 {
-    if ( Output )
-        return _("Yes");
+    if ( IOSelect == DS_TYPE_INPUT )
+        return _("Input");
+    else if ( IOSelect == DS_TYPE_OUTPUT )
+        return _("Output");
     else
-        return _("No");
+        return _("In/Out");
 }
 
 wxString ConnectionParams::FilterTypeToStr(ListType type, FilterDirection dir)

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -2471,11 +2471,7 @@ MyFrame::MyFrame( wxFrame *frame, const wxString& title, const wxPoint& pos, con
             }
 #endif    
                 
-            dsPortType port_type;
-            if (cp->Output)
-                port_type = DS_TYPE_INPUT_OUTPUT;
-            else
-                port_type = DS_TYPE_INPUT;
+            dsPortType port_type = cp->IOSelect;
             DataStream *dstr = new DataStream( g_pMUX,
                                            cp->GetDSPort(),
                                            wxString::Format(wxT("%i"),cp->Baudrate),

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -10683,7 +10683,7 @@ wxString ChartCanvas::FindValidUploadPort()
             // then use the first available serial connection which has output defined.
             for( size_t i = 0; i < g_pConnectionParams->Count(); i++ ) {
                 ConnectionParams *cp = g_pConnectionParams->Item( i );
-                if( cp->Output && cp->Type == SERIAL )
+                if( (cp->IOSelect != DS_TYPE_INPUT) && cp->Type == SERIAL )
                     port << _T("Serial:") << cp->Port;
             }
     }

--- a/src/multiplexer.cpp
+++ b/src/multiplexer.cpp
@@ -146,6 +146,7 @@ void Multiplexer::SendNMEAMessage(const wxString &msg)
     for (size_t i = 0; i < m_pdatastreams->Count(); i++)
     {
         DataStream* s = m_pdatastreams->Item(i);
+
         if ( s->IsOk() && (s->GetIoSelect() == DS_TYPE_INPUT_OUTPUT || s->GetIoSelect() == DS_TYPE_OUTPUT) ) {
             bool bout_filter = true;
 

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -1531,6 +1531,11 @@ int MyConfig::LoadMyConfig( int iteration )
     for (size_t i = 0; i < confs.Count(); i++)
     {
         ConnectionParams * prm = new ConnectionParams(confs[i]);
+        if (!prm->Valid) {
+            wxLogMessage( _T( "Skipped invalid DataStream config") );
+            delete prm;
+            continue;
+        }
         g_pConnectionParams->Add(prm);
     }
 
@@ -1653,12 +1658,12 @@ int MyConfig::LoadMyConfig( int iteration )
                 prm->Port = port;
                 prm->OutputSentenceListType = WHITELIST;
                 prm->OutputSentenceList.Add( _T("RMB") );
-                prm->Output = true;
+                prm->IOSelect = DS_TYPE_INPUT_OUTPUT;
 
                 g_pConnectionParams->Add(prm);
             }
             else {                                  // port was found, so make sure it is set for output
-                cp->Output = true;
+                cp->IOSelect = DS_TYPE_INPUT_OUTPUT;
                 cp->OutputSentenceListType = WHITELIST;
                 cp->OutputSentenceList.Add( _T("RMB") );
             }


### PR DESCRIPTION
- Change send buffer sockopt to Linux minimum
- Fix crash in creating datastreams from badly formatted params
- Fix crash when commiting datastreams with unvalidated options

This patch changes the behaviour of TCP DataStreams in OpenCPN.  Serial and UDP DataStreams should be unaffected, with changes to the options tab set/greyed out as appropriate.  With this patch "Server" no longer means "Output Only" and "Client" no longer means "Input Only".

Backwards compatibility and not breaking existing configs was a priority.  Behaviour of existing configs _should_ be unaffected.

There's lots more work to do here but I thought I'd submit this for feedback before proceeding further. This has been tested on Linux (Ubuntu 12.04).  Assuming feedback on the patch is OK I will get hold of a mac to test on but there's nothing too platform-specific in here

New TCP Behaviour:
In addition to the "Output on this port" checkbox, there's a checkbox on the connections tab to receive input.  For serial and udp connections this is checked and greyed out: Per pre-existing code there is no "output only" option: I will come back to that in a later patch if this one works out ok. To preserve compatibility with existing config files I had to change round the order of DS_TYPE_INPUT_OUTPUT and DS_TYPE_OUTPUT in the dsPortType enum.  You might prefer to sacrifice backwards compatibility for a more logical ordering.  For TCP connections:
With input box checked and output box unchecked, the connection is DS_TYPE_INPUT
With Input box checked and output box checked, the connection is DS_TYPE_INPUT_OUTPUT
With the Input box unchecked and the output box checked the connection is DS_TYPE_OUTPUT
If neither box is checked the Apply callback will put up an error telling the user to check at least one of the two boxes.  This also fixed an existing crash bug where connection data wasn't being validated when apply was hit.

When a user specifies an address of 0.0.0.0, a server datastream is created.  This still has some of the same flaws as the current version: It's not a concurrent server (that comes in a subsequent patch) and things are _very_ dodgy when a second client attempts to connect.  This is unchanged from existing behaviour.  This connection may be input, output or bi-directional according to the datastream options.   The (to my mind a little aggressive) read timeout applies on these connections for input and bi-directional connections.  I would probably drop that if the server was concurrent, but as we're currently only allowing a single client, dropping potentially dead connections makes sense.

When a user specifies a non-zero address a client datastream is created.  Again this may be input, output or both and the watchdog timer doesn't apply on output connections.  This _should_ solve the issue that was being raised last week regarding bi-directional connections to the vesper unit.

The (very sensible) reduction in SO_SNDBUF that's been added recently is a little too aggressive for Linux: The minimum you can set SO_SNDBUF to on linux is 2048 (which equates to a parameter to setsockopt of 1024 which isn't very explicitly documented) so I've changed it to that.  Previously the setsockopt was failing but the return code wasn't being checked.  The return code _still_ isn't being checked. I will confirm that value is ok for MacOS when I get a test rig set up.

If this is accepted, the next plan is to make the server side concurrent, followed by altering UDP sockets to follow the TCP model a bit more.

My C++ is a bit rusty but I've tried to follow your style and resist the temptation to do anything with pointers and bit masks :-). Criticism/rejection happily received
