### PR TITLE
Implement API extension for plug-ins needing information about vector chart objects.

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -87,6 +87,7 @@ class       wxScrolledWindow;
 #define     WANTS_LATE_INIT                           0x00020000
 #define     INSTALLS_PLUGIN_CHART_GL                  0x00040000
 #define     WANTS_MOUSE_HOOK                          0x00080000
+#define     WANTS_VECTOR_CHART_OBJECT_INFO            0x00100000
 
 //----------------------------------------------------------------------------------------------------------
 //    Some PlugIn API interface object class definitions
@@ -484,7 +485,7 @@ class DECL_EXP opencpn_plugin_111 : public opencpn_plugin_110
 public:
     opencpn_plugin_111(void *pmgr);
     virtual ~opencpn_plugin_111();
-
+    
 };
 
 class DECL_EXP opencpn_plugin_112 : public opencpn_plugin_111
@@ -493,7 +494,8 @@ public:
     opencpn_plugin_112(void *pmgr);
     virtual ~opencpn_plugin_112();
     
-    virtual void MouseEventHook( wxMouseEvent &event );   
+    virtual void MouseEventHook( wxMouseEvent &event );
+    virtual void SendVectorChartObjectInfo(wxString &chart, wxString &feature, wxString &objname, double lat, double lon, double scale, int nativescale);
     
 };
 

--- a/include/pluginmanager.h
+++ b/include/pluginmanager.h
@@ -266,6 +266,8 @@ public:
       void SetColorSchemeForAllPlugIns(ColorScheme cs);
       void NotifyAuiPlugIns(void);
       bool CallLateInit(void);
+      
+      void SendVectorChartObjectInfo(const wxString &chart, const wxString &feature, const wxString &objname, double &lat, double &lon, double &scale, int &nativescale);
 
       wxArrayString GetPlugInChartClassNameArray(void);
 

--- a/include/s52s57.h
+++ b/include/s52s57.h
@@ -317,7 +317,7 @@ public:
       ~S57Obj();
       S57Obj(char *first_line, wxInputStream *fpx, double ref_lat, double ref_lon);
 
-      wxString GetAttrValueAsString ( char *attr );
+      wxString GetAttrValueAsString ( const char *attr );
       int GetAttributeIndex( const char *AttrSeek );
           
       // Private Methods

--- a/src/cm93.cpp
+++ b/src/cm93.cpp
@@ -47,6 +47,7 @@
 #include "navutil.h"                            // for LogMessageOnce
 #include "ocpn_pixel.h"                         // for ocpnUSE_DIBSECTION
 #include "ocpndc.h"
+#include "pluginmanager.h"  // for PlugInManager
 
 #include <stdio.h>
 
@@ -78,7 +79,7 @@ extern double           g_CM93Maps_Offset_x;
 extern double           g_CM93Maps_Offset_y;
 extern bool             g_CM93Maps_Offset_on;
 extern bool             g_bopengl;
-
+extern PlugInManager    *g_pi_manager;
 
 
 // TODO  These should be gotten from the ctor
@@ -2338,6 +2339,9 @@ int cm93chart::CreateObjChain ( int cell_index, int subcell, double view_scale_p
 
       int iObj = 0;
       S57Obj *obj;
+      
+      double scale = gFrame->GetBestVPScale(this);
+      int nativescale = GetNativeScale();
 
       while ( iObj < m_CIB.m_nfeature_records )
       {
@@ -2352,6 +2356,13 @@ int cm93chart::CreateObjChain ( int cell_index, int subcell, double view_scale_p
 
                   if ( obj )
                   {
+                        wxString objnam  = obj->GetAttrValueAsString("OBJNAM");
+                        wxString fe_name = wxString(obj->FeatureName, wxConvUTF8);
+                        wxString cellname = wxString::Format(_T("%i_%i"), cell_index, subcell);
+                        if ( fe_name == _T("_texto") )
+                            objnam  = obj->GetAttrValueAsString("_texta");
+                        if (objnam.Len() > 0)
+                            g_pi_manager->SendVectorChartObjectInfo( cellname, fe_name, objnam, obj->m_lat, obj->m_lon, scale, nativescale );
 
 //      Build/Maintain the ATON floating/rigid arrays
                         if ( GEO_POINT == obj->Primitive_type )

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -353,6 +353,36 @@ bool PlugInManager::CallLateInit(void)
     return bret;
 }
 
+void PlugInManager::SendVectorChartObjectInfo(const wxString &chart, const wxString &feature, const wxString &objname, double &lat, double &lon, double &scale, int &nativescale)
+{
+    wxString decouple_chart(chart);
+    wxString decouple_feature(feature);
+    wxString decouple_objname(objname);
+    for(unsigned int i = 0 ; i < plugin_array.GetCount() ; i++)
+    {
+        PlugInContainer *pic = plugin_array.Item(i);
+        if(pic->m_bEnabled && pic->m_bInitState)
+        {
+            if(pic->m_cap_flag & WANTS_VECTOR_CHART_OBJECT_INFO)
+            {
+                switch(pic->m_api_version)
+                {
+                case 112:
+                {
+                    opencpn_plugin_112 *ppi = dynamic_cast<opencpn_plugin_112 *>(pic->m_pplugin);
+                    if(ppi)
+                        ppi->SendVectorChartObjectInfo(decouple_chart, decouple_feature, decouple_objname, lat, lon, scale, nativescale);
+                    break;
+                }
+                default:
+                    break;
+                }
+            }
+        }
+    }
+}
+
+
 bool PlugInManager::UpdatePlugIns()
 {
     bool bret = false;
@@ -917,7 +947,6 @@ void PlugInManager::SendViewPortToRequestingPlugIns( ViewPort &vp )
         }
     }
 }
-
 
 void PlugInManager::SendCursorLatLonToAllPlugIns( double lat, double lon)
 {
@@ -2726,7 +2755,9 @@ opencpn_plugin_112::~opencpn_plugin_112(void)
 void opencpn_plugin_112::MouseEventHook( wxMouseEvent &event )
 {}
 
-
+void opencpn_plugin_112::SendVectorChartObjectInfo(wxString &chart, wxString &feature, wxString &objname, double lat, double lon, double scale, int nativescale)
+{
+}
 
 
 //          Helper and interface classes

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -901,7 +901,7 @@ int S57Obj::GetAttributeIndex( const char *AttrSeek ) {
 }
     
     
-wxString S57Obj::GetAttrValueAsString( char *AttrName )
+wxString S57Obj::GetAttrValueAsString( const char *AttrName )
 {
     wxString str;
     
@@ -3985,7 +3985,9 @@ int s57chart::BuildRAZFromSENCFile( const wxString& FullPath )
 
 //        if(my_fgets(buf, MAX_LINE, fpx) == 0)
 //           dun = 1;
-
+    double scale = gFrame->GetBestVPScale(this);
+    int nativescale = GetNativeScale();
+    
     while( !dun ) {
 
         if( my_fgets( buf, MAX_LINE, fpx ) == 0 ) {
@@ -3997,7 +3999,11 @@ int s57chart::BuildRAZFromSENCFile( const wxString& FullPath )
 
             S57Obj *obj = new S57Obj( buf, &fpx, 0, 0 );
             if( obj ) {
-
+                wxString objnam  = obj->GetAttrValueAsString("OBJNAM");
+                wxString fe_name = wxString(obj->FeatureName, wxConvUTF8);
+                if (objnam.Len() > 0)
+                    g_pi_manager->SendVectorChartObjectInfo( FullPath, fe_name, objnam, obj->m_lat, obj->m_lon, scale, nativescale );
+                
 //      Build/Maintain the ATON floating/rigid arrays
                 if( GEO_POINT == obj->Primitive_type ) {
 


### PR DESCRIPTION
Supports S-57/CM93 objects with OBJNAM attribute and _texto/_texta in CM93 (as this feature is widely misused for important chart objects there)
I did not implement any support for S-63 or or other vector charts provided by plug-ins. Also the API could perhaps provide more info - I did implement just what I need for https://github.com/nohal/objsearch_pi
