### PR TITLE
Transparent toolbar opengl

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -61,6 +61,10 @@
 #include <setjmp.h>
 #endif
 
+#ifdef __WXGTK__
+#include <X11/Xatom.h>
+#endif
+
 #include "chart1.h"
 #include "chcanv.h"
 #include "chartdb.h"
@@ -287,6 +291,7 @@ bool                      g_bPlayShipsBells;
 bool                      g_bFullscreenToolbar;
 bool                      g_bShowLayers;
 bool                      g_bTransparentToolbar;
+bool                      g_bTransparentToolbarInOpenGLOK;
 int                       g_nAutoHideToolbar;
 bool                      g_bAutoHideToolbar;
 
@@ -1094,6 +1099,42 @@ void LoadS57()
 }
 #endif
 
+#ifdef __WXGTK__
+static char *get_X11_property (Display *disp, Window win,
+                            Atom xa_prop_type, gchar *prop_name) {
+    Atom xa_prop_name;
+    Atom xa_ret_type;
+    int ret_format;
+    unsigned long ret_nitems;
+    unsigned long ret_bytes_after;
+    unsigned long tmp_size;
+    unsigned char *ret_prop;
+    char *ret;
+
+    xa_prop_name = XInternAtom(disp, prop_name, False);
+
+    if (XGetWindowProperty(disp, win, xa_prop_name, 0, 1024, False,
+                           xa_prop_type, &xa_ret_type, &ret_format,
+                           &ret_nitems, &ret_bytes_after, &ret_prop) != Success) {
+        return NULL;
+    }
+
+    if (xa_ret_type != xa_prop_type) {
+        XFree(ret_prop);
+        return NULL;
+    }
+
+    /* null terminate the result to make string handling easier */
+    tmp_size = (ret_format / 8) * ret_nitems;
+    ret = (char*)malloc(tmp_size + 1);
+    memcpy(ret, ret_prop, tmp_size);
+    ret[tmp_size] = '\0';
+
+    XFree(ret_prop);
+    return ret;
+}
+#endif
+
 bool MyApp::OnInit()
 {
     wxStopWatch sw;
@@ -1469,6 +1510,34 @@ bool MyApp::OnInit()
 
 #else
     g_bdisable_opengl = true;;
+#endif
+
+    // Determine if a transparent toolbar is possible under linux with opengl
+#ifdef __WXGTK__
+    g_bTransparentToolbarInOpenGLOK = false;
+    if(!g_bdisable_opengl) {
+        Display *disp = XOpenDisplay(NULL);
+        Window *sup_window;
+        if ((sup_window = (Window *)get_X11_property(disp, DefaultRootWindow(disp),
+                                                 XA_WINDOW, "_NET_SUPPORTING_WM_CHECK")) ||
+            (sup_window = (Window *)get_X11_property(disp, DefaultRootWindow(disp),
+                                                 XA_CARDINAL, "_WIN_SUPPORTING_WM_CHECK"))) {
+            /* WM_NAME */
+            char *wm_name;
+            if ((wm_name = get_X11_property(disp, *sup_window,
+                                        XInternAtom(disp, "UTF8_STRING", False), "_NET_WM_NAME")) ||
+                (wm_name = get_X11_property(disp, *sup_window,
+                                        XA_STRING, "_NET_WM_NAME"))) {
+                // we know it works in xfce4, add other checks as we can validate them
+                if(strstr(wm_name, "Xfwm4"))
+                    g_bTransparentToolbarInOpenGLOK = true;
+
+                free(wm_name);
+            }
+            free(sup_window);
+        }
+        XCloseDisplay(disp);
+    }
 #endif
 
 // Set default color scheme

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1991,7 +1991,7 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
     pTransparentToolbar = new wxCheckBox( m_ChartDisplayPage, ID_TRANSTOOLBARCHECKBOX,
                                           _("Enable Transparent Toolbar") );
     itemBoxSizerUI->Add( pTransparentToolbar, 0, wxALL, border_size );
-    if( g_bopengl ) pTransparentToolbar->Disable();
+//    if( g_bopengl ) pTransparentToolbar->Disable();
     
     
 
@@ -3529,7 +3529,7 @@ void options::OnWaypointRangeRingSelect( wxCommandEvent& event )
 
 void options::OnGLClicked( wxCommandEvent& event )
 {
-    pTransparentToolbar->Enable(!pOpenGL->GetValue());
+//    pTransparentToolbar->Enable(!pOpenGL->GetValue());
 }
 
 void options::OnOpenGLOptions( wxCommandEvent& event )

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -152,6 +152,7 @@ extern bool             g_bPreserveScaleOnX;
 extern bool             g_bPlayShipsBells;
 extern bool             g_bFullscreenToolbar;
 extern bool             g_bTransparentToolbar;
+extern bool             g_bTransparentToolbarInOpenGLOK;
 
 extern int              g_OwnShipIconType;
 extern double           g_n_ownship_length_meters;
@@ -1991,11 +1992,7 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
     pTransparentToolbar = new wxCheckBox( m_ChartDisplayPage, ID_TRANSTOOLBARCHECKBOX,
                                           _("Enable Transparent Toolbar") );
     itemBoxSizerUI->Add( pTransparentToolbar, 0, wxALL, border_size );
-//    if( g_bopengl ) pTransparentToolbar->Disable();
-    
-    
-
-
+    if( g_bopengl && !g_bTransparentToolbarInOpenGLOK ) pTransparentToolbar->Disable();
 }
 
 
@@ -3529,7 +3526,8 @@ void options::OnWaypointRangeRingSelect( wxCommandEvent& event )
 
 void options::OnGLClicked( wxCommandEvent& event )
 {
-//    pTransparentToolbar->Enable(!pOpenGL->GetValue());
+    if(!g_bTransparentToolbarInOpenGLOK)
+        pTransparentToolbar->Enable(!pOpenGL->GetValue());
 }
 
 void options::OnOpenGLOptions( wxCommandEvent& event )

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -570,7 +570,6 @@ void ocpnFloatingToolbarDialog::FadeTimerEvent( wxTimerEvent& event )
         SubmergeToGrabber();
         m_fade_timer.Stop();
     }
-    
 }
 
 void ocpnFloatingToolbarDialog::DoFade( int value )

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -41,6 +41,7 @@
 
 extern ocpnFloatingToolbarDialog* g_FloatingToolbarDialog;
 extern bool                       g_bTransparentToolbar;
+extern bool                       g_bTransparentToolbarInOpenGLOK;
 extern ChartCanvas*               cc1;
 extern bool                       g_bopengl;
 extern ocpnToolBarSimple*         g_toolbar;
@@ -561,7 +562,7 @@ void ocpnFloatingToolbarDialog::MouseEvent( wxMouseEvent& event )
 
 void ocpnFloatingToolbarDialog::FadeTimerEvent( wxTimerEvent& event )
 {
-    if( g_bTransparentToolbar && !g_bopengl ){
+    if( g_bTransparentToolbar && (!g_bopengl || g_bTransparentToolbarInOpenGLOK) ){
         DoFade( 128 );
         m_fade_timer.Start( 5000 );           // retrigger the continuous timer
     }


### PR DESCRIPTION
enable the transparent toolbar for xfce4 window manager.. hopefully some developers can test this on other window managers enable support.

Eventually we should just render the toolbar using opengl and it will work everywhere on all operating systems