### PR TITLE
Options fixes

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1915,8 +1915,8 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
 
 
     // spacer
-    optionsColumn->Add( new wxStaticText(ps57Ctl, wxID_ANY, _T("")) );
-    optionsColumn->Add( new wxStaticText(ps57Ctl, wxID_ANY, _T("")) );
+    optionsColumn->Add( 0, border_size*4 );
+    optionsColumn->Add( 0, border_size*4 );
 
 
     // graphics options
@@ -1940,8 +1940,8 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
 
 
     // spacer
-    optionsColumn->Add( new wxStaticText(ps57Ctl, wxID_ANY, _T("")) );
-    optionsColumn->Add( new wxStaticText(ps57Ctl, wxID_ANY, _T("")) );
+    optionsColumn->Add( 0, border_size*4 );
+    optionsColumn->Add( 0, border_size*4 );
 
 
     // depth options
@@ -1971,8 +1971,8 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
 
 
     // spacer
-    optionsColumn->Add( new wxStaticText(ps57Ctl, wxID_ANY, _T("")) );
-    optionsColumn->Add( new wxStaticText(ps57Ctl, wxID_ANY, _T("")) );
+    optionsColumn->Add( 0, border_size*4 );
+    optionsColumn->Add( 0, border_size*4 );
 
 
 #ifdef USE_S57
@@ -2170,8 +2170,8 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
 
 
     // spacer
-    generalSizer->Add( new wxStaticText(pDisplayPanel, wxID_ANY, _T("")) );
-    generalSizer->Add( new wxStaticText(pDisplayPanel, wxID_ANY, _T("")) );
+    generalSizer->Add( 0, border_size*4 );
+    generalSizer->Add( 0, border_size*4 );
 
 
     // Nav Mode
@@ -2192,8 +2192,8 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
     
     
     // spacer
-    generalSizer->Add( new wxStaticText(pDisplayPanel, wxID_ANY, _T("")) );
-    generalSizer->Add( new wxStaticText(pDisplayPanel, wxID_ANY, _T("")) );
+    generalSizer->Add( 0, border_size*4 );
+    generalSizer->Add( 0, border_size*4 );
 
     
     // Control Options
@@ -2209,8 +2209,8 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
 
 
     // spacer
-    generalSizer->Add( new wxStaticText(pDisplayPanel, wxID_ANY, _T("")) );
-    generalSizer->Add( new wxStaticText(pDisplayPanel, wxID_ANY, _T("")) );
+    generalSizer->Add( 0, border_size*4 );
+    generalSizer->Add( 0, border_size*4 );
 
     
     // Control Options
@@ -2227,8 +2227,8 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
     
 
     // spacer
-    generalSizer->Add( new wxStaticText(pDisplayPanel, wxID_ANY, _T("")) );
-    generalSizer->Add( new wxStaticText(pDisplayPanel, wxID_ANY, _T("")) );
+    generalSizer->Add( 0, border_size*4 );
+    generalSizer->Add( 0, border_size*4 );
 
     
     // Display Options
@@ -2265,8 +2265,8 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
 
 
     // spacer
-    unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
-    unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
+    unitsSizer->Add( 0, border_size*4 );
+    unitsSizer->Add( 0, border_size*4 );
 
 
     // distance units
@@ -2310,8 +2310,8 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
 
 
     // spacer
-    unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
-    unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
+    unitsSizer->Add( 0, border_size*4 );
+    unitsSizer->Add( 0, border_size*4 );
 
 
     // bearings (magnetic/true, variation)


### PR DESCRIPTION
Dave,

This primarily makes the change I mentioned to the new Screen Width UI: It moves the unit label (mm) to _after_ the number input instead of being part of the label, for consistency with the rest of the new options layout. I have also made some minor tweaks to the layout of the option.

I have also taken the liberty of renaming the new option to "Physical Screen Width"; I think this is clearer than "Screen horizontal size". I hope you agree.

In the second commit are some fixes to the "temporary" fake sizers I used while designing the other options pages, but forgot to remove at the time...

Caesar

PS - I have found a way to correctly read the screen size on OS X. I will send a separate pull request when I have implemented it fully.
