### PR TITLE
Cache entry leak

### DIFF
--- a/src/chartdb.cpp
+++ b/src/chartdb.cpp
@@ -826,7 +826,8 @@ bool ChartDB::IsChartInCache(int dbindex)
                 CacheEntry *pce = (CacheEntry *)(pChartCache->Item(i));
                 if(pce->dbIndex == dbindex)
                 {
-                    bInCache = true;
+                    if (pce->pChart != 0 && ((ChartBase *)pce->pChart)->IsReadyToRender())
+                        bInCache = true;
                     break;
                 }
         }
@@ -849,7 +850,8 @@ bool ChartDB::IsChartInCache(wxString path)
             CacheEntry *pce = (CacheEntry *)(pChartCache->Item(i));
             if(pce->FullPath == path)
             {
-                bInCache = true;
+                if (pce->pChart != 0 && ((ChartBase *)pce->pChart)->IsReadyToRender())
+                    bInCache = true;
                 break;
             }
         }
@@ -1322,8 +1324,9 @@ ChartBase *ChartDB::OpenChartUsingCache(int dbindex, ChartInitFlag init_flag)
                   if(INIT_OK == ir)
                   {
 
-//    Only add to cache if requesting a full init
-                        if(FULL_INIT == init_flag)
+//    always cache after a new chart has been created
+//    or it may leak CacheEntry in createthumbnail
+//                        if(FULL_INIT == init_flag)
                         {
                               pce = new CacheEntry;
                               pce->FullPath = ChartFullPath;

--- a/src/chartdb.cpp
+++ b/src/chartdb.cpp
@@ -1059,7 +1059,10 @@ ChartBase *ChartDB::OpenChartUsingCache(int dbindex, ChartInitFlag init_flag)
               }
               else
               {
+                    if(pthumbwin && pthumbwin->pThumbChart == Ch)
+                       pthumbwin->pThumbChart = NULL;
                     delete Ch;                                  // chart is not useable
+                    
                     if( wxMUTEX_NO_ERROR == m_cache_mutex.Lock() ){
                         pChartCache->Remove(pce);                   // so remove it
                         m_cache_mutex.Unlock();
@@ -1421,12 +1424,6 @@ bool ChartDB::DeleteCacheChart(ChartBase *pDeleteCandidate)
                   pChartCache->Remove(pce);
                   delete pce;
                   
-                  if(pthumbwin)
-                  {
-                        if(pthumbwin->pThumbChart == pDeleteCandidate)
-                              pthumbwin->pThumbChart = NULL;
-                  }
-
                   retval = true;
             }
       }


### PR DESCRIPTION
Hi,
Code was leaking a CacheEntry  on piano rollover for every vector chart not in the cache.
This change always add the new entry to the cache but it has to change IsChartInCache method.

Regards,
Didier