### PR TITLE
OS X menu items - standard 'preferences' and 'about', plus view menu

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -2513,6 +2513,16 @@ MyFrame::MyFrame( wxFrame *frame, const wxString& title, const wxPoint& pos, con
 #ifdef __WXOSX__
     osx_menuBar = new wxMenuBar();
 
+    wxMenu* view_menu = new wxMenu();
+    view_menu->Append(ID_ZOOMIN, _("Zoom In"));
+    view_menu->Append(ID_ZOOMOUT, _("Zoom Out"));
+    view_menu->AppendSeparator();
+    view_menu->Append(ID_STKDN, _("Larger Scale Chart"));
+    view_menu->Append(ID_STKUP, _("Smaller Scale Chart"));
+    view_menu->AppendSeparator();
+    view_menu->Append(ID_COLSCHEME, _("Change Color Scheme"));
+    osx_menuBar->Append(view_menu, _("View"));
+
     wxMenu* help_menu = new wxMenu();
     help_menu->Append(wxID_ABOUT, _("About OpenCPN"));
     help_menu->Append(wxID_HELP, _("Help"));


### PR DESCRIPTION
I added the standard 'Preferences' and 'About' menu items to the OS X menu bar.

While I was about it, I thought it would be good to populate the menu bar properly on OS X, since it is always shown anyway. It looks bad having an empty menu bar, and we can use it to surface some commands which are otherwise only available by keyboard shortcuts.

I would like to go further with this, but thought I would gauge the opinions of others first.
