### PR TITLE
Setcursor

### DIFF
--- a/include/chcanv.h
+++ b/include/chcanv.h
@@ -306,6 +306,7 @@ public:
       wxCursor    *pCursorPencil;
       wxCursor    *pCursorArrow;
       wxCursor    *pCursorCross;
+      wxCursor    *pPlugIn_Cursor;
       TCWin       *pCwin;
       wxBitmap    *pscratch_bm;
       double      m_cursor_lon, m_cursor_lat;

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -990,7 +990,7 @@ extern DECL_EXP void SetCanvasRotation(double rotation);
 extern DECL_EXP bool GetSingleWaypoint( wxString &GUID, PlugIn_Waypoint *pwaypoint );
 extern DECL_EXP bool CheckEdgePan_PlugIn( int x, int y, bool dragging, int margin, int delta );
 extern DECL_EXP wxBitmap GetIcon_PlugIn(const wxString & name);
-extern DECL_EXP void SetCursor_PlugIn( wxCursor *pPlugin_Cursor );
+extern DECL_EXP void SetCursor_PlugIn( wxCursor *pPlugin_Cursor = NULL );
 
 /* API 1.13 */
 extern DECL_EXP void SetCanvasRotation(double rotation);

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -990,6 +990,7 @@ extern DECL_EXP void SetCanvasRotation(double rotation);
 extern DECL_EXP bool GetSingleWaypoint( wxString &GUID, PlugIn_Waypoint *pwaypoint );
 extern DECL_EXP bool CheckEdgePan_PlugIn( int x, int y, bool dragging, int margin, int delta );
 extern DECL_EXP wxBitmap GetIcon_PlugIn(const wxString & name);
+extern DECL_EXP void SetCursor_PlugIn( wxCursor *pPlugin_Cursor );
 
 /* API 1.13 */
 extern DECL_EXP void SetCanvasRotation(double rotation);

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -712,6 +712,7 @@ ChartCanvas::ChartCanvas ( wxFrame *frame ) :
 
 #endif      // MSW, X11
     pCursorArrow = new wxCursor( wxCURSOR_ARROW );
+    pPlugIn_Cursor = NULL;
 
     SetCursor( *pCursorArrow );
 
@@ -6135,28 +6136,32 @@ void ChartCanvas::SetCanvasCursor( wxMouseEvent& event )
 {
     //    Switch to the appropriate cursor on mouse movement
 
-    wxCursor *ptarget_cursor;
-    if( !pPlugIn_Cursor ) ptarget_cursor = pCursorArrow;
-    else ptarget_cursor = pPlugIn_Cursor;
+    wxCursor *ptarget_cursor = pCursorArrow;
+    if( !pPlugIn_Cursor ) {
+        ptarget_cursor = pCursorArrow;
+        if( ( !parent_frame->nRoute_State )
+            && ( !m_bMeasure_Active ) /*&& ( !m_bCM93MeasureOffset_Active )*/) {
+            
+            if( cursor_region == MID_RIGHT ) {
+                ptarget_cursor = pCursorRight;
+            } else if( cursor_region == MID_LEFT ) {
+                ptarget_cursor = pCursorLeft;
+            } else if( cursor_region == MID_TOP ) {
+                ptarget_cursor = pCursorDown;
+            } else if( cursor_region == MID_BOT ) {
+                ptarget_cursor = pCursorUp;
+            } else {
+                ptarget_cursor = pCursorArrow;
+            }
+            } else if( m_bMeasure_Active || parent_frame->nRoute_State ) // If Measure tool use Pencil Cursor
+                ptarget_cursor = pCursorPencil;
+    }
+    else {
+        ptarget_cursor = pPlugIn_Cursor;
+    }
     
-    if( ( !parent_frame->nRoute_State )
-        && ( !m_bMeasure_Active ) /*&& ( !m_bCM93MeasureOffset_Active )*/) {
-        
-        if( cursor_region == MID_RIGHT ) {
-            ptarget_cursor = pCursorRight;
-        } else if( cursor_region == MID_LEFT ) {
-            ptarget_cursor = pCursorLeft;
-        } else if( cursor_region == MID_TOP ) {
-            ptarget_cursor = pCursorDown;
-        } else if( cursor_region == MID_BOT ) {
-            ptarget_cursor = pCursorUp;
-        } else {
-            ptarget_cursor = pCursorArrow;
-        }
-        } else if( m_bMeasure_Active || parent_frame->nRoute_State ) // If Measure tool use Pencil Cursor
-            ptarget_cursor = pCursorPencil;
 
-    SetCursor( *ptarget_cursor );
+        SetCursor( *ptarget_cursor );
 
 }
 

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -6135,7 +6135,9 @@ void ChartCanvas::SetCanvasCursor( wxMouseEvent& event )
 {
     //    Switch to the appropriate cursor on mouse movement
 
-    wxCursor *ptarget_cursor = pCursorArrow;
+    wxCursor *ptarget_cursor;
+    if( !pPlugIn_Cursor ) ptarget_cursor = pCursorArrow;
+    else ptarget_cursor = pPlugIn_Cursor;
     
     if( ( !parent_frame->nRoute_State )
         && ( !m_bMeasure_Active ) /*&& ( !m_bCM93MeasureOffset_Active )*/) {

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -4601,6 +4601,11 @@ wxBitmap GetIcon_PlugIn(const wxString & name)
     return style->GetIcon( name );
 }
 
+void SetCursor_PlugIn( wxCursor *pCursor )
+{
+    cc1->pPlugIn_Cursor = pCursor;
+}
+
 void AddChartDirectory( wxString &path )
 {
     if( g_options )


### PR DESCRIPTION
This change is to add a new SetCursor_PlugIn API to allow a plugin to set the cursor to be used. This stops the flashing that occurs when the cursor moves and the SetCanvasCursor in chcanv.cpp sets the cursor to the default arrow when the plugin wants something else.