### PR TITLE
memory/db cache leak and uninitalised value

### DIFF
--- a/src/Route.cpp
+++ b/src/Route.cpp
@@ -479,6 +479,7 @@ void Route::DrawGLLines( ViewPort &VP, ocpnDC *dc )
             bool lat1r = prp1->m_lat > bbox.GetMaxY(), lat2r = prp2->m_lat > bbox.GetMaxY();
             if( (lat1l && lat2l) || (lat1r && lat2r) ) {
                 r1valid = false;
+                prp1->m_pos_on_screen = false;
                 continue;
             }
 
@@ -487,6 +488,7 @@ void Route::DrawGLLines( ViewPort &VP, ocpnDC *dc )
             TestLongitude(prp2->m_lon, bbox.GetMinX(), bbox.GetMaxX(), lon2l, lon2r);
             if( (lon1l && lon2l) || (lon1r && lon2r) ) {
                 r1valid = false;
+                prp1->m_pos_on_screen = false;
                 continue;
             }
 

--- a/src/chartdb.cpp
+++ b/src/chartdb.cpp
@@ -345,6 +345,7 @@ void ChartDB::PurgeCacheUnusedCharts( double factor)
 
                                 //remove the cache entry
                         pChartCache->Remove(pce);
+                        delete pce;
 
                     }
                     
@@ -1114,6 +1115,7 @@ ChartBase *ChartDB::OpenChartUsingCache(int dbindex, ChartInitFlag init_flag)
                                 
                                 //remove the cache entry
                             pChartCache->Remove(pce);
+                            delete pce;
                             
                             GetMemoryStatus(&mem_total, &mem_used);
     
@@ -1158,6 +1160,7 @@ ChartBase *ChartDB::OpenChartUsingCache(int dbindex, ChartInitFlag init_flag)
                                     
                                     //remove the cache entry
                                     pChartCache->Remove(pce);
+                                    delete pce;
                                     
                                     if(nCache <= (unsigned int)g_nCacheLimit)
                                         break;
@@ -1410,7 +1413,8 @@ bool ChartDB::DeleteCacheChart(ChartBase *pDeleteCandidate)
 
                         //remove the cache entry
                   pChartCache->Remove(pce);
-
+                  delete pce;
+                  
                   if(pthumbwin)
                   {
                         if(pthumbwin->pThumbChart == pDeleteCandidate)

--- a/src/chartdb.cpp
+++ b/src/chartdb.cpp
@@ -982,7 +982,7 @@ CacheEntry *ChartDB::FindOldestDeleteCandidate( bool blog)
                 CacheEntry *pce = (CacheEntry *)(pChartCache->Item(i));
                 if((ChartBase *)(pce->pChart) != Current_Ch)
                 {
-                    if(pce->RecentTime < LRUTime)
+                    if(pce->RecentTime < LRUTime && !pce->n_lock)
                     {
                         LRUTime = pce->RecentTime;
                         iOldest = i;

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -1062,8 +1062,10 @@ ChartCanvas::~ChartCanvas()
 
     delete undo;
 #ifdef ocpnUSE_GL
-    if( !g_bdisable_opengl )
+    if( !g_bdisable_opengl ) {
         delete m_glcc;
+        delete m_pGLcontext;
+    }
 #endif
 
 }

--- a/src/cm93.cpp
+++ b/src/cm93.cpp
@@ -1948,7 +1948,6 @@ cm93chart::~cm93chart()
 
       free ( m_pDrawBuffer );
 
-      free ( m_this_chart_context );
 }
 
 void  cm93chart::Unload_CM93_Cell ( void )

--- a/src/cm93.cpp
+++ b/src/cm93.cpp
@@ -3301,6 +3301,7 @@ S57Obj *cm93chart::CreateS57Obj ( int cell_index, int iobject, int subcell, Obje
             wxString msg;
             msg.Printf ( _T ( "   CM93 Error...object type %d not found in CM93OBJ.DIC" ), iclass );
             wxLogMessage ( msg );
+            delete xgeom;
             return NULL;
       }
 
@@ -4017,13 +4018,7 @@ S57Obj *cm93chart::CreateS57Obj ( int cell_index, int iobject, int subcell, Obje
       //      Build/Maintain a list of found OBJL types for later use
       //      And back-reference the appropriate list index in S57Obj for Display Filtering
 
-
-      if ( pobj )
-      {
-            pobj->iOBJL = -1; // deferred, done by OBJL filtering in the PLIB as needed
-      }
-
-
+      pobj->iOBJL = -1; // deferred, done by OBJL filtering in the PLIB as needed
 
       // Everything in Xgeom that is needed later has been given to the object
       // So, the xgeom object can be deleted

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -1043,6 +1043,7 @@ s57chart::s57chart()
     m_next_safe_cnt = 1e6;
     m_LineVBO_name = -1;
     m_line_vertex_buffer = 0;
+    m_this_chart_context =  0;
 }
 
 s57chart::~s57chart()
@@ -1099,7 +1100,7 @@ s57chart::~s57chart()
     if(s_glDeleteBuffers && (m_LineVBO_name > 0))
         s_glDeleteBuffers(1, (GLuint *)&m_LineVBO_name);
 #endif
-    
+    free (m_this_chart_context);    
 }
 
 void s57chart::GetValidCanvasRegion( const ViewPort& VPoint, OCPNRegion *pValidRegion )

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -201,7 +201,17 @@ S57Obj::~S57Obj()
         }
         free( att_array );
 
-        if( pPolyTessGeo ) delete pPolyTessGeo;
+        if( pPolyTessGeo ) {
+#ifdef ocpnUSE_GL 
+            bool b_useVBO = g_b_EnableVBO  && !auxParm1;    // VBO allowed?
+
+            PolyTriGroup *ppg_vbo = pPolyTessGeo->Get_PolyTriGroup_head();
+            if (b_useVBO && ppg_vbo && auxParm0 > 0 && ppg_vbo->single_buffer && s_glDeleteBuffers) {
+                s_glDeleteBuffers(1, (GLuint *)&auxParm0);
+            }
+#endif
+            delete pPolyTessGeo;
+        }
 
         if( pPolyTrapGeo ) delete pPolyTrapGeo;
 


### PR DESCRIPTION
Hi,

valgrind again...

For pPolyTessGeo is not a full fix as opencpn is still unable to display zoom out Zeeland ENCs in quilt mode for me on linux, too many VBO ID allocated, have to use some kind of pool.

Regards
Didier