### PR TITLE
Waypoint arrival

### DIFF
--- a/include/NavObjectCollection.h
+++ b/include/NavObjectCollection.h
@@ -49,6 +49,7 @@ class Track;
 #define         OUT_ACTION_DEL  1 << 15
 #define         OUT_ACTION_UPD  1 << 16
 #define         OUT_EXTENSION   1 << 17
+#define         OUT_ARRIVAL_RADIUS 1 << 18
 
 #define  OPT_TRACKPT    OUT_TIME
 #define  OPT_WPT        (OUT_TYPE) +\
@@ -61,7 +62,8 @@ class Track;
                         (OUT_VIZ_NAME) +\
                         (OUT_SHARED) +\
                         (OUT_AUTO_NAME) +\
-                        (OUT_HYPERLINKS)
+                        (OUT_HYPERLINKS) +\
+                        (OUT_ARRIVAL_RADIUS)
 #define OPT_ROUTEPT     OPT_WPT                        
 
 //      Bitfield definitions controlling the GPX nodes output for Route.Track objects

--- a/include/RoutePoint.h
+++ b/include/RoutePoint.h
@@ -80,6 +80,9 @@ public:
       void SetDistance( double distance) { m_routeprop_distance = distance; };
       double GetDistance() { return m_routeprop_distance; };
 
+      void SetWaypointArrivalRadius(double dArrivalDistance) { m_WaypointArrivalRadius = dArrivalDistance; };
+      void SetWaypointArrivalRadius( wxString wxArrivalDistance ) { wxArrivalDistance.ToDouble( &m_WaypointArrivalRadius ); };
+      double GetWaypointArrivalRadius();
 
       bool SendToGPS(const wxString& com_name, wxGauge *pProgress);
 
@@ -142,6 +145,8 @@ public:
       static bool s_bUpdateWaypointsDisplayList;
 #endif
 
+      double m_WaypointArrivalRadius;
+      
 private:
       wxString          m_MarkName;
       wxDateTime        m_CreateTimeX;

--- a/include/routeprop.h
+++ b/include/routeprop.h
@@ -297,6 +297,8 @@ class MarkInfoDef : public wxDialog
         wxToggleButton*         m_toggleBtnEdit;
         wxStaticBoxSizer*       sbSizerLinks;
         wxSize                  m_defaultClientSize;
+        wxStaticText*           m_staticTextArrivalRadius;
+        wxTextCtrl*             m_textArrivalRadius;
 
     // Virtual event handlers, overide them in your derived class
         virtual void OnPositionCtlUpdated( wxCommandEvent& event ) { event.Skip(); }
@@ -309,6 +311,7 @@ class MarkInfoDef : public wxDialog
         virtual void OnDescChangedExt( wxCommandEvent& event ) { event.Skip(); }
         virtual void OnMarkInfoCancelClick( wxCommandEvent& event ) { event.Skip(); }
         virtual void OnMarkInfoOKClick( wxCommandEvent& event ) { event.Skip(); }
+        virtual void OnArrivalRadiusChange( wxCommandEvent& event ) { event.Skip(); }
         void OnCopyPasteLatLon( wxCommandEvent& event );
 
     public:

--- a/src/NavObjectCollection.cpp
+++ b/src/NavObjectCollection.cpp
@@ -78,7 +78,8 @@ RoutePoint * GPXLoadWaypoint1( pugi::xml_node &wpt_node,
     HyperlinkList *linklist = NULL;
 
     double rlat = wpt_node.attribute( "lat" ).as_double();
-    double rlon = wpt_node.attribute( "lon" ).as_double();;
+    double rlon = wpt_node.attribute( "lon" ).as_double();
+    double ArrivalRadius = 0;
 
     for( pugi::xml_node child = wpt_node.first_child(); child != 0; child = child.next_sibling() ) {
         const char *pcn = child.name();
@@ -168,6 +169,9 @@ RoutePoint * GPXLoadWaypoint1( pugi::xml_node &wpt_node,
                     if( s.ToLong( &v ) )
                         bshared = ( v != 0 );
                 }
+                if( ext_name == _T ( "opencpn:arrival_radius" ) ) {
+                    wxString::FromUTF8(ext_child.first_child().value()).ToDouble(&ArrivalRadius ) ;
+                }
             }// for 
         } //extensions
     }   // for
@@ -182,6 +186,7 @@ RoutePoint * GPXLoadWaypoint1( pugi::xml_node &wpt_node,
     pWP = new RoutePoint( rlat, rlon, SymString, NameString, GuidString, false ); // do not add to global WP list yet...
     pWP->m_MarkDescription = DescString;
     pWP->m_bIsolatedMark = bshared;      // This is an isolated mark
+    pWP->SetWaypointArrivalRadius( ArrivalRadius );
     
 
     if( b_propvizname )
@@ -660,6 +665,11 @@ bool GPXCreateWpt( pugi::xml_node node, RoutePoint *pr, unsigned int flags )
              child = child_ext.append_child("opencpn:shared");
              child.append_child(pugi::node_pcdata).set_value("1");
          }
+        if(flags & OUT_ARRIVAL_RADIUS) {
+            child = child_ext.append_child("opencpn:arrival_radius");
+            s.Printf(_T("%.3f"), pr->GetWaypointArrivalRadius());
+            child.append_child(pugi::node_pcdata).set_value( s.mbc_str() );
+        }
     }
     
     return true;

--- a/src/RoutePoint.cpp
+++ b/src/RoutePoint.cpp
@@ -45,6 +45,7 @@ extern MyFrame *gFrame;
 extern bool g_btouch;
 extern bool g_bresponsive;
 extern ocpnStyle::StyleManager* g_StyleManager;
+extern double g_n_arrival_circle_radius;
 
 #include <wx/listimpl.cpp>
 WX_DEFINE_LIST ( RoutePointList );
@@ -90,6 +91,8 @@ RoutePoint::RoutePoint()
 
     m_bIsInLayer = false;
     m_LayerID = 0;
+    
+    m_WaypointArrivalRadius = g_n_arrival_circle_radius;
 }
 
 // Copy Constructor
@@ -131,6 +134,8 @@ RoutePoint::RoutePoint( RoutePoint* orig )
     
     m_SelectNode = NULL;
     m_ManagerNode = NULL;
+    
+    m_WaypointArrivalRadius = orig->GetWaypointArrivalRadius();
     
 }
 
@@ -197,6 +202,8 @@ RoutePoint::RoutePoint( double lat, double lon, const wxString& icon_ident, cons
         m_bIsListed = false;
     } else
         m_LayerID = 0;
+    
+    SetWaypointArrivalRadius( g_n_arrival_circle_radius );
 }
 
 RoutePoint::~RoutePoint( void )
@@ -647,5 +654,14 @@ bool RoutePoint::SendToGPS(const wxString & com_name, wxGauge *pProgress)
     OCPNMessageBox( NULL, msg, _("OpenCPN Info"), wxOK | wxICON_INFORMATION );
 
     return (result == 0);
+}
+
+double RoutePoint::GetWaypointArrivalRadius() {
+    if (m_WaypointArrivalRadius < 0.001) {
+        SetWaypointArrivalRadius( g_n_arrival_circle_radius );
+        return g_n_arrival_circle_radius;
+    }
+    else
+        return m_WaypointArrivalRadius;
 }
 

--- a/src/routeman.cpp
+++ b/src/routeman.cpp
@@ -449,8 +449,8 @@ bool Routeman::UpdateProgress()
 
         // Special signal:  if ArrivalRadius < 0, NEVER arrive...
         //  Used for MOB auto-created routes.
-        if( pActiveRoute->GetRouteArrivalRadius() > 0){
-            if( CurrentRangeToActiveNormalCrossing <= pActiveRoute->GetRouteArrivalRadius() ) {
+        if( pActivePoint->GetWaypointArrivalRadius() > 0){
+            if( CurrentRangeToActiveNormalCrossing <= pActivePoint->GetWaypointArrivalRadius() ) {
                 m_bArrival = true;
                 UpdateAutopilot();
 
@@ -462,7 +462,7 @@ bool Routeman::UpdateProgress()
             //      Test to see if we are moving away from the arrival point, and
             //      have been mving away for 2 seconds.  
             //      If so, we should declare "Arrival"
-                if( (CurrentRangeToActiveNormalCrossing - m_arrival_min) >  pActiveRoute->GetRouteArrivalRadius() ){
+                if( (CurrentRangeToActiveNormalCrossing - m_arrival_min) >  pActivePoint->GetWaypointArrivalRadius() ){
                     if(++m_arrival_test > 2) {
                         m_bArrival = true;
                         UpdateAutopilot();

--- a/src/routeprop.cpp
+++ b/src/routeprop.cpp
@@ -1930,6 +1930,18 @@ MarkInfoDef::MarkInfoDef( wxWindow* parent, wxWindowID id, const wxString& title
 
     bSizerTextProperties->Add( bSizerLatLon, 0, wxEXPAND, 5 );
 
+    wxBoxSizer* bSizerArrivalRadius;
+    bSizerArrivalRadius = new wxBoxSizer( wxHORIZONTAL );
+    m_staticTextArrivalRadius = new wxStaticText( m_panelBasicProperties, wxID_ANY, _("Arrival Radius"),
+            wxDefaultPosition, wxDefaultSize, 0 );
+    m_staticTextArrivalRadius->Wrap( -1 );
+    bSizerArrivalRadius->Add( m_staticTextArrivalRadius, 1, wxALL, 5 );
+
+    m_textArrivalRadius = new wxTextCtrl( m_panelBasicProperties, wxID_ANY, wxEmptyString,
+            wxDefaultPosition, wxDefaultSize, 0 );
+    bSizerArrivalRadius->Add( m_textArrivalRadius, 1, wxALL, 5 );
+    bSizerTextProperties->Add( bSizerArrivalRadius, 0, wxEXPAND, 5 );
+
     m_staticTextDescription = new wxStaticText( m_panelBasicProperties, wxID_ANY, _("Description"),
             wxDefaultPosition, wxDefaultSize, 0 );
     m_staticTextDescription->Wrap( -1 );
@@ -2097,6 +2109,8 @@ MarkInfoDef::MarkInfoDef( wxWindow* parent, wxWindowID id, const wxString& title
             wxCommandEventHandler( MarkInfoImpl::OnRightClick ), NULL, this );
     m_textLongitude->Connect( wxEVT_CONTEXT_MENU,
             wxCommandEventHandler( MarkInfoImpl::OnRightClick ), NULL, this );
+    m_textArrivalRadius->Connect( wxEVT_COMMAND_TEXT_ENTER,
+            wxCommandEventHandler( MarkInfoDef::OnArrivalRadiusChange ), NULL, this );
 
     m_textDescription->Connect( wxEVT_COMMAND_TEXT_UPDATED,
             wxCommandEventHandler( MarkInfoDef::OnDescChangedBasic ), NULL, this );
@@ -2139,6 +2153,8 @@ MarkInfoDef::~MarkInfoDef()
             wxCommandEventHandler( MarkInfoDef::OnPositionCtlUpdated ), NULL, this );
     m_textDescription->Disconnect( wxEVT_COMMAND_TEXT_UPDATED,
             wxCommandEventHandler( MarkInfoDef::OnDescChangedBasic ), NULL, this );
+    m_textArrivalRadius->Disconnect( wxEVT_COMMAND_TEXT_ENTER,
+            wxCommandEventHandler( MarkInfoDef::OnArrivalRadiusChange ), NULL, this );
     m_buttonExtDescription->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED,
             wxCommandEventHandler( MarkInfoDef::OnExtDescriptionClick ), NULL, this );
     this->Disconnect( wxID_ANY, wxEVT_COMMAND_MENU_SELECTED,
@@ -2219,6 +2235,7 @@ bool MarkInfoImpl::UpdateProperties( bool positionOnly )
             m_toggleBtnEdit->SetValue( false );
             m_checkBoxShowName->Enable( false );
             m_checkBoxVisible->Enable( false );
+            m_textArrivalRadius->SetEditable ( false );
         } else {
             m_staticTextLayer->Enable( false );
             m_staticTextLayer->Show( false );
@@ -2232,8 +2249,14 @@ bool MarkInfoImpl::UpdateProperties( bool positionOnly )
             m_toggleBtnEdit->Enable( true );
             m_checkBoxShowName->Enable( true );
             m_checkBoxVisible->Enable( true );
+            m_textArrivalRadius->SetEditable ( true );
         }
         m_textName->SetValue( m_pRoutePoint->GetName() );
+
+        wxString s_ArrivalRadius;
+        s_ArrivalRadius.Printf( _T("%.3f"), m_pRoutePoint->GetWaypointArrivalRadius() );
+        m_textArrivalRadius->SetValue( s_ArrivalRadius.mbc_str() );        
+        
         m_textDescription->SetValue( m_pRoutePoint->m_MarkDescription );
         m_textCtrlExtDescription->SetValue( m_pRoutePoint->m_MarkDescription );
         m_bitmapIcon->SetBitmap( *m_pRoutePoint->GetIconBitmap() );
@@ -2526,6 +2549,7 @@ bool MarkInfoImpl::SaveChanges()
 
         // Get User input Text Fields
         m_pRoutePoint->SetName( m_textName->GetValue() );
+        m_pRoutePoint->SetWaypointArrivalRadius( m_textArrivalRadius->GetValue() );
         m_pRoutePoint->m_MarkDescription = m_textDescription->GetValue();
         m_pRoutePoint->SetVisible( m_checkBoxVisible->GetValue() );
         m_pRoutePoint->SetNameShown( m_checkBoxShowName->GetValue() );


### PR DESCRIPTION
This allows the user to set individual waypoint arrival radius's. If the user does not do this then the system default is used. The information is stored in the navobj.xml in a new element:
opencpn:arrival_radius0.050/opencpn:arrival_radius

This is for FS#1565
