### PR TITLE
Compass window, don't propagate any mouse event

### DIFF
--- a/src/compass.cpp
+++ b/src/compass.cpp
@@ -94,10 +94,11 @@ void ocpnCompass::Paint( ocpnDC& dc )
 
 bool ocpnCompass::MouseEvent( wxMouseEvent& event )
 {
-    if(!m_shown || !m_rect.Contains(event.GetPosition()) || !event.LeftDown())
+    if(!m_shown || !m_rect.Contains(event.GetPosition()))
         return false;
 
-    gFrame->ToggleCourseUp();
+    if (event.LeftDown())
+        gFrame->ToggleCourseUp();
     return true;
 }
 


### PR DESCRIPTION
Hi,
if it was a true window its parent wouldn't get them.

Fix the issue:
When toggling the course up mode by clicking on the icon the chart is moved to
the cursor position in the right corner, the canvas is reacting to the
left click release event.

Regards.
Didier