### PR TITLE
Improve changes file management  to ovoid points proliferation after crash(#FS1824 -1785)

### DIFF
--- a/include/chcanv.h
+++ b/include/chcanv.h
@@ -387,6 +387,7 @@ private:
       bool        m_bDrawingRoute;
       bool        m_bRouteEditing;
       bool        m_bMarkEditing;
+	  bool		  m_bRoutePoinDragging;
       bool        m_bIsInRadius;
       bool        m_bMayToggleMenuBar;
 

--- a/src/NavObjectCollection.cpp
+++ b/src/NavObjectCollection.cpp
@@ -1505,7 +1505,7 @@ bool NavObjectChanges::ApplyChanges(void)
             
             if(pWp && pWayPointMan) {
                 pWp->m_bIsolatedMark = true;
-                RoutePoint *pExisting = WaypointExists( pWp->GetName(), pWp->m_lat, pWp->m_lon );
+                RoutePoint *pExisting = WaypointExists( pWp->m_GUID );
                 
                 pugi::xml_node xchild = object.child("extensions");
                 pugi::xml_node child = xchild.child("opencpn:action");

--- a/src/NavObjectCollection.cpp
+++ b/src/NavObjectCollection.cpp
@@ -417,7 +417,8 @@ Track *GPXLoadTrack1( pugi::xml_node &trk_node, bool b_fullviz,
 Route *GPXLoadRoute1( pugi::xml_node &wpt_node, bool b_fullviz,
                       bool b_layer,
                       bool b_layerviz,
-                      int layer_id )
+                      int layer_id,
+					  bool b_change )
 {
     wxString RouteName;
     wxString DescString;
@@ -438,19 +439,24 @@ Route *GPXLoadRoute1( pugi::xml_node &wpt_node, bool b_fullviz,
             if( ChildName == _T ( "rtept" ) ) {
                 RoutePoint *tpWp = ::GPXLoadWaypoint1(  tschild, _T("square"), _T(""), b_fullviz, b_layer, b_layerviz, layer_id);
                 RoutePoint *erp = ::WaypointExists( tpWp->m_GUID );
-                if( erp != NULL )
-                    pWp = erp;
-                else
-                    pWp = tpWp;
+                if( !b_change ) {
+					if(  erp != NULL )
+						pWp = erp;
+					else
+						pWp = tpWp;
+				} else				//when applying change after crash wps must keep the "change" values for the next step
+					pWp = tpWp;
                 
                 pTentRoute->AddPoint( pWp, false, true, true );          // defer BBox calculation
                 pWp->m_bIsInRoute = true;                      // Hack
                 pWp->m_bIsInTrack = false;
                 
-                if( erp == NULL )
-                    pWayPointMan->AddRoutePoint( pWp );
-                else
-                    delete tpWp;
+                if( !b_change ) {  //when applying change after crash, do not add any point at this step
+					if( erp == NULL )
+						pWayPointMan->AddRoutePoint( pWp );
+					else
+						delete tpWp;
+				}
                     
             }
             else
@@ -1122,29 +1128,73 @@ void InsertTrack( Route *pTentTrack )
 }                       
                        
 void UpdateRouteA( Route *pTentRoute )
-                       {
-                           Route * rt = ::RouteExists( pTentRoute->m_GUID );
-                           if( rt ) {
-                               wxRoutePointListNode *node = pTentRoute->pRoutePointList->GetFirst();
-                               while( node ) {
-                                   RoutePoint *prp = node->GetData();
-                                   RoutePoint *ex_rp = rt->GetPoint( prp->m_GUID );
-                                   if( ex_rp ) {
-                                       ex_rp->m_lat = prp->m_lat;
-                                       ex_rp->m_lon = prp->m_lon;
-                                       ex_rp->SetIconName( prp->GetIconName() );
-                                       ex_rp->m_MarkDescription = prp->m_MarkDescription;
-                                       ex_rp->SetName( prp->GetName() );
-                                   } else {
-                                       pSelect->AddSelectableRoutePoint( prp->m_lat, prp->m_lon, prp );
-                                   }
-                                   node = node->GetNext();
-                               }
-                           } else {
-                               ::InsertRouteA( pTentRoute );
-                           }
+ {
+    if( !pTentRoute )
+        return;
+	if( pTentRoute->GetnPoints() < 2 )
+        return;
+
+	//first delete the route to be modified if exists
+    Route *pExisting = ::RouteExists( pTentRoute->m_GUID );
+	if( pExisting ) {
+		pConfig->m_bSkipChangeSetUpdate = true;
+        g_pRouteMan->DeleteRoute( pExisting );
+        pConfig->m_bSkipChangeSetUpdate = false;
+	}
+
+    //create a new route
+	Route *pChangeRoute = new Route();
+    pRouteList->Append( pChangeRoute );
+
+	//update new route keeping the same gui
+	pChangeRoute->m_GUID = pTentRoute->m_GUID;
+	pChangeRoute->m_RouteNameString = pTentRoute->m_RouteNameString;
+    pChangeRoute->m_RouteStartString = pTentRoute->m_RouteStartString;
+    pChangeRoute->m_RouteEndString = pTentRoute->m_RouteEndString;
+	pChangeRoute->SetVisible( pTentRoute->IsVisible() );
+
+    //Add points and segments to new route
+    int ip = 0;
+    float prev_rlat = 0., prev_rlon = 0.;
+    RoutePoint *prev_pConfPoint = NULL;
+
+    wxRoutePointListNode *node = pTentRoute->pRoutePointList->GetFirst();
+    while( node ) {
+		RoutePoint *prp = node->GetData();
+
+		//if some wpts have been not deleted, that meens they should be used in other routes
+		//or are isolated way points so need to be updated
+		RoutePoint *ex_rp = ::WaypointExists( prp->m_GUID );
+		if( ex_rp ) {
+			pSelect->DeleteSelectableRoutePoint(ex_rp);
+			ex_rp->m_lat = prp->m_lat;
+			ex_rp->m_lon = prp->m_lon;
+			ex_rp->SetIconName( prp->GetIconName() );
+			ex_rp->m_MarkDescription = prp->m_MarkDescription;
+			ex_rp->SetName( prp->GetName() );
+			pChangeRoute->AddPoint( ex_rp );
+			pSelect->AddSelectableRoutePoint(prp->m_lat, prp->m_lon, ex_rp);
+
+		} else {
+			pChangeRoute->AddPoint( prp );
+			pSelect->AddSelectableRoutePoint(prp->m_lat, prp->m_lon, prp);
+		}
+
+        if( ip )
+			pSelect->AddSelectableRouteSegment( prev_rlat, prev_rlon, prp->m_lat,
+					prp->m_lon, prev_pConfPoint, prp, pChangeRoute );
+        prev_rlat = prp->m_lat;
+        prev_rlon = prp->m_lon;
+        prev_pConfPoint = prp;
+
+        ip++;
+
+        node = node->GetNext();
+	}
+	//    Do the (deferred) calculation of BBox
+    pChangeRoute->FinalizeForRendering();
 }
-                       
+
                        
 bool NavObjectCollection1::CreateNavObjGPXPoints( void )
 {
@@ -1330,7 +1380,7 @@ bool NavObjectCollection1::LoadAllGPXObjects( bool b_full_viz )
             }
             else
                 if( !strcmp(object.name(), "rte") ) {
-                    Route *pRoute = GPXLoadRoute1( object, b_full_viz, false, false, 0 );
+                    Route *pRoute = GPXLoadRoute1( object, b_full_viz, false, false, 0, false );
                     InsertRouteA( pRoute );
                 }
                 
@@ -1370,7 +1420,7 @@ int NavObjectCollection1::LoadAllGPXObjectsAsLayer(int layer_id, bool b_layerviz
             }
             else
                 if( !strcmp(object.name(), "rte") ) {
-                    Route *pRoute = GPXLoadRoute1( object, true, true, b_layerviz, layer_id );
+                    Route *pRoute = GPXLoadRoute1( object, true, true, b_layerviz, layer_id, false );
                     n_obj++;
                     InsertRouteA( pRoute );
                 }
@@ -1566,14 +1616,14 @@ bool NavObjectChanges::ApplyChanges(void)
             
             else
                 if( !strcmp(object.name(), "rte") ) {
-                    Route *pRoute = GPXLoadRoute1( object, true, false, false, 0 );
+                    Route *pRoute = GPXLoadRoute1( object, true, false, false, 0, true );
                     
                     if(pRoute && g_pRouteMan) {
                         pugi::xml_node xchild = object.child("extensions");
                         pugi::xml_node child = xchild.child("opencpn:action");
 
                         if(!strcmp(child.first_child().value(), "add") ){
-                            ::InsertRouteA( pRoute );
+                            ::UpdateRouteA( pRoute );
                         }                    
                     
                         else if(!strcmp(child.first_child().value(), "update") ){

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -500,6 +500,7 @@ ChartCanvas::ChartCanvas ( wxFrame *frame ) :
     m_bDrawingRoute = false;
     m_bRouteEditing = false;
     m_bMarkEditing = false;
+	m_bRoutePoinDragging = false;
     m_bIsInRadius = false;
     m_bMayToggleMenuBar = true;
 
@@ -5223,6 +5224,7 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
                                                         pre_rect.Union( post_rect );
                                                         RefreshRect( pre_rect, false );
                                                     }
+													m_bRoutePoinDragging = true;
                                                 }
                                                 ret = true;
         }     // if Route Editing
@@ -5302,8 +5304,10 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
                             pre_rect.Union( post_rect );
                             RefreshRect( pre_rect, false );
                         }
+						m_bRoutePoinDragging = true;
                     }
                     ret = true;
+
         }
         
         if(ret)
@@ -5637,7 +5641,7 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
                         if( g_pRouteMan->IsRouteValid(pr) ) {
                             pr->FinalizeForRendering();
                             pr->UpdateSegmentDistances();
-                            pConfig->UpdateRoute( pr );
+                            if( m_bRoutePoinDragging ) pConfig->UpdateRoute( pr );
                         }
                     }
                 }
@@ -5661,17 +5665,20 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
             }
             }
             
-            if( m_pRoutePointEditTarget ) {
-                pConfig->UpdateWayPoint( m_pRoutePointEditTarget );
+			else if(  m_bMarkEditing ) {				// End of way point drag
+				if( m_pRoutePointEditTarget )
+					if( m_bRoutePoinDragging ) pConfig->UpdateWayPoint( m_pRoutePointEditTarget );
+			}
+
+			if( m_pRoutePointEditTarget )
                 undo->AfterUndoableAction( m_pRoutePointEditTarget );
-            }
             
             if(!m_pRoutePointEditTarget){
                 delete m_pEditRouteArray;
                 m_pEditRouteArray = NULL;
                 m_bRouteEditing = false;
             }
-            
+            m_bRoutePoinDragging = false;
         }       // g_btouch
         
         
@@ -5689,7 +5696,7 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
                             pr->UpdateSegmentDistances();
                             pr->m_bIsBeingEdited = false;
                             
-                            pConfig->UpdateRoute( pr );
+                            if( m_bRoutePoinDragging ) pConfig->UpdateRoute( pr );
                             
                             pr->SetHiLite( 0 );
                         }
@@ -5732,7 +5739,7 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
         
         else if( m_bMarkEditing) {         // end of Waypoint drag
             if( m_pRoutePointEditTarget ) {
-                pConfig->UpdateWayPoint( m_pRoutePointEditTarget );
+                if( m_bRoutePoinDragging ) pConfig->UpdateWayPoint( m_pRoutePointEditTarget );
                 undo->AfterUndoableAction( m_pRoutePointEditTarget );
                 m_pRoutePointEditTarget->m_bIsBeingEdited = false;
                 wxRect wp_rect;
@@ -5747,7 +5754,7 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
                 gFrame->SurfaceToolbar();
             ret = true;
         }
-        
+
         else if( leftIsDown ) {  // left click for chart center
             leftIsDown = false;
             ret = false;
@@ -5760,6 +5767,7 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
             }
             
         }
+		 m_bRoutePoinDragging = false;
         }       // !btouch
         
         if(ret)

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -2915,8 +2915,8 @@ void MyConfig::UpdateNavObj( void )
     if( ::wxFileExists( m_sNavObjSetChangesFile ) )
         wxRemoveFile( m_sNavObjSetChangesFile );
 
-    delete m_pNavObjectChangesSet;
-    m_pNavObjectChangesSet = new NavObjectChanges(m_sNavObjSetChangesFile);
+    //delete m_pNavObjectChangesSet;
+    //m_pNavObjectChangesSet = new NavObjectChanges(m_sNavObjSetChangesFile);
 
 }
 


### PR DESCRIPTION
1)  The point to be changed is searched by his GUI instead of his name/position as in certain conditions and mainly when dragging, these parameters have been changed. This ovoids to create some unexpected points. This is the main raison to way points proliferation  after a crash.
2) Do not generate an "updateWaypoint" when dragging a route point.
3) Do not generate an "updateroute" or "updatewaypoint" when only clicking on a route point or a way point without doing anything else or only highlighting in case of touch screen . This ovoids to overload the file with many useless entries.
Nevertheless I am not sure these commits will solve all the problems in all cases. Particularly I faced some randomly cases with W8.1 where the change file was not removed after a crash,  
Jean Pierre