### PR TITLE
Corrected typo VERCLL and added VERCOP to feet conversion.

### DIFF
--- a/src/s52plib.cpp
+++ b/src/s52plib.cpp
@@ -1344,7 +1344,7 @@ char *_getParamVal( ObjRazRules *rzRules, char *str, char *buf, int bsz )
     } else {
 
         //    Special case for conversion of some vertical (height) attributes to feet
-        if( ( !strncmp( buf, "VERCLR", 6 ) ) || ( !strncmp( buf, "VERCCL", 6 ) ) ) {
+        if( ( !strncmp( buf, "VERCLR", 6 ) ) || ( !strncmp( buf, "VERCCL", 6 ) ) || ( !strncmp( buf, "VERCOP", 6 ) ) ) {
             switch( ps52plib->m_nDepthUnitDisplay ){
                 case 0: // feet
                 case 2: // fathoms

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -6679,7 +6679,7 @@ wxString s57chart::GetObjectAttributeValueAsString( S57Obj *obj, int iatt, wxStr
             wxString val_suffix = _T(" m");
 
             //    As a special case, convert some attribute values to feet.....
-            if( ( curAttrName == _T("VERCLR") ) || ( curAttrName == _T("VERCLL") )
+            if( ( curAttrName == _T("VERCLR") ) || ( curAttrName == _T("VERCCL") ) || ( curAttrName == _T("VERCOP") )
                     || ( curAttrName == _T("HEIGHT") ) || ( curAttrName == _T("HORCLR") ) ) {
                 switch( ps52plib->m_nDepthUnitDisplay ){
                     case 0:                       // feet
@@ -6808,7 +6808,7 @@ wxString s57chart::GetAttributeValueAsString( S57attVal *pAttrVal, wxString Attr
             wxString val_suffix = _T(" m");
             
             //    As a special case, convert some attribute values to feet.....
-            if( ( AttrName == _T("VERCLR") ) || ( AttrName == _T("VERCLL") )
+            if( ( AttrName == _T("VERCLR") ) || ( AttrName == _T("VERCCL") ) || ( AttrName == _T("VERCOP") )
                 || ( AttrName == _T("HEIGHT") ) || ( AttrName == _T("HORCLR") ) ) {
                     switch( ps52plib->m_nDepthUnitDisplay ){
                         case 0:                       // feet


### PR DESCRIPTION
This should fix FS #1704. I also wonder whether attribute HEIGHT should be converted to feet or not.

VERCLL is not a valid attribute at least not that I can find. And VERCOP was not being converted at all which leads to confusion on charts. OpenCPN has been displaying vertical clearance open and closed in meters instead of the requested units. If fathoms is the requested depth units these few attributes should remain as feet.
