### PR TITLE
Message dialog fixes

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -10300,7 +10300,6 @@ TimedMessageBox::TimedMessageBox(wxWindow* parent, const wxString& message,
     ret_val = ret;
 }
 
-
 TimedMessageBox::~TimedMessageBox()
 {
 }
@@ -10312,65 +10311,22 @@ void TimedMessageBox::OnTimer(wxTimerEvent &evt)
 }
 
 
-
-
-
-
 int OCPNMessageBox( wxWindow *parent, const wxString& message, const wxString& caption, int style,
                     int timeout_sec, int x, int y  )
 {
+    int ret = wxID_OK;
 
-#ifdef __WXOSX__
-    long parent_style;
-    bool b_toolviz = false;
-    bool b_compassviz = false;
-    bool b_statsviz = false;
-
-    if(g_FloatingToolbarDialog && g_FloatingToolbarDialog->IsShown()){
-        g_FloatingToolbarDialog->Hide();
-        b_toolviz = true;
+    if (timeout_sec > 0) {
+        // wxMessageDialog is a wrapper around the system's native message dialog, so we can't
+        // subclass it and create a timed version, so we use a custom dialog instead.
+        TimedMessageBox tbox(parent, message, caption, style, timeout_sec, wxPoint( x, y )  );
+        ret = tbox.GetRetVal();
+    } else {
+        // If we don't need a timed dialog, use the system's native message dialog
+        // for better compatibility and greater user familiarity.
+        wxMessageDialog dlg( parent, message, caption, style, wxPoint( x, y ) );
+        ret = dlg.ShowModal();
     }
-
-    if( g_FloatingCompassDialog && g_FloatingCompassDialog->IsShown()){
-        g_FloatingCompassDialog->Hide();
-        b_compassviz = true;
-    }
-
-    if( stats && stats->IsShown()) {
-        stats->Hide();
-        b_statsviz = true;
-    }
-
-    if(parent) {
-        parent_style = parent->GetWindowStyle();
-        parent->SetWindowStyle( parent_style & !wxSTAY_ON_TOP );
-    }
-
-#endif
-
-      int ret =  wxID_OK;
-
-      TimedMessageBox tbox(parent, message, caption, style, timeout_sec, wxPoint( x, y )  );
-      ret = tbox.GetRetVal() ;
-
-//    wxMessageDialog dlg( parent, message, caption, style | wxSTAY_ON_TOP, wxPoint( x, y ) );
-//    ret = dlg.ShowModal();
-
-#ifdef __WXOSX__
-    if(gFrame && b_toolviz)
-        gFrame->SurfaceToolbar();
-
-    if( g_FloatingCompassDialog && b_compassviz)
-        g_FloatingCompassDialog->Show();
-
-    if( stats && b_statsviz)
-        stats->Show();
-
-    if(parent){
-        parent->Raise();
-        parent->SetWindowStyle( parent_style );
-    }
-#endif
 
     return ret;
 }

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -239,6 +239,8 @@ extern CompressionWorkerPool   *g_CompressorPool;
 
 bool                      g_bcompression_wait;
 
+bool                      g_bModalDialogOpen;
+
 wxString                  g_uploadConnection;
 
 int                       user_user_id;
@@ -10316,6 +10318,8 @@ int OCPNMessageBox( wxWindow *parent, const wxString& message, const wxString& c
 {
     int ret = wxID_OK;
 
+    g_bModalDialogOpen = true;
+
     if (timeout_sec > 0) {
         // wxMessageDialog is a wrapper around the system's native message dialog, so we can't
         // subclass it and create a timed version, so we use a custom dialog instead.
@@ -10327,6 +10331,8 @@ int OCPNMessageBox( wxWindow *parent, const wxString& message, const wxString& c
         wxMessageDialog dlg( parent, message, caption, style, wxPoint( x, y ) );
         ret = dlg.ShowModal();
     }
+
+    g_bModalDialogOpen = false;
 
     return ret;
 }

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -5392,7 +5392,7 @@ void ChartCanvas::MouseEvent( wxMouseEvent& event )
                     int dlg_return;
                     dlg_return = OCPNMessageBox( this, _("Use nearby waypoint?"),
                                                     _("OpenCPN Route Create"),
-                                                    (long) wxYES_NO | wxCANCEL | wxYES_DEFAULT );
+                                                    (long) wxYES_NO | wxYES_DEFAULT );
                     if( dlg_return == wxID_YES ) {
                         pMousePoint = pNearbyPoint;
 
@@ -5793,7 +5793,7 @@ void ChartCanvas::MouseEvent( wxMouseEvent& event )
                     int dlg_return;
                     dlg_return = OCPNMessageBox( this, _("Use nearby waypoint?"),
                                                 _("OpenCPN Route Create"),
-                                                (long) wxYES_NO | wxCANCEL | wxYES_DEFAULT );
+                                                (long) wxYES_NO | wxYES_DEFAULT );
 
                     if( dlg_return == wxID_YES ) {
                         pMousePoint = pNearbyPoint;
@@ -7925,7 +7925,7 @@ void ChartCanvas::PopupMenuHandler( wxCommandEvent& event )
         int dlg_return = wxID_YES;
         if( g_bConfirmObjectDelete ) {
             dlg_return = OCPNMessageBox( this,  _("Are you sure you want to delete this route?"),
-                _("OpenCPN Route Delete"), (long) wxYES_NO | wxCANCEL | wxYES_DEFAULT );
+                _("OpenCPN Route Delete"), (long) wxYES_NO | wxYES_DEFAULT );
         }
 
         if( dlg_return == wxID_YES ) {
@@ -8183,7 +8183,7 @@ void ChartCanvas::PopupMenuHandler( wxCommandEvent& event )
         int dlg_return = wxID_YES;
         if( g_bConfirmObjectDelete ) {
             dlg_return = OCPNMessageBox( this, _("Are you sure you want to delete this track?"),
-                _("OpenCPN Track Delete"), (long) wxYES_NO | wxCANCEL | wxYES_DEFAULT );
+                _("OpenCPN Track Delete"), (long) wxYES_NO | wxYES_DEFAULT );
         }
 
         if( dlg_return == wxID_YES ) {

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -7458,6 +7458,7 @@ void pupHandler_PasteRoute() {
 
         if( answer == wxID_CANCEL ) {
             delete kml;
+            ::wxEndBusyCursor();
             return;
         }
     }

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -277,6 +277,8 @@ extern bool              g_bShowMag;
 extern bool              g_btouch;
 extern bool              g_bresponsive;
 
+extern bool              g_bModalDialogOpen;
+
 #ifdef ocpnUSE_GL
 extern ocpnGLOptions g_GLOptions;
 #endif
@@ -1153,7 +1155,6 @@ ChartCanvas::ChartCanvas ( wxFrame *frame ) :
     m_pRouteRolloverWin = NULL;
     m_pAISRolloverWin = NULL;
     m_bedge_pan = false;
-    m_disable_edge_pan = false;
     m_brecapture = false;
     
     m_pCIWin = NULL;
@@ -4927,9 +4928,6 @@ void ChartCanvas::MovementStopTimerEvent( wxTimerEvent& )
 
 bool ChartCanvas::CheckEdgePan( int x, int y, bool bdragging, int margin, int delta )
 {
-    if(m_disable_edge_pan)
-        return false;
-    
     bool bft = false;
     int pan_margin = m_canvas_width * margin / 100;
     int pan_timer_set = 200;
@@ -5048,6 +5046,9 @@ void ChartCanvas::MouseTimedEvent( wxTimerEvent& event )
 
 void ChartCanvas::MouseEvent( wxMouseEvent& event )
 {
+    // Don't do anything if a modal dialog is visible
+    if (g_bModalDialogOpen) return;
+
     int x, y;
     int mx, my;
 
@@ -5440,12 +5441,8 @@ void ChartCanvas::MouseEvent( wxMouseEvent& event )
                                 << FormatDistanceAdaptive( rhumbDist - gcDistNM ) << _(" shorter than rhumbline.\n\n")
                                 << _("Would you like include the Great Circle routing points for this leg?");
                                 
-                            m_disable_edge_pan = true;  // This helps on OS X if MessageBox does not fully capture mouse
-
                             int answer = OCPNMessageBox( this, msg, _("OpenCPN Route Create"), wxYES_NO | wxNO_DEFAULT );
 
-                            m_disable_edge_pan = false;
-                            
                             if( answer == wxID_YES ) {
                                 RoutePoint* gcPoint;
                                 RoutePoint* prevGcPoint = m_prev_pMousePoint;

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -5390,13 +5390,9 @@ void ChartCanvas::MouseEvent( wxMouseEvent& event )
                         && !pNearbyPoint->m_bIsInTrack && !pNearbyPoint->m_bIsInLayer )
                 {
                     int dlg_return;
-    #ifndef __WXOSX__
                     dlg_return = OCPNMessageBox( this, _("Use nearby waypoint?"),
                                                     _("OpenCPN Route Create"),
                                                     (long) wxYES_NO | wxCANCEL | wxYES_DEFAULT );
-    #else
-                    dlg_return = wxID_YES;
-    #endif
                     if( dlg_return == wxID_YES ) {
                         pMousePoint = pNearbyPoint;
 
@@ -5795,25 +5791,22 @@ void ChartCanvas::MouseEvent( wxMouseEvent& event )
                     && !pNearbyPoint->m_bIsInTrack && !pNearbyPoint->m_bIsInLayer )
                 {
                     int dlg_return;
-                    #ifndef __WXOSX__
                     dlg_return = OCPNMessageBox( this, _("Use nearby waypoint?"),
                                                 _("OpenCPN Route Create"),
                                                 (long) wxYES_NO | wxCANCEL | wxYES_DEFAULT );
-                                                #else
-                                                dlg_return = wxID_YES;
-                                                #endif
-                                                if( dlg_return == wxID_YES ) {
-                                                    pMousePoint = pNearbyPoint;
 
-                                                    // Using existing waypoint, so nothing to delete for undo.
-                                                    if( parent_frame->nRoute_State > 1 )
-                                                        undo->BeforeUndoableAction( Undo_AppendWaypoint, pMousePoint, Undo_HasParent, NULL );
+                    if( dlg_return == wxID_YES ) {
+                        pMousePoint = pNearbyPoint;
 
-                                                    // check all other routes to see if this point appears in any other route
-                                                        // If it appears in NO other route, then it should e considered an isolated mark
-                                                        if( !g_pRouteMan->FindRouteContainingWaypoint( pMousePoint ) ) pMousePoint->m_bKeepXRoute =
-                                                            true;
-                                                }
+                        // Using existing waypoint, so nothing to delete for undo.
+                        if( parent_frame->nRoute_State > 1 )
+                            undo->BeforeUndoableAction( Undo_AppendWaypoint, pMousePoint, Undo_HasParent, NULL );
+
+                        // check all other routes to see if this point appears in any other route
+                        // If it appears in NO other route, then it should e considered an isolated mark
+                        if( !g_pRouteMan->FindRouteContainingWaypoint( pMousePoint ) ) pMousePoint->m_bKeepXRoute =
+                            true;
+                    }
                 }
 
                 if( NULL == pMousePoint ) {                 // need a new point
@@ -5845,11 +5838,7 @@ void ChartCanvas::MouseEvent( wxMouseEvent& event )
                         << FormatDistanceAdaptive( rhumbDist - gcDistNM ) << _(" shorter than rhumbline.\n\n")
                         << _("Would you like include the Great Circle routing points for this leg?");
 
-                        #ifndef __WXOSX__
                         int answer = OCPNMessageBox( this, msg, _("OpenCPN Route Create"), wxYES_NO | wxNO_DEFAULT );
-                        #else
-                        int answer = wxID_NO;
-                        #endif
 
                         if( answer == wxID_YES ) {
                             RoutePoint* gcPoint;


### PR DESCRIPTION
Here are the `OCPNMessageBox` fixes I talked about on the forum.

- The first commit, 2902368, makes the biggest change; it uses native message dialogs where possible, to avoid all the issues we have with our custom dialogs.

- 63a8422 prevents the unwanted chart interactions while message dialogs are visible.

The others are some minor things I came across while working on these dialogs:

- da6c103 enables some dialogs which are needlessly disabled on OS X.

- 26cc270 removes cancel buttons from some dialogs which shouldn't have them - plain yes/no dialogs where cancel makes no sense. (Note that some dialogs remain where cancel does make sense, and in those I have left it.)

- bbac728 fixes an error I came across which causes the app to freeze if a route paste action is cancelled.

I hope you do not consider these fixes too major to commit now, as I feel it would be nice to fix the current dialog issues and so the first two commits are important.
But if you do decide to defer until 4.2 I will understand...

Caesar