### PR TITLE
Improve performance of loading raster charts

### DIFF
--- a/include/chartimg.h
+++ b/include/chartimg.h
@@ -103,15 +103,18 @@ public:
 
 
 
-
+struct TileOffsetCache
+{
+    int offset; // offset from start of line pointer
+    int pixel; // offset from current pixel
+};
 
 class CachedLine
 {
 public:
-      int               xstart;
-      int               xlength;
-      unsigned char     *pPix;
-      unsigned char     *pRGB;
+      unsigned char    *pPix;
+      TileOffsetCache  *pTileOffset; // entries for random access
+
       bool              bValid;
 };
 


### PR DESCRIPTION
This change eliminates the use of the line buffer cache (of palette index)
which as it turns out is actually slower (due to requiring more memory manipulation)
and uses a lot more ram

The performance is anywhere from 15-50% faster and ram usage is greatly reduced
if the cache is disabled (android or low ram systems), the performance improvement
is even more significant

It would be possible to improve the performance further:

1)  Using 32 bit data instead of 24 bit data.  Initial tests show a 15-20% speed up
    because 4 bytes is much more efficient to work with than 3 (can use avx and sse instructions)
    In opengl mode there is even more improvement because the opengl driver will convert the 24 bit
    data into 32 bits in graphics memory anyway.  The 25% more memory used is temporary just for this
    tile and so overall memory usage will not appear different.

2)  expanding the cached rle data into a more efficient form, it will use slightly more
    ram and give slightly more speed, not sure if it's worthwhile

3)  Tuning the tight loops possibly with inline assembly