### PR TITLE
Correct a possible crash in main GRIB dialog right click menu

### DIFF
--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -436,7 +436,6 @@ void GRIBUIDialog::OnMouseEvent( wxMouseEvent& event )
         case GribOverlaySettings::PRESSURE:
             MenuAppend( menu, ISO_LINE, _("Display Isobars"), id );
             MenuAppend( menu, NUMBERS, _("Numbers"), id );
-            menu->Remove( 2 );
             break;
         case GribOverlaySettings::AIR_TEMPERATURE:
         case GribOverlaySettings::SEA_TEMPERATURE:


### PR DESCRIPTION
Seems to be visible only in debug mode ( vs2010 ). Anyway it's a bug due to not correctly cleared code.
Sorry
Jean Pierre
