### PR TITLE
Let CMAKE choose optimistion based on setting of CMAKE_BUILD_TYPE

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,7 +396,7 @@ INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/include ${CMAKE_SOURCE_DIR}/src)
 #  IF NOT DEBUGGING CFLAGS="-O2 -march=native"
 IF(NOT WIN32 AND NOT APPLE )
   ADD_DEFINITIONS( "-Wall -Wno-unused -fexceptions -rdynamic" )
-  ADD_DEFINITIONS( " -g -O0 -fno-strict-aliasing")
+  ADD_DEFINITIONS( " -g -fno-strict-aliasing")
 
   ADD_DEFINITIONS( " -DPREFIX=\\\"${CMAKE_INSTALL_PREFIX}\\\"")
   # profiling with gprof


### PR DESCRIPTION
Debug no -O flag generated
Release -O3
RelWithDebInfo -O2
MinSizeRel -O2

Change only for Linux (i.e. NOT WIN32 and NOT APPLE )