### PR TITLE
Corrected over-zealous check for GPSD / UDP Output addresses

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2526,19 +2526,16 @@ ConnectionParams *options::CreateConnectionParamsFromSelectedItem()
             wxMessageBox( _("You must enter a port..."), _("Error!") );
             return NULL;
         }
-        if (m_rbNetProtoUDP->GetValue() && (!m_cbOutput->GetValue())) {
-            m_tNetAddress->SetValue(_T("0.0.0.0"));
+        if (m_tNetAddress->GetValue() == wxEmptyString) {
+            if ((m_rbNetProtoGPSD->GetValue()) ||
+                (m_rbNetProtoUDP->GetValue() && m_cbOutput->GetValue()))
+            {
+                wxMessageBox( _("You must enter the address..."), _("Error!") );
+                return NULL;
+            } else {
+                m_tNetAddress->SetValue(_T("0.0.0.0"));
+            }
         }
-        else if (((m_rbNetProtoGPSD->GetValue()) ||
-                (m_rbNetProtoUDP->GetValue() && m_cbOutput->GetValue())) &&
-                wxStrpbrk(m_tNetAddress->GetValue(),_T("123456789")) == NULL )
-        {
-            wxMessageBox( _("You must enter the address..."), _("Error!") );
-            return NULL;
-        }
-
-        if (!m_tNetAddress->GetValue())
-            m_tNetAddress->SetValue(_T("0.0.0.0"));
     }
 
     ConnectionParams * pConnectionParams = new ConnectionParams();


### PR DESCRIPTION
As reported by redog in the beta thread last week.  This only corrects the problem with entering a non-numeric address (over zealous and erroneous validation on my part).  The last lot of changes I did shouldn't have touched GPSD data flow so I can't say what that is about.  I don't have a GPS unit with me today to check this but certainly I see the outbound connection correctly being made. Suspect that problem may be unconnected.
