### PR TITLE
Apply general User Font setting for grib_pi dialogs

### DIFF
--- a/plugins/grib_pi/GRIB.fbp
+++ b/plugins/grib_pi/GRIB.fbp
@@ -26,7 +26,7 @@
         <property name="ui_table">UI</property>
         <property name="use_enum">0</property>
         <property name="use_microsoft_bom">0</property>
-        <object class="Dialog" expanded="0">
+        <object class="Dialog" expanded="1">
             <property name="aui_managed">0</property>
             <property name="aui_manager_style">wxAUI_MGR_DEFAULT</property>
             <property name="bg"></property>
@@ -88,7 +88,7 @@
             <event name="OnSetFocus"></event>
             <event name="OnSize">OnSize</event>
             <event name="OnUpdateUI"></event>
-            <object class="wxFlexGridSizer" expanded="0">
+            <object class="wxFlexGridSizer" expanded="1">
                 <property name="cols">1</property>
                 <property name="flexible_direction">wxVERTICAL</property>
                 <property name="growablecols"></property>
@@ -210,10 +210,10 @@
                             </object>
                         </object>
                         <object class="sizeritem" expanded="0">
-                            <property name="border">1</property>
-                            <property name="flag">wxEXPAND|wxALL</property>
+                            <property name="border">5</property>
+                            <property name="flag">wxALL</property>
                             <property name="proportion">0</property>
-                            <object class="wxComboBox" expanded="0">
+                            <object class="wxChoice" expanded="0">
                                 <property name="BottomDockable">1</property>
                                 <property name="LeftDockable">1</property>
                                 <property name="RightDockable">1</property>
@@ -257,7 +257,7 @@
                                 <property name="pin_button">1</property>
                                 <property name="pos"></property>
                                 <property name="resize">Resizable</property>
-                                <property name="selection">-1</property>
+                                <property name="selection">0</property>
                                 <property name="show">1</property>
                                 <property name="size"></property>
                                 <property name="style"></property>
@@ -268,12 +268,11 @@
                                 <property name="validator_style">wxFILTER_NONE</property>
                                 <property name="validator_type">wxDefaultValidator</property>
                                 <property name="validator_variable"></property>
-                                <property name="value"></property>
                                 <property name="window_extra_style"></property>
                                 <property name="window_name"></property>
                                 <property name="window_style"></property>
                                 <event name="OnChar"></event>
-                                <event name="OnCombobox">OnRecordForecast</event>
+                                <event name="OnChoice">OnRecordForecast</event>
                                 <event name="OnEnterWindow"></event>
                                 <event name="OnEraseBackground"></event>
                                 <event name="OnKeyDown"></event>
@@ -295,8 +294,6 @@
                                 <event name="OnRightUp"></event>
                                 <event name="OnSetFocus"></event>
                                 <event name="OnSize"></event>
-                                <event name="OnText"></event>
-                                <event name="OnTextEnter"></event>
                                 <event name="OnUpdateUI"></event>
                             </object>
                         </object>
@@ -1155,7 +1152,7 @@
                                                 <property name="resize">Resizable</property>
                                                 <property name="selection">0</property>
                                                 <property name="show">1</property>
-                                                <property name="size">60,-1</property>
+                                                <property name="size">-1,-1</property>
                                                 <property name="style"></property>
                                                 <property name="subclass"></property>
                                                 <property name="toolbar_pane">0</property>
@@ -4522,7 +4519,7 @@
                                 </object>
                                 <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
-                                    <property name="flag">wxALL|wxEXPAND</property>
+                                    <property name="flag">wxALL</property>
                                     <property name="proportion">0</property>
                                     <object class="wxSpinCtrl" expanded="0">
                                         <property name="BottomDockable">1</property>
@@ -4560,7 +4557,7 @@
                                         <property name="min">1</property>
                                         <property name="min_size"></property>
                                         <property name="minimize_button">0</property>
-                                        <property name="minimum_size"></property>
+                                        <property name="minimum_size">-1,-1</property>
                                         <property name="moveable">1</property>
                                         <property name="name">m_sUpdatesPerSecond</property>
                                         <property name="pane_border">1</property>
@@ -4571,7 +4568,7 @@
                                         <property name="pos"></property>
                                         <property name="resize">Resizable</property>
                                         <property name="show">1</property>
-                                        <property name="size"></property>
+                                        <property name="size">90,-1</property>
                                         <property name="style">wxSP_ARROW_KEYS</property>
                                         <property name="subclass"></property>
                                         <property name="toolbar_pane">0</property>
@@ -5611,7 +5608,7 @@
                                         </object>
                                         <object class="sizeritem" expanded="0">
                                             <property name="border">5</property>
-                                            <property name="flag">wxALL|wxEXPAND</property>
+                                            <property name="flag">wxALL</property>
                                             <property name="proportion">0</property>
                                             <object class="wxSpinCtrl" expanded="0">
                                                 <property name="BottomDockable">1</property>
@@ -5660,7 +5657,7 @@
                                                 <property name="pos"></property>
                                                 <property name="resize">Resizable</property>
                                                 <property name="show">1</property>
-                                                <property name="size">70,-1</property>
+                                                <property name="size">90,-1</property>
                                                 <property name="style">wxSP_ARROW_KEYS</property>
                                                 <property name="subclass"></property>
                                                 <property name="toolbar_pane">0</property>
@@ -6501,7 +6498,7 @@
                                 </object>
                                 <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
-                                    <property name="flag">wxALL|wxEXPAND</property>
+                                    <property name="flag">wxALL</property>
                                     <property name="proportion">0</property>
                                     <object class="wxSpinCtrl" expanded="0">
                                         <property name="BottomDockable">1</property>
@@ -6550,7 +6547,7 @@
                                         <property name="pos"></property>
                                         <property name="resize">Resizable</property>
                                         <property name="show">1</property>
-                                        <property name="size">-1,-1</property>
+                                        <property name="size">90,-1</property>
                                         <property name="style">wxSP_ARROW_KEYS</property>
                                         <property name="subclass"></property>
                                         <property name="toolbar_pane">0</property>
@@ -6587,11 +6584,11 @@
                                         <event name="OnUpdateUI"></event>
                                     </object>
                                 </object>
-                                <object class="sizeritem" expanded="1">
+                                <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
                                     <property name="flag">wxALL</property>
                                     <property name="proportion">0</property>
-                                    <object class="wxCheckBox" expanded="1">
+                                    <object class="wxCheckBox" expanded="0">
                                         <property name="BottomDockable">1</property>
                                         <property name="LeftDockable">1</property>
                                         <property name="RightDockable">1</property>
@@ -6675,11 +6672,11 @@
                                         <event name="OnUpdateUI"></event>
                                     </object>
                                 </object>
-                                <object class="sizeritem" expanded="1">
+                                <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
                                     <property name="flag">wxALL</property>
                                     <property name="proportion">0</property>
-                                    <object class="wxStaticText" expanded="1">
+                                    <object class="wxStaticText" expanded="0">
                                         <property name="BottomDockable">1</property>
                                         <property name="LeftDockable">1</property>
                                         <property name="RightDockable">1</property>
@@ -6758,11 +6755,11 @@
                                         <event name="OnUpdateUI"></event>
                                     </object>
                                 </object>
-                                <object class="sizeritem" expanded="1">
+                                <object class="sizeritem" expanded="0">
                                     <property name="border">5</property>
                                     <property name="flag">wxALL|wxEXPAND</property>
                                     <property name="proportion">0</property>
-                                    <object class="wxSlider" expanded="1">
+                                    <object class="wxSlider" expanded="0">
                                         <property name="BottomDockable">1</property>
                                         <property name="LeftDockable">1</property>
                                         <property name="RightDockable">1</property>
@@ -12039,7 +12036,7 @@
                                         <property name="maxlength"></property>
                                         <property name="min_size"></property>
                                         <property name="minimize_button">0</property>
-                                        <property name="minimum_size">-1,80</property>
+                                        <property name="minimum_size">-1,-1</property>
                                         <property name="moveable">1</property>
                                         <property name="name">m_MailImage</property>
                                         <property name="pane_border">1</property>

--- a/plugins/grib_pi/src/GribRequestDialog.cpp
+++ b/plugins/grib_pi/src/GribRequestDialog.cpp
@@ -108,9 +108,8 @@ void GribRequestSetting::InitRequestConfig()
 
 #ifdef __WXMSW__                                 //show / hide sender elemants as necessary
     m_pSenderSizer->ShowItems(false);
-    m_MailImage->SetMinSize(wxSize(-1, -1));
 #else
-    if(m_SendMethod == 0 )                              
+    if(m_SendMethod == 0 )
         m_pSenderSizer->ShowItems(false);
     else
         m_pSenderSizer->ShowItems(true);                //possibility to use "sendmail" method with Linux
@@ -126,8 +125,20 @@ void GribRequestSetting::InitRequestConfig()
 
     m_AllowSend = true;
     m_MailImage->SetValue( WriteMail() );
+
+    SetMailImageSize();
 }
 
+void GribRequestSetting::SetMailImageSize()
+{
+#ifndef __WXMSW__                   //default resizing do not work properly on no Windows plateforms
+    int h;
+    GetTextExtent( _T("abc"), NULL, &h, 0, 0, OCPNGetFont(_("Dialog"), 10) );
+    m_MailImage->SetMinSize( wxSize( -1, (h * m_MailImage->GetNumberOfLines()) + 5 ) );
+#endif
+    this->Fit();
+    this->Refresh();
+}
 void GribRequestSetting::SetVpSize(PlugIn_ViewPort *vp)
 {
     double lonmax=vp->lon_max;
@@ -242,8 +253,7 @@ void GribRequestSetting::OnTopChange(wxCommandEvent &event)
 
     if(m_AllowSend) m_MailImage->SetValue( WriteMail() );
 
-    this->Fit();
-    this->Refresh();
+    SetMailImageSize();
 }
 
 void GribRequestSetting::OnMovingClick( wxCommandEvent& event )
@@ -265,8 +275,7 @@ void GribRequestSetting::OnAnyChange(wxCommandEvent &event)
 
     if(m_AllowSend) m_MailImage->SetValue( WriteMail() );
 
-    this->Fit();
-    this->Refresh();
+    SetMailImageSize();
 }
 
 void GribRequestSetting::OnTimeRangeChange(wxCommandEvent &event)
@@ -286,8 +295,7 @@ void GribRequestSetting::OnTimeRangeChange(wxCommandEvent &event)
 
     if(m_AllowSend) m_MailImage->SetValue( WriteMail() );
 
-    this->Fit();
-    this->Refresh();
+    SetMailImageSize();
 }
 
 void GribRequestSetting::OnSaveMail( wxCommandEvent& event )
@@ -465,7 +473,7 @@ wxString GribRequestSetting::WriteMail()
 bool GribRequestSetting::EstimateFileSize()
 {
     //define size limits for zyGrib
-    int limit = IsZYGRIB ? 4 : 0;                                            //new limit  4 mb 
+    int limit = IsZYGRIB ? 2 : 0;                                            //new limit  2 mb
 
     //too small zone ? ( mini 2 * resolutions )
     double reso,time,inter;
@@ -566,6 +574,7 @@ void GribRequestSetting::OnSendMaiL( wxCommandEvent& event  )
         m_AllowSend = true;
 
         m_MailImage->SetValue( WriteMail() );
+        SetMailImageSize();
 
         return;
     }
@@ -585,8 +594,7 @@ void GribRequestSetting::OnSendMaiL( wxCommandEvent& event  )
         m_rButtonCancel->Hide();
         m_rButtonApply->Hide();
         m_rButtonYes->SetLabel(_("Continue..."));
-        this->Fit();
-        this->Refresh();
+        SetMailImageSize();
         return;
     }
 
@@ -617,6 +625,5 @@ void GribRequestSetting::OnSendMaiL( wxCommandEvent& event  )
         m_rButtonYes->Hide();
     }
     m_rButtonYes->SetLabel(_("Continue..."));
-    this->Fit();
-    this->Refresh();
+    SetMailImageSize();
 }

--- a/plugins/grib_pi/src/GribRequestDialog.h
+++ b/plugins/grib_pi/src/GribRequestDialog.h
@@ -69,6 +69,7 @@ private:
       void OnTimeRangeChange( wxCommandEvent& event );
       void OnSendMaiL( wxCommandEvent& event );
       void OnSaveMail( wxCommandEvent& event );
+      void SetMailImageSize();
 
       bool IsZYGRIB;
       bool IsGFS;

--- a/plugins/grib_pi/src/GribUIDialog.h
+++ b/plugins/grib_pi/src/GribUIDialog.h
@@ -115,7 +115,8 @@ private:
     void OnPlayStopTimer( wxTimerEvent & event);
     void OnCursorTrackTimer( wxTimerEvent & event);
 
-    void AddTrackingControl( wxControl *ctrl1,  wxControl *ctrl2,  wxControl *ctrl3, bool show, bool altitude = false );
+    void AddTrackingControl( wxControl *ctrl1,  wxControl *ctrl2,  wxControl *ctrl3, bool show,
+            int wictrl2, int wictrl3 = 0, bool altitude = false );
     void UpdateTrackingControls( void );
 
     void OnZoomToCenterClick( wxCommandEvent& event );
@@ -137,6 +138,9 @@ private:
     int GetNearestValue(wxDateTime time, int model);
     bool GetGribZoneLimits(GribTimelineRecordSet *timelineSet, double *latmin, double *latmax, double *lonmin, double *lonmax);
     wxDateTime GetNow();
+    void RestaureSelectionString();
+    void SaveSelectionString()  { m_SelectionIsSaved = true; m_Selection_index = m_cRecordForecast->GetSelection();
+            m_Selection_label = m_cRecordForecast->GetString( m_Selection_index); }
 
     //    Data
     wxWindow *pParent;
@@ -150,6 +154,9 @@ private:
     bool m_InterpolateMode;
     bool m_pNowMode;
 
+    bool             m_SelectionIsSaved;
+    int              m_Selection_index;
+    wxString         m_Selection_label;
     wxString         m_file_name;   /* selected file */
     wxString         m_grib_dir;
 };

--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Sep 30 2014)
+// C++ code generated with wxFormBuilder (version Jun  6 2014)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO "NOT" EDIT THIS FILE!
@@ -30,8 +30,10 @@ GRIBUIDialogBase::GRIBUIDialogBase( wxWindow* parent, wxWindowID id, const wxStr
 	
 	fgSizer51->Add( m_bpPrev, 0, wxALL, 1 );
 	
-	m_cRecordForecast = new wxComboBox( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 ); 
-	fgSizer51->Add( m_cRecordForecast, 0, wxEXPAND|wxALL, 1 );
+	wxArrayString m_cRecordForecastChoices;
+	m_cRecordForecast = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_cRecordForecastChoices, 0 );
+	m_cRecordForecast->SetSelection( 0 );
+	fgSizer51->Add( m_cRecordForecast, 0, wxALL|wxEXPAND, 5 );
 	
 	m_bpNext = new wxBitmapButton( this, wxID_ANY, wxNullBitmap, wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
 	m_bpNext->SetToolTip( _("Next") );
@@ -86,7 +88,7 @@ GRIBUIDialogBase::GRIBUIDialogBase( wxWindow* parent, wxWindowID id, const wxStr
 	m_fcAltitude->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 	
 	wxArrayString m_cbAltitudeChoices;
-	m_cbAltitude = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxSize( 60,-1 ), m_cbAltitudeChoices, 0 );
+	m_cbAltitude = new wxChoice( this, wxID_ANY, wxDefaultPosition, wxSize( -1,-1 ), m_cbAltitudeChoices, 0 );
 	m_cbAltitude->SetSelection( 0 );
 	m_cbAltitude->SetFont( wxFont( wxNORMAL_FONT->GetPointSize(), 70, 90, 90, false, wxEmptyString ) );
 	
@@ -280,7 +282,7 @@ GRIBUIDialogBase::GRIBUIDialogBase( wxWindow* parent, wxWindowID id, const wxStr
 	this->Connect( wxEVT_CLOSE_WINDOW, wxCloseEventHandler( GRIBUIDialogBase::OnClose ) );
 	this->Connect( wxEVT_SIZE, wxSizeEventHandler( GRIBUIDialogBase::OnSize ) );
 	m_bpPrev->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GRIBUIDialogBase::OnPrev ), NULL, this );
-	m_cRecordForecast->Connect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( GRIBUIDialogBase::OnRecordForecast ), NULL, this );
+	m_cRecordForecast->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( GRIBUIDialogBase::OnRecordForecast ), NULL, this );
 	m_bpNext->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GRIBUIDialogBase::OnNext ), NULL, this );
 	m_bpNow->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GRIBUIDialogBase::OnNow ), NULL, this );
 	m_bpZoomToCenter->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GRIBUIDialogBase::OnZoomToCenterClick ), NULL, this );
@@ -316,7 +318,7 @@ GRIBUIDialogBase::~GRIBUIDialogBase()
 	this->Disconnect( wxEVT_CLOSE_WINDOW, wxCloseEventHandler( GRIBUIDialogBase::OnClose ) );
 	this->Disconnect( wxEVT_SIZE, wxSizeEventHandler( GRIBUIDialogBase::OnSize ) );
 	m_bpPrev->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GRIBUIDialogBase::OnPrev ), NULL, this );
-	m_cRecordForecast->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( GRIBUIDialogBase::OnRecordForecast ), NULL, this );
+	m_cRecordForecast->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( GRIBUIDialogBase::OnRecordForecast ), NULL, this );
 	m_bpNext->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GRIBUIDialogBase::OnNext ), NULL, this );
 	m_bpNow->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GRIBUIDialogBase::OnNow ), NULL, this );
 	m_bpZoomToCenter->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GRIBUIDialogBase::OnZoomToCenterClick ), NULL, this );
@@ -385,8 +387,8 @@ GribSettingsDialogBase::GribSettingsDialogBase( wxWindow* parent, wxWindowID id,
 	m_staticText4->Wrap( -1 );
 	fgSizer13->Add( m_staticText4, 0, wxALL|wxEXPAND, 5 );
 	
-	m_sUpdatesPerSecond = new wxSpinCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, 60, 4 );
-	fgSizer13->Add( m_sUpdatesPerSecond, 0, wxALL|wxEXPAND, 5 );
+	m_sUpdatesPerSecond = new wxSpinCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 90,-1 ), wxSP_ARROW_KEYS, 1, 60, 4 );
+	fgSizer13->Add( m_sUpdatesPerSecond, 0, wxALL, 5 );
 	
 	m_cInterpolate = new wxCheckBox( this, wxID_ANY, _("Interpolate between gribs"), wxDefaultPosition, wxDefaultSize, 0 );
 	fgSizer13->Add( m_cInterpolate, 0, wxALL, 5 );
@@ -457,8 +459,8 @@ GribSettingsDialogBase::GribSettingsDialogBase( wxWindow* parent, wxWindowID id,
 	m_tIsoBarSpacing->Wrap( -1 );
 	m_fIsoBarSpacing->Add( m_tIsoBarSpacing, 0, wxBOTTOM|wxEXPAND|wxRIGHT, 5 );
 	
-	m_sIsoBarSpacing = new wxSpinCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 70,-1 ), wxSP_ARROW_KEYS, 1, 1000, 1 );
-	m_fIsoBarSpacing->Add( m_sIsoBarSpacing, 0, wxALL|wxEXPAND, 5 );
+	m_sIsoBarSpacing = new wxSpinCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 90,-1 ), wxSP_ARROW_KEYS, 1, 1000, 1 );
+	m_fIsoBarSpacing->Add( m_sIsoBarSpacing, 0, wxALL, 5 );
 	
 	
 	fgSizer15->Add( m_fIsoBarSpacing, 1, wxALL|wxEXPAND, 5 );
@@ -508,8 +510,8 @@ GribSettingsDialogBase::GribSettingsDialogBase( wxWindow* parent, wxWindowID id,
 	m_ctNumbers->Wrap( -1 );
 	fgSizer15->Add( m_ctNumbers, 0, wxALL|wxEXPAND, 5 );
 	
-	m_sNumbersSpacing = new wxSpinCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( -1,-1 ), wxSP_ARROW_KEYS, 30, 100, 50 );
-	fgSizer15->Add( m_sNumbersSpacing, 0, wxALL|wxEXPAND, 5 );
+	m_sNumbersSpacing = new wxSpinCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 90,-1 ), wxSP_ARROW_KEYS, 30, 100, 50 );
+	fgSizer15->Add( m_sNumbersSpacing, 0, wxALL, 5 );
 	
 	m_cbParticles = new wxCheckBox( this, wxID_ANY, _("Particle Map"), wxDefaultPosition, wxDefaultSize, 0 );
 	fgSizer15->Add( m_cbParticles, 0, wxALL, 5 );
@@ -973,8 +975,6 @@ GribRequestSettingBase::GribRequestSettingBase( wxWindow* parent, wxWindowID id,
 	fgSizer11->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 	
 	m_MailImage = new wxTextCtrl( this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE|wxTE_READONLY );
-	m_MailImage->SetMinSize( wxSize( -1,80 ) );
-	
 	fgSizer11->Add( m_MailImage, 0, wxALL|wxEXPAND, 5 );
 	
 	

--- a/plugins/grib_pi/src/GribUIDialogBase.h
+++ b/plugins/grib_pi/src/GribUIDialogBase.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////
-// C++ code generated with wxFormBuilder (version Sep 30 2014)
+// C++ code generated with wxFormBuilder (version Jun  6 2014)
 // http://www.wxformbuilder.org/
 //
 // PLEASE DO "NOT" EDIT THIS FILE!
@@ -21,10 +21,9 @@
 #include <wx/settings.h>
 #include <wx/string.h>
 #include <wx/button.h>
-#include <wx/combobox.h>
+#include <wx/choice.h>
 #include <wx/slider.h>
 #include <wx/sizer.h>
-#include <wx/choice.h>
 #include <wx/checkbox.h>
 #include <wx/textctrl.h>
 #include <wx/statbox.h>
@@ -59,7 +58,7 @@ class GRIBUIDialogBase : public wxDialog
 	protected:
 		wxFlexGridSizer* m_fgTrackingDisplay;
 		wxBitmapButton* m_bpPrev;
-		wxComboBox* m_cRecordForecast;
+		wxChoice* m_cRecordForecast;
 		wxBitmapButton* m_bpNext;
 		wxBitmapButton* m_bpNow;
 		wxBitmapButton* m_bpZoomToCenter;

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -343,6 +343,10 @@ void grib_pi::OnToolbarToolCallback(int id)
 
       //    Toggle dialog?
       if(m_bShowGrib) {
+          if( m_pGribDialog->GetFont() != *OCPNGetFont(_("Dialog"), 10) ) {
+              m_pGribDialog->PopulateTrackingControls();
+              SetDialogFont( m_pGribDialog );
+          }
           m_pGribDialog->Show();
           if( m_pGribDialog->m_bGRIBActiveFile ) {
               if( m_pGribDialog->m_bGRIBActiveFile->IsOK() ) {
@@ -418,6 +422,20 @@ void grib_pi::OnContextMenuItemCallback(int id)
 {
     if(!m_pGribDialog->m_bGRIBActiveFile) return;
     m_pGribDialog->ContextMenuItemCallback(id);
+}
+
+void grib_pi::SetDialogFont( wxWindow *dialog, wxFont *font)
+{
+    dialog->SetFont( *font );
+    wxWindowList list = dialog->GetChildren();
+    wxWindowListNode *node = list.GetFirst();
+    for( size_t i = 0; i < list.GetCount(); i++ ) {
+        wxWindow *win = node->GetData();
+        win->SetFont( *font );
+        node = node->GetNext();
+    }
+    dialog->Fit();
+    dialog->Refresh();
 }
 
 void grib_pi::SetPluginMessage(wxString &message_id, wxString &message_body)
@@ -560,6 +578,6 @@ void GribPreferencesDialog::OnStartOptionChange( wxCommandEvent& event )
     if(m_rbStartOptions->GetSelection() == 2) {
         wxMessageDialog mes(this, _("You have chosen to authorize interpolation.\nDon't forget that data displayed at current time will not be real but interpolated!"),
                 _("Warning!"), wxOK);
-            mes.ShowModal();
-        }
+        mes.ShowModal();
+    }
 }

--- a/plugins/grib_pi/src/grib_pi.h
+++ b/plugins/grib_pi/src/grib_pi.h
@@ -92,6 +92,7 @@ public:
       void SetGribDialogSizeX(int x){ m_grib_dialog_sx = x;}
       void SetGribDialogSizeY(int x){ m_grib_dialog_sy = x;}
       void SetColorScheme(PI_ColorScheme cs);
+      void SetDialogFont( wxWindow *window, wxFont *font = OCPNGetFont(_("Dialog"), 10) );
 
       void OnGribDialogClose();
 


### PR DESCRIPTION
I noted that Linux and Windows do not handle Fonts and sizing exactly the same way:
- wxCombobox do not react to font setting with Linux. I had to migrate to WxChoice and add some tweaks to get all the functionalities needed
- wxTextCtrl sizing do not handle multi lines requesting some tweak too

The "weather table" is not concerned for the moment
JP
