### PR TITLE
Make CheckEdgePan avaialble to plugins

### DIFF
--- a/include/chcanv.h
+++ b/include/chcanv.h
@@ -330,6 +330,8 @@ public:
 
       void OnEvtCompressProgress( OCPN_CompressProgressEvent & event );
       void JaggyCircle(ocpnDC &dc, wxPen pen, int x, int y, int radius);
+      
+      bool CheckEdgePan( int x, int y, bool bdragging, int margin, int delta );
 
       Route       *m_pMouseRoute;
       bool        m_bMeasure_Active;
@@ -440,7 +442,6 @@ private:
       void PanTimerEvent(wxTimerEvent& event);
       void MovementTimerEvent(wxTimerEvent& );
       void MovementStopTimerEvent( wxTimerEvent& );
-      bool CheckEdgePan( int x, int y, bool bdragging, int margin, int delta );
       void OnCursorTrackTimerEvent(wxTimerEvent& event);
 
       void DrawAllRoutesInBBox(ocpnDC& dc, LLBBox& BltBBox, const wxRegion& clipregion);

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -987,6 +987,6 @@ extern "C"  DECL_EXP void GetDoubleCanvasPixLL(PlugIn_ViewPort *vp, wxPoint2DDou
 
 extern DECL_EXP double fromDMM_Plugin( wxString sdms );
 extern DECL_EXP bool CheckEdgePan_PlugIn( int x, int y, bool dragging, int margin, int delta );
-
+extern DECL_EXP wxBitmap GetIcon_PlugIn(const wxString & name);
 
 #endif //_PLUGIN_H_

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -734,10 +734,6 @@ extern "C"  DECL_EXP int RemoveChartFromDBInPlace( wxString &full_path );
 
 //      A flag field that defines the object capabilities passed by a chart to the S52 PLIB
 
-/* API 1.13 */
-/* adds more common functions to avoid unnecessary code duplication */
-extern DECL_EXP bool CheckEdgePan_PlugIn( int x, int y, bool dragging, int margin, int delta );
-
 #define PLIB_CAPS_LINE_VBO              1
 #define PLIB_CAPS_LINE_BUFFER           1 << 1
 #define PLIB_CAPS_SINGLEGEO_BUFFER      1 << 2
@@ -990,6 +986,7 @@ extern "C"  DECL_EXP void GetDoubleCanvasPixLL(PlugIn_ViewPort *vp, wxPoint2DDou
 
 
 extern DECL_EXP double fromDMM_Plugin( wxString sdms );
+extern DECL_EXP bool CheckEdgePan_PlugIn( int x, int y, bool dragging, int margin, int delta );
 
 
 #endif //_PLUGIN_H_

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -734,6 +734,10 @@ extern "C"  DECL_EXP int RemoveChartFromDBInPlace( wxString &full_path );
 
 //      A flag field that defines the object capabilities passed by a chart to the S52 PLIB
 
+/* API 1.13 */
+/* adds more common functions to avoid unnecessary code duplication */
+extern DECL_EXP bool CheckEdgePan_PlugIn( int x, int y, bool dragging, int margin, int delta );
+
 #define PLIB_CAPS_LINE_VBO              1
 #define PLIB_CAPS_LINE_BUFFER           1 << 1
 #define PLIB_CAPS_SINGLEGEO_BUFFER      1 << 2

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -4430,3 +4430,7 @@ double fromDMM_Plugin( wxString sdms )
     return fromDMM( sdms );
 }
 
+bool CheckEdgePan_PlugIn( int x, int y, bool dragging, int margin, int delta )
+{
+    return cc1->CheckEdgePan( x, y, dragging, margin, delta );
+}

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -4434,3 +4434,10 @@ bool CheckEdgePan_PlugIn( int x, int y, bool dragging, int margin, int delta )
 {
     return cc1->CheckEdgePan( x, y, dragging, margin, delta );
 }
+
+wxBitmap GetIcon_PlugIn(const wxString & name)
+{
+    ocpnStyle::Style* style = g_StyleManager->GetCurrentStyle();
+    return style->GetIcon( name );
+}
+


### PR DESCRIPTION
This change is to allow scrolling when creating a boundary. It moves the CheckEdgePan from private to public in the chcanv class and provides an external CheckEdgePan_PlugIn API call.