### PR TITLE
small leak in cm93

### DIFF
--- a/src/cm93.cpp
+++ b/src/cm93.cpp
@@ -4994,8 +4994,10 @@ int cm93compchart::PrepareChartScale ( const ViewPort &vpt, int cmscale, bool bO
                         printf ( " b_nochart return\n" );
 
                   m_pcm93chart_current = NULL;
-                  for ( int i = 0 ; i < 8 ; i++ )
+                  for ( int i = 0 ; i < 8 ; i++ ) {
+                        delete m_pcm93chart_array[i];
                         m_pcm93chart_array[i] = NULL;
+                  }
 
                   return cmscale;
             }


### PR DESCRIPTION
Hi,
The last one at least for displaying charts.
The few remaining leaks found with valgrind are in Init functions and hopefully are one-off and not growing.

There's still issues with memory fragmentations though.

Regards
Didier

BTW I'd like to access a recent coverty report, is it possible?
Thanks.
 
