### PR TITLE
Fix build with Visual Studio 2013

### DIFF
--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -49,6 +49,7 @@
 #include <wx/arrimpl.cpp>
 
 #if defined (_WIN32)
+#if _MSC_VER < 1700
 int round (double x) {
 	int i = (int) x;
 	if (x >= 0.0) {
@@ -57,6 +58,7 @@ int round (double x) {
 		return (-x+i >= 0.5) ? (i - 1) : (i);
 	}
 }
+#endif
 #endif
 
 WX_DEFINE_OBJARRAY( ArrayOfGribRecordSets );

--- a/src/printtable.cpp
+++ b/src/printtable.cpp
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <sstream>
 #include <vector>
+#include <algorithm>
 using namespace std;
 
 #include "wx/wxprec.h"


### PR DESCRIPTION
This patch makes building with VS2013 possible.
I took some notes regarding the use of this toolchain at https://github.com/nohal/OpenCPN/wiki/Building-using-Visual-Studio-2013
Surprisingly enough, the resulting binary (while using wx2.8) is compatible with the existing plugin DLLs built with VS2010 so if we decide to switch the default Windows toolchain, the transition seems transparent until we move to wx3.