### PR TITLE
Cache rebuild

### DIFF
--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -509,6 +509,9 @@ void BuildCompressedCache()
         if(!pchart) /* probably a corrupt chart */
             continue;
 
+        // bad things if more than one texfactory for a chart
+        cc1->PurgeGLCanvasChartCache( pchart, true );
+
         bool skip = false;
         wxString msg;
         msg.Printf( _("Distance from Ownship:  %4.0f NMi"), distance);

--- a/src/glTexCache.cpp
+++ b/src/glTexCache.cpp
@@ -1950,6 +1950,7 @@ bool glTexFactory::WriteCatalogAndHeader()
         hdr.chartdate = m_chart_date_binary;
         
         m_fs->Write( &hdr, sizeof(hdr));
+        m_fs->Flush();
         
         return true;
     }


### PR DESCRIPTION
Hi,
I've been able to trigger this one by displaying a big chart with an empty texture cache and starting a cache rebuild, either the cache is corrupted or texture entries are lost.

Also flush to system after writing the header.

Regards
Didier
