### PR TITLE
Move add and remove connection buttons to make connection window large...

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -568,13 +568,13 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
 
 
     wxBoxSizer* bSizer17;
-    bSizer17 = new wxBoxSizer( wxHORIZONTAL );
+    bSizer17 = new wxBoxSizer( wxVERTICAL );
 
     m_lcSources = new wxListCtrl( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxSize(-1, 150), wxLC_REPORT|wxLC_SINGLE_SEL);
     bSizer17->Add( m_lcSources, 1, wxALL|wxEXPAND, 5 );
 
     wxBoxSizer* bSizer18;
-    bSizer18 = new wxBoxSizer( wxVERTICAL );
+    bSizer18 = new wxBoxSizer( wxHORIZONTAL );
 
     m_buttonAdd = new wxButton( m_pNMEAForm, wxID_ANY, _("Add Connection"), wxDefaultPosition, wxDefaultSize, 0 );
     bSizer18->Add( m_buttonAdd, 0, wxALL, 5 );


### PR DESCRIPTION
This is only a suggestion so feel free to disregard.  The connections pane in the options window requires scrolling to see much of the information.  This change simply moves the add/remove connections buttons below the pane.  The options window already requires scrolling when adding a connection so I don't think this makes things significantly worse by adding slightly more height, but YMMV.
