### PR TITLE
Right click on own vessel when a route is active and there is a cross tr...

### DIFF
--- a/include/routeman.h
+++ b/include/routeman.h
@@ -96,6 +96,7 @@ public:
       double GetCurrentBrgToActivePoint(){ return CurrentBrgToActivePoint;}
       double GetCurrentRngToActiveNormalArrival(){ return CurrentRangeToActiveNormalCrossing;}
       double GetCurrentXTEToActivePoint(){ return CurrentXTEToActivePoint;}
+      void   ZeroCurrentXTEToActivePoint();
       double GetCurrentSegmentCourse(){ return CurrentSegmentCourse;}
       int   GetXTEDir(){ return XTEDir;}
 

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -377,6 +377,8 @@ enum
 
     ID_DEF_MENU_GROUPBASE,
 
+    ID_DEF_ZERO_XTE,
+    
     ID_DEF_MENU_LAST
 };
 
@@ -1064,6 +1066,8 @@ BEGIN_EVENT_TABLE ( ChartCanvas, wxWindow )
     EVT_MENU ( ID_DEF_MENU_TIDEINFO,        ChartCanvas::PopupMenuHandler )
     EVT_MENU ( ID_DEF_MENU_CURRENTINFO,     ChartCanvas::PopupMenuHandler )
     EVT_MENU ( ID_DEF_MENU_GROUPBASE,       ChartCanvas::PopupMenuHandler )
+    
+    EVT_MENU ( ID_DEF_ZERO_XTE, ChartCanvas::PopupMenuHandler )
 END_EVENT_TABLE()
 
 // Define a constructor for my canvas
@@ -6553,6 +6557,8 @@ void ChartCanvas::CanvasPopupMenu( int x, int y, int seltype )
         else
             MenuAppend( contextMenu, ID_DEF_MENU_NORTHUP, _("North Up Mode") );
     }
+    
+    if ( g_pRouteMan->IsAnyRouteActive() && g_pRouteMan->GetCurrentXTEToActivePoint() > 0. ) MenuAppend( contextMenu, ID_DEF_ZERO_XTE, _("Zero XTE") );
 
     Kml* kml = new Kml;
     int pasteBuffer = kml->ParsePasteBuffer();
@@ -8095,6 +8101,10 @@ void ChartCanvas::PopupMenuHandler( wxCommandEvent& event )
         FinishRoute();
         gFrame->SurfaceToolbar();
         Refresh( false );
+        break;
+
+    case ID_DEF_ZERO_XTE:
+        g_pRouteMan->ZeroCurrentXTEToActivePoint();
         break;
 
     default: {

--- a/src/routeman.cpp
+++ b/src/routeman.cpp
@@ -1018,6 +1018,17 @@ Route *Routeman::FindRouteByGUID(wxString &guid)
     return pRoute;
 }
 
+void Routeman::ZeroCurrentXTEToActivePoint()
+{
+    // When zeroing XTE create a "virtual" waypoint at present position
+    if( pRouteActivatePoint ) delete pRouteActivatePoint;
+    pRouteActivatePoint = new RoutePoint( gLat, gLon, wxString( _T("") ), wxString( _T("") ),
+    GPX_EMPTY_STRING, false ); // Current location
+    pRouteActivatePoint->m_bShowName = false;
+
+    pActiveRouteSegmentBeginPoint = pRouteActivatePoint;
+    m_arrival_min = 1e6;
+}
 
 //--------------------------------------------------------------------------------
 //      WayPointman   Implementation


### PR DESCRIPTION
...ack error to provide a 'Zero XTE' option.

This option will use the same logic as getting to the first waypoint of a route by creating a virtual waypoint to get a route from the current postion to the active waypoint.

This is for FS#1563

This change allows the autopilot to follow a direct route to the next waypoint without haveing to converge on the original route first. It is very useful when sailing or motor/sailing.
