### PR TITLE
Texture, use O(1) for searching texture in cache

### DIFF
--- a/src/glTexCache.cpp
+++ b/src/glTexCache.cpp
@@ -1008,6 +1008,7 @@ glTexFactory::glTexFactory(ChartBase *chart, GLuint raster_format)
     m_hdrOK = false;
     m_catalogOK = false;
 
+    m_catalogCorrupted = false;
 
     m_fs = 0;
 


### PR DESCRIPTION
Hi,

Replace the O(n) texture lookup with an O(1) one.

For a fully populated cache the memory footprint is also smaller, store only 2 integers per entry vs 6 integers.

May need to test if there's a mismatch between process texture size on one stored in cache. 

Regards
Didier
