### PR TITLE
Fix grib particle looping (FS#1794)

### DIFF
--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -1645,7 +1645,7 @@ void GRIBOverlayFactory::RenderGribParticles( int settings, GribRecord **pGR,
 
     // add new particles as needed
     int run = 0;
-    int new_particles = (total_particles - particles.size()) / 64;
+    int new_particles = (total_particles - (int)particles.size()) / 64;
 
     for(int npi=0; npi<new_particles; npi++) {
         float p[2];


### PR DESCRIPTION
If the grib file entries switch from .25 degree data to .5 degree data while particles are displayed, the number of particles are miscalculated and thousands of new particles are created stalling OpenCPN.