### PR TITLE
use Buffered io for cache and raster charts

### DIFF
--- a/include/chartimg.h
+++ b/include/chartimg.h
@@ -79,7 +79,7 @@ class ViewPort;
 class PixelCache;
 class ocpnBitmap;
 
-class wxFileInputStream;
+class wxFFileInputStream;
 
 //-----------------------------------------------------------------------------
 //    Helper classes
@@ -216,7 +216,7 @@ protected:
 
 
       virtual int BSBScanScanline(wxInputStream *pinStream);
-      virtual int ReadBSBHdrLine( wxFileInputStream*, char *, int );
+      virtual int ReadBSBHdrLine( wxFFileInputStream*, char *, int );
       virtual int AnalyzeRefpoints(void);
       virtual bool AnalyzeSkew(void);
       
@@ -268,8 +268,8 @@ protected:
 
       CachedLine  *pLineCache;
 
-      wxFileInputStream     *ifs_hdr;
-      wxFileInputStream     *ifss_bitmap;
+      wxFFileInputStream    *ifs_hdr;
+      wxFFileInputStream    *ifss_bitmap;
       wxBufferedInputStream *ifs_bitmap;
 
       wxString          *pBitmapFilePath;

--- a/include/glTexCache.h
+++ b/include/glTexCache.h
@@ -26,7 +26,7 @@
 #define __GLTEXTCACHE_H__
 
 #include <wx/glcanvas.h>
-#include <wx/file.h>
+#include <wx/ffile.h>
 #include <wx/timer.h>
 #include <stdint.h>
 
@@ -123,7 +123,7 @@ private:
     int         m_catalog_offset;
     bool        m_hdrOK;
     bool        m_catalogOK;
-    wxFile      *m_fs;
+    wxFFile     *m_fs;
     uint32_t    m_chart_date_binary;
     
     int         m_stride;

--- a/src/chartdbs.cpp
+++ b/src/chartdbs.cpp
@@ -978,7 +978,7 @@ bool ChartDatabase::Read(const wxString &filePath)
 
     m_DBFileName = filePath;
 
-    wxFileInputStream ifs(filePath);
+    wxFFileInputStream ifs(filePath);
     if(!ifs.Ok()) return false;
 
     ChartTableHeader cth;
@@ -1044,7 +1044,7 @@ bool ChartDatabase::Write(const wxString &filePath)
 
     if (!dir.DirExists() && !dir.Mkdir()) return false;
 
-    wxFileOutputStream ofs(filePath);
+    wxFFileOutputStream ofs(filePath);
     if(!ofs.Ok()) return false;
 
     ChartTableHeader cth(m_chartDirs.GetCount(), active_chartTable.GetCount());

--- a/src/chartimg.cpp
+++ b/src/chartimg.cpp
@@ -332,7 +332,7 @@ InitReturn ChartGEO::Init( const wxString& name, ChartInitFlag init_flags)
 
       char buffer[BUF_LEN_MAX];
 
-      ifs_hdr = new wxFileInputStream(name);          // open the file as a read-only stream
+      ifs_hdr = new wxFFileInputStream(name);          // open the file as a read-only stream
 
       m_filesize = wxFileName::GetSize( name );
       
@@ -556,7 +556,7 @@ InitReturn ChartGEO::Init( const wxString& name, ChartInitFlag init_flags)
       wxFileName NOS_filename(*pBitmapFilePath);
       if(NOS_filename.FileExists())
       {
-            ifss_bitmap = new wxFileInputStream(*pBitmapFilePath); // open the bitmap file
+            ifss_bitmap = new wxFFileInputStream(*pBitmapFilePath); // open the bitmap file
             ifs_bitmap = new wxBufferedInputStream(*ifss_bitmap);
       }
 //    File as fetched verbatim from the .geo file doesn't exist.
@@ -631,7 +631,7 @@ found_uclc_file:
 
             delete pBitmapFilePath;                   // fix up the member element
             pBitmapFilePath = new wxString(NOS_filename.GetFullPath());
-            ifss_bitmap = new wxFileInputStream(*pBitmapFilePath); // open the bitmap file
+            ifss_bitmap = new wxFFileInputStream(*pBitmapFilePath); // open the bitmap file
             ifs_bitmap = new wxBufferedInputStream(*ifss_bitmap);
 
       }           //else
@@ -825,7 +825,7 @@ InitReturn ChartKAP::Init( const wxString& name, ChartInitFlag init_flags )
 
       char buffer[BUF_LEN_MAX];
 
-      ifs_hdr = new wxFileInputStream(name);          // open the Header file as a read-only stream
+      ifs_hdr = new wxFFileInputStream(name);          // open the Header file as a read-only stream
 
       m_filesize = wxFileName::GetSize( name );
       
@@ -838,7 +838,7 @@ InitReturn ChartKAP::Init( const wxString& name, ChartInitFlag init_flags )
       m_FullPath = name;
       m_Description = m_FullPath;
 
-      ifss_bitmap = new wxFileInputStream(name); // Open again, as the bitmap
+      ifss_bitmap = new wxFFileInputStream(name); // Open again, as the bitmap
       ifs_bitmap = new wxBufferedInputStream(*ifss_bitmap);
 
       //    Clear georeferencing coefficients
@@ -4020,7 +4020,7 @@ bool ChartBaseBSB::GetChartBits(wxRect& source, unsigned char *pPix, int sub_sam
 //    Read and return count of a line of BSB header file
 //-----------------------------------------------------------------------------------------------
 
-int ChartBaseBSB::ReadBSBHdrLine(wxFileInputStream* ifs, char* buf, int buf_len_max)
+int ChartBaseBSB::ReadBSBHdrLine(wxFFileInputStream* ifs, char* buf, int buf_len_max)
 
 {
       char  read_char;

--- a/src/glTexCache.cpp
+++ b/src/glTexCache.cpp
@@ -1020,6 +1020,7 @@ glTexFactory::~glTexFactory()
     if(m_fs && m_fs->IsOpened()){
         m_fs->Close();
     }
+    delete m_fs;
 
     WX_CLEAR_ARRAY (m_catalog); 	 
 
@@ -1788,7 +1789,7 @@ bool glTexFactory::LoadHeader(void)
 
         if(wxFileName::FileExists(m_CompressedCacheFilePath)) {
             
-            m_fs = new wxFile(m_CompressedCacheFilePath, wxFile::read_write);
+            m_fs = new wxFFile(m_CompressedCacheFilePath, _T("rb+"));
             if(m_fs->IsOpened()){
             
                 CompressedCacheHeader hdr;
@@ -1806,14 +1807,14 @@ bool glTexFactory::LoadHeader(void)
                         m_fs->Close();
                         delete m_fs;
                     
-                        m_fs = new wxFile(m_CompressedCacheFilePath, wxFile::write);
+                        m_fs = new wxFFile(m_CompressedCacheFilePath, _T("wb"));
                         n_catalog_entries = 0;
                         m_catalog_offset = 0;
                         WriteCatalogAndHeader();
                         m_fs->Close();
                         delete m_fs;
                     
-                        m_fs = new wxFile(m_CompressedCacheFilePath, wxFile::read_write);
+                        m_fs = new wxFFile(m_CompressedCacheFilePath, _T("rb+"));
                     
                         m_hdrOK = true;
                     }
@@ -1837,14 +1838,14 @@ bool glTexFactory::LoadHeader(void)
                 delete m_fs;
                 wxRemoveFile(m_CompressedCacheFilePath);
                 
-                m_fs = new wxFile(m_CompressedCacheFilePath, wxFile::write);
+                m_fs = new wxFFile(m_CompressedCacheFilePath, _T("wb"));
                 n_catalog_entries = 0;
                 m_catalog_offset = 0;
                 WriteCatalogAndHeader();
                 m_fs->Close();
                 delete m_fs;
                 
-                m_fs = new wxFile(m_CompressedCacheFilePath, wxFile::read_write);
+                m_fs = new wxFFile(m_CompressedCacheFilePath, _T("rb+"));
                 
                 m_hdrOK = true;
                 ret = true;
@@ -1860,14 +1861,14 @@ bool glTexFactory::LoadHeader(void)
                 fn.Mkdir();
             
             //  Create new file, with empty catalog, and correct header
-            m_fs = new wxFile(m_CompressedCacheFilePath, wxFile::write);
+            m_fs = new wxFFile(m_CompressedCacheFilePath, _T("wb"));
             n_catalog_entries = 0;
             m_catalog_offset = 0;
             WriteCatalogAndHeader();
             m_fs->Close();
             delete m_fs;
-            
-            m_fs = new wxFile(m_CompressedCacheFilePath, wxFile::read_write);
+
+            m_fs = new wxFFile(m_CompressedCacheFilePath, _T("rb+"));
             ret = true;
             
         }
@@ -1974,11 +1975,11 @@ bool glTexFactory::UpdateCache(unsigned char *data, int data_size, glTextureDesc
                 fn.Mkdir();
             
             if(!fn.FileExists()){
-                wxFile new_file(m_CompressedCacheFilePath, wxFile::write);
+                wxFFile new_file(m_CompressedCacheFilePath, _T("wb"));
                 new_file.Close();
             }
             
-            m_fs = new wxFile(m_CompressedCacheFilePath, wxFile::read_write);
+            m_fs = new wxFFile(m_CompressedCacheFilePath, _T("rb+"));
             
             WriteCatalogAndHeader();
         }
@@ -2045,11 +2046,11 @@ bool glTexFactory::UpdateCachePrecomp(unsigned char *data, int data_size, glText
                 fn.Mkdir();
             
             if(!fn.FileExists()){
-                wxFile new_file(m_CompressedCacheFilePath, wxFile::write);
+                wxFFile new_file(m_CompressedCacheFilePath, _T("wb"));
                 new_file.Close();
             }
             
-            m_fs = new wxFile(m_CompressedCacheFilePath, wxFile::read_write);
+            m_fs = new wxFFile(m_CompressedCacheFilePath, _T("rwb"));
             
             WriteCatalogAndHeader();
         }


### PR DESCRIPTION
Hi,

replace wxFile... with wxFFile...

- It speeds up a little ocpn start and chart rendering.

- It speeds up a lot, at least for me on linux, opengl cache building:
nearly twice as fast on a 2 cores cpu when the cache is on a normal partition.

5 time faster when files and the cache are stored on an encrypted partition.

Regards
Didier