### PR TITLE
opencpn_nl_NL.po: translation of 'port' (haven -> poort)

### DIFF
--- a/po/opencpn_nl_NL.po
+++ b/po/opencpn_nl_NL.po
@@ -3835,11 +3835,11 @@ msgstr "Dataverbinding instellen als input, output of beide."
 
 #: src/options.cpp:3506
 msgid "You must select or enter the port..."
-msgstr "U moet de haven selecteren of invoeren ..."
+msgstr "U moet de poort selecteren of invoeren ..."
 
 #: src/options.cpp:3514
 msgid "You must enter a port..."
-msgstr "U moet de haven selecteren of invoeren ..."
+msgstr "U moet een poort invoeren ..."
 
 #: src/options.cpp:3521
 msgid "You must enter the address..."


### PR DESCRIPTION
The translation for two sentences in options.cpp had the word 'port' translated with the Dutch word for 'harbour'. It should be 'poort' in this sentences.