### PR TITLE
add missing colors used before chartsymbols is loaded

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -9826,6 +9826,16 @@ static const char *usercolors[] = { "Table:DAY", "GREEN1;120;255;120;", "GREEN2;
         "DILG2; 255;255;255;",              // Control Background
         "DILG3;   0;  0;  0;",              // Text
         "UITX1;   0;  0;  0;",              // Menu Text, derived from UINFF
+
+        "CHGRF; 163; 180; 183;",
+        "UINFM; 197;  69; 195;",
+        "UINFG; 104; 228;  86;",
+        "UINFF; 125; 137; 140;",
+        "UINFR; 241;  84; 105;",
+        "SHIPS;   7;   7;   7;",
+        "CHYLW; 244; 218;  72;",
+        "CHWHT; 212; 234; 238;",
+
         "UDKRD; 124; 16;  0;",
         "UARTE; 200;  0;  0;",              // Active Route, Grey on Dusk/Night
 
@@ -9856,6 +9866,16 @@ static const char *usercolors[] = { "Table:DAY", "GREEN1;120;255;120;", "GREEN2;
         "GREY1; 100;100;100;", "GREY2; 128;128;128;", "RED1;  150;100;100;", "UBLCK;   0;  0;  0;",
         "UWHIT; 255;255;255;", "URED;  120; 54; 11;", "UGREN;  35;110; 20;", "YELO1; 120;115; 24;",
         "YELO2;  64; 40;  0;", "TEAL1;   0; 64; 64;", "GREEN5; 85;128; 0;",
+
+        "CHGRF;  41; 46; 46;",
+        "UINFM;  58; 20; 57;",
+        "UINFG;  35; 76; 29;",
+        "UINFF;  41; 46; 46;",
+        "UINFR;  80; 28; 35;",
+        "SHIPS;  71; 78; 79;",
+        "CHYLW;  81; 73; 24;",
+        "CHWHT;  71; 78; 79;",
+
         "DILG0; 110;110;110;",              // Dialog Background
         "DILG1; 110;110;110;",              // Dialog Background
         "DILG2;   0;  0;  0;",              // Control Background
@@ -9898,6 +9918,15 @@ static const char *usercolors[] = { "Table:DAY", "GREEN1;120;255;120;", "GREEN2;
         "UITX1;  31; 34; 35;",              // Menu Text, derived from UINFF
         "UDKRD;  50;  0;  0;",
         "UARTE;  64; 64; 64;",              // Active Route, Grey on Dusk/Night
+
+        "CHGRF;  16; 18; 18;",
+        "UINFM;  52; 18; 52;",
+        "UINFG;  22; 24;  7;",
+        "UINFF;  31; 34; 35;",
+        "UINFR;  59; 17; 10;",
+        "SHIPS;  37; 41; 41;",
+        "CHYLW;  31; 33; 10;",
+        "CHWHT;  37; 41; 41;",
 
         "NODTA;   7;   7;   7;",
         "CHBLK;  31;  34;  35;",


### PR DESCRIPTION
Hi,
Most of them are used by AIS and I haven't tested it very well.

There's still two missing colors:
CHDRD in chcanv.cpp with no definition in chartsymbols
UBLK in ais.cpp, typo for UBLCK?

regards
Didier

