### PR TITLE
Trigger controls update by a timer to improve dragging performance

### DIFF
--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -345,6 +345,7 @@ GRIBUIDialog::GRIBUIDialog(wxWindow *parent, grib_pi *ppi)
     //connect events have not been done in dialog base
     this->Connect( wxEVT_MOVE, wxMoveEventHandler( GRIBUIDialog::OnMove ) );
     m_tPlayStop.Connect(wxEVT_TIMER, wxTimerEventHandler( GRIBUIDialog::OnPlayStopTimer ), NULL, this);
+    m_tCursorTrackTimer.Connect(wxEVT_TIMER, wxTimerEventHandler( GRIBUIDialog::OnCursorTrackTimer ), NULL, this);
 
     m_OverlaySettings.Read();
 
@@ -391,9 +392,13 @@ GRIBUIDialog::~GRIBUIDialog()
 
 void GRIBUIDialog::SetCursorLatLon( double lat, double lon )
 {
+    if(!m_tCursorTrackTimer.IsRunning()) m_tCursorTrackTimer.Start(50, wxTIMER_ONE_SHOT );
     m_cursor_lon = lon;
     m_cursor_lat = lat;
+}
 
+void GRIBUIDialog::OnCursorTrackTimer( wxTimerEvent & event)
+{
     UpdateTrackingControls();
 }
 
@@ -885,7 +890,7 @@ void GRIBUIDialog::OnPlayStop( wxCommandEvent& event )
     m_InterpolateMode = m_OverlaySettings.m_bInterpolate;
 }
 
-void GRIBUIDialog::OnPlayStopTimer( wxTimerEvent & )
+void GRIBUIDialog::OnPlayStopTimer( wxTimerEvent & event )
 {
     if( m_bPlay->IsSameAs( m_bpPlay->GetBitmapLabel()) ) {
         m_bpPlay->SetToolTip( _("Play") );

--- a/plugins/grib_pi/src/GribUIDialog.h
+++ b/plugins/grib_pi/src/GribUIDialog.h
@@ -99,19 +99,20 @@ public:
     GribOverlaySettings m_OverlaySettings;
 
     wxTimer m_tPlayStop;
+    wxTimer m_tCursorTrackTimer;
 
     grib_pi             *pPlugIn;
     GribRequestSetting  *pReq_Dialog;
     GRIBFile        *m_bGRIBActiveFile;
     double m_cursor_lat, m_cursor_lon;
-
 private:
     void OnClose( wxCloseEvent& event );
     void OnMove( wxMoveEvent& event );
     void OnSize( wxSizeEvent& event );
     void OnSettings( wxCommandEvent& event );
     void OnPlayStop( wxCommandEvent& event );
-    void OnPlayStopTimer( wxTimerEvent & );
+    void OnPlayStopTimer( wxTimerEvent & event);
+    void OnCursorTrackTimer( wxTimerEvent & event);
 
     void AddTrackingControl( wxControl *ctrl1,  wxControl *ctrl2,  wxControl *ctrl3, bool show, bool altitude = false );
     void UpdateTrackingControls( void );


### PR DESCRIPTION
On some plateform( for example my low powered netbook windows 8.1 )
dragging when grib_pi is running is slowed down by controld update
triggered directly by "setCursorLatLon" function.
To improve that, I propose to use a timer. That off course delays
the update by a few milliseconds, but should not be visible even on a
hight powered device
