### PR TITLE
Avoid mis-use of pointer

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -4275,6 +4275,7 @@ bool MyFrame::ToggleLights( bool doToggle, bool temporary )
                 oldstate = pOLE->nViz != 0;
                 break;
             }
+	    pOLE = NULL;
         }
     }
 
@@ -4349,6 +4350,7 @@ void MyFrame::ToggleAnchor( void )
                     old_vis = pOLE->nViz;
                     break;
                 }
+		pOLE = NULL;
             }
         }
         else if(OTHER == ps52plib->GetDisplayCategory())


### PR DESCRIPTION
`pOLE` is set in the loop, but then tested outside of the loop.  This works of the loop terminates early because then `pOLE` really points to the correct entry.  However, if the list does not contain an entry with the required name, pOLE simply points to the last element of the list.

Solution is to simply reset pOLE to null inside the list.