### PR TITLE
cm93 Array_Of_M_COVR_Desc_Ptr is a plain array not an obj array, (was…

### DIFF
--- a/include/cm93.h
+++ b/include/cm93.h
@@ -80,7 +80,7 @@ class M_COVR_Desc
 };
 
 WX_DECLARE_OBJARRAY(M_COVR_Desc, Array_Of_M_COVR_Desc);
-WX_DECLARE_OBJARRAY(M_COVR_Desc *, Array_Of_M_COVR_Desc_Ptr);
+WX_DEFINE_ARRAY_PTR(M_COVR_Desc *, Array_Of_M_COVR_Desc_Ptr);
 
 WX_DECLARE_LIST(M_COVR_Desc, List_Of_M_COVR_Desc);
 

--- a/src/cm93.cpp
+++ b/src/cm93.cpp
@@ -93,7 +93,6 @@ extern MyFrame          *gFrame;
 
 #include <wx/arrimpl.cpp>
 WX_DEFINE_OBJARRAY ( Array_Of_M_COVR_Desc );
-WX_DEFINE_OBJARRAY ( Array_Of_M_COVR_Desc_Ptr );
 
 #include <wx/listimpl.cpp>
 WX_DEFINE_LIST ( List_Of_M_COVR_Desc );


### PR DESCRIPTION
… leaking cover)

Hi,
Remove a small leak in cm93 code. OBJARRAY doesn't work with pointers, M_COVR_Desc were refcounts and never deleted.

Regards
Didier