### PR TITLE
reset rollover on piano or color scheme change

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -2516,7 +2516,17 @@ void MyFrame::SetAndApplyColorScheme( ColorScheme cs )
 
     if( ChartData ) ChartData->ApplyColorSchemeToCachedCharts( cs );
 
-    if( stats ) stats->SetColorScheme( cs );
+    if( stats ) {
+        // reset rollover, updating it is unreliable; too many
+        // wx versions, native toolkits and so on.
+        SetChartThumbnail( -1 );
+        if ( cc1 ) {
+            cc1->HideChartInfoWindow();
+            cc1->SetQuiltChartHiLiteIndex( -1 );
+        }
+        stats->pPiano->ResetRollover();
+        stats->SetColorScheme( cs );
+    }
 
     if( console ) console->SetColorScheme( cs );
 
@@ -7007,8 +7017,13 @@ void MyFrame::UpdateControlBar( void )
     stats->FormatStat();
     
     wxString new_hash = stats->pPiano->GenerateAndStoreNewHash();
-    if(new_hash != old_hash)
+    if(new_hash != old_hash) {
+        SetChartThumbnail( -1 );
+        cc1->HideChartInfoWindow();
+        stats->pPiano->ResetRollover();
+        cc1->SetQuiltChartHiLiteIndex( -1 );
         stats->Refresh( false );
+    }
 
 }
 

--- a/src/statwin.cpp
+++ b/src/statwin.cpp
@@ -642,10 +642,7 @@ void PianoWin::MouseEvent( wxMouseEvent& event )
         if( event.ButtonUp() ) {
             gFrame->HandlePianoRollover( -1, -1 );
             gFrame->HandlePianoRolloverIcon( -1, -1 );
-
-            m_index_last = -1;
-            m_hover_icon_last = -1;
-            m_hover_last = -1;
+            ResetRollover();
         }
 
 
@@ -676,10 +673,7 @@ void PianoWin::MouseEvent( wxMouseEvent& event )
         if( event.Leaving() ) {
             gFrame->HandlePianoRollover( -1, -1 );
             gFrame->HandlePianoRolloverIcon( -1, -1 );
-
-            m_index_last = -1;
-            m_hover_icon_last = -1;
-            m_hover_last = -1;
+            ResetRollover();
         }
     }
 


### PR DESCRIPTION
Hi,
Hide the chart info window, thumbnail and quilt highlight on:
- piano change, there's no guarantee that the chart under the mouse pointer hasn't changed. 
It could be smarter though.

- on color scheme change, the chart info text color was wrong and the thumbnail was replaced by a white rectangle. I tried to update them but gave up it works with wx3 but with 2.8 the main canvas wasn't updated until the mouse leaves the piano.

Regards
Didier
