### PR TITLE
Give more consistent behavior for options dialog in gtk

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -5060,8 +5060,7 @@ int MyFrame::DoOptionsDialog()
     if(stats) stats->Hide();
 #endif
 
-    if( options_lastPage >= 0 )
-        g_options->SetInitialPage(options_lastPage );
+    g_options->SetInitialPage(options_lastPage );
 
     if(!g_bresponsive){
         g_options->lastWindowPos = options_lastWindowPos;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -940,7 +940,7 @@ void options::Init()
     m_pagePlugins = -1;
     m_pageConnections = -1;
     
-    lastPage = -1;
+    lastPage = 0;
     
     m_pPlugInCtrl = NULL;       // for deferred loading
     m_pNMEAForm = NULL;


### PR DESCRIPTION
The first time the options window is opened, the "General" tab is selected,
the second time, the "Units" tab is selected.  This change ensures that
the behavior is consistent and less confusing.