### PR TITLE
Enhance the plugin API to allow chart DB manipulation

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -995,5 +995,7 @@ extern DECL_EXP wxBitmap GetIcon_PlugIn(const wxString & name);
 extern DECL_EXP void SetCanvasRotation(double rotation);
 extern DECL_EXP bool GetSingleWaypoint( wxString &GUID, PlugIn_Waypoint *pwaypoint );
 extern DECL_EXP bool PlugInPlaySoundEx( wxString &sound_file, int deviceIndex=-1 );
+extern DECL_EXP void AddChartDirectory( wxString &path );
+extern DECL_EXP void ForceChartDBUpdate();
 
 #endif //_PLUGIN_H_

--- a/include/options.h
+++ b/include/options.h
@@ -251,6 +251,8 @@ public:
         return m_pWorkDirList;
     }
 
+    void AddChartDir( wxString &dir );
+    
     void UpdateDisplayedChartDirList(ArrayOfCDI p);
 
     void UpdateOptionsUnits();

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -2303,6 +2303,7 @@ MyFrame::MyFrame( wxFrame *frame, const wxString& title, const wxPoint& pos, con
     
     m_pMenuBar = NULL;
     g_toolbar = NULL;
+    g_options = NULL;
     m_toolbar_scale_tools_shown = false;
     piano_ctx_menu = NULL;
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3731,7 +3731,6 @@ void options::OnCharHook( wxKeyEvent& event ) {
 void options::OnButtonaddClick( wxCommandEvent& event )
 {
     wxString selDir;
-    wxFileName dirname;
     wxDirDialog *dirSelector = new wxDirDialog( this, _("Add a directory containing chart files"),
             *pInit_Chart_Dir, wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST );
 
@@ -3745,27 +3744,33 @@ void options::OnButtonaddClick( wxCommandEvent& event )
         goto done;
 
     selDir = dirSelector->GetPath();
-    dirname = wxFileName( selDir );
 
-    pInit_Chart_Dir->Empty();
-    if( !g_bportable )
-        pInit_Chart_Dir->Append( dirname.GetPath() );
-
-    if( g_bportable ) {
-        wxFileName f( selDir );
-        f.MakeRelativeTo( g_Platform->GetHomeDir() );
-        pActiveChartsList->Append( f.GetFullPath() );
-    } else
-        pActiveChartsList->Append( selDir );
-
-    k_charts |= CHANGE_CHARTS;
-
-    pScanCheckBox->Disable();
+    AddChartDir( selDir );
 
     done:
 
     delete dirSelector;
     event.Skip();
+}
+
+void options::AddChartDir( wxString &dir )
+{
+    wxFileName dirname = wxFileName( dir );
+    
+    pInit_Chart_Dir->Empty();
+    if( !g_bportable )
+        pInit_Chart_Dir->Append( dirname.GetPath() );
+
+    if( g_bportable ) {
+        wxFileName f( dir );
+        f.MakeRelativeTo( g_Platform->GetHomeDir() );
+        pActiveChartsList->Append( f.GetFullPath() );
+    } else
+        pActiveChartsList->Append( dir );
+
+    k_charts |= CHANGE_CHARTS;
+
+    pScanCheckBox->Disable();
 }
 
 void options::UpdateDisplayedChartDirList(ArrayOfCDI p)

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -4601,3 +4601,18 @@ wxBitmap GetIcon_PlugIn(const wxString & name)
     return style->GetIcon( name );
 }
 
+void AddChartDirectory( wxString &path )
+{
+    if( g_options )
+    {
+        g_options->AddChartDir( path );
+    }
+}
+
+void ForceChartDBUpdate()
+{
+    if( g_options )
+    {
+        g_options->pScanCheckBox->SetValue(true);
+    }
+}


### PR DESCRIPTION
The chart downloader plugin will be able to directly add chart dirs and triger DB updates uppon chart downloads.
For the purposes of the chart downloader we can rely on the toolbox being shown. If we would like to allow the DB manipulations even for plugins not integrating into the toolbox, we would have to implement the codepath for g_options == NULL