### PR TITLE
use char instead of gchar

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -1104,7 +1104,7 @@ void LoadS57()
 
 #ifdef __WXGTK__
 static char *get_X11_property (Display *disp, Window win,
-                            Atom xa_prop_type, gchar *prop_name) {
+                            Atom xa_prop_type, char *prop_name) {
     Atom xa_prop_name;
     Atom xa_ret_type;
     int ret_format;


### PR DESCRIPTION
gchar is `typedef char   gchar;` /usr/include/glib-2.0/glib/gtypes.h, but gtypes.h is not used and this also is currently the only gchar in the source code.  So instead simply use a plain char.