### PR TITLE
Clear particles structure when loadind a new grib file

### DIFF
--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -201,8 +201,7 @@ GRIBOverlayFactory::~GRIBOverlayFactory()
 {
     ClearCachedData();
 
-    delete m_ParticleMap;
-    m_ParticleMap = NULL;
+    ClearParticles();
 }
 
 void GRIBOverlayFactory::Reset()
@@ -1207,8 +1206,7 @@ void GRIBOverlayFactory::RenderGribParticles( int settings, GribRecord **pGR,
     sw.Start();
 
     if(m_ParticleMap && m_ParticleMap->m_Setting != settings) {
-        delete m_ParticleMap;
-        m_ParticleMap = NULL;
+        ClearParticles();
     }
 
    if(!m_ParticleMap)

--- a/plugins/grib_pi/src/GribOverlayFactory.h
+++ b/plugins/grib_pi/src/GribOverlayFactory.h
@@ -121,6 +121,7 @@ public:
     void Reset();
     void ClearCachedData( void );
     void ClearCachedLabel( void ) { m_labelCache.clear(); }
+    void ClearParticles() { delete m_ParticleMap; m_ParticleMap = NULL; }
 
     GribTimelineRecordSet *m_pGribTimelineRecordSet;
 

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -157,6 +157,7 @@ void GRIBUIDialog::OpenFile(bool newestFile)
     m_bpPlay->SetToolTip(_("Play"));
     m_cRecordForecast->Clear();
     m_cbAltitude->Clear();
+    pPlugIn->GetGRIBOverlayFactory()->ClearParticles();
     pPlugIn->GetGRIBOverlayFactory()->SetAltitude( 0 );
     m_FileIntervalIndex = m_OverlaySettings.m_SlicesPerUpdate;
     delete m_bGRIBActiveFile;


### PR DESCRIPTION
When loading a new file, while the new data are displayed, particles from the previous file can be stay displayed for
a short time.
