### PR TITLE
Correct introduced bug from 99fae02ed30f9bbf1055b27b493448fab772faa4

### DIFF
--- a/plugins/grib_pi/src/GribRecord.cpp
+++ b/plugins/grib_pi/src/GribRecord.cpp
@@ -569,7 +569,7 @@ void  GribRecord::multiplyAllData(double k)
 	for (zuint j=0; j<Nj; j++) {
 		for (zuint i=0; i<Ni; i++)
 		{
-			if (hasValue(i,j)) {
+			if (isDefined(i,j)) {
 				data[j*Ni+i] *= k;
 			}
 		}
@@ -1166,13 +1166,13 @@ double GribRecord::getInterpolatedValue(double px, double py, bool numericalInte
 
     bool h00,h01,h10,h11;
     int nbval = 0;     // how many values in grid ?
-    if ((h00=hasValue(i0, j0)))
+    if ((h00=isDefined(i0, j0)))
         nbval ++;
-    if ((h10=hasValue(i1, j0)))
+    if ((h10=isDefined(i1, j0)))
         nbval ++;
-    if ((h01=hasValue(i0, j1)))
+    if ((h01=isDefined(i0, j1)))
         nbval ++;
-    if ((h11=hasValue(i1, j1)))
+    if ((h11=isDefined(i1, j1)))
         nbval ++;
 
     if (nbval < 3)
@@ -1311,13 +1311,13 @@ bool GribRecord::getInterpolatedValues(double &M, double &A,
 
     bool h00,h01,h10,h11;
     int nbval = 0;     // how many values in grid ?
-    if ((h00=GRX->hasValue(i0, j0) && GRX->hasValue(i0, j0)))
+    if ((h00=GRX->isDefined(i0, j0) && GRX->isDefined(i0, j0)))
         nbval ++;
-    if ((h10=GRX->hasValue(i1, j0) && GRY->hasValue(i1, j0)))
+    if ((h10=GRX->isDefined(i1, j0) && GRY->isDefined(i1, j0)))
         nbval ++;
-    if ((h01=GRX->hasValue(i0, j1) && GRY->hasValue(i0, j1)))
+    if ((h01=GRX->isDefined(i0, j1) && GRY->isDefined(i0, j1)))
         nbval ++;
-    if ((h11=GRX->hasValue(i1, j1) && GRY->hasValue(i1, j1)))
+    if ((h11=GRX->isDefined(i1, j1) && GRY->isDefined(i1, j1)))
         nbval ++;
 
     if (nbval < 3)

--- a/plugins/grib_pi/src/GribRecord.h
+++ b/plugins/grib_pi/src/GribRecord.h
@@ -206,6 +206,9 @@ class GribRecord
         inline bool   isYInMap(double y) const;
         // Is there a value at a particular grid point ?
         inline bool   hasValue(int i, int j) const;
+        // Is there a value that is not GRIB_NOTDEF ?
+        inline bool   isDefined(int i, int j) const
+        { return hasValue(i, j) && getValue(i, j) != GRIB_NOTDEF; }
 
         // Reference date Date (file creation date)
         time_t getRecordRefDate () const         { return refDate; }
@@ -333,7 +336,7 @@ inline bool   GribRecord::hasValue(int i, int j) const
         return false;
     }
     if (!hasBMS) {
-        return getValue(i, j) != GRIB_NOTDEF;
+        return true;
     }
     int bit;
     if (isAdjacentI) {


### PR DESCRIPTION
in GribRecord.cpp hasValue is used when reading the grib file, even
if the value is not defined.  It is also used in other places,
where it needs to test that the value is also defined.
