### PR TITLE
Fix error with Tessellation error msg. Ensure message is printed in t…

### DIFF
--- a/src/ocpndc.cpp
+++ b/src/ocpndc.cpp
@@ -831,7 +831,7 @@ void APIENTRY ocpnDCerrorCallback( GLenum errorCode )
 {
    const GLubyte *estring;
    estring = gluErrorString(errorCode);
-   wxLogMessage( _T("OpenGL Tessellation Error: %s"), estring );
+   wxLogMessage( _T("OpenGL Tessellation Error: %s"), (char *)estring );
 }
 
 void APIENTRY ocpnDCbeginCallback( GLenum type )


### PR DESCRIPTION
…ext not gibberish.

Error found when debugging tessellation. Error messages were not readable.