### PR TITLE
Missing StartTopJob in background compression OnEvtThread

### DIFF
--- a/src/glTexCache.cpp
+++ b/src/glTexCache.cpp
@@ -738,6 +738,8 @@ void CompressionWorkerPool::OnEvtThread( OCPN_CompressionThreadEvent & event )
     
 ///    qDebug() << "Finished" << m_njobs_running <<  (unsigned long)todo_list.GetCount() << mem_used << g_tex_mem_used;
     
+    StartTopJob();
+
     delete ticket;
 }
 


### PR DESCRIPTION
Hi, 
My mistake.

in CompressionWorkerPool::OnEvtThread add back missing StartTopJob(),
it was wrongly removed in commit 9909f946199837310154b421bd94d9b388437869,
copy and paste error.

Regards
Didier