### PR TITLE
Low/High labels for grib_pi plugin

### DIFF
--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -1417,29 +1417,43 @@ void GRIBOverlayFactory::RenderGribLowHigh( int settings, GribRecord **pGR, Plug
             }
 
             if ( isMin || isMax ) { // draw a label at the current grid point
+
+                wxString label;
+                if( isMin ) label = wxString::FromUTF8( "L" );
+                if( isMax ) label = wxString::FromUTF8( "H" );
+
                 double lon = pGRA->getX( ci );
                 double lat = pGRA->getY( cj );
                 wxPoint p;
                 GetCanvasPixLL( vp, &p, lat, lon );
 
-                wxScreenDC sdc;
-                wxString label;
-                if ( isMin ) label = wxString::FromUTF8( "L" );
-                if ( isMax ) label = wxString::FromUTF8( "H" );
-                int w, h;
-                wxFont mfont( 14, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD );
-                sdc.GetTextExtent( label, &w, &h, NULL, NULL, &mfont );
-                wxBitmap bmp( w, h );
-                wxMemoryDC mdc( bmp );
-                mdc.SetFont( mfont );
-                mdc.SetTextForeground( *wxBLACK );
-                mdc.SetBackground( *wxWHITE_BRUSH ); // TODO set background color to canvas color
-                mdc.Clear();
-                mdc.DrawText( label, 0, 0 );
-                mdc.SelectObject( wxNullBitmap );
-                wxImage labelImg = bmp.ConvertToImage();
-                labelImg.SetMaskColour( 255, 255, 255 );
-                m_pdc->DrawBitmap( labelImg, p.x, p.y, true );
+                if( m_pdc ) {
+                    wxScreenDC sdc;
+                    int w, h;
+                    wxFont mfont( 10, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL );
+                    sdc.GetTextExtent( label, &w, &h, NULL, NULL, &mfont );
+                    wxBitmap bmp( w, h );
+                    wxMemoryDC mdc( bmp );
+                    mdc.SetFont( mfont );
+                    mdc.SetTextForeground( *wxBLACK );
+                    mdc.SetBackground( *wxWHITE_BRUSH );
+                    mdc.Clear();
+                    mdc.DrawText( label, 0, 0 );
+                    mdc.SelectObject( wxNullBitmap );
+                    wxImage labelImg = bmp.ConvertToImage();
+                    labelImg.SetMaskColour( 255, 255, 255 );
+                    m_pdc->DrawBitmap( labelImg, p.x, p.y, true );
+                } else {
+#ifdef ocpnUSE_GL
+                    glEnable( GL_BLEND );
+                    glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
+                    glColor4ub( 0, 0, 0, 0 );
+                    glEnable( GL_TEXTURE_2D );
+                    m_TexFontNumbers.RenderString( label, p.x, p.y );
+                    glDisable( GL_TEXTURE_2D );
+                    glDisable( GL_BLEND );
+#endif
+                }
             }
 
         }

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -448,6 +448,7 @@ bool GRIBOverlayFactory::DoRenderGribOverlay( PlugIn_ViewPort *vp )
                     if( m_dlg.m_cbPressure->GetValue() ) {
                         RenderGribIsobar( i, pGR, pIA, vp );
                         RenderGribNumbers( i, pGR, vp );
+                        RenderGribLowHigh( i, pGR, vp );
                     } else {
                         if(m_Settings.Settings[i].m_iIsoBarVisibility) RenderGribIsobar( i, pGR, pIA, vp );
                     }
@@ -472,7 +473,7 @@ bool GRIBOverlayFactory::DoRenderGribOverlay( PlugIn_ViewPort *vp )
             RenderGribDirectionArrows( i, pGR, vp );
             RenderGribNumbers( i, pGR, vp );
             RenderGribParticles( i, pGR, vp );
-            RenderGribLowHigh( pGR, vp );
+            RenderGribLowHigh( i, pGR, vp );
         }
     }
     if( m_Altitude ) {
@@ -1387,8 +1388,10 @@ void GRIBOverlayFactory::RenderGribNumbers( int settings, GribRecord **pGR, Plug
 }
 
 /* Put an "L" in the center of a low and an "H" in the center of a high */
-void GRIBOverlayFactory::RenderGribLowHigh( GribRecord **pGR, PlugIn_ViewPort *vp )
+void GRIBOverlayFactory::RenderGribLowHigh( int settings, GribRecord **pGR, PlugIn_ViewPort *vp )
 {
+    if( !m_Settings.Settings[settings].m_bLowHighLabels ) return;
+
     GribRecord *pGRA = pGR[Idx_PRESSURE];
     int imax = pGRA->getNi(); // max longitude
     int jmax = pGRA->getNj(); // max latitude
@@ -1441,6 +1444,7 @@ void GRIBOverlayFactory::RenderGribLowHigh( GribRecord **pGR, PlugIn_ViewPort *v
 
         }
     }
+    return;
 }
 
 void GRIBOverlayFactory::DrawNumbers( wxPoint p, double value, int settings, wxColour back_color )

--- a/plugins/grib_pi/src/GribOverlayFactory.h
+++ b/plugins/grib_pi/src/GribOverlayFactory.h
@@ -172,6 +172,7 @@ private:
     void RenderGribParticles( int settings, GribRecord **pGR, PlugIn_ViewPort *vp );
     void DrawLineBuffer(LineBuffer &buffer);
     void OnParticleTimer( wxTimerEvent & event );
+    void RenderGribLowHigh( GribRecord **pGR, PlugIn_ViewPort *vp );
 
     wxString GetRefString( GribRecord *rec, int map );
     void DrawMessageWindow( wxString msg, int x, int y , wxFont *mfont);

--- a/plugins/grib_pi/src/GribOverlayFactory.h
+++ b/plugins/grib_pi/src/GribOverlayFactory.h
@@ -172,7 +172,7 @@ private:
     void RenderGribParticles( int settings, GribRecord **pGR, PlugIn_ViewPort *vp );
     void DrawLineBuffer(LineBuffer &buffer);
     void OnParticleTimer( wxTimerEvent & event );
-    void RenderGribLowHigh( GribRecord **pGR, PlugIn_ViewPort *vp );
+    void RenderGribLowHigh( int settings, GribRecord **pGR, PlugIn_ViewPort *vp );
 
     wxString GetRefString( GribRecord *rec, int map );
     void DrawMessageWindow( wxString msg, int x, int y , wxFont *mfont);

--- a/plugins/grib_pi/src/GribSettingsDialog.h
+++ b/plugins/grib_pi/src/GribSettingsDialog.h
@@ -92,6 +92,7 @@ struct GribOverlaySettings
         int m_iNumbersSpacing;
         bool m_bParticles;
         double m_dParticleDensity;
+        bool m_bLowHighLabels;
 
     } Settings[SETTINGS_COUNT];
 };

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -63,7 +63,7 @@ int round (double x) {
 
 WX_DEFINE_OBJARRAY( ArrayOfGribRecordSets );
 
-enum SettingsDisplay {B_ARROWS, ISO_LINE, D_ARROWS, OVERLAY, NUMBERS, PARTICLES};
+enum SettingsDisplay {B_ARROWS, ISO_LINE, D_ARROWS, OVERLAY, NUMBERS, PARTICLES, LOW_HIGH_LABELS};
 
 //    Sort compare function for File Modification Time
 static int CompareFileStringTime( const wxString& first, const wxString& second )
@@ -439,6 +439,7 @@ void GRIBUIDialog::OnMouseEvent( wxMouseEvent& event )
         case GribOverlaySettings::PRESSURE:
             MenuAppend( menu, ISO_LINE, _("Display Isobars"), id );
             MenuAppend( menu, NUMBERS, _("Numbers"), id );
+            MenuAppend( menu, LOW_HIGH_LABELS, _("Low/High Labels"), id );
             break;
         case GribOverlaySettings::AIR_TEMPERATURE:
         case GribOverlaySettings::SEA_TEMPERATURE:
@@ -463,6 +464,7 @@ void GRIBUIDialog::OnMouseEvent( wxMouseEvent& event )
             MenuAppend( menu, OVERLAY, _("OverlayMap"), id );
             MenuAppend( menu, NUMBERS, _("Numbers"), id );
             MenuAppend( menu, PARTICLES, _("Particle Map"), id );
+            break;
     }
 
     PopupMenu( menu );
@@ -489,6 +491,10 @@ void GRIBUIDialog::OnMouseEvent( wxMouseEvent& event )
                 break;
             case PARTICLES:
                 m_OverlaySettings.Settings[id].m_bParticles = it->IsChecked();
+                break;
+            case LOW_HIGH_LABELS:
+                m_OverlaySettings.Settings[id].m_bLowHighLabels = it->IsChecked();
+                break;
         }
         node = node->GetNext();
     }
@@ -535,6 +541,8 @@ void GRIBUIDialog::MenuAppend( wxMenu *menu, int id, wxString label, int setting
         check = m_OverlaySettings.Settings[setting].m_bNumbers;
     else if( id == PARTICLES )
         check = m_OverlaySettings.Settings[setting].m_bParticles;
+    else if( id == LOW_HIGH_LABELS )
+        check = m_OverlaySettings.Settings[setting].m_bLowHighLabels;
     else
         check = false;
     item->Check( check );
@@ -635,7 +643,9 @@ void GRIBUIDialog::ResolveDisplayConflicts( wxWindow *window, int enventId )
                         || (m_OverlaySettings.Settings[enventId].m_bOverlayMap &&
                         m_OverlaySettings.Settings[winId].m_bOverlayMap)
                         || (m_OverlaySettings.Settings[enventId].m_bParticles &&
-                        m_OverlaySettings.Settings[winId].m_bParticles) )
+                        m_OverlaySettings.Settings[winId].m_bParticles)
+                        || (m_OverlaySettings.Settings[enventId].m_bLowHighLabels &&
+                        m_OverlaySettings.Settings[winId].m_bLowHighLabels) )
                     ((wxCheckBox*) win )->SetValue(false);
             }
         }

--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -625,6 +625,9 @@ GribSettingsDialogBase::GribSettingsDialogBase( wxWindow* parent, wxWindowID id,
 	m_sNumbersSpacing = new wxSpinCtrl( m_scrolledSettingsDialog, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 90,-1 ), wxSP_ARROW_KEYS, 30, 100, 50 );
 	fgSizer15->Add( m_sNumbersSpacing, 0, wxALL, 5 );
 	
+    m_cbLowHighLabels = new wxCheckBox( m_scrolledSettingsDialog, wxID_ANY, _("Low/High Labels"), wxDefaultPosition, wxDefaultSize, 0 );
+    fgSizer15->Add( m_cbLowHighLabels, 0, wxBOTTOM|wxTOP, 5 );
+
 	m_cbParticles = new wxCheckBox( m_scrolledSettingsDialog, wxID_ANY, _("Particle Map"), wxDefaultPosition, wxDefaultSize, 0 );
 	fgSizer15->Add( m_cbParticles, 0, wxBOTTOM|wxTOP, 5 );
 	
@@ -634,7 +637,6 @@ GribSettingsDialogBase::GribSettingsDialogBase( wxWindow* parent, wxWindowID id,
 	
 	m_sParticleDensity = new wxSlider( m_scrolledSettingsDialog, wxID_ANY, 5, 1, 10, wxDefaultPosition, wxDefaultSize, wxSL_BOTTOM|wxSL_HORIZONTAL|wxSL_LABELS );
 	fgSizer15->Add( m_sParticleDensity, 0, wxALL|wxEXPAND, 5 );
-	
 	
 	sbSizer5->Add( fgSizer15, 1, wxALL|wxEXPAND, 5 );
 	

--- a/plugins/grib_pi/src/GribUIDialogBase.h
+++ b/plugins/grib_pi/src/GribUIDialogBase.h
@@ -186,6 +186,7 @@ class GribSettingsDialogBase : public wxDialog
 		wxSlider* m_sParticleDensity;
 		wxStaticText* m_staticText24;
 		wxSlider* m_sTransparency;
+		wxCheckBox* m_cbLowHighLabels;
 		
 		// Virtual event handlers, overide them in your derived class
 		virtual void OnIntepolateChange( wxCommandEvent& event ) { event.Skip(); }


### PR DESCRIPTION
This patch adds a feature to the grib_pi plugin along the lines of the feature request 'FS#1375 - Pressure Grib --Put an "L" in the center of a low' posted at FlySpray on Wednesday, 23 April 2014.

The "L"/"H" labels are placed at local minima/maxima of the pressure field, respectively. wx and GL rendering is supported. The functionality is controlled by an appropriate option in the plugin configuration dialog ("Low/High Labels"). Tested under Linux so far, however it is a small change so should be harmless.
