### PR TITLE
Fix menu items not working on Windows

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -4116,19 +4116,22 @@ void MyFrame::OnToolLeftClick( wxCommandEvent& event )
                     PlugInToolbarToolContainer *pttc = tool_array.Item( i );
                     if( event.GetId() == pttc->id ) {
                         if( pttc->m_pplugin ) pttc->m_pplugin->OnToolbarToolCallback( pttc->id );
+                        return; // required to prevent event.Skip() being called
                     }
                 }
             }
+
+            // If we didn't handle the event, allow it to bubble up to other handlers.
+            // This is required for the system menu items (Hide, etc) on OS X to work.
+            // This must only be called if we did NOT handle the event, otherwise it
+            // stops the menu items from working on Windows.
+            event.Skip();
+
             break;
         }
 
     }         // switch
 
-    // If we didn't handle the event, allow it to bubble up to other handlers.
-    // This is ncessary eg for the system default menu items (Hide, etc) on OS X to work.
-#ifdef __WXOSX__
-    event.Skip();
-#endif    
 }
 
 void MyFrame::ToggleColorScheme()


### PR DESCRIPTION
Dave,

I think this may be a slightly better fix than your d57914c.

You have put the `event.Skip()` in an `ifdef __WXOSX__`, which _does_ solve this particular issue, but I think it may be better to tackle the root cause of the problem: `event.Skip()` should be called _if, and only if, we have not handled the event ourselves_.

This commit does that by moving the call to `event.Skip()` into the `default` block of the `switch`.

Let me know what you think.
Caesar
