### PR TITLE
Enable temporary toggling of menu bar using Alt

### DIFF
--- a/include/chcanv.h
+++ b/include/chcanv.h
@@ -349,7 +349,8 @@ private:
       bool        m_bRouteEditing;
       bool        m_bMarkEditing;
       bool        m_bIsInRadius;
-      
+      bool        m_bMayToggleMenuBar;
+
       RoutePoint  *m_pRoutePointEditTarget;
       RoutePoint  *m_lastRoutePointEditTarget;
       SelectItem  *m_pFoundPoint;

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -292,6 +292,7 @@ bool                      g_bFullscreenToolbar;
 bool                      g_bShowLayers;
 bool                      g_bTransparentToolbar;
 bool                      g_bPermanentMOBIcon;
+bool                      g_bTempShowMenuBar;
 
 int                       g_iSDMMFormat;
 int                       g_iDistanceFormat;
@@ -4534,12 +4535,15 @@ void MyFrame::ApplyGlobalSettings( bool bFlyingUpdate, bool bnewtoolbar )
     SendSizeEvent();               
     
     /*
-     * Menu Bar - add or remove is if necessary, and update the state of the menu items
+     * Menu Bar - add or remove it if necessary, and update the state of the menu items
      */
 #ifdef __WXOSX__
     bool showMenuBar = true;    // the menu bar is always visible in OS X
 #else
-    bool showMenuBar = pConfig->m_bShowMenuBar;
+    bool showMenuBar = pConfig->m_bShowMenuBar; // get visibility from options
+
+    if (!showMenuBar && g_bTempShowMenuBar)     // allows pressing alt to temporarily show
+        showMenuBar = true;
 #endif
 
     if ( showMenuBar ) {
@@ -4599,7 +4603,7 @@ void MyFrame::RegisterGlobalMenuItems()
     nav_menu->AppendSeparator();
     nav_menu->Append( ID_MENU_SCALE_IN, _menuText(_("Larger Scale Chart"), _T("Ctrl-Left")) );
     nav_menu->Append( ID_MENU_SCALE_OUT, _menuText(_("Smaller Scale Chart"), _T("Ctrl-Right")) );
-    m_pMenuBar->Append( nav_menu, _("Navigate") );
+    m_pMenuBar->Append( nav_menu, _("&Navigate") );
 
 
     wxMenu* view_menu = new wxMenu();
@@ -4624,7 +4628,7 @@ void MyFrame::RegisterGlobalMenuItems()
 #else
     view_menu->Append(ID_MENU_UI_FULLSCREEN, _menuText(_("Enter Full Screen"), _T("F11")) );
 #endif
-    m_pMenuBar->Append( view_menu, _("View") );
+    m_pMenuBar->Append( view_menu, _("&View") );
 
 
     wxMenu* ais_menu = new wxMenu();
@@ -4634,7 +4638,7 @@ void MyFrame::RegisterGlobalMenuItems()
     ais_menu->AppendCheckItem( ID_MENU_AIS_CPASOUND, _("Sound CPA Alarms") );
     ais_menu->AppendSeparator();
     ais_menu->Append( ID_MENU_AIS_TARGETLIST, _("AIS Target List...") );
-    m_pMenuBar->Append( ais_menu, _("AIS") );
+    m_pMenuBar->Append( ais_menu, _("&AIS") );
 
 
     wxMenu* tools_menu = new wxMenu();
@@ -4653,13 +4657,13 @@ void MyFrame::RegisterGlobalMenuItems()
 #endif
     tools_menu->AppendSeparator();
     tools_menu->Append( wxID_PREFERENCES, _menuText(_("Preferences..."), _T("Ctrl-,")) );
-    m_pMenuBar->Append( tools_menu, _("Tools") );
+    m_pMenuBar->Append( tools_menu, _("&Tools") );
 
 
     wxMenu* help_menu = new wxMenu();
     help_menu->Append( wxID_ABOUT, _("About OpenCPN") );
     help_menu->Append( wxID_HELP, _("OpenCPN Help") );
-    m_pMenuBar->Append( help_menu, _("Help") );
+    m_pMenuBar->Append( help_menu, _("&Help") );
 
 
     // Set initial values for menu check items and radio items


### PR DESCRIPTION
If the menu bar is not set to be permanently visible, allow it to be shown temporarily by pressing the Alt key, as is normal on Linux and Windows.
