### PR TITLE
Scrub options.cpp and options.h

### DIFF
--- a/include/options.h
+++ b/include/options.h
@@ -884,7 +884,7 @@ class OpenGLOptionsDlg : public wxDialog
     void Populate( void );
     void OnButtonRebuild( wxCommandEvent& event );
     void OnButtonClear( wxCommandEvent& event );
-    wxString TextureCacheSize( void );
+    wxString GetTextureCacheSize( void );
 
     wxStaticText *m_cacheSize, *m_memorySize;
 

--- a/include/options.h
+++ b/include/options.h
@@ -849,7 +849,7 @@ class SentenceListDlg : public wxDialog
   public:
     explicit SentenceListDlg( wxWindow *parent, FilterDirection dir,
                               ListType type, const wxArrayString &list );
-    wxString GetSentencesAsText( void );
+    wxString GetSentences( void );
 
   private:
     void OnAddClick( wxCommandEvent& event );
@@ -858,10 +858,8 @@ class SentenceListDlg : public wxDialog
     void OnCheckAllClick( wxCommandEvent& event );
     void OnClearAllClick( wxCommandEvent& event );
 
-    void BuildSentenceArray( void );
-    const wxString GetType( void );
-    void SetSentenceList( void );
-    void FillSentences( void );
+    void Populate( const wxArrayString &list );
+    const wxString GetBoxLabel( void );
 
     wxCheckListBox* m_clbSentences;
     wxStdDialogButtonSizer* m_sdbSizer4;
@@ -869,7 +867,7 @@ class SentenceListDlg : public wxDialog
 
     ListType m_type;
     FilterDirection m_dir;
-    wxArrayString standard_sentences, m_sentences;
+    wxArrayString m_sentences;
 };
 
 class OpenGLOptionsDlg : public wxDialog

--- a/include/options.h
+++ b/include/options.h
@@ -862,7 +862,6 @@ class SentenceListDlg : public wxDialog
     const wxString GetBoxLabel( void ) const;
 
     wxCheckListBox* m_clbSentences;
-    wxStdDialogButtonSizer* m_sdbSizer4;
     wxButton *m_btnDel;
 
     ListType m_type;

--- a/include/options.h
+++ b/include/options.h
@@ -877,12 +877,9 @@ class OpenGLOptionsDlg : public wxDialog
     void OnButtonClear( wxCommandEvent& event );
     wxString TextureCacheSize( void );
 
-    wxGridSizer *m_bSizer1;
-    wxBoxSizer *m_bSizer2;
     wxCheckBox *m_cbUseAcceleratedPanning, *m_cbTextureCompression;
     wxCheckBox *m_cbTextureCompressionCaching, *m_cbShowFPS, *m_cbSoftwareGL;
-    wxButton *m_bRebuildTextureCache, *m_bClearTextureCache;
-    wxStaticText *m_stTextureCacheSize;
+    wxStaticText *m_cacheSize;
     wxSpinCtrl *m_sTextureDimension, *m_sTextureMemorySize;
 
     bool m_brebuild_cache;

--- a/include/options.h
+++ b/include/options.h
@@ -873,20 +873,26 @@ class OpenGLOptionsDlg : public wxDialog
 {
   public:
     explicit OpenGLOptionsDlg( wxWindow *parent );
-
-    wxCheckBox *m_cbUseAcceleratedPanning, *m_cbTextureCompression;
-    wxCheckBox *m_cbTextureCompressionCaching, *m_cbShowFPS, *m_cbSoftwareGL;
-    wxSpinCtrl *m_sTextureDimension, *m_sTextureMemorySize;
-
-    bool m_brebuild_cache;
+    const bool GetAcceleratedPanning( void ) const;
+    const bool GetTextureCompression( void ) const;
+    const bool GetShowFPS( void ) const;
+    const bool GetSoftwareGL( void ) const;
+    const bool GetTextureCompressionCaching( void ) const;
+    const bool GetRebuildCache( void ) const;
+    const int GetTextureMemorySize( void ) const;
 
   private:
     void Populate( void );
     void OnButtonRebuild( wxCommandEvent& event );
     void OnButtonClear( wxCommandEvent& event );
-    wxString GetTextureCacheSize( void );
+    const wxString GetTextureCacheSize( void );
 
+    wxCheckBox *m_cbUseAcceleratedPanning, *m_cbTextureCompression;
+    wxCheckBox *m_cbTextureCompressionCaching, *m_cbShowFPS, *m_cbSoftwareGL;
+    wxSpinCtrl *m_sTextureDimension, *m_sTextureMemorySize;
     wxStaticText *m_cacheSize, *m_memorySize;
+
+    bool m_brebuild_cache;
 
     DECLARE_EVENT_TABLE()
 };

--- a/include/options.h
+++ b/include/options.h
@@ -203,9 +203,6 @@ class options: public wxDialog
 class options: public wxScrollingDialog
 #endif
 {
-    DECLARE_DYNAMIC_CLASS( options )
-    DECLARE_EVENT_TABLE()
-
   public:
     explicit options();
     explicit options( MyFrame* parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME,
@@ -554,11 +551,12 @@ class options: public wxScrollingDialog
 
     int m_fontHeight, m_scrollRate, m_BTscanning, m_btNoChangeCounter;
     int m_btlastResultCount;
+
+    DECLARE_DYNAMIC_CLASS( options )
+    DECLARE_EVENT_TABLE()
 };
 
 class ChartGroupsUI: public wxScrolledWindow {
-    DECLARE_EVENT_TABLE()
-
   public:
     explicit ChartGroupsUI( wxWindow *parent );
     ~ChartGroupsUI();
@@ -610,6 +608,8 @@ class ChartGroupsUI: public wxScrolledWindow {
     ChartGroupArray *m_pGroupArray;
 
     int m_border_size, m_group_item_spacing, m_GroupSelectedPage;
+
+    DECLARE_EVENT_TABLE()
 };
 
 #if wxUSE_XLOCALE || !wxCHECK_VERSION(3,0,0)
@@ -846,9 +846,6 @@ static int lang_list[] = {
 };
 #endif
 
-///////////////////////////////////////////////////////////////////////////////
-/// Class SentenceListDlg
-///////////////////////////////////////////////////////////////////////////////
 class SentenceListDlg : public wxDialog
 {
   public:
@@ -892,13 +889,8 @@ class SentenceListDlg : public wxDialog
     FilterDirection m_dir;
 };
 
-///////////////////////////////////////////////////////////////////////////////
-/// Class OpenGLOptionsDlg
-///////////////////////////////////////////////////////////////////////////////
 class OpenGLOptionsDlg : public wxDialog
 {
-    DECLARE_EVENT_TABLE()
-
   public:
     explicit OpenGLOptionsDlg( wxWindow *parent, bool glTicked );
     void OnButtonRebuild( wxCommandEvent& event );
@@ -914,6 +906,8 @@ class OpenGLOptionsDlg : public wxDialog
     wxSpinCtrl *m_sTextureDimension, *m_sTextureMemorySize;
 
     bool m_brebuild_cache;
+
+    DECLARE_EVENT_TABLE()
 };
 
 #define ID_MMSI_PROPS_LIST 10073
@@ -926,9 +920,6 @@ enum {
     mlVDM
 }; // MMSIListCtrl Columns;
 
-///////////////////////////////////////////////////////////////////////////////
-/// Class MMSIListCtrl
-///////////////////////////////////////////////////////////////////////////////
 class MMSIListCtrl: public wxListCtrl
 {
   public:
@@ -937,7 +928,6 @@ class MMSIListCtrl: public wxListCtrl
     ~MMSIListCtrl();
 
     wxString OnGetItemText( long item, long column ) const;
-//    int OnGetItemColumnImage( long item, long column ) const;
     void OnListItemClick( wxListEvent &event);
     void OnListItemActivated( wxListEvent &event);
     void OnListItemRightClick( wxListEvent &event);
@@ -955,14 +945,8 @@ class MMSIListCtrl: public wxListCtrl
 #define ID_DEF_MENU_MMSI_EDIT   8194
 #define ID_DEF_MENU_MMSI_DELETE 8195
 
-///////////////////////////////////////////////////////////////////////////////
-/// Class MMSIEditDialog
-///////////////////////////////////////////////////////////////////////////////
 class MMSIEditDialog: public wxDialog
 {
-    DECLARE_DYNAMIC_CLASS( MMSIEditDialog )
-    DECLARE_EVENT_TABLE()
-
   public:
     explicit MMSIEditDialog( );
     explicit MMSIEditDialog( MMSIProperties *props, wxWindow *parent,
@@ -990,18 +974,17 @@ class MMSIEditDialog: public wxDialog
     wxRadioButton *m_rbTypeTrackNever;
     wxCheckBox *m_cbTrackPersist, *m_IgnoreButton, *m_MOBButton, *m_VDMButton;
     wxButton *m_CancelButton, *m_OKButton;
+
+    DECLARE_DYNAMIC_CLASS( MMSIEditDialog )
+    DECLARE_EVENT_TABLE()
 };
 
-///////////////////////////////////////////////////////////////////////////////
-/// Class MMSI_Props_Panel
-///////////////////////////////////////////////////////////////////////////////
 class MMSI_Props_Panel: public wxPanel
 {
   public:
     explicit MMSI_Props_Panel( wxWindow *parent );
     ~MMSI_Props_Panel( );
 
-//    void OnClose(wxCloseEvent &event);
     void OnNewButton( wxCommandEvent &event );
     void SetColorScheme( ColorScheme cs );
     void UpdateMMSIList( void );

--- a/include/options.h
+++ b/include/options.h
@@ -206,8 +206,8 @@ class options: public wxScrollingDialog
     DECLARE_EVENT_TABLE()
 
 public:
-    options();
-    options( MyFrame* parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME, const wxString& caption =
+    explicit options();
+    explicit options( MyFrame* parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME, const wxString& caption =
              SYMBOL_OPTIONS_TITLE, const wxPoint& pos = SYMBOL_OPTIONS_POSITION, const wxSize& size =
              SYMBOL_OPTIONS_SIZE, long style = SYMBOL_OPTIONS_STYLE );
 
@@ -697,7 +697,7 @@ class ChartGroupsUI: public wxScrolledWindow {
     DECLARE_EVENT_TABLE()
 
 public:
-    ChartGroupsUI( wxWindow* parent );
+    explicit ChartGroupsUI( wxWindow* parent );
     ~ChartGroupsUI();
 
     void CreatePanel( size_t parent, int border_size, int group_item_spacing, wxSize small_button_size );
@@ -999,13 +999,13 @@ static int lang_list[] = {
 ///////////////////////////////////////////////////////////////////////////////
 class SentenceListDlg : public wxDialog
 {
-    private:
+  private:
         wxArrayString m_sentences;
         void FillSentences();
         ListType m_type;
         FilterDirection m_dir;
 
-    protected:
+  protected:
         wxCheckListBox* m_clbSentences;
         wxButton* m_btnAdd;
         wxButton* m_btnDel;
@@ -1028,15 +1028,14 @@ class SentenceListDlg : public wxDialog
         void OnCheckAllClick( wxCommandEvent& event );
         void OnClearAllClick( wxCommandEvent& event );
 
-    public:
-
-    SentenceListDlg( FilterDirection dir,
-                     wxWindow* parent,
-                     wxWindowID id = wxID_ANY,
-                     const wxString& title = _("Sentence Filter"),
-                     const wxPoint& pos = wxDefaultPosition,
-                     const wxSize& size = wxSize( 280,420 ),
-                     long style = wxDEFAULT_DIALOG_STYLE );
+  public:
+    explicit SentenceListDlg( FilterDirection dir,
+                              wxWindow* parent,
+                              wxWindowID id = wxID_ANY,
+                              const wxString& title = _("Sentence Filter"),
+                              const wxPoint& pos = wxDefaultPosition,
+                              const wxSize& size = wxSize( 280,420 ),
+                              long style = wxDEFAULT_DIALOG_STYLE );
     ~SentenceListDlg();
     void SetSentenceList(wxArrayString sentences);
     wxString GetSentencesAsText();
@@ -1070,7 +1069,7 @@ public:
     wxSpinCtrl *m_sTextureDimension;
     wxSpinCtrl *m_sTextureMemorySize;
 
-    OpenGLOptionsDlg( wxWindow* parent, bool glTicked );
+    explicit OpenGLOptionsDlg( wxWindow* parent, bool glTicked );
 
     void OnButtonRebuild( wxCommandEvent& event );
     void OnButtonClear( wxCommandEvent& event );
@@ -1102,8 +1101,8 @@ class MMSI_Props_Panel;
 class MMSIListCtrl: public wxListCtrl
 {
 public:
-    MMSIListCtrl( wxWindow* parent, wxWindowID id, const wxPoint& pos,
-                  const wxSize& size, long style );
+     explicit MMSIListCtrl( wxWindow* parent, wxWindowID id, const wxPoint& pos,
+                           const wxSize& size, long style );
     ~MMSIListCtrl();
 
     wxString OnGetItemText( long item, long column ) const;
@@ -1142,12 +1141,13 @@ class MMSIEditDialog: public wxDialog
     DECLARE_EVENT_TABLE()
 
 public:
-    MMSIEditDialog( );
-    MMSIEditDialog( MMSIProperties *props, wxWindow* parent, wxWindowID id = -1,
-                    const wxString& caption = _T(""),
-                    const wxPoint& pos = wxDefaultPosition,
-                    const wxSize& size = wxDefaultSize,
-                    long style = 0 );
+    explicit MMSIEditDialog( );
+    explicit MMSIEditDialog( MMSIProperties *props, wxWindow* parent,
+                             wxWindowID id = -1,
+                             const wxString& caption = _T(""),
+                             const wxPoint& pos = wxDefaultPosition,
+                             const wxSize& size = wxDefaultSize,
+                             long style = 0 );
 
     ~MMSIEditDialog();
 
@@ -1189,7 +1189,7 @@ class MMSI_Props_Panel: public wxPanel
 {
 
 public:
-    MMSI_Props_Panel( wxWindow *parent );
+    explicit MMSI_Props_Panel( wxWindow *parent );
     ~MMSI_Props_Panel( );
 
 //    void OnClose(wxCloseEvent &event);

--- a/include/options.h
+++ b/include/options.h
@@ -847,17 +847,9 @@ static int lang_list[] = {
 class SentenceListDlg : public wxDialog
 {
   public:
-    explicit SentenceListDlg( FilterDirection dir,
-                              wxWindow *parent,
-                              wxWindowID id = wxID_ANY,
-                              const wxString& title = _("Sentence Filter"),
-                              const wxPoint& pos = wxDefaultPosition,
-                              const wxSize& size = wxSize( 280,420 ),
-                              long style = wxDEFAULT_DIALOG_STYLE );
-    void SetSentenceList(wxArrayString sentences);
+    explicit SentenceListDlg( wxWindow *parent, FilterDirection dir,
+                              ListType type, const wxArrayString &list );
     wxString GetSentencesAsText( void );
-    void BuildSentenceArray( void );
-    void SetType(int io, ListType type);
 
   private:
     void OnStcSelect( wxCommandEvent& event );
@@ -867,16 +859,19 @@ class SentenceListDlg : public wxDialog
     void OnCLBToggle( wxCommandEvent& event );
     void OnCheckAllClick( wxCommandEvent& event );
     void OnClearAllClick( wxCommandEvent& event );
+
+    void BuildSentenceArray( void );
+    const wxString GetType( void );
+    void SetSentenceList( void );
     void FillSentences( void );
 
     wxCheckListBox* m_clbSentences;
     wxStdDialogButtonSizer* m_sdbSizer4;
-    wxArrayString standard_sentences, m_sentences;
-    wxStaticBox *m_pclbBox;
     wxButton *m_btnDel;
 
     ListType m_type;
     FilterDirection m_dir;
+    wxArrayString standard_sentences, m_sentences;
 };
 
 class OpenGLOptionsDlg : public wxDialog

--- a/include/options.h
+++ b/include/options.h
@@ -204,14 +204,14 @@ class options: public wxScrollingDialog
 #endif
 {
   public:
-    explicit options();
+    explicit options( void );
     explicit options( MyFrame* parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME,
                       const wxString& caption = SYMBOL_OPTIONS_TITLE,
                       const wxPoint& pos = SYMBOL_OPTIONS_POSITION,
                       const wxSize& size = SYMBOL_OPTIONS_SIZE,
                       long style = SYMBOL_OPTIONS_STYLE );
 
-    ~options();
+    ~options( void );
 
     bool Create( MyFrame* parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME,
                  const wxString& caption = SYMBOL_OPTIONS_TITLE,
@@ -222,26 +222,26 @@ class options: public wxScrollingDialog
     void SetInitialPage( int page_sel);
     void Finish( void);
 
-    wxWindow *GetContentWindow() const;
+    wxWindow *GetContentWindow( void ) const;
     void OnClose( wxCloseEvent& event );
 
-    void CreateControls();
+    void CreateControls( void );
     size_t CreatePanel( const wxString & title );
     wxScrolledWindow *AddPage( size_t parent, const wxString & title );
     bool DeletePage( wxScrolledWindow *page );
     void SetColorScheme( ColorScheme cs );
-    void RecalculateSize();
+    void RecalculateSize( void );
 
     void SetInitChartDir( const wxString &dir ) { m_init_chart_dir = dir; }
-    void SetInitialSettings();
+    void SetInitialSettings( void );
     void SetCurrentDirList( ArrayOfCDI p ) { m_CurrentDirList = p; }
     void SetWorkDirListPtr( ArrayOfCDI *p ) { m_pWorkDirList = p; }
-    ArrayOfCDI *GetWorkDirListPtr() { return m_pWorkDirList; }
+    ArrayOfCDI *GetWorkDirListPtr( void ) { return m_pWorkDirList; }
 
     void AddChartDir( wxString &dir );
 
     void UpdateDisplayedChartDirList(ArrayOfCDI p);
-    void UpdateOptionsUnits();
+    void UpdateOptionsUnits( void );
 
     void SetConfigPtr( MyConfig *p ) { m_pConfig = p; }
     void OnDebugcheckbox1Click( wxCommandEvent& event );
@@ -288,10 +288,10 @@ class options: public wxScrollingDialog
     void onBTScanTimer( wxTimerEvent &event );
     void StopBTScan( void );
 
-    void UpdateWorkArrayFromTextCtl();
+    void UpdateWorkArrayFromTextCtl( void );
 
     // Should we show tooltips?
-    static bool ShowToolTips();
+    static bool ShowToolTips( void );
 
 #ifdef __OCPN__OPTIONS_USE_LISTBOOK__
     wxListbook* m_pListbook;
@@ -479,7 +479,7 @@ class options: public wxScrollingDialog
     int k_plugins;
 
   private:
-    void Init();
+    void Init( void );
     void CreatePanel_MMSI( size_t parent, int border_size,
                            int group_item_spacing, wxSize small_button_size );
     void CreatePanel_AIS( size_t parent, int border_size,
@@ -529,19 +529,19 @@ class options: public wxScrollingDialog
     void ShowNMEAGPS( bool visible );
     void ShowNMEABT( bool visible );
 
-    void SetNMEAFormToSerial();
-    void SetNMEAFormToNet();
-    void SetNMEAFormToGPS();
-    void SetNMEAFormToBT();
+    void SetNMEAFormToSerial( void );
+    void SetNMEAFormToNet( void );
+    void SetNMEAFormToGPS( void );
+    void SetNMEAFormToBT( void );
 
-    void ClearNMEAForm();
+    void ClearNMEAForm( void );
     bool m_bNMEAParams_shown;
 
     void SetConnectionParams(ConnectionParams *cp);
     void SetDefaultConnectionParams(void);
-    void SetDSFormRWStates();
-    void FillSourceList();
-    ConnectionParams *CreateConnectionParamsFromSelectedItem();
+    void SetDSFormRWStates( void );
+    void FillSourceList( void );
+    ConnectionParams *CreateConnectionParamsFromSelectedItem( void );
 
     wxNotebookPage *m_groupsPage;
     wxFont *smallFont;
@@ -559,7 +559,7 @@ class options: public wxScrollingDialog
 class ChartGroupsUI: public wxScrolledWindow {
   public:
     explicit ChartGroupsUI( wxWindow *parent );
-    ~ChartGroupsUI();
+    ~ChartGroupsUI( void );
 
     void CreatePanel( size_t parent, int border_size, int group_item_spacing,
                       wxSize small_button_size );
@@ -568,9 +568,9 @@ class ChartGroupsUI: public wxScrolledWindow {
     void SetGroupArray( ChartGroupArray *pGroupArray ) {
         m_pGroupArray = pGroupArray;
     }
-    void SetInitialSettings();
-    void CompleteInitialSettings();
-    void PopulateTrees();
+    void SetInitialSettings( void );
+    void CompleteInitialSettings( void );
+    void PopulateTrees( void );
     void PopulateTreeCtrl( wxTreeCtrl *ptc, const wxArrayString &dir_array,
                            const wxColour &col, wxFont *pFont = NULL );
     void BuildNotebookPages( ChartGroupArray *pGroupArray );
@@ -856,10 +856,10 @@ class SentenceListDlg : public wxDialog
                               const wxPoint& pos = wxDefaultPosition,
                               const wxSize& size = wxSize( 280,420 ),
                               long style = wxDEFAULT_DIALOG_STYLE );
-    ~SentenceListDlg();
+    ~SentenceListDlg( void );
     void SetSentenceList(wxArrayString sentences);
-    wxString GetSentencesAsText();
-    void BuildSentenceArray();
+    wxString GetSentencesAsText( void );
+    void BuildSentenceArray( void );
     void SetType(int io, ListType type);
 
   protected:
@@ -882,7 +882,7 @@ class SentenceListDlg : public wxDialog
     wxStaticBox *m_pclbBox;
 
   private:
-    void FillSentences();
+    void FillSentences( void );
 
     wxArrayString m_sentences;
     ListType m_type;
@@ -895,7 +895,7 @@ class OpenGLOptionsDlg : public wxDialog
     explicit OpenGLOptionsDlg( wxWindow *parent, bool glTicked );
     void OnButtonRebuild( wxCommandEvent& event );
     void OnButtonClear( wxCommandEvent& event );
-    wxString TextureCacheSize();
+    wxString TextureCacheSize( void );
 
     wxGridSizer *m_bSizer1;
     wxBoxSizer *m_bSizer2;
@@ -925,7 +925,7 @@ class MMSIListCtrl: public wxListCtrl
   public:
      explicit MMSIListCtrl( wxWindow *parent, wxWindowID id, const wxPoint& pos,
                             const wxSize& size, long style );
-    ~MMSIListCtrl();
+    ~MMSIListCtrl( void );
 
     wxString OnGetItemText( long item, long column ) const;
     void OnListItemClick( wxListEvent &event);
@@ -955,7 +955,7 @@ class MMSIEditDialog: public wxDialog
                              const wxPoint& pos = wxDefaultPosition,
                              const wxSize& size = wxDefaultSize,
                              long style = 0 );
-    ~MMSIEditDialog();
+    ~MMSIEditDialog( void );
 
     bool Create( MMSIProperties *props, wxWindow *parent,
                  wxWindowID id = wxID_ANY,
@@ -963,7 +963,7 @@ class MMSIEditDialog: public wxDialog
                  const wxPoint& pos = wxDefaultPosition,
                  const wxSize& size = wxDefaultSize, long style = 0 );
     void SetColorScheme(ColorScheme cs);
-    void CreateControls();
+    void CreateControls( void );
     void OnMMSIEditCancelClick( wxCommandEvent& event );
     void OnMMSIEditOKClick( wxCommandEvent& event );
     void OnCtlUpdated( wxCommandEvent& event );

--- a/include/options.h
+++ b/include/options.h
@@ -382,6 +382,8 @@ class options: public wxScrollingDialog
     void OnConnValChange( wxCommandEvent& event );
     void OnValChange( wxCommandEvent& event );
     void OnUploadFormatChange( wxCommandEvent& event );
+    void EnableItem( const long index );
+    void OnConnectionToggleEnable( wxListEvent &event );
     void OnConnectionToggleEnable( wxMouseEvent &event );
 
     bool connectionsaved;

--- a/include/options.h
+++ b/include/options.h
@@ -863,8 +863,6 @@ class SentenceListDlg : public wxDialog
     void OnStcSelect( wxCommandEvent& event );
     void OnAddClick( wxCommandEvent& event );
     void OnDeleteClick( wxCommandEvent& event );
-    void OnCancelClick( wxCommandEvent& event );
-    void OnOkClick( wxCommandEvent& event );
     void OnCLBSelect( wxCommandEvent& event );
     void OnCLBToggle( wxCommandEvent& event );
     void OnCheckAllClick( wxCommandEvent& event );
@@ -872,11 +870,10 @@ class SentenceListDlg : public wxDialog
     void FillSentences( void );
 
     wxCheckListBox* m_clbSentences;
-    wxButton *m_btnAdd, *m_btnDel, *m_btnCheckAll, *m_btnClearAll;
-    wxButton *m_sdbSizer4OK, *m_sdbSizer4Cancel;
     wxStdDialogButtonSizer* m_sdbSizer4;
     wxArrayString standard_sentences, m_sentences;
     wxStaticBox *m_pclbBox;
+    wxButton *m_btnDel;
 
     ListType m_type;
     FilterDirection m_dir;

--- a/include/options.h
+++ b/include/options.h
@@ -208,16 +208,14 @@ class options: public wxScrollingDialog
 public:
     options();
     options( MyFrame* parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME, const wxString& caption =
-            SYMBOL_OPTIONS_TITLE, const wxPoint& pos = SYMBOL_OPTIONS_POSITION, const wxSize& size =
-            SYMBOL_OPTIONS_SIZE, long style = SYMBOL_OPTIONS_STYLE );
+             SYMBOL_OPTIONS_TITLE, const wxPoint& pos = SYMBOL_OPTIONS_POSITION, const wxSize& size =
+             SYMBOL_OPTIONS_SIZE, long style = SYMBOL_OPTIONS_STYLE );
 
     ~options();
 
     bool Create( MyFrame* parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME, const wxString& caption =
-            SYMBOL_OPTIONS_TITLE, const wxPoint& pos = SYMBOL_OPTIONS_POSITION, const wxSize& size =
-            SYMBOL_OPTIONS_SIZE, long style = SYMBOL_OPTIONS_STYLE );
-
-    void Init();
+                 SYMBOL_OPTIONS_TITLE, const wxPoint& pos = SYMBOL_OPTIONS_POSITION, const wxSize& size =
+                 SYMBOL_OPTIONS_SIZE, long style = SYMBOL_OPTIONS_STYLE );
 
     void SetInitialPage( int page_sel);
     void Finish( void);
@@ -623,6 +621,7 @@ public:
     wxArrayString           *m_pSerialArray;
 
 private:
+    void Init();
     void CreatePanel_MMSI( size_t parent, int border_size, int group_item_spacing,
             wxSize small_button_size );
     void CreatePanel_AIS( size_t parent, int border_size, int group_item_spacing,

--- a/include/options.h
+++ b/include/options.h
@@ -859,7 +859,7 @@ class SentenceListDlg : public wxDialog
     void OnClearAllClick( wxCommandEvent& event );
 
     void Populate( const wxArrayString &list );
-    const wxString GetBoxLabel( void );
+    const wxString GetBoxLabel( void ) const;
 
     wxCheckListBox* m_clbSentences;
     wxStdDialogButtonSizer* m_sdbSizer4;

--- a/include/options.h
+++ b/include/options.h
@@ -873,16 +873,19 @@ class OpenGLOptionsDlg : public wxDialog
 {
   public:
     explicit OpenGLOptionsDlg( wxWindow *parent, bool glTicked );
+
+    wxCheckBox *m_cbUseAcceleratedPanning, *m_cbTextureCompression;
+    wxCheckBox *m_cbTextureCompressionCaching, *m_cbShowFPS, *m_cbSoftwareGL;
+    wxSpinCtrl *m_sTextureDimension, *m_sTextureMemorySize;
+
+    bool m_brebuild_cache;
+
+  private:
     void OnButtonRebuild( wxCommandEvent& event );
     void OnButtonClear( wxCommandEvent& event );
     wxString TextureCacheSize( void );
 
-    wxCheckBox *m_cbUseAcceleratedPanning, *m_cbTextureCompression;
-    wxCheckBox *m_cbTextureCompressionCaching, *m_cbShowFPS, *m_cbSoftwareGL;
     wxStaticText *m_cacheSize;
-    wxSpinCtrl *m_sTextureDimension, *m_sTextureMemorySize;
-
-    bool m_brebuild_cache;
 
     DECLARE_EVENT_TABLE()
 };

--- a/include/options.h
+++ b/include/options.h
@@ -26,7 +26,6 @@
 #ifndef _OPTIONS_H_
 #define _OPTIONS_H_
 
-
 #include <wx/listbook.h>
 #include <wx/dirctrl.h>
 #include <wx/spinctrl.h>
@@ -49,7 +48,7 @@
 #define __OCPN__OPTIONS_USE_LISTBOOK__
 #endif
 
-//      Forward Declarations
+// Forward Declarations
 class wxGenericDirCtrl;
 class MyConfig;
 class ChartGroupsUI;
@@ -58,9 +57,12 @@ class SentenceListDlg;
 class PluginListPanel;
 class ChartGroupArray;
 class ChartGroup;
+class MMSI_Props_Panel;
+class MMSIProperties;
 
 #define ID_DIALOG 10001
-#define SYMBOL_OPTIONS_STYLE wxCAPTION|wxRESIZE_BORDER|wxSYSTEM_MENU|wxCLOSE_BOX
+#define SYMBOL_OPTIONS_STYLE wxCAPTION | wxRESIZE_BORDER | wxSYSTEM_MENU | \
+                             wxCLOSE_BOX
 #define SYMBOL_OPTIONS_TITLE _("Options")
 #define SYMBOL_OPTIONS_IDNAME ID_DIALOG
 #define SYMBOL_OPTIONS_SIZE wxSize(500, 500)
@@ -169,23 +171,22 @@ enum {
     ID_BT_SCANTIMER
 };
 
-//    Define an int bit field for dialog return value
-//    To indicate which types of settings have changed
-#define     GENERIC_CHANGED             1
-#define     S52_CHANGED                 2
-#define     FONT_CHANGED                4
-#define     FORCE_UPDATE                8
-#define     VISIT_CHARTS                16
-#define     LOCALE_CHANGED              32
-#define     TOOLBAR_CHANGED             64
-#define     CHANGE_CHARTS               128
-#define     SCAN_UPDATE                 256
-#define     GROUPS_CHANGED              512
-#define     STYLE_CHANGED               1024
-#define     TIDES_CHANGED               2048
-#define     GL_CHANGED                  4096
-#define     REBUILD_RASTER_CACHE        8192
-
+/* Define an int bit field for dialog return value
+ * to indicate which types of settings have changed */
+#define GENERIC_CHANGED      1
+#define S52_CHANGED          2
+#define FONT_CHANGED         4
+#define FORCE_UPDATE         8
+#define VISIT_CHARTS         16
+#define LOCALE_CHANGED       32
+#define TOOLBAR_CHANGED      64
+#define CHANGE_CHARTS        128
+#define SCAN_UPDATE          256
+#define GROUPS_CHANGED       512
+#define STYLE_CHANGED        1024
+#define TIDES_CHANGED        2048
+#define GL_CHANGED           4096
+#define REBUILD_RASTER_CACHE 8192
 
 #ifndef wxCLOSE_BOX
 #define wxCLOSE_BOX 0x1000
@@ -196,7 +197,7 @@ enum {
 
 WX_DECLARE_OBJARRAY(wxGenericDirCtrl *, ArrayOfDirCtrls);
 
-#ifndef bert// wxCHECK_VERSION(2, 9, 0)
+#ifndef bert // wxCHECK_VERSION(2, 9, 0)
 class options: public wxDialog
 #else
 class options: public wxScrollingDialog
@@ -205,60 +206,47 @@ class options: public wxScrollingDialog
     DECLARE_DYNAMIC_CLASS( options )
     DECLARE_EVENT_TABLE()
 
-public:
+  public:
     explicit options();
-    explicit options( MyFrame* parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME, const wxString& caption =
-             SYMBOL_OPTIONS_TITLE, const wxPoint& pos = SYMBOL_OPTIONS_POSITION, const wxSize& size =
-             SYMBOL_OPTIONS_SIZE, long style = SYMBOL_OPTIONS_STYLE );
+    explicit options( MyFrame* parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME,
+                      const wxString& caption = SYMBOL_OPTIONS_TITLE,
+                      const wxPoint& pos = SYMBOL_OPTIONS_POSITION,
+                      const wxSize& size = SYMBOL_OPTIONS_SIZE,
+                      long style = SYMBOL_OPTIONS_STYLE );
 
     ~options();
 
-    bool Create( MyFrame* parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME, const wxString& caption =
-                 SYMBOL_OPTIONS_TITLE, const wxPoint& pos = SYMBOL_OPTIONS_POSITION, const wxSize& size =
-                 SYMBOL_OPTIONS_SIZE, long style = SYMBOL_OPTIONS_STYLE );
+    bool Create( MyFrame* parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME,
+                 const wxString& caption = SYMBOL_OPTIONS_TITLE,
+                 const wxPoint& pos = SYMBOL_OPTIONS_POSITION,
+                 const wxSize& size = SYMBOL_OPTIONS_SIZE,
+                 long style = SYMBOL_OPTIONS_STYLE );
 
     void SetInitialPage( int page_sel);
     void Finish( void);
 
-    wxWindow* GetContentWindow() const;
+    wxWindow *GetContentWindow() const;
     void OnClose( wxCloseEvent& event );
 
     void CreateControls();
-    size_t CreatePanel(const wxString & title);
-    wxScrolledWindow *AddPage(size_t parent, const wxString & title);
+    size_t CreatePanel( const wxString & title );
+    wxScrolledWindow *AddPage( size_t parent, const wxString & title );
     bool DeletePage( wxScrolledWindow *page );
     void SetColorScheme( ColorScheme cs );
     void RecalculateSize();
 
-    void SetInitChartDir(const wxString &dir)
-    {
-        m_init_chart_dir = dir;
-    }
+    void SetInitChartDir( const wxString &dir ) { m_init_chart_dir = dir; }
     void SetInitialSettings();
-
-    void SetCurrentDirList( ArrayOfCDI p )
-    {
-        m_CurrentDirList = p;
-    }
-    void SetWorkDirListPtr( ArrayOfCDI *p )
-    {
-        m_pWorkDirList = p;
-    }
-    ArrayOfCDI* GetWorkDirListPtr()
-    {
-        return m_pWorkDirList;
-    }
+    void SetCurrentDirList( ArrayOfCDI p ) { m_CurrentDirList = p; }
+    void SetWorkDirListPtr( ArrayOfCDI *p ) { m_pWorkDirList = p; }
+    ArrayOfCDI *GetWorkDirListPtr() { return m_pWorkDirList; }
 
     void AddChartDir( wxString &dir );
 
     void UpdateDisplayedChartDirList(ArrayOfCDI p);
-
     void UpdateOptionsUnits();
 
-    void SetConfigPtr( MyConfig *p )
-    {
-        m_pConfig = p;
-    }
+    void SetConfigPtr( MyConfig *p ) { m_pConfig = p; }
     void OnDebugcheckbox1Click( wxCommandEvent& event );
     void OnDirctrlSelChanged( wxTreeEvent& event );
     void OnButtonaddClick( wxCommandEvent& event );
@@ -269,10 +257,8 @@ public:
     void OnCancelClick( wxCommandEvent& event );
     void OnChooseFont( wxCommandEvent& event );
     void OnCPAWarnClick( wxCommandEvent& event );
-
     void OnSizeAutoButton( wxCommandEvent& event );
     void OnSizeManualButton( wxCommandEvent& event );
-
 
 #ifdef __WXGTK__
     void OnChooseFontColor( wxCommandEvent& event );
@@ -302,143 +288,78 @@ public:
     void OnChartDirListSelect( wxCommandEvent& event );
     void OnUnitsChoice( wxCommandEvent& event );
     void OnScanBTClick( wxCommandEvent& event );
-    void onBTScanTimer(wxTimerEvent &event);
+    void onBTScanTimer( wxTimerEvent &event );
     void StopBTScan( void );
 
     void UpdateWorkArrayFromTextCtl();
 
-// Should we show tooltips?
+    // Should we show tooltips?
     static bool ShowToolTips();
 
 #ifdef __OCPN__OPTIONS_USE_LISTBOOK__
-    wxListbook*             m_pListbook;
+    wxListbook* m_pListbook;
 #else
-    wxNotebook*             m_pListbook;
+    wxNotebook* m_pListbook;
 #endif
 
-    size_t                  m_pageDisplay, m_pageConnections, m_pageCharts, m_pageShips, m_pageUI, m_pagePlugins;
-    int                     lastPage;
-    wxPoint                 lastWindowPos;
-    wxSize                  lastWindowSize;
-    wxButton*               m_ApplyButton;
-    wxButton*               m_OKButton;
-    wxButton*               m_CancelButton;
+    size_t m_pageDisplay, m_pageConnections, m_pageCharts, m_pageShips;
+    size_t m_pageUI, m_pagePlugins;
+    int lastPage;
+    wxPoint lastWindowPos;
+    wxSize lastWindowSize;
+    wxButton *m_ApplyButton, *m_OKButton, *m_CancelButton;
 
-    ChartGroupArray         *m_pGroupArray;
-    int                     m_groups_changed;
+    ChartGroupArray *m_pGroupArray;
+    int m_groups_changed;
 
-//  Sizer Flags
-    wxSizerFlags inputFlags;
-    wxSizerFlags labelFlags;
-    wxSizerFlags groupInputFlags;
+    // Sizer flags
+    wxSizerFlags inputFlags, labelFlags, groupInputFlags;
     wxSizerFlags groupLabelFlags;
 
-//    For General Options
-    wxScrolledWindow        *pDisplayPanel;
-    wxCheckBox              *pShowStatusBar;
-    wxCheckBox              *pShowMenuBar;
-    wxCheckBox              *pShowChartBar;
-    wxCheckBox              *pShowCompassWin;
-    wxCheckBox              *pPrintShowIcon;
-    wxCheckBox              *pCDOOutlines;
-    wxCheckBox              *pSDepthUnits;
-    wxCheckBox              *pSDisplayGrid;
-    wxCheckBox              *pAutoAnchorMark;
-    wxCheckBox              *pCDOQuilting;
-    wxCheckBox              *pCBRaster;
-    wxCheckBox              *pCBVector;
-    wxCheckBox              *pCBCM93;
-    wxRadioButton           *pCBCourseUp;
-    wxRadioButton           *pCBNorthUp;
-    wxTextCtrl              *pCOGUPUpdateSecs;
-    wxCheckBox              *pCBLookAhead;
-    wxTextCtrl              *m_pText_OSCOG_Predictor;
-    wxTextCtrl              *m_pText_OSHDT_Predictor;
-    wxChoice                *m_pShipIconType;
-    wxCheckBox              *pSkewComp;
-    wxCheckBox              *pOpenGL;
-    wxCheckBox              *pSmoothPanZoom;
-    wxCheckBox              *pFullScreenQuilt;
-    wxChoice                *m_pcTCDatasets;
-    wxCheckBox              *pMobile;
-    wxCheckBox              *pResponsive;
-    wxSlider                *m_pSlider_Zoom;
-    wxSlider                *m_pSlider_GUI_Factor;
-    wxSlider                *m_pSlider_Chart_Factor;
+    // For general options
+    wxScrolledWindow *pDisplayPanel;
+    wxCheckBox *pShowStatusBar, *pShowMenuBar, *pShowChartBar, *pShowCompassWin;
+    wxCheckBox *pPrintShowIcon, *pCDOOutlines, *pSDepthUnits, *pSDisplayGrid;
+    wxCheckBox *pAutoAnchorMark, *pCDOQuilting, *pCBRaster, *pCBVector;
+    wxCheckBox *pCBCM93, *pCBLookAhead, *pSkewComp, *pOpenGL, *pSmoothPanZoom;
+    wxCheckBox *pFullScreenQuilt, *pMobile, *pResponsive, *pOverzoomEmphasis;
+    wxCheckBox *pOZScaleVector, *pToolbarAutoHideCB;
+    wxTextCtrl *pCOGUPUpdateSecs, *m_pText_OSCOG_Predictor, *pScreenMM;
+    wxTextCtrl *pToolbarHideSecs, *m_pText_OSHDT_Predictor;
+    wxChoice *m_pShipIconType, *m_pcTCDatasets;
+    wxSlider *m_pSlider_Zoom, *m_pSlider_GUI_Factor, *m_pSlider_Chart_Factor;
 
-    int                      k_tides;
-    wxCheckBox              *pOverzoomEmphasis;
-    wxCheckBox              *pOZScaleVector;
-    wxTextCtrl              *pScreenMM;
-    wxRadioButton           *pRBSizeAuto;
-    wxRadioButton           *pRBSizeManual;
+    wxRadioButton *pCBCourseUp, *pCBNorthUp, *pRBSizeAuto, *pRBSizeManual;
+    int k_tides;
 
-    wxCheckBox              *pToolbarAutoHideCB;
-    wxTextCtrl              *pToolbarHideSecs;
-
-//    For GPS Page
-    wxListCtrl* m_lcSources;
-    wxButton* m_buttonAdd;
-    wxButton* m_buttonRemove;
-    wxStaticBoxSizer* sbSizerConnectionProps;
-    wxRadioButton* m_rbTypeSerial;
-    wxRadioButton* m_rbTypeNet;
-    wxRadioButton* m_rbTypeInternalGPS;
-    wxRadioButton* m_rbTypeInternalBT;
-    wxButton* m_buttonScanBT;
-    wxStaticText* m_stBTPairs;
-    wxChoice* m_choiceBTDataSources;
-
-    wxGridSizer* gSizerNetProps;
-    wxStaticText* m_stNetProto;
-    wxRadioButton* m_rbNetProtoTCP;
-    wxRadioButton* m_rbNetProtoUDP;
-    wxRadioButton* m_rbNetProtoGPSD;
-    wxStaticText* m_stNetAddr;
-    wxTextCtrl* m_tNetAddress;
-    wxStaticText* m_stNetPort;
-    wxTextCtrl* m_tNetPort;
-    wxGridSizer* gSizerSerProps;
-    wxStaticText* m_stSerPort;
-    wxComboBox* m_comboPort;
-    wxStaticText* m_stSerBaudrate;
-    wxChoice* m_choiceBaudRate;
-    wxStaticText* m_stSerProtocol;
-    wxChoice* m_choiceSerialProtocol;
-    wxStaticText* m_stPriority;
-    wxChoice* m_choicePriority;
-    wxCheckBox* m_cbCheckCRC;
-    wxCheckBox* m_cbGarminHost;
-    wxCheckBox* m_cbGarminUploadHost;
-    wxCheckBox* m_cbFurunoGP3X;
-    wxCheckBox* m_cbNMEADebug;
-    wxCheckBox* m_cbFilterSogCog;
-    wxStaticText* m_stFilterSec;
-    wxTextCtrl* m_tFilterSec;
-    wxRadioButton* m_rbIAccept;
-    wxRadioButton* m_rbIIgnore;
-    wxTextCtrl* m_tcInputStc;
-    wxButton* m_btnInputStcList;
-    wxCheckBox* m_cbInput;
-    wxCheckBox* m_cbOutput;
-    wxStaticText* m_stPrecision;
-    wxChoice* m_choicePrecision;
-    wxRadioButton* m_rbOAccept;
+    // For the GPS page
+    wxListCtrl *m_lcSources;
+    wxButton *m_buttonAdd, *m_buttonRemove, *m_buttonScanBT, *m_btnInputStcList;
+    wxButton *m_btnOutputStcList, *m_sdbSizerDlgButtonsOK;
+    wxButton *m_sdbSizerDlgButtonsApply, *m_sdbSizerDlgButtonsCancel;
+    wxStaticBoxSizer *sbSizerConnectionProps, *sbSizerInFilter;
+    wxStaticBoxSizer *sbSizerOutFilter;
+    wxRadioButton *m_rbTypeSerial, *m_rbTypeNet, *m_rbTypeInternalGPS;
+    wxRadioButton *m_rbTypeInternalBT, *m_rbNetProtoTCP, *m_rbNetProtoUDP;
+    wxRadioButton *m_rbNetProtoGPSD, *m_rbIAccept, *m_rbIIgnore, *m_rbOAccept;
     wxRadioButton* m_rbOIgnore;
-    wxTextCtrl* m_tcOutputStc;
-    wxButton* m_btnOutputStcList;
-    wxStdDialogButtonSizer* m_sdbSizerDlgButtons;
-    wxButton* m_sdbSizerDlgButtonsOK;
-    wxButton* m_sdbSizerDlgButtonsApply;
-    wxButton* m_sdbSizerDlgButtonsCancel;
-    wxStaticBoxSizer* sbSizerInFilter;
-    wxStaticBoxSizer* sbSizerOutFilter;
-    wxCheckBox *m_cbAPBMagnetic;
-    wxStaticText* m_stTalkerIdText;
-    wxTextCtrl* m_TalkerIdText;
+    wxStaticText *m_stBTPairs, *m_stNetProto, *m_stNetAddr, *m_stNetPort;
+    wxStaticText *m_stSerPort, *m_stSerBaudrate, *m_stSerProtocol;
+    wxStaticText *m_stPriority, *m_stFilterSec, *m_stPrecision;
+    wxStaticText *m_stTalkerIdText;
+    wxChoice *m_choiceBTDataSources, *m_choiceBaudRate, *m_choiceSerialProtocol;
+    wxChoice *m_choicePriority, *m_choicePrecision;
 
-    SentenceListDlg* m_stcdialog_in;
-    SentenceListDlg* m_stcdialog_out;
+    wxGridSizer *gSizerNetProps, *gSizerSerProps;
+    wxTextCtrl *m_tNetAddress, *m_tNetPort, *m_tFilterSec, *m_tcInputStc;
+    wxTextCtrl *m_tcOutputStc, *m_TalkerIdText;
+    wxCheckBox *m_cbCheckCRC, *m_cbGarminHost, *m_cbGarminUploadHost;
+    wxCheckBox *m_cbFurunoGP3X, *m_cbNMEADebug, *m_cbFilterSogCog, *m_cbInput;
+    wxCheckBox *m_cbOutput, *m_cbAPBMagnetic;
+    wxComboBox *m_comboPort;
+    wxStdDialogButtonSizer* m_sdbSizerDlgButtons;
+
+    SentenceListDlg *m_stcdialog_in, *m_stcdialog_out;
 
     // Virtual event handlers, overide them in your derived class
     void OnSelectDatasource( wxListEvent& event );
@@ -469,185 +390,133 @@ public:
     bool connectionsaved;
     bool m_connection_enabled;
 
-//    For "S57" page
-    wxBoxSizer              *vectorPanel;
-    wxScrolledWindow        *ps57Ctl;
-    wxCheckListBox          *ps57CtlListBox;
-    wxChoice                *pDispCat;
-    wxButton                *itemButtonClearList;
-    wxButton                *itemButtonSelectList;
-    wxChoice                *pPointStyle;
-    wxChoice                *pBoundStyle;
-    wxChoice                *p24Color;
-    wxCheckBox              *pCheck_SOUNDG;
-    wxCheckBox              *pCheck_META;
-    wxCheckBox              *pCheck_SHOWIMPTEXT;
-    wxCheckBox              *pCheck_SCAMIN;
-    wxCheckBox              *pCheck_ATONTEXT;
-    wxCheckBox              *pCheck_LDISTEXT;
-    wxCheckBox              *pCheck_XLSECTTEXT;
-    wxCheckBox              *pCheck_DECLTEXT;
-    wxCheckBox              *pCheck_NATIONALTEXT;
-    wxTextCtrl              *m_ShallowCtl;
-    wxTextCtrl              *m_SafetyCtl;
-    wxTextCtrl              *m_DeepCtl;
-    wxStaticText            *m_depthUnitsShal;
-    wxStaticText            *m_depthUnitsSafe;
-    wxStaticText            *m_depthUnitsDeep;
-    wxSlider                *m_pSlider_CM93_Zoom;
-    wxCheckBox              *pSEnableCM93Offset;
-    int                       k_vectorcharts;
+    // For "S57" page
+    wxBoxSizer *vectorPanel;
+    wxScrolledWindow *ps57Ctl;
+    wxCheckListBox *ps57CtlListBox;
+    wxChoice *pDispCat, *pPointStyle, *pBoundStyle, *p24Color;
+    wxButton *itemButtonClearList, *itemButtonSelectList;
+    wxCheckBox *pCheck_SOUNDG, *pCheck_META, *pCheck_SHOWIMPTEXT;
+    wxCheckBox *pCheck_SCAMIN, *pCheck_ATONTEXT, *pCheck_LDISTEXT;
+    wxCheckBox *pCheck_XLSECTTEXT, *pCheck_DECLTEXT, *pCheck_NATIONALTEXT;
+    wxCheckBox *pSEnableCM93Offset;
+    wxTextCtrl *m_ShallowCtl, *m_SafetyCtl, *m_DeepCtl;
+    wxStaticText *m_depthUnitsShal, *m_depthUnitsSafe, *m_depthUnitsDeep;
+    wxSlider *m_pSlider_CM93_Zoom;
+    int k_vectorcharts;
 
-// For "Units" page
-    wxChoice                *pSDMMFormat;
-    wxChoice                *pDistanceFormat;
-    wxChoice                *pSpeedFormat;
-    wxChoice                *pDepthUnitSelect;
-    wxCheckBox              *pCBMagShow;
-    wxTextCtrl              *pMagVar;
+    // For "Units" page
+    wxChoice *pSDMMFormat, *pDistanceFormat, *pSpeedFormat, *pDepthUnitSelect;
+    wxCheckBox *pCBMagShow;
+    wxTextCtrl *pMagVar;
 
-//    For "Charts" page
-    wxStaticBoxSizer          *activeSizer;
-    wxBoxSizer                *chartPanel;
-    wxTextCtrl                *pSelCtl;
-    wxListBox                 *pActiveChartsList;
-    wxStaticBox               *itemActiveChartStaticBox;
-    wxCheckBox                *pUpdateCheckBox;
-    wxCheckBox                *pScanCheckBox;
-    int                       k_charts;
-    wxButton                  *m_removeBtn;
+    // For "Charts" page
+    wxStaticBoxSizer *activeSizer;
+    wxBoxSizer *chartPanel;
+    wxTextCtrl *pSelCtl;
+    wxListBox *pActiveChartsList;
+    wxStaticBox *itemActiveChartStaticBox;
+    wxCheckBox *pUpdateCheckBox, *pScanCheckBox;
+    wxButton *m_removeBtn;
+    int k_charts;
 
-//      For :Charts->Display Options" page
+    // For the "Charts->Display Options" page
+    wxScrolledWindow *m_ChartDisplayPage;
 
-    wxScrolledWindow          *m_ChartDisplayPage;
+    // For the "AIS" page
+    wxCheckBox *m_pCheck_CPA_Max, *m_pCheck_CPA_Warn, *m_pCheck_CPA_WarnT;
+    wxCheckBox *m_pCheck_Mark_Lost, *m_pCheck_Remove_Lost, *m_pCheck_Show_COG;
+    wxCheckBox *m_pCheck_Show_Tracks, *m_pCheck_Show_Moored;
+    wxCheckBox *m_pCheck_AlertDialog, *m_pCheck_AlertAudio;
+    wxCheckBox *m_pCheck_Alert_Moored, *m_pCheck_Rollover_Class;
+    wxCheckBox *m_pCheck_Rollover_COG, *m_pCheck_Rollover_CPA;
+    wxCheckBox *m_pCheck_Ack_Timout, *m_pCheck_Show_Area_Notices;
+    wxCheckBox *m_pCheck_Draw_Target_Size, *m_pCheck_Show_Target_Name;
+    wxCheckBox *m_pCheck_Wpl_Aprs, *m_pCheck_ShowAllCPA;
+    wxTextCtrl *m_pText_CPA_Max, *m_pText_CPA_Warn, *m_pText_CPA_WarnT;
+    wxTextCtrl *m_pText_Mark_Lost, *m_pText_Remove_Lost, *m_pText_COG_Predictor;
+    wxTextCtrl *m_pText_Track_Length, *m_pText_Moored_Speed;
+    wxTextCtrl *m_pText_ACK_Timeout, *m_pText_Show_Target_Name_Scale;
 
-//    For "AIS" Page
-    wxCheckBox                *m_pCheck_CPA_Max;
-    wxTextCtrl                *m_pText_CPA_Max;
-    wxCheckBox                *m_pCheck_CPA_Warn;
-    wxTextCtrl                *m_pText_CPA_Warn;
-    wxCheckBox                *m_pCheck_CPA_WarnT;
-    wxTextCtrl                *m_pText_CPA_WarnT;
-    wxCheckBox                *m_pCheck_Mark_Lost;
-    wxTextCtrl                *m_pText_Mark_Lost;
-    wxCheckBox                *m_pCheck_Remove_Lost;
-    wxTextCtrl                *m_pText_Remove_Lost;
-    wxCheckBox                *m_pCheck_Show_COG;
-    wxTextCtrl                *m_pText_COG_Predictor;
-    wxCheckBox                *m_pCheck_Show_Tracks;
-    wxTextCtrl                *m_pText_Track_Length;
-    wxCheckBox                *m_pCheck_Show_Moored;
-    wxTextCtrl                *m_pText_Moored_Speed;
-    wxCheckBox                *m_pCheck_AlertDialog;
-    wxCheckBox                *m_pCheck_AlertAudio;
-    wxCheckBox                *m_pCheck_Alert_Moored;
-    wxCheckBox                *m_pCheck_Rollover_Class;
-    wxCheckBox                *m_pCheck_Rollover_COG;
-    wxCheckBox                *m_pCheck_Rollover_CPA;
-    wxCheckBox                *m_pCheck_Ack_Timout;
-    wxTextCtrl                *m_pText_ACK_Timeout;
-    wxCheckBox                *m_pCheck_Show_Area_Notices;
-    wxCheckBox                *m_pCheck_Draw_Target_Size;
-    wxCheckBox                *m_pCheck_Show_Target_Name;
-    wxTextCtrl                *m_pText_Show_Target_Name_Scale;
-    wxCheckBox                *m_pCheck_Wpl_Aprs;
-    wxCheckBox                *m_pCheck_ShowAllCPA;
-//    For Ship page
-    wxFlexGridSizer*        realSizes;
-    wxTextCtrl              *m_pOSLength;
-    wxTextCtrl              *m_pOSWidth;
-    wxTextCtrl              *m_pOSGPSOffsetX;
-    wxTextCtrl              *m_pOSGPSOffsetY;
-    wxTextCtrl              *m_pOSMinSize;
-    wxStaticBoxSizer        *dispOptions;
-    wxStaticBoxSizer        *dispWaypointOptions;
-    wxScrolledWindow        *itemPanelShip;
-    wxBoxSizer              *ownShip;
-    wxTextCtrl              *m_pText_ACRadius;
+    // For the ship page
+    wxFlexGridSizer* realSizes;
+    wxTextCtrl *m_pOSLength, *m_pOSWidth, *m_pOSGPSOffsetX, *m_pOSGPSOffsetY;
+    wxTextCtrl *m_pOSMinSize, *m_pText_ACRadius;
+    wxStaticBoxSizer *dispOptions, *dispWaypointOptions;
+    wxScrolledWindow *itemPanelShip;
+    wxBoxSizer *ownShip;
 
-//    For Fonts page
-    wxBoxSizer              *m_itemBoxSizerFontPanel;
-    wxChoice                *m_itemFontElementListBox;
-    wxChoice                *m_itemStyleListBox;
-    wxChoice                *m_itemLangListBox;
-    bool                    m_bVisitLang;
+    // For the font page
+    wxBoxSizer *m_itemBoxSizerFontPanel;
+    wxChoice *m_itemFontElementListBox, *m_itemStyleListBox, *m_itemLangListBox;
+    bool m_bVisitLang;
 
-//    For "AIS Options"
-    wxComboBox              *m_itemAISListBox;
+    // For "AIS Options"
+    wxComboBox *m_itemAISListBox;
 
-//    For "PlugIns" Panel
-    PluginListPanel         *m_pPlugInCtrl;
-    int                     k_plugins;
+    // For "PlugIns" Panel
+    PluginListPanel *m_pPlugInCtrl;
+    wxScrolledWindow *itemPanelPlugins;
+    wxBoxSizer *itemBoxSizerPanelPlugins;
+    wxFlexGridSizer *radarGrid, *waypointradarGrid;
+    wxChoice *pNavAidRadarRingsNumberVisible, *pWaypointRangeRingsNumber;
+    wxChoice *m_itemRadarRingsUnits, *m_itemWaypointRangeRingsUnits;
+    wxChoice *pTrackPrecision;
+    wxTextCtrl *pNavAidRadarRingsStep, *pWaypointRangeRingsStep;
+    wxTextCtrl *m_pText_TP_Secs, *m_pText_TP_Dist;
+    wxCheckBox *pWayPointPreventDragging, *pConfirmObjectDeletion;
+    wxCheckBox *pEnableZoomToCursor, *pPreserveScale, *pPlayShipsBells;
+    wxCheckBox *pFullScreenToolbar, *pTransparentToolbar;
+    wxCheckBox *pAdvanceRouteWaypointOnArrivalOnly, *pTrackShowIcon;
+    wxCheckBox *pTrackDaily, *pTrackHighlite;
+    wxColourPickerCtrl *m_colourWaypointRangeRingsColour;
+    wxSpinCtrl *pSoundDeviceIndex;
+    wxArrayPtrVoid OBJLBoxArray;
+    wxString m_init_chart_dir;
+    wxArrayString *m_pSerialArray;
 
-    wxScrolledWindow        *itemPanelPlugins;
-    wxBoxSizer              *itemBoxSizerPanelPlugins;
+    ArrayOfCDI m_CurrentDirList, *m_pWorkDirList;
+    MyConfig *m_pConfig;
+    MyFrame *pParent;
 
-    wxChoice                *pNavAidRadarRingsNumberVisible;
-    wxChoice                *pWaypointRangeRingsNumber;
-    wxFlexGridSizer         *radarGrid;
-    wxFlexGridSizer         *waypointradarGrid;
-    wxTextCtrl              *pNavAidRadarRingsStep;
-    wxChoice                *m_itemRadarRingsUnits;
-    wxTextCtrl              *pWaypointRangeRingsStep;
-    wxChoice                *m_itemWaypointRangeRingsUnits;
-    wxColourPickerCtrl      *m_colourWaypointRangeRingsColour;
-    wxCheckBox              *pWayPointPreventDragging;
-    wxCheckBox              *pConfirmObjectDeletion;
-    wxCheckBox              *pEnableZoomToCursor;
-    wxCheckBox              *pPreserveScale;
-    wxCheckBox              *pPlayShipsBells;
-    wxSpinCtrl              *pSoundDeviceIndex;
-    wxCheckBox              *pFullScreenToolbar;
-    wxCheckBox              *pTransparentToolbar;
+    int k_plugins;
 
-    wxCheckBox              *pAdvanceRouteWaypointOnArrivalOnly;
-
-    wxCheckBox              *pTrackShowIcon;
-    wxCheckBox              *pTrackDaily;
-    wxCheckBox              *pTrackHighlite;
-    wxChoice                *pTrackPrecision;
-    wxTextCtrl              *m_pText_TP_Secs;
-    wxTextCtrl              *m_pText_TP_Dist;
-
-    ArrayOfCDI              m_CurrentDirList;
-    ArrayOfCDI              *m_pWorkDirList;
-
-    MyConfig                *m_pConfig;
-
-    wxArrayPtrVoid          OBJLBoxArray;
-    wxString                m_init_chart_dir;
-    MyFrame                 *pParent;
-
-    wxArrayString           *m_pSerialArray;
-
-private:
+  private:
     void Init();
-    void CreatePanel_MMSI( size_t parent, int border_size, int group_item_spacing,
-            wxSize small_button_size );
-    void CreatePanel_AIS( size_t parent, int border_size, int group_item_spacing,
-            wxSize small_button_size );
-    void CreatePanel_Ownship( size_t parent, int border_size, int group_item_spacing,
-            wxSize small_button_size );
-    void CreatePanel_NMEA( size_t parent, int border_size, int group_item_spacing,
-            wxSize small_button_size );
-    void CreatePanel_NMEA_Compact( size_t parent, int border_size, int group_item_spacing,
-            wxSize small_button_size );
-    void CreatePanel_ChartsLoad( size_t parent, int border_size, int group_item_spacing,
-            wxSize small_button_size );
-    void CreatePanel_VectorCharts( size_t parent, int border_size, int group_item_spacing,
-            wxSize small_button_size );
-    void CreatePanel_TidesCurrents( size_t parent, int border_size, int group_item_spacing,
-            wxSize small_button_size );
-    void CreatePanel_ChartGroups( size_t parent, int border_size, int group_item_spacing,
-            wxSize small_button_size );
-    void CreatePanel_Display( size_t parent, int border_size, int group_item_spacing,
-            wxSize small_button_size );
+    void CreatePanel_MMSI( size_t parent, int border_size,
+                           int group_item_spacing, wxSize small_button_size );
+    void CreatePanel_AIS( size_t parent, int border_size,
+                          int group_item_spacing, wxSize small_button_size );
+    void CreatePanel_Ownship( size_t parent, int border_size,
+                              int group_item_spacing,
+                              wxSize small_button_size );
+    void CreatePanel_NMEA( size_t parent, int border_size,
+                           int group_item_spacing, wxSize small_button_size );
+    void CreatePanel_NMEA_Compact( size_t parent, int border_size,
+                                   int group_item_spacing,
+                                   wxSize small_button_size );
+    void CreatePanel_ChartsLoad( size_t parent, int border_size,
+                                 int group_item_spacing,
+                                 wxSize small_button_size );
+    void CreatePanel_VectorCharts( size_t parent, int border_size,
+                                   int group_item_spacing,
+                                   wxSize small_button_size );
+    void CreatePanel_TidesCurrents( size_t parent, int border_size,
+                                    int group_item_spacing,
+                                    wxSize small_button_size );
+    void CreatePanel_ChartGroups( size_t parent, int border_size,
+                                  int group_item_spacing,
+                                  wxSize small_button_size );
+    void CreatePanel_Display( size_t parent, int border_size,
+                              int group_item_spacing,
+                              wxSize small_button_size );
     void CreatePanel_UI( size_t parent, int border_size, int group_item_spacing,
-            wxSize small_button_size );
-    void CreatePanel_Units( size_t parent, int border_size, int group_item_spacing,
-            wxSize small_button_size );
-    void CreatePanel_Advanced( size_t parent, int border_size, int group_item_spacing,
-            wxSize small_button_size );
+                         wxSize small_button_size );
+    void CreatePanel_Units( size_t parent, int border_size,
+                            int group_item_spacing, wxSize small_button_size );
+    void CreatePanel_Advanced( size_t parent, int border_size,
+                               int group_item_spacing,
+                               wxSize small_button_size );
 
     int m_returnChanges;
     wxListBox *tcDataSelected;
@@ -671,49 +540,42 @@ private:
     void ClearNMEAForm();
     bool m_bNMEAParams_shown;
 
-
     void SetConnectionParams(ConnectionParams *cp);
     void SetDefaultConnectionParams(void);
     void SetDSFormRWStates();
     void FillSourceList();
     ConnectionParams *CreateConnectionParamsFromSelectedItem();
 
-    wxNotebookPage*             m_groupsPage;
-    wxFont*     smallFont;
-    wxSize      m_small_button_size;
-    int         m_fontHeight;
-    int         m_scrollRate;
-
-    wxTimer     m_BTScanTimer;
-    int         m_BTscanning;
+    wxNotebookPage *m_groupsPage;
+    wxFont *smallFont;
+    wxSize m_small_button_size;
+    wxTimer m_BTScanTimer;
     wxArrayString m_BTscan_results;
-    int         m_btNoChangeCounter;
-    int         m_btlastResultCount;
 
+    int m_fontHeight, m_scrollRate, m_BTscanning, m_btNoChangeCounter;
+    int m_btlastResultCount;
 };
 
 class ChartGroupsUI: public wxScrolledWindow {
-
     DECLARE_EVENT_TABLE()
 
-public:
-    explicit ChartGroupsUI( wxWindow* parent );
+  public:
+    explicit ChartGroupsUI( wxWindow *parent );
     ~ChartGroupsUI();
 
-    void CreatePanel( size_t parent, int border_size, int group_item_spacing, wxSize small_button_size );
+    void CreatePanel( size_t parent, int border_size, int group_item_spacing,
+                      wxSize small_button_size );
     void CompletePanel( void );
     void SetDBDirs( ArrayOfCDI &array ) { m_db_dirs = array; }
-    void SetGroupArray( ChartGroupArray *pGroupArray ) { m_pGroupArray = pGroupArray; }
+    void SetGroupArray( ChartGroupArray *pGroupArray ) {
+        m_pGroupArray = pGroupArray;
+    }
     void SetInitialSettings();
     void CompleteInitialSettings();
     void PopulateTrees();
-
-    void PopulateTreeCtrl( wxTreeCtrl *ptc, const wxArrayString &dir_array, const wxColour &col,
-            wxFont *pFont = NULL );
-    wxTreeCtrl *AddEmptyGroupPage( const wxString& label );
-
+    void PopulateTreeCtrl( wxTreeCtrl *ptc, const wxArrayString &dir_array,
+                           const wxColour &col, wxFont *pFont = NULL );
     void BuildNotebookPages( ChartGroupArray *pGroupArray );
-    ChartGroupArray* CloneChartGroupArray( ChartGroupArray* s );
     void EmptyChartGroupArray( ChartGroupArray* s );
 
     void OnNodeExpanded( wxTreeEvent& event );
@@ -724,274 +586,264 @@ public:
     void OnNewGroup( wxCommandEvent &event );
     void OnDeleteGroup( wxCommandEvent &event );
 
-    bool modified;
-    bool m_UIcomplete;
-    bool m_settingscomplete;
-    bool m_treespopulated;
+    ChartGroupArray* CloneChartGroupArray( ChartGroupArray* s );
+    wxTreeCtrl *AddEmptyGroupPage( const wxString& label );
 
+    bool modified, m_UIcomplete, m_settingscomplete, m_treespopulated;
 
-private:
-    int FindGroupBranch( ChartGroup *pGroup, wxTreeCtrl *ptree, wxTreeItemId item,
-            wxString *pbranch_adder );
+  private:
+    int FindGroupBranch( ChartGroup *pGroup, wxTreeCtrl *ptree,
+                         wxTreeItemId item, wxString *pbranch_adder );
 
     wxWindow *pParent;
-
     wxFlexGridSizer *groupsSizer;
-    wxButton *m_pAddButton;
-    wxButton *m_pRemoveButton;
-    wxButton *m_pNewGroupButton;
+    wxButton *m_pAddButton, *m_pRemoveButton, *m_pNewGroupButton;
     wxButton *m_pDeleteGroupButton;
-    int m_border_size;
-    int m_group_item_spacing;
-
-    wxGenericDirCtrl *allAvailableCtl;
-    wxGenericDirCtrl *defaultAllCtl;
-    wxTreeCtrl* m_pActiveChartsTree;
-    wxTreeCtrl* lastSelectedCtl;
+    wxGenericDirCtrl *allAvailableCtl, *defaultAllCtl;
+    wxTreeCtrl *m_pActiveChartsTree, *lastSelectedCtl;
     wxTreeItemId lastDeletedItem;
     wxNotebook* m_GroupNB;
-    ArrayOfCDI m_db_dirs;
-    int m_GroupSelectedPage;
     wxFont *iFont;
 
+    ArrayOfCDI m_db_dirs;
     ArrayOfDirCtrls m_DirCtrlArray;
-
     ChartGroupArray *m_pGroupArray;
+
+    int m_border_size, m_group_item_spacing, m_GroupSelectedPage;
 };
 
 #if wxUSE_XLOCALE || !wxCHECK_VERSION(3,0,0)
-
 static int lang_list[] = {
-            wxLANGUAGE_DEFAULT,
-            wxLANGUAGE_ABKHAZIAN,
-            wxLANGUAGE_AFAR,
-            wxLANGUAGE_AFRIKAANS,
-            wxLANGUAGE_ALBANIAN,
-            wxLANGUAGE_AMHARIC,
-            wxLANGUAGE_ARABIC,
-            wxLANGUAGE_ARABIC_ALGERIA,
-            wxLANGUAGE_ARABIC_BAHRAIN,
-            wxLANGUAGE_ARABIC_EGYPT,
-            wxLANGUAGE_ARABIC_IRAQ,
-            wxLANGUAGE_ARABIC_JORDAN,
-            wxLANGUAGE_ARABIC_KUWAIT,
-            wxLANGUAGE_ARABIC_LEBANON,
-            wxLANGUAGE_ARABIC_LIBYA,
-            wxLANGUAGE_ARABIC_MOROCCO,
-            wxLANGUAGE_ARABIC_OMAN,
-            wxLANGUAGE_ARABIC_QATAR,
-            wxLANGUAGE_ARABIC_SAUDI_ARABIA,
-            wxLANGUAGE_ARABIC_SUDAN,
-            wxLANGUAGE_ARABIC_SYRIA,
-            wxLANGUAGE_ARABIC_TUNISIA,
-//            wxLANGUAGE_ARABIC_UAE,
-            wxLANGUAGE_ARABIC_YEMEN,
-            wxLANGUAGE_ARMENIAN,
-            wxLANGUAGE_ASSAMESE,
-            wxLANGUAGE_AYMARA,
-            wxLANGUAGE_AZERI,
-            wxLANGUAGE_AZERI_CYRILLIC,
-            wxLANGUAGE_AZERI_LATIN,
-            wxLANGUAGE_BASHKIR,
-            wxLANGUAGE_BASQUE,
-            wxLANGUAGE_BELARUSIAN,
-            wxLANGUAGE_BENGALI,
-            wxLANGUAGE_BHUTANI,
-            wxLANGUAGE_BIHARI,
-            wxLANGUAGE_BISLAMA,
-            wxLANGUAGE_BRETON,
-            wxLANGUAGE_BULGARIAN,
-            wxLANGUAGE_BURMESE,
-            wxLANGUAGE_CAMBODIAN,
-            wxLANGUAGE_CATALAN,
-//            wxLANGUAGE_CHINESE,
-//            wxLANGUAGE_CHINESE_SIMPLIFIED,
-//            wxLANGUAGE_CHINESE_TRADITIONAL,
-//            wxLANGUAGE_CHINESE_HONGKONG,
-//            wxLANGUAGE_CHINESE_MACAU,
-//            wxLANGUAGE_CHINESE_SINGAPORE,
-            wxLANGUAGE_CHINESE_TAIWAN,
-            wxLANGUAGE_CORSICAN,
-            wxLANGUAGE_CROATIAN,
-            wxLANGUAGE_CZECH,
-            wxLANGUAGE_DANISH,
-            wxLANGUAGE_DUTCH,
-            wxLANGUAGE_DUTCH_BELGIAN,
-            wxLANGUAGE_ENGLISH,
-            wxLANGUAGE_ENGLISH_UK,
-            wxLANGUAGE_ENGLISH_US,
-            wxLANGUAGE_ENGLISH_AUSTRALIA,
-            wxLANGUAGE_ENGLISH_BELIZE,
-            wxLANGUAGE_ENGLISH_BOTSWANA,
-            wxLANGUAGE_ENGLISH_CANADA,
-            wxLANGUAGE_ENGLISH_CARIBBEAN,
-            wxLANGUAGE_ENGLISH_DENMARK,
-            wxLANGUAGE_ENGLISH_EIRE,
-            wxLANGUAGE_ENGLISH_JAMAICA,
-            wxLANGUAGE_ENGLISH_NEW_ZEALAND,
-            wxLANGUAGE_ENGLISH_PHILIPPINES,
-            wxLANGUAGE_ENGLISH_SOUTH_AFRICA,
-            wxLANGUAGE_ENGLISH_TRINIDAD,
-            wxLANGUAGE_ENGLISH_ZIMBABWE,
-            wxLANGUAGE_ESPERANTO,
-            wxLANGUAGE_ESTONIAN,
-            wxLANGUAGE_FAEROESE,
-            wxLANGUAGE_FARSI,
-            wxLANGUAGE_FIJI,
-            wxLANGUAGE_FINNISH,
-            wxLANGUAGE_FRENCH,
-            wxLANGUAGE_FRENCH_BELGIAN,
-            wxLANGUAGE_FRENCH_CANADIAN,
-            wxLANGUAGE_FRENCH_LUXEMBOURG,
-            wxLANGUAGE_FRENCH_MONACO,
-            wxLANGUAGE_FRENCH_SWISS,
-            wxLANGUAGE_FRISIAN,
-            wxLANGUAGE_GALICIAN,
-            wxLANGUAGE_GEORGIAN,
-            wxLANGUAGE_GERMAN,
-            wxLANGUAGE_GERMAN_AUSTRIAN,
-            wxLANGUAGE_GERMAN_BELGIUM,
-            wxLANGUAGE_GERMAN_LIECHTENSTEIN,
-            wxLANGUAGE_GERMAN_LUXEMBOURG,
-            wxLANGUAGE_GERMAN_SWISS,
-            wxLANGUAGE_GREEK,
-            wxLANGUAGE_GREENLANDIC,
-            wxLANGUAGE_GUARANI,
-            wxLANGUAGE_GUJARATI,
-            wxLANGUAGE_HAUSA,
-            wxLANGUAGE_HEBREW,
-            wxLANGUAGE_HINDI,
-            wxLANGUAGE_HUNGARIAN,
-            wxLANGUAGE_ICELANDIC,
-            wxLANGUAGE_INDONESIAN,
-            wxLANGUAGE_INTERLINGUA,
-            wxLANGUAGE_INTERLINGUE,
-            wxLANGUAGE_INUKTITUT,
-            wxLANGUAGE_INUPIAK,
-            wxLANGUAGE_IRISH,
-            wxLANGUAGE_ITALIAN,
-            wxLANGUAGE_ITALIAN_SWISS,
-            wxLANGUAGE_JAPANESE,
-            wxLANGUAGE_JAVANESE,
-            wxLANGUAGE_KANNADA,
-            wxLANGUAGE_KASHMIRI,
-            wxLANGUAGE_KASHMIRI_INDIA,
-            wxLANGUAGE_KAZAKH,
-            wxLANGUAGE_KERNEWEK,
-            wxLANGUAGE_KINYARWANDA,
-            wxLANGUAGE_KIRGHIZ,
-            wxLANGUAGE_KIRUNDI,
-//            wxLANGUAGE_KONKANI,
-            wxLANGUAGE_KOREAN,
-            wxLANGUAGE_KURDISH,
-            wxLANGUAGE_LAOTHIAN,
-            wxLANGUAGE_LATIN,
-            wxLANGUAGE_LATVIAN,
-            wxLANGUAGE_LINGALA,
-            wxLANGUAGE_LITHUANIAN,
-            wxLANGUAGE_MACEDONIAN,
-            wxLANGUAGE_MALAGASY,
-            wxLANGUAGE_MALAY,
-            wxLANGUAGE_MALAYALAM,
-            wxLANGUAGE_MALAY_BRUNEI_DARUSSALAM,
-            wxLANGUAGE_MALAY_MALAYSIA,
-            wxLANGUAGE_MALTESE,
-//            wxLANGUAGE_MANIPURI,
-            wxLANGUAGE_MAORI,
-            wxLANGUAGE_MARATHI,
-            wxLANGUAGE_MOLDAVIAN,
-            wxLANGUAGE_MONGOLIAN,
-            wxLANGUAGE_NAURU,
-            wxLANGUAGE_NEPALI,
-            wxLANGUAGE_NEPALI_INDIA,
-            wxLANGUAGE_NORWEGIAN_BOKMAL,
-            wxLANGUAGE_NORWEGIAN_NYNORSK,
-            wxLANGUAGE_OCCITAN,
-            wxLANGUAGE_ORIYA,
-            wxLANGUAGE_OROMO,
-            wxLANGUAGE_PASHTO,
-            wxLANGUAGE_POLISH,
-            wxLANGUAGE_PORTUGUESE,
-            wxLANGUAGE_PORTUGUESE_BRAZILIAN,
-            wxLANGUAGE_PUNJABI,
-            wxLANGUAGE_QUECHUA,
-            wxLANGUAGE_RHAETO_ROMANCE,
-            wxLANGUAGE_ROMANIAN,
-            wxLANGUAGE_RUSSIAN,
-            wxLANGUAGE_RUSSIAN_UKRAINE,
-            wxLANGUAGE_SAMOAN,
-            wxLANGUAGE_SANGHO,
-            wxLANGUAGE_SANSKRIT,
-            wxLANGUAGE_SCOTS_GAELIC,
-            wxLANGUAGE_SERBIAN,
-            wxLANGUAGE_SERBIAN_CYRILLIC,
-            wxLANGUAGE_SERBIAN_LATIN,
-            wxLANGUAGE_SERBO_CROATIAN,
-            wxLANGUAGE_SESOTHO,
-            wxLANGUAGE_SETSWANA,
-            wxLANGUAGE_SHONA,
-            wxLANGUAGE_SINDHI,
-            wxLANGUAGE_SINHALESE,
-            wxLANGUAGE_SISWATI,
-            wxLANGUAGE_SLOVAK,
-            wxLANGUAGE_SLOVENIAN,
-            wxLANGUAGE_SOMALI,
-            wxLANGUAGE_SPANISH,
-            wxLANGUAGE_SPANISH_ARGENTINA,
-            wxLANGUAGE_SPANISH_BOLIVIA,
-            wxLANGUAGE_SPANISH_CHILE,
-            wxLANGUAGE_SPANISH_COLOMBIA,
-            wxLANGUAGE_SPANISH_COSTA_RICA,
-            wxLANGUAGE_SPANISH_DOMINICAN_REPUBLIC,
-            wxLANGUAGE_SPANISH_ECUADOR,
-            wxLANGUAGE_SPANISH_EL_SALVADOR,
-            wxLANGUAGE_SPANISH_GUATEMALA,
-            wxLANGUAGE_SPANISH_HONDURAS,
-            wxLANGUAGE_SPANISH_MEXICAN,
-//            wxLANGUAGE_SPANISH_MODERN,
-            wxLANGUAGE_SPANISH_NICARAGUA,
-            wxLANGUAGE_SPANISH_PANAMA,
-            wxLANGUAGE_SPANISH_PARAGUAY,
-            wxLANGUAGE_SPANISH_PERU,
-            wxLANGUAGE_SPANISH_PUERTO_RICO,
-            wxLANGUAGE_SPANISH_URUGUAY,
-            wxLANGUAGE_SPANISH_US,
-            wxLANGUAGE_SPANISH_VENEZUELA,
-            wxLANGUAGE_SUNDANESE,
-            wxLANGUAGE_SWAHILI,
-            wxLANGUAGE_SWEDISH,
-            wxLANGUAGE_SWEDISH_FINLAND,
-            wxLANGUAGE_TAGALOG,
-            wxLANGUAGE_TAJIK,
-            wxLANGUAGE_TAMIL,
-            wxLANGUAGE_TATAR,
-            wxLANGUAGE_TELUGU,
-            wxLANGUAGE_THAI,
-            wxLANGUAGE_TIBETAN,
-            wxLANGUAGE_TIGRINYA,
-            wxLANGUAGE_TONGA,
-            wxLANGUAGE_TSONGA,
-            wxLANGUAGE_TURKISH,
-            wxLANGUAGE_TURKMEN,
-            wxLANGUAGE_TWI,
-            wxLANGUAGE_UIGHUR,
-            wxLANGUAGE_UKRAINIAN,
-            wxLANGUAGE_URDU,
-            wxLANGUAGE_URDU_INDIA,
-            wxLANGUAGE_URDU_PAKISTAN,
-            wxLANGUAGE_UZBEK,
-            wxLANGUAGE_UZBEK_CYRILLIC,
-            wxLANGUAGE_UZBEK_LATIN,
-            wxLANGUAGE_VIETNAMESE,
-            wxLANGUAGE_VOLAPUK,
-            wxLANGUAGE_WELSH,
-            wxLANGUAGE_WOLOF,
-            wxLANGUAGE_XHOSA,
-            wxLANGUAGE_YIDDISH,
-            wxLANGUAGE_YORUBA,
-            wxLANGUAGE_ZHUANG,
-            wxLANGUAGE_ZULU
-            };
+    wxLANGUAGE_DEFAULT,
+    wxLANGUAGE_ABKHAZIAN,
+    wxLANGUAGE_AFAR,
+    wxLANGUAGE_AFRIKAANS,
+    wxLANGUAGE_ALBANIAN,
+    wxLANGUAGE_AMHARIC,
+    wxLANGUAGE_ARABIC,
+    wxLANGUAGE_ARABIC_ALGERIA,
+    wxLANGUAGE_ARABIC_BAHRAIN,
+    wxLANGUAGE_ARABIC_EGYPT,
+    wxLANGUAGE_ARABIC_IRAQ,
+    wxLANGUAGE_ARABIC_JORDAN,
+    wxLANGUAGE_ARABIC_KUWAIT,
+    wxLANGUAGE_ARABIC_LEBANON,
+    wxLANGUAGE_ARABIC_LIBYA,
+    wxLANGUAGE_ARABIC_MOROCCO,
+    wxLANGUAGE_ARABIC_OMAN,
+    wxLANGUAGE_ARABIC_QATAR,
+    wxLANGUAGE_ARABIC_SAUDI_ARABIA,
+    wxLANGUAGE_ARABIC_SUDAN,
+    wxLANGUAGE_ARABIC_SYRIA,
+    wxLANGUAGE_ARABIC_TUNISIA,
+//    wxLANGUAGE_ARABIC_UAE,
+    wxLANGUAGE_ARABIC_YEMEN,
+    wxLANGUAGE_ARMENIAN,
+    wxLANGUAGE_ASSAMESE,
+    wxLANGUAGE_AYMARA,
+    wxLANGUAGE_AZERI,
+    wxLANGUAGE_AZERI_CYRILLIC,
+    wxLANGUAGE_AZERI_LATIN,
+    wxLANGUAGE_BASHKIR,
+    wxLANGUAGE_BASQUE,
+    wxLANGUAGE_BELARUSIAN,
+    wxLANGUAGE_BENGALI,
+    wxLANGUAGE_BHUTANI,
+    wxLANGUAGE_BIHARI,
+    wxLANGUAGE_BISLAMA,
+    wxLANGUAGE_BRETON,
+    wxLANGUAGE_BULGARIAN,
+    wxLANGUAGE_BURMESE,
+    wxLANGUAGE_CAMBODIAN,
+    wxLANGUAGE_CATALAN,
+//    wxLANGUAGE_CHINESE,
+//    wxLANGUAGE_CHINESE_SIMPLIFIED,
+//    wxLANGUAGE_CHINESE_TRADITIONAL,
+//    wxLANGUAGE_CHINESE_HONGKONG,
+//    wxLANGUAGE_CHINESE_MACAU,
+//    wxLANGUAGE_CHINESE_SINGAPORE,
+    wxLANGUAGE_CHINESE_TAIWAN,
+    wxLANGUAGE_CORSICAN,
+    wxLANGUAGE_CROATIAN,
+    wxLANGUAGE_CZECH,
+    wxLANGUAGE_DANISH,
+    wxLANGUAGE_DUTCH,
+    wxLANGUAGE_DUTCH_BELGIAN,
+    wxLANGUAGE_ENGLISH,
+    wxLANGUAGE_ENGLISH_UK,
+    wxLANGUAGE_ENGLISH_US,
+    wxLANGUAGE_ENGLISH_AUSTRALIA,
+    wxLANGUAGE_ENGLISH_BELIZE,
+    wxLANGUAGE_ENGLISH_BOTSWANA,
+    wxLANGUAGE_ENGLISH_CANADA,
+    wxLANGUAGE_ENGLISH_CARIBBEAN,
+    wxLANGUAGE_ENGLISH_DENMARK,
+    wxLANGUAGE_ENGLISH_EIRE,
+    wxLANGUAGE_ENGLISH_JAMAICA,
+    wxLANGUAGE_ENGLISH_NEW_ZEALAND,
+    wxLANGUAGE_ENGLISH_PHILIPPINES,
+    wxLANGUAGE_ENGLISH_SOUTH_AFRICA,
+    wxLANGUAGE_ENGLISH_TRINIDAD,
+    wxLANGUAGE_ENGLISH_ZIMBABWE,
+    wxLANGUAGE_ESPERANTO,
+    wxLANGUAGE_ESTONIAN,
+    wxLANGUAGE_FAEROESE,
+    wxLANGUAGE_FARSI,
+    wxLANGUAGE_FIJI,
+    wxLANGUAGE_FINNISH,
+    wxLANGUAGE_FRENCH,
+    wxLANGUAGE_FRENCH_BELGIAN,
+    wxLANGUAGE_FRENCH_CANADIAN,
+    wxLANGUAGE_FRENCH_LUXEMBOURG,
+    wxLANGUAGE_FRENCH_MONACO,
+    wxLANGUAGE_FRENCH_SWISS,
+    wxLANGUAGE_FRISIAN,
+    wxLANGUAGE_GALICIAN,
+    wxLANGUAGE_GEORGIAN,
+    wxLANGUAGE_GERMAN,
+    wxLANGUAGE_GERMAN_AUSTRIAN,
+    wxLANGUAGE_GERMAN_BELGIUM,
+    wxLANGUAGE_GERMAN_LIECHTENSTEIN,
+    wxLANGUAGE_GERMAN_LUXEMBOURG,
+    wxLANGUAGE_GERMAN_SWISS,
+    wxLANGUAGE_GREEK,
+    wxLANGUAGE_GREENLANDIC,
+    wxLANGUAGE_GUARANI,
+    wxLANGUAGE_GUJARATI,
+    wxLANGUAGE_HAUSA,
+    wxLANGUAGE_HEBREW,
+    wxLANGUAGE_HINDI,
+    wxLANGUAGE_HUNGARIAN,
+    wxLANGUAGE_ICELANDIC,
+    wxLANGUAGE_INDONESIAN,
+    wxLANGUAGE_INTERLINGUA,
+    wxLANGUAGE_INTERLINGUE,
+    wxLANGUAGE_INUKTITUT,
+    wxLANGUAGE_INUPIAK,
+    wxLANGUAGE_IRISH,
+    wxLANGUAGE_ITALIAN,
+    wxLANGUAGE_ITALIAN_SWISS,
+    wxLANGUAGE_JAPANESE,
+    wxLANGUAGE_JAVANESE,
+    wxLANGUAGE_KANNADA,
+    wxLANGUAGE_KASHMIRI,
+    wxLANGUAGE_KASHMIRI_INDIA,
+    wxLANGUAGE_KAZAKH,
+    wxLANGUAGE_KERNEWEK,
+    wxLANGUAGE_KINYARWANDA,
+    wxLANGUAGE_KIRGHIZ,
+    wxLANGUAGE_KIRUNDI,
+//    wxLANGUAGE_KONKANI,
+    wxLANGUAGE_KOREAN,
+    wxLANGUAGE_KURDISH,
+    wxLANGUAGE_LAOTHIAN,
+    wxLANGUAGE_LATIN,
+    wxLANGUAGE_LATVIAN,
+    wxLANGUAGE_LINGALA,
+    wxLANGUAGE_LITHUANIAN,
+    wxLANGUAGE_MACEDONIAN,
+    wxLANGUAGE_MALAGASY,
+    wxLANGUAGE_MALAY,
+    wxLANGUAGE_MALAYALAM,
+    wxLANGUAGE_MALAY_BRUNEI_DARUSSALAM,
+    wxLANGUAGE_MALAY_MALAYSIA,
+    wxLANGUAGE_MALTESE,
+//    wxLANGUAGE_MANIPURI,
+    wxLANGUAGE_MAORI,
+    wxLANGUAGE_MARATHI,
+    wxLANGUAGE_MOLDAVIAN,
+    wxLANGUAGE_MONGOLIAN,
+    wxLANGUAGE_NAURU,
+    wxLANGUAGE_NEPALI,
+    wxLANGUAGE_NEPALI_INDIA,
+    wxLANGUAGE_NORWEGIAN_BOKMAL,
+    wxLANGUAGE_NORWEGIAN_NYNORSK,
+    wxLANGUAGE_OCCITAN,
+    wxLANGUAGE_ORIYA,
+    wxLANGUAGE_OROMO,
+    wxLANGUAGE_PASHTO,
+    wxLANGUAGE_POLISH,
+    wxLANGUAGE_PORTUGUESE,
+    wxLANGUAGE_PORTUGUESE_BRAZILIAN,
+    wxLANGUAGE_PUNJABI,
+    wxLANGUAGE_QUECHUA,
+    wxLANGUAGE_RHAETO_ROMANCE,
+    wxLANGUAGE_ROMANIAN,
+    wxLANGUAGE_RUSSIAN,
+    wxLANGUAGE_RUSSIAN_UKRAINE,
+    wxLANGUAGE_SAMOAN,
+    wxLANGUAGE_SANGHO,
+    wxLANGUAGE_SANSKRIT,
+    wxLANGUAGE_SCOTS_GAELIC,
+    wxLANGUAGE_SERBIAN,
+    wxLANGUAGE_SERBIAN_CYRILLIC,
+    wxLANGUAGE_SERBIAN_LATIN,
+    wxLANGUAGE_SERBO_CROATIAN,
+    wxLANGUAGE_SESOTHO,
+    wxLANGUAGE_SETSWANA,
+    wxLANGUAGE_SHONA,
+    wxLANGUAGE_SINDHI,
+    wxLANGUAGE_SINHALESE,
+    wxLANGUAGE_SISWATI,
+    wxLANGUAGE_SLOVAK,
+    wxLANGUAGE_SLOVENIAN,
+    wxLANGUAGE_SOMALI,
+    wxLANGUAGE_SPANISH,
+    wxLANGUAGE_SPANISH_ARGENTINA,
+    wxLANGUAGE_SPANISH_BOLIVIA,
+    wxLANGUAGE_SPANISH_CHILE,
+    wxLANGUAGE_SPANISH_COLOMBIA,
+    wxLANGUAGE_SPANISH_COSTA_RICA,
+    wxLANGUAGE_SPANISH_DOMINICAN_REPUBLIC,
+    wxLANGUAGE_SPANISH_ECUADOR,
+    wxLANGUAGE_SPANISH_EL_SALVADOR,
+    wxLANGUAGE_SPANISH_GUATEMALA,
+    wxLANGUAGE_SPANISH_HONDURAS,
+    wxLANGUAGE_SPANISH_MEXICAN,
+//    wxLANGUAGE_SPANISH_MODERN,
+    wxLANGUAGE_SPANISH_NICARAGUA,
+    wxLANGUAGE_SPANISH_PANAMA,
+    wxLANGUAGE_SPANISH_PARAGUAY,
+    wxLANGUAGE_SPANISH_PERU,
+    wxLANGUAGE_SPANISH_PUERTO_RICO,
+    wxLANGUAGE_SPANISH_URUGUAY,
+    wxLANGUAGE_SPANISH_US,
+    wxLANGUAGE_SPANISH_VENEZUELA,
+    wxLANGUAGE_SUNDANESE,
+    wxLANGUAGE_SWAHILI,
+    wxLANGUAGE_SWEDISH,
+    wxLANGUAGE_SWEDISH_FINLAND,
+    wxLANGUAGE_TAGALOG,
+    wxLANGUAGE_TAJIK,
+    wxLANGUAGE_TAMIL,
+    wxLANGUAGE_TATAR,
+    wxLANGUAGE_TELUGU,
+    wxLANGUAGE_THAI,
+    wxLANGUAGE_TIBETAN,
+    wxLANGUAGE_TIGRINYA,
+    wxLANGUAGE_TONGA,
+    wxLANGUAGE_TSONGA,
+    wxLANGUAGE_TURKISH,
+    wxLANGUAGE_TURKMEN,
+    wxLANGUAGE_TWI,
+    wxLANGUAGE_UIGHUR,
+    wxLANGUAGE_UKRAINIAN,
+    wxLANGUAGE_URDU,
+    wxLANGUAGE_URDU_INDIA,
+    wxLANGUAGE_URDU_PAKISTAN,
+    wxLANGUAGE_UZBEK,
+    wxLANGUAGE_UZBEK_CYRILLIC,
+    wxLANGUAGE_UZBEK_LATIN,
+    wxLANGUAGE_VIETNAMESE,
+    wxLANGUAGE_VOLAPUK,
+    wxLANGUAGE_WELSH,
+    wxLANGUAGE_WOLOF,
+    wxLANGUAGE_XHOSA,
+    wxLANGUAGE_YIDDISH,
+    wxLANGUAGE_YORUBA,
+    wxLANGUAGE_ZHUANG,
+    wxLANGUAGE_ZULU
+};
 #endif
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -999,38 +851,9 @@ static int lang_list[] = {
 ///////////////////////////////////////////////////////////////////////////////
 class SentenceListDlg : public wxDialog
 {
-  private:
-        wxArrayString m_sentences;
-        void FillSentences();
-        ListType m_type;
-        FilterDirection m_dir;
-
-  protected:
-        wxCheckListBox* m_clbSentences;
-        wxButton* m_btnAdd;
-        wxButton* m_btnDel;
-        wxButton* m_btnCheckAll;
-        wxButton* m_btnClearAll;
-        wxStdDialogButtonSizer* m_sdbSizer4;
-        wxButton* m_sdbSizer4OK;
-        wxButton* m_sdbSizer4Cancel;
-        wxArrayString standard_sentences;
-        wxStaticBox *m_pclbBox;
-
-    // Virtual event handlers, overide them in your derived class
-        void OnStcSelect( wxCommandEvent& event );
-        void OnAddClick( wxCommandEvent& event );
-        void OnDeleteClick( wxCommandEvent& event );
-        void OnCancelClick( wxCommandEvent& event );
-        void OnOkClick( wxCommandEvent& event );
-        void OnCLBSelect( wxCommandEvent& event );
-        void OnCLBToggle( wxCommandEvent& event );
-        void OnCheckAllClick( wxCommandEvent& event );
-        void OnClearAllClick( wxCommandEvent& event );
-
   public:
     explicit SentenceListDlg( FilterDirection dir,
-                              wxWindow* parent,
+                              wxWindow *parent,
                               wxWindowID id = wxID_ANY,
                               const wxString& title = _("Sentence Filter"),
                               const wxPoint& pos = wxDefaultPosition,
@@ -1041,8 +864,33 @@ class SentenceListDlg : public wxDialog
     wxString GetSentencesAsText();
     void BuildSentenceArray();
     void SetType(int io, ListType type);
-};
 
+  protected:
+    // Virtual event handlers, overide them in your derived class
+    void OnStcSelect( wxCommandEvent& event );
+    void OnAddClick( wxCommandEvent& event );
+    void OnDeleteClick( wxCommandEvent& event );
+    void OnCancelClick( wxCommandEvent& event );
+    void OnOkClick( wxCommandEvent& event );
+    void OnCLBSelect( wxCommandEvent& event );
+    void OnCLBToggle( wxCommandEvent& event );
+    void OnCheckAllClick( wxCommandEvent& event );
+    void OnClearAllClick( wxCommandEvent& event );
+
+    wxCheckListBox* m_clbSentences;
+    wxButton *m_btnAdd, *m_btnDel, *m_btnCheckAll, *m_btnClearAll;
+    wxButton *m_sdbSizer4OK, *m_sdbSizer4Cancel;
+    wxStdDialogButtonSizer* m_sdbSizer4;
+    wxArrayString standard_sentences;
+    wxStaticBox *m_pclbBox;
+
+  private:
+    void FillSentences();
+
+    wxArrayString m_sentences;
+    ListType m_type;
+    FilterDirection m_dir;
+};
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Class OpenGLOptionsDlg
@@ -1051,35 +899,22 @@ class OpenGLOptionsDlg : public wxDialog
 {
     DECLARE_EVENT_TABLE()
 
-public:
-    wxGridSizer *m_bSizer1;
-    wxBoxSizer *m_bSizer2;
-
-    wxCheckBox *m_cbUseAcceleratedPanning;
-
-    wxCheckBox *m_cbTextureCompression, *m_cbTextureCompressionCaching;
-    wxCheckBox *m_cbShowFPS;
-    wxCheckBox *m_cbSoftwareGL;
-
-    wxButton *m_bRebuildTextureCache;
-    wxButton *m_bClearTextureCache;
-
-    wxStaticText *m_stTextureCacheSize;
-
-    wxSpinCtrl *m_sTextureDimension;
-    wxSpinCtrl *m_sTextureMemorySize;
-
-    explicit OpenGLOptionsDlg( wxWindow* parent, bool glTicked );
-
+  public:
+    explicit OpenGLOptionsDlg( wxWindow *parent, bool glTicked );
     void OnButtonRebuild( wxCommandEvent& event );
     void OnButtonClear( wxCommandEvent& event );
-
     wxString TextureCacheSize();
 
+    wxGridSizer *m_bSizer1;
+    wxBoxSizer *m_bSizer2;
+    wxCheckBox *m_cbUseAcceleratedPanning, *m_cbTextureCompression;
+    wxCheckBox *m_cbTextureCompressionCaching, *m_cbShowFPS, *m_cbSoftwareGL;
+    wxButton *m_bRebuildTextureCache, *m_bClearTextureCache;
+    wxStaticText *m_stTextureCacheSize;
+    wxSpinCtrl *m_sTextureDimension, *m_sTextureMemorySize;
+
     bool m_brebuild_cache;
-
 };
-
 
 #define ID_MMSI_PROPS_LIST 10073
 
@@ -1089,124 +924,94 @@ enum {
     mlIgnore,
     mlMOB,
     mlVDM
-};// MMSIListCtrl Columns;
-
+}; // MMSIListCtrl Columns;
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Class MMSIListCtrl
 ///////////////////////////////////////////////////////////////////////////////
-
-class MMSI_Props_Panel;
-
 class MMSIListCtrl: public wxListCtrl
 {
-public:
-     explicit MMSIListCtrl( wxWindow* parent, wxWindowID id, const wxPoint& pos,
-                           const wxSize& size, long style );
+  public:
+     explicit MMSIListCtrl( wxWindow *parent, wxWindowID id, const wxPoint& pos,
+                            const wxSize& size, long style );
     ~MMSIListCtrl();
 
     wxString OnGetItemText( long item, long column ) const;
-    //    int OnGetItemColumnImage( long item, long column ) const;
-
+//    int OnGetItemColumnImage( long item, long column ) const;
     void OnListItemClick( wxListEvent &event);
     void OnListItemActivated( wxListEvent &event);
     void OnListItemRightClick( wxListEvent &event);
     void PopupMenuHandler( wxCommandEvent& event );
 
     wxWindow *m_parent;
-    int         m_context_item;
+    int m_context_item;
 
     DECLARE_EVENT_TABLE()
-
 };
-
-
-
 
 #define ID_MMSIEDIT_OK          8191
 #define ID_MMSIEDIT_CANCEL      8192
 #define ID_MMSI_CTL             8193
-
 #define ID_DEF_MENU_MMSI_EDIT   8194
 #define ID_DEF_MENU_MMSI_DELETE 8195
 
-class MMSIProperties;
 ///////////////////////////////////////////////////////////////////////////////
 /// Class MMSIEditDialog
 ///////////////////////////////////////////////////////////////////////////////
-
 class MMSIEditDialog: public wxDialog
 {
     DECLARE_DYNAMIC_CLASS( MMSIEditDialog )
     DECLARE_EVENT_TABLE()
 
-public:
+  public:
     explicit MMSIEditDialog( );
-    explicit MMSIEditDialog( MMSIProperties *props, wxWindow* parent,
-                             wxWindowID id = -1,
-                             const wxString& caption = _T(""),
+    explicit MMSIEditDialog( MMSIProperties *props, wxWindow *parent,
+                             wxWindowID id = wxID_ANY,
+                             const wxString& caption = wxEmptyString,
                              const wxPoint& pos = wxDefaultPosition,
                              const wxSize& size = wxDefaultSize,
                              long style = 0 );
-
     ~MMSIEditDialog();
 
-    bool Create( MMSIProperties *props, wxWindow* parent, wxWindowID id = -1,
-                 const wxString& caption = _T(""),
+    bool Create( MMSIProperties *props, wxWindow *parent,
+                 wxWindowID id = wxID_ANY,
+                 const wxString& caption = wxEmptyString,
                  const wxPoint& pos = wxDefaultPosition,
                  const wxSize& size = wxDefaultSize, long style = 0 );
-
     void SetColorScheme(ColorScheme cs);
-
     void CreateControls();
-
     void OnMMSIEditCancelClick( wxCommandEvent& event );
     void OnMMSIEditOKClick( wxCommandEvent& event );
     void OnCtlUpdated( wxCommandEvent& event );
 
-    MMSIProperties      *m_props;
-
-    wxTextCtrl          *m_MMSICtl;
-    wxRadioButton       *m_rbTypeTrackDefault;
-    wxRadioButton       *m_rbTypeTrackAlways;
-    wxRadioButton       *m_rbTypeTrackNever;
-    wxCheckBox          *m_cbTrackPersist;
-
-    wxCheckBox          *m_IgnoreButton;
-    wxCheckBox          *m_MOBButton;
-    wxCheckBox          *m_VDMButton;
-
-    wxButton            *m_CancelButton;
-    wxButton            *m_OKButton;
-
+    MMSIProperties *m_props;
+    wxTextCtrl *m_MMSICtl;
+    wxRadioButton *m_rbTypeTrackDefault, *m_rbTypeTrackAlways;
+    wxRadioButton *m_rbTypeTrackNever;
+    wxCheckBox *m_cbTrackPersist, *m_IgnoreButton, *m_MOBButton, *m_VDMButton;
+    wxButton *m_CancelButton, *m_OKButton;
 };
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Class MMSI_Props_Panel
 ///////////////////////////////////////////////////////////////////////////////
-
 class MMSI_Props_Panel: public wxPanel
 {
-
-public:
+  public:
     explicit MMSI_Props_Panel( wxWindow *parent );
     ~MMSI_Props_Panel( );
 
 //    void OnClose(wxCloseEvent &event);
     void OnNewButton( wxCommandEvent &event );
-
     void SetColorScheme( ColorScheme cs );
     void UpdateMMSIList( void );
 
     MMSIListCtrl      *m_pListCtrlMMSI;
     wxButton          *m_pButtonNew;
 
-private:
-
+  private:
     wxWindow          *m_pparent;
-
 };
-
 
 #endif
     // _OPTIONS_H_

--- a/include/options.h
+++ b/include/options.h
@@ -852,11 +852,9 @@ class SentenceListDlg : public wxDialog
     wxString GetSentencesAsText( void );
 
   private:
-    void OnStcSelect( wxCommandEvent& event );
     void OnAddClick( wxCommandEvent& event );
     void OnDeleteClick( wxCommandEvent& event );
     void OnCLBSelect( wxCommandEvent& event );
-    void OnCLBToggle( wxCommandEvent& event );
     void OnCheckAllClick( wxCommandEvent& event );
     void OnClearAllClick( wxCommandEvent& event );
 

--- a/include/options.h
+++ b/include/options.h
@@ -872,7 +872,7 @@ class SentenceListDlg : public wxDialog
 class OpenGLOptionsDlg : public wxDialog
 {
   public:
-    explicit OpenGLOptionsDlg( wxWindow *parent, bool glTicked );
+    explicit OpenGLOptionsDlg( wxWindow *parent );
 
     wxCheckBox *m_cbUseAcceleratedPanning, *m_cbTextureCompression;
     wxCheckBox *m_cbTextureCompressionCaching, *m_cbShowFPS, *m_cbSoftwareGL;

--- a/include/options.h
+++ b/include/options.h
@@ -858,14 +858,12 @@ class SentenceListDlg : public wxDialog
                               const wxPoint& pos = wxDefaultPosition,
                               const wxSize& size = wxSize( 280,420 ),
                               long style = wxDEFAULT_DIALOG_STYLE );
-    ~SentenceListDlg( void );
     void SetSentenceList(wxArrayString sentences);
     wxString GetSentencesAsText( void );
     void BuildSentenceArray( void );
     void SetType(int io, ListType type);
 
-  protected:
-    // Virtual event handlers, overide them in your derived class
+  private:
     void OnStcSelect( wxCommandEvent& event );
     void OnAddClick( wxCommandEvent& event );
     void OnDeleteClick( wxCommandEvent& event );
@@ -875,18 +873,15 @@ class SentenceListDlg : public wxDialog
     void OnCLBToggle( wxCommandEvent& event );
     void OnCheckAllClick( wxCommandEvent& event );
     void OnClearAllClick( wxCommandEvent& event );
+    void FillSentences( void );
 
     wxCheckListBox* m_clbSentences;
     wxButton *m_btnAdd, *m_btnDel, *m_btnCheckAll, *m_btnClearAll;
     wxButton *m_sdbSizer4OK, *m_sdbSizer4Cancel;
     wxStdDialogButtonSizer* m_sdbSizer4;
-    wxArrayString standard_sentences;
+    wxArrayString standard_sentences, m_sentences;
     wxStaticBox *m_pclbBox;
 
-  private:
-    void FillSentences( void );
-
-    wxArrayString m_sentences;
     ListType m_type;
     FilterDirection m_dir;
 };

--- a/include/options.h
+++ b/include/options.h
@@ -53,7 +53,6 @@ class wxGenericDirCtrl;
 class MyConfig;
 class ChartGroupsUI;
 class ConnectionParams;
-class SentenceListDlg;
 class PluginListPanel;
 class ChartGroupArray;
 class ChartGroup;
@@ -356,9 +355,6 @@ class options: public wxScrollingDialog
     wxComboBox *m_comboPort;
     wxStdDialogButtonSizer* m_sdbSizerDlgButtons;
 
-    SentenceListDlg *m_stcdialog_in, *m_stcdialog_out;
-
-    // Virtual event handlers, overide them in your derived class
     void OnSelectDatasource( wxListEvent& event );
     void OnAddDatasourceClick( wxCommandEvent& event );
     void OnRemoveDatasourceClick( wxCommandEvent& event );

--- a/include/options.h
+++ b/include/options.h
@@ -881,11 +881,12 @@ class OpenGLOptionsDlg : public wxDialog
     bool m_brebuild_cache;
 
   private:
+    void Populate( void );
     void OnButtonRebuild( wxCommandEvent& event );
     void OnButtonClear( wxCommandEvent& event );
     wxString TextureCacheSize( void );
 
-    wxStaticText *m_cacheSize;
+    wxStaticText *m_cacheSize, *m_memorySize;
 
     DECLARE_EVENT_TABLE()
 };

--- a/include/options.h
+++ b/include/options.h
@@ -221,17 +221,17 @@ public:
 
     void SetInitialPage( int page_sel);
     void Finish( void);
-    
+
     wxWindow* GetContentWindow() const;
     void OnClose( wxCloseEvent& event );
-    
+
     void CreateControls();
     size_t CreatePanel(const wxString & title);
     wxScrolledWindow *AddPage(size_t parent, const wxString & title);
     bool DeletePage( wxScrolledWindow *page );
     void SetColorScheme( ColorScheme cs );
     void RecalculateSize();
-    
+
     void SetInitChartDir(const wxString &dir)
     {
         m_init_chart_dir = dir;
@@ -252,7 +252,7 @@ public:
     }
 
     void AddChartDir( wxString &dir );
-    
+
     void UpdateDisplayedChartDirList(ArrayOfCDI p);
 
     void UpdateOptionsUnits();
@@ -271,11 +271,11 @@ public:
     void OnCancelClick( wxCommandEvent& event );
     void OnChooseFont( wxCommandEvent& event );
     void OnCPAWarnClick( wxCommandEvent& event );
-    
+
     void OnSizeAutoButton( wxCommandEvent& event );
     void OnSizeManualButton( wxCommandEvent& event );
-    
-    
+
+
 #ifdef __WXGTK__
     void OnChooseFontColor( wxCommandEvent& event );
 #endif
@@ -284,11 +284,11 @@ public:
     void OnDisplayCategoryRadioButton( wxCommandEvent& event );
     void OnButtonClearClick( wxCommandEvent& event );
     void OnButtonSelectClick( wxCommandEvent& event );
-    
+
     void OnPageChange( wxListbookEvent& event );
     void OnNBPageChange( wxNotebookEvent& event );
     void DoOnPageChange( size_t page );
-    
+
     void OnButtonSelectSound( wxCommandEvent& event );
     void OnButtonTestSound( wxCommandEvent& event );
     void OnShowGpsWindowCheckboxClick( wxCommandEvent& event );
@@ -306,7 +306,7 @@ public:
     void OnScanBTClick( wxCommandEvent& event );
     void onBTScanTimer(wxTimerEvent &event);
     void StopBTScan( void );
-    
+
     void UpdateWorkArrayFromTextCtl();
 
 // Should we show tooltips?
@@ -317,7 +317,7 @@ public:
 #else
     wxNotebook*             m_pListbook;
 #endif
-    
+
     size_t                  m_pageDisplay, m_pageConnections, m_pageCharts, m_pageShips, m_pageUI, m_pagePlugins;
     int                     lastPage;
     wxPoint                 lastWindowPos;
@@ -364,20 +364,20 @@ public:
     wxChoice                *m_pcTCDatasets;
     wxCheckBox              *pMobile;
     wxCheckBox              *pResponsive;
-    wxSlider                *m_pSlider_Zoom;    
+    wxSlider                *m_pSlider_Zoom;
     wxSlider                *m_pSlider_GUI_Factor;
     wxSlider                *m_pSlider_Chart_Factor;
-    
+
     int                      k_tides;
     wxCheckBox              *pOverzoomEmphasis;
     wxCheckBox              *pOZScaleVector;
     wxTextCtrl              *pScreenMM;
     wxRadioButton           *pRBSizeAuto;
     wxRadioButton           *pRBSizeManual;
-    
+
     wxCheckBox              *pToolbarAutoHideCB;
     wxTextCtrl              *pToolbarHideSecs;
-    
+
 //    For GPS Page
     wxListCtrl* m_lcSources;
     wxButton* m_buttonAdd;
@@ -390,7 +390,7 @@ public:
     wxButton* m_buttonScanBT;
     wxStaticText* m_stBTPairs;
     wxChoice* m_choiceBTDataSources;
-    
+
     wxGridSizer* gSizerNetProps;
     wxStaticText* m_stNetProto;
     wxRadioButton* m_rbNetProtoTCP;
@@ -446,12 +446,12 @@ public:
     void OnSelectDatasource( wxListEvent& event );
     void OnAddDatasourceClick( wxCommandEvent& event );
     void OnRemoveDatasourceClick( wxCommandEvent& event );
-    
+
     void OnTypeSerialSelected( wxCommandEvent& event );
     void OnTypeNetSelected( wxCommandEvent& event );
     void OnTypeGPSSelected( wxCommandEvent& event );
     void OnTypeBTSelected( wxCommandEvent& event );
-    
+
     void OnNetProtocolSelected( wxCommandEvent& event );
     void OnBaudrateChoice( wxCommandEvent& event ) { OnConnValChange(event); }
     void OnProtocolChoice( wxCommandEvent& event ) { OnConnValChange(event); }
@@ -518,9 +518,9 @@ public:
     wxCheckBox                *pScanCheckBox;
     int                       k_charts;
     wxButton                  *m_removeBtn;
-    
+
 //      For :Charts->Display Options" page
-    
+
     wxScrolledWindow          *m_ChartDisplayPage;
 
 //    For "AIS" Page
@@ -566,7 +566,7 @@ public:
     wxScrolledWindow        *itemPanelShip;
     wxBoxSizer              *ownShip;
     wxTextCtrl              *m_pText_ACRadius;
-    
+
 //    For Fonts page
     wxBoxSizer              *m_itemBoxSizerFontPanel;
     wxChoice                *m_itemFontElementListBox;
@@ -583,9 +583,9 @@ public:
 
     wxScrolledWindow        *itemPanelPlugins;
     wxBoxSizer              *itemBoxSizerPanelPlugins;
-    
+
     wxChoice                *pNavAidRadarRingsNumberVisible;
-    wxChoice                *pWaypointRangeRingsNumber; 
+    wxChoice                *pWaypointRangeRingsNumber;
     wxFlexGridSizer         *radarGrid;
     wxFlexGridSizer         *waypointradarGrid;
     wxTextCtrl              *pNavAidRadarRingsStep;
@@ -603,7 +603,7 @@ public:
     wxCheckBox              *pTransparentToolbar;
 
     wxCheckBox              *pAdvanceRouteWaypointOnArrivalOnly;
-    
+
     wxCheckBox              *pTrackShowIcon;
     wxCheckBox              *pTrackDaily;
     wxCheckBox              *pTrackHighlite;
@@ -649,7 +649,7 @@ private:
             wxSize small_button_size );
     void CreatePanel_Advanced( size_t parent, int border_size, int group_item_spacing,
             wxSize small_button_size );
-    
+
     int m_returnChanges;
     wxListBox *tcDataSelected;
     std::vector<int> marinersStdXref;
@@ -658,17 +658,17 @@ private:
 
     wxScrolledWindow *m_pNMEAForm;
     void ShowNMEACommon( bool visible );
-    
+
     void ShowNMEASerial( bool visible );
     void ShowNMEANet( bool visible );
     void ShowNMEAGPS( bool visible );
     void ShowNMEABT( bool visible );
-    
+
     void SetNMEAFormToSerial();
     void SetNMEAFormToNet();
     void SetNMEAFormToGPS();
     void SetNMEAFormToBT();
-    
+
     void ClearNMEAForm();
     bool m_bNMEAParams_shown;
 
@@ -678,19 +678,19 @@ private:
     void SetDSFormRWStates();
     void FillSourceList();
     ConnectionParams *CreateConnectionParamsFromSelectedItem();
-    
+
     wxNotebookPage*             m_groupsPage;
     wxFont*     smallFont;
     wxSize      m_small_button_size;
     int         m_fontHeight;
     int         m_scrollRate;
-    
+
     wxTimer     m_BTScanTimer;
     int         m_BTscanning;
     wxArrayString m_BTscan_results;
     int         m_btNoChangeCounter;
-    int         m_btlastResultCount;   
-    
+    int         m_btlastResultCount;
+
 };
 
 class ChartGroupsUI: public wxScrolledWindow {
@@ -994,7 +994,7 @@ static int lang_list[] = {
             wxLANGUAGE_ZULU
             };
 #endif
-            
+
 ///////////////////////////////////////////////////////////////////////////////
 /// Class SentenceListDlg
 ///////////////////////////////////////////////////////////////////////////////
@@ -1062,22 +1062,22 @@ public:
     wxCheckBox *m_cbTextureCompression, *m_cbTextureCompressionCaching;
     wxCheckBox *m_cbShowFPS;
     wxCheckBox *m_cbSoftwareGL;
-    
+
     wxButton *m_bRebuildTextureCache;
     wxButton *m_bClearTextureCache;
 
     wxStaticText *m_stTextureCacheSize;
-    
+
     wxSpinCtrl *m_sTextureDimension;
     wxSpinCtrl *m_sTextureMemorySize;
 
     OpenGLOptionsDlg( wxWindow* parent, bool glTicked );
-    
+
     void OnButtonRebuild( wxCommandEvent& event );
     void OnButtonClear( wxCommandEvent& event );
 
     wxString TextureCacheSize();
-    
+
     bool m_brebuild_cache;
 
 };
@@ -1106,20 +1106,20 @@ public:
     MMSIListCtrl( wxWindow* parent, wxWindowID id, const wxPoint& pos,
                   const wxSize& size, long style );
     ~MMSIListCtrl();
-    
+
     wxString OnGetItemText( long item, long column ) const;
     //    int OnGetItemColumnImage( long item, long column ) const;
-    
+
     void OnListItemClick( wxListEvent &event);
     void OnListItemActivated( wxListEvent &event);
     void OnListItemRightClick( wxListEvent &event);
     void PopupMenuHandler( wxCommandEvent& event );
-    
+
     wxWindow *m_parent;
     int         m_context_item;
-    
+
     DECLARE_EVENT_TABLE()
-    
+
 };
 
 
@@ -1141,7 +1141,7 @@ class MMSIEditDialog: public wxDialog
 {
     DECLARE_DYNAMIC_CLASS( MMSIEditDialog )
     DECLARE_EVENT_TABLE()
-    
+
 public:
     MMSIEditDialog( );
     MMSIEditDialog( MMSIProperties *props, wxWindow* parent, wxWindowID id = -1,
@@ -1149,37 +1149,37 @@ public:
                     const wxPoint& pos = wxDefaultPosition,
                     const wxSize& size = wxDefaultSize,
                     long style = 0 );
-    
+
     ~MMSIEditDialog();
-    
+
     bool Create( MMSIProperties *props, wxWindow* parent, wxWindowID id = -1,
                  const wxString& caption = _T(""),
                  const wxPoint& pos = wxDefaultPosition,
                  const wxSize& size = wxDefaultSize, long style = 0 );
-    
+
     void SetColorScheme(ColorScheme cs);
-    
+
     void CreateControls();
-    
+
     void OnMMSIEditCancelClick( wxCommandEvent& event );
     void OnMMSIEditOKClick( wxCommandEvent& event );
     void OnCtlUpdated( wxCommandEvent& event );
-    
+
     MMSIProperties      *m_props;
-    
+
     wxTextCtrl          *m_MMSICtl;
     wxRadioButton       *m_rbTypeTrackDefault;
     wxRadioButton       *m_rbTypeTrackAlways;
     wxRadioButton       *m_rbTypeTrackNever;
     wxCheckBox          *m_cbTrackPersist;
-    
+
     wxCheckBox          *m_IgnoreButton;
     wxCheckBox          *m_MOBButton;
     wxCheckBox          *m_VDMButton;
-    
+
     wxButton            *m_CancelButton;
     wxButton            *m_OKButton;
-    
+
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -1188,24 +1188,24 @@ public:
 
 class MMSI_Props_Panel: public wxPanel
 {
-    
+
 public:
     MMSI_Props_Panel( wxWindow *parent );
     ~MMSI_Props_Panel( );
-    
+
 //    void OnClose(wxCloseEvent &event);
     void OnNewButton( wxCommandEvent &event );
-    
+
     void SetColorScheme( ColorScheme cs );
     void UpdateMMSIList( void );
-    
+
     MMSIListCtrl      *m_pListCtrlMMSI;
     wxButton          *m_pButtonNew;
-    
+
 private:
-    
+
     wxWindow          *m_pparent;
-    
+
 };
 
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6692,37 +6692,45 @@ void SentenceListDlg::OnCLBToggle( wxCommandEvent& event )
 
 void SentenceListDlg::OnAddClick( wxCommandEvent& event )
 {
-    wxString stc = wxGetTextFromUser(_("Enter the NMEA sentence (2, 3 or 5 characters)"), _("Enter the NMEA sentence"));
-    if (stc.Length() == 2 ||stc.Length() == 3 || stc.Length() == 5)
-    {
-        m_sentences.Add(stc);
-        m_clbSentences->Append(stc);
-        int item = m_clbSentences->FindString(stc);
-        m_clbSentences->Check(item);
+    wxString stc =
+        wxGetTextFromUser( _( "Enter the NMEA sentence (2, 3 or 5 characters) " ),
+                           _( "Enter the NMEA sentence" ) );
+    if ( stc.Length() == 2 || stc.Length() == 3 || stc.Length() == 5 ) {
+        m_sentences.Add( stc );
+        m_clbSentences->Append( stc );
+        m_clbSentences->Check( m_clbSentences->FindString(stc) );
+        return;
     }
-    else
-        OCPNMessageBox( NULL, _("An NMEA sentence is generally 3 characters long (like RMC, GGA etc.)\n It can also have a two letter prefix identifying the source, or TALKER, of the message.\n The whole sentences then looks like GPGGA or AITXT.\n You may filter out all the sentences with certain TALKER prefix (like GP, AI etc.).\n\n The filter accepts just these three formats."),
-                    _("OpenCPN Info"));
+
+    OCPNMessageBox(
+        this,
+        _("An NMEA sentence is generally 3 characters long (like RMC, GGA etc.)\n "
+          "It can also have a two letter prefix identifying the source, or TALKER, of the message.\n "
+          "The whole sentences then looks like GPGGA or AITXT.\n "
+          "You may filter out all the sentences with certain TALKER prefix (like GP, AI etc.).\n\n "
+          "The filter accepts just these three formats."),
+          _("OpenCPN Info")
+    );
 }
 
 void SentenceListDlg::OnDeleteClick( wxCommandEvent& event )
 {
     BuildSentenceArray();
 
-    // One can only delete items that do not appear in the standard sentence list
+    // Only delete items that do not appear in the standard sentence list
     int isel = m_clbSentences->GetSelection();
-    wxString s = m_clbSentences->GetString(isel);
+    wxString s = m_clbSentences->GetString( isel );
     bool bdelete = TRUE;
-    for (size_t i = 0; i < standard_sentences.Count(); i++) {
-        if(standard_sentences[i] == s){
+    for ( size_t i = 0; i < standard_sentences.Count(); i++ ) {
+        if ( standard_sentences[i] == s ) {
             bdelete = FALSE;
             break;
         }
     }
 
-    if(bdelete) {
+    if ( bdelete ) {
         m_sentences.Remove( s );
-        m_clbSentences->Delete(isel);
+        m_clbSentences->Delete( isel );
     }
 
     FillSentences();
@@ -6730,16 +6738,16 @@ void SentenceListDlg::OnDeleteClick( wxCommandEvent& event )
 
 void SentenceListDlg::OnClearAllClick( wxCommandEvent& event )
 {
-    for (size_t i = 0; i < m_clbSentences->GetCount(); i++)
-        m_clbSentences->Check(i, FALSE);
+    for ( size_t i = 0; i < m_clbSentences->GetCount(); i++ )
+        m_clbSentences->Check( i, FALSE );
 
     BuildSentenceArray();
 }
 
 void SentenceListDlg::OnCheckAllClick( wxCommandEvent& event )
 {
-    for (size_t i = 0; i < m_clbSentences->GetCount(); i++)
-        m_clbSentences->Check(i, TRUE);
+    for ( size_t i = 0; i < m_clbSentences->GetCount(); i++ )
+        m_clbSentences->Check( i, TRUE );
 
     BuildSentenceArray();
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3234,8 +3234,8 @@ void options::CreatePanel_UI( size_t parent, int border_size, int group_item_spa
 void options::CreateControls()
 {
     int border_size = 4;
-    int check_spacing = 2;
-    int group_item_spacing = 2;           // use for items within one group, with Add(...wxALL)
+    // use for items within one group, with Add(...wxALL)
+    int group_item_spacing = 2;
 
     int font_size_y, font_descent, font_lead;
     GetTextExtent( _T("0"), NULL, &font_size_y, &font_descent, &font_lead );
@@ -3243,18 +3243,17 @@ void options::CreateControls()
 
     m_small_button_size = wxSize( -1, (int) ( 1.4 * ( font_size_y + font_descent + font_lead ) ) );
 
-    //      Some members (pointers to controls) need to initialized
+    // Some members (pointers to controls) need to initialized
     pEnableZoomToCursor = NULL;
     pSmoothPanZoom = NULL;
 
-    //      Check the display size.
-    //      If "small", adjust some factors to squish out some more white space
+    // Check the display size.
+    // If "small", adjust some factors to squish out some more white space
     int width, height;
     ::wxDisplaySize( &width, &height );
 
     if ( !g_bresponsive && height <= 800 ) {
         border_size = 2;
-        check_spacing = 2;
         group_item_spacing = 1;
     }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6680,6 +6680,7 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked ) :
         flexSizer->Add( m_cbUseAcceleratedPanning, 0, wxALL | wxEXPAND, 5 );
     }
 
+    flexSizer->AddGrowableCol( 1 );
     mainSizer->Add( flexSizer, 0, wxALL | wxEXPAND, 5 );
 
     wxStdDialogButtonSizer * btnSizer = new wxStdDialogButtonSizer();
@@ -6687,6 +6688,7 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked ) :
     btnSizer->AddButton( new wxButton( this, wxID_CANCEL ) );
     btnSizer->Realize();
 
+    mainSizer->AddStretchSpacer( );
     mainSizer->Add( btnSizer, 0, wxALL | wxEXPAND, 5 );
 
     SetSizer( mainSizer );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -5230,37 +5230,31 @@ void options::OnButtonSelectSound( wxCommandEvent& event )
 {
     wxString sound_dir = g_Platform->GetSharedDataDir();
     sound_dir.Append( _T("sounds") );
-/*
-    wxFileDialog *openDialog = new wxFileDialog( NULL, _("Select Sound File"), sound_dir, wxT(""),
-            _("WAV files (*.wav)|*.wav|All files (*.*)|*.*"), wxFD_OPEN );
-
-    if(g_bresponsive)
-        openDialog = g_Platform->AdjustFileDialogFont(this, openDialog);
-
-    int response = openDialog->ShowModal();*/
-
     wxString sel_file;
-    int response = wxID_CANCEL;
+    int response;
 
 #ifndef __OCPN__ANDROID__
-    wxFileDialog *popenDialog = new wxFileDialog( NULL, _( "Select Sound File" ), sound_dir, wxT ( "" ),
-                                                  _T("WAV files (*.wav)|*.wav|All files (*.*)|*.*"), wxFD_OPEN );
-    if(g_bresponsive)
-        popenDialog = g_Platform->AdjustFileDialogFont(this, popenDialog);
+    wxFileDialog *popenDialog =
+        new wxFileDialog( NULL, _( "Select Sound File" ), sound_dir,
+                          wxEmptyString,
+                          _T("WAV files (*.wav)|*.wav|All files (*.*)|*.*"),
+                          wxFD_OPEN );
+    if ( g_bresponsive )
+        popenDialog = g_Platform->AdjustFileDialogFont( this, popenDialog );
 
     response = popenDialog->ShowModal();
     sel_file = popenDialog->GetPath();
     delete popenDialog;
 
 #else
-    wxString path;
-    response = g_Platform->DoFileSelectorDialog( NULL, &path, _( "Select Sound File" ),
-                                                 sound_dir, _T(""), wxT ( "*.*" ) );
-    sel_file = path;
+    response =
+        g_Platform->DoFileSelectorDialog( NULL, &sel_file,
+                                          _( "Select Sound File" ), sound_dir,
+                                          wxEmptyString, wxT( "*.*" ) );
 #endif
 
-    if( response == wxID_OK ) {
-        if( g_bportable ) {
+    if ( response == wxID_OK ) {
+        if ( g_bportable ) {
             wxFileName f( sel_file );
             f.MakeRelativeTo( g_Platform->GetHomeDir() );
             g_sAIS_Alert_Sound_File = f.GetFullPath();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -799,49 +799,11 @@ options::options( MyFrame* parent, wxWindowID id, const wxString& caption,
 
 options::~options( void )
 {
-    // Disconnect Connection page Events
-    if ( m_pNMEAForm ) {
-        m_lcSources->Disconnect( wxEVT_COMMAND_LIST_ITEM_SELECTED, wxListEventHandler( options::OnSelectDatasource ), NULL, this );
-        m_buttonAdd->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnAddDatasourceClick ), NULL, this );
-        m_buttonRemove->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnRemoveDatasourceClick ), NULL, this );
-        m_tFilterSec->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-        m_rbTypeSerial->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnTypeSerialSelected ), NULL, this );
-        m_rbTypeNet->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnTypeNetSelected ), NULL, this );
-        m_rbNetProtoTCP->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
-        m_rbNetProtoUDP->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
-        m_rbNetProtoGPSD->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
-        m_tNetAddress->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-        m_tNetPort->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-        m_comboPort->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-        m_comboPort->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-        m_choiceBaudRate->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( options::OnBaudrateChoice ), NULL, this );
-        m_choiceSerialProtocol->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( options::OnProtocolChoice ), NULL, this );
-        m_choicePriority->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-        m_cbCheckCRC->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnCrcCheck ), NULL, this );
-        m_cbGarminHost->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnUploadFormatChange ), NULL, this );
-        m_cbGarminUploadHost->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnUploadFormatChange ), NULL, this );
-        m_cbFurunoGP3X->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnUploadFormatChange ), NULL, this );
-        m_rbIAccept->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnRbAcceptInput ), NULL, this );
-        m_rbIIgnore->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnRbIgnoreInput ), NULL, this );
-        m_tcInputStc->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-        m_btnInputStcList->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnBtnIStcs ), NULL, this );
-        m_cbInput->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnCbInput ), NULL, this );
-        m_cbOutput->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnCbOutput ), NULL, this );
-        m_rbOAccept->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnRbOutput ), NULL, this );
-        m_rbOIgnore->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnRbOutput ), NULL, this );
-        m_tcOutputStc->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-        m_btnOutputStcList->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnBtnOStcs ), NULL, this );
-        m_cbNMEADebug->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnShowGpsWindowCheckboxClick ), NULL, this );
-        pOpenGL->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnGLClicked ), NULL, this );
-    }
-
-    delete m_pSerialArray;
     groupsPanel->EmptyChartGroupArray( m_pGroupArray );
-    delete m_pGroupArray;
-    m_pGroupArray = NULL;
-    m_groupsPage = NULL;
     g_pOptions = NULL;
-    if ( m_topImgList ) delete m_topImgList;
+    delete m_pSerialArray;
+    delete m_pGroupArray;
+    delete m_topImgList;
     delete smallFont;
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -958,11 +958,7 @@ bool options::Create( MyFrame* parent, wxWindowID id, const wxString& caption, c
 
     CreateControls();
     Fit();
-    if ( lastWindowPos == wxPoint( 0, 0 ) ) {
-        Centre();
-    } else {
-        Move( lastWindowPos );
-    }
+    lastWindowPos == wxPoint( 0, 0 ) ? Centre() : Move( lastWindowPos );
     lastWindowPos = GetPosition();
     return TRUE;
 }
@@ -996,8 +992,8 @@ wxScrolledWindow *options::AddPage( size_t parent, const wxString & title)
     int style = wxVSCROLL | wxTAB_TRAVERSAL;
     if ( page->IsKindOf( CLASSINFO( wxNotebook ) ) ) {
         window = new wxScrolledWindow( page, wxID_ANY, wxDefaultPosition, wxDefaultSize, style );
-        window->SetScrollRate(m_scrollRate, m_scrollRate);
-        ( ( wxNotebook * ) page )->AddPage( window, title );
+        window->SetScrollRate( m_scrollRate, m_scrollRate );
+        dynamic_cast<wxNotebook *>( page )->AddPage( window, title );
     } else if ( page->IsKindOf( CLASSINFO( wxScrolledWindow ) ) ) {
         wxString toptitle = m_pListbook->GetPageText( parent );
         wxNotebook *nb = new wxNotebook( m_pListbook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP );
@@ -1035,7 +1031,7 @@ bool options::DeletePage( wxScrolledWindow *page  )
         wxNotebookPage* pg = m_pListbook->GetPage( i );
 
         if( pg->IsKindOf( CLASSINFO( wxNotebook ) ) ) {
-            wxNotebook *nb = ((wxNotebook *)pg);
+            wxNotebook *nb = dynamic_cast<wxNotebook *>( pg );
             for ( size_t j = 0; j < nb->GetPageCount(); j++ ) {
                 wxNotebookPage* spg = nb->GetPage( j );
                 if ( spg == page ) {
@@ -1055,7 +1051,7 @@ bool options::DeletePage( wxScrolledWindow *page  )
         } else if ( pg->IsKindOf( CLASSINFO( wxScrolledWindow ) ) && pg == page ) {
             /* There's only one page, replace it with empty panel */
             m_pListbook->DeletePage( i );
-            wxPanel *panel = new wxPanel( m_pListbook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T( "" ) );
+            wxPanel *panel = new wxPanel( m_pListbook );
             wxString toptitle = m_pListbook->GetPageText( i );
             m_pListbook->InsertPage( i, panel, toptitle, FALSE, i );
             return TRUE;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6526,14 +6526,12 @@ void SentenceListDlg::SetSentenceList(wxArrayString sentences)
 {
     m_sentences = sentences;
 
-    if ( m_sentences.Count() == 0 && m_type == WHITELIST ) {
-        for ( size_t i = 0; i < m_clbSentences->GetCount(); i++ )
-            m_clbSentences->Check( i, TRUE );
-    }
-    if ( m_sentences.Count() == 0 && m_type == BLACKLIST ) {
-        for ( size_t i = 0; i < m_clbSentences->GetCount(); i++ )
-            m_clbSentences->Check( i, FALSE );
-    }
+    if ( m_sentences.Count() == 0 ) return;
+        for ( size_t i = 0; i < m_clbSentences->GetCount(); ++i )
+            if ( m_type == WHITELIST )
+                m_clbSentences->Check( i, TRUE );
+            else if ( m_type == BLACKLIST )
+                m_clbSentences->Check( i, FALSE );
 
     FillSentences();
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6670,17 +6670,13 @@ void SentenceListDlg::OnCLBSelect( wxCommandEvent& event )
 {
     // Only active the "Delete" button if the selection is not in the standard list
     int isel = m_clbSentences->GetSelection();
+
     bool bdelete = TRUE;
-    if(isel >= 0) {
-        wxString s = m_clbSentences->GetString(isel);
-        for (size_t i = 0; i < standard_sentences.Count(); i++) {
-            if(standard_sentences[i] == s){
-                bdelete = FALSE;
-                break;
-            }
-        }
-    }
-    else
+    if ( isel >= 0 ) {
+        wxString s = m_clbSentences->GetString( isel );
+        if ( standard_sentences.Index( s ) != wxNOT_FOUND )
+            bdelete = FALSE;
+    } else
         bdelete = FALSE;
     m_btnDel->Enable( bdelete );
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6426,78 +6426,76 @@ void options::OnRemoveDatasourceClick( wxCommandEvent& event )
 void options::OnSelectDatasource( wxListEvent& event )
 {
     connectionsaved = FALSE;
-    int params_index = event.GetData();
-    SetConnectionParams(g_pConnectionParams->Item(params_index));
+    SetConnectionParams( g_pConnectionParams->Item( event.GetData() ) );
     m_buttonRemove->Enable();
     event.Skip();
 }
 
 void options::OnBtnIStcs( wxCommandEvent& event )
 {
-    m_stcdialog_in->SetSentenceList(wxStringTokenize(m_tcInputStc->GetValue(), _T(",")));
-    m_stcdialog_in->SetType(0, (m_rbIAccept->GetValue() == TRUE) ? WHITELIST:BLACKLIST);
+    m_stcdialog_in->SetSentenceList(
+        wxStringTokenize( m_tcInputStc->GetValue(), _T( "," ) )
+    );
+    m_stcdialog_in->SetType( 0, m_rbIAccept->GetValue() ? WHITELIST :
+                                                          BLACKLIST);
 
-    if (m_stcdialog_in->ShowModal() == wxID_OK)
-        m_tcInputStc->SetValue(m_stcdialog_in->GetSentencesAsText());
+    if ( m_stcdialog_in->ShowModal() == wxID_OK )
+        m_tcInputStc->SetValue( m_stcdialog_in->GetSentencesAsText() );
 }
 
 void options::OnBtnOStcs( wxCommandEvent& event )
 {
-    m_stcdialog_out->SetSentenceList(wxStringTokenize(m_tcOutputStc->GetValue(), _T(",")));
-    m_stcdialog_out->SetType(1, (m_rbOAccept->GetValue() == TRUE) ? WHITELIST:BLACKLIST);
+    m_stcdialog_out->SetSentenceList(
+        wxStringTokenize( m_tcOutputStc->GetValue(), _T( "," ) )
+    );
+    m_stcdialog_out->SetType( 1, m_rbOAccept->GetValue() ? WHITELIST :
+                                                           BLACKLIST );
 
-    if (m_stcdialog_out->ShowModal() == wxID_OK)
-        m_tcOutputStc->SetValue(m_stcdialog_out->GetSentencesAsText());
+    if ( m_stcdialog_out->ShowModal() == wxID_OK )
+        m_tcOutputStc->SetValue( m_stcdialog_out->GetSentencesAsText() );
 }
 
 void options::OnNetProtocolSelected( wxCommandEvent& event )
 {
-    if (m_rbNetProtoGPSD->GetValue())
-    {
-        if (m_tNetPort->GetValue() == wxEmptyString)
-            m_tNetPort->SetValue(_T("2947"));
-    }
-    else if (m_rbNetProtoUDP->GetValue())
-    {
-        if (m_tNetPort->GetValue() == wxEmptyString)
-            m_tNetPort->SetValue(_T("10110"));
-
-        if (m_tNetAddress->GetValue() == wxEmptyString)
-            m_tNetAddress->SetValue(_T("0.0.0.0"));
-
-    }
-    else if (m_rbNetProtoTCP->GetValue())
-    {
-        if (m_tNetPort->GetValue() == wxEmptyString)
-            m_tNetPort->SetValue(_T("10110"));
+    if ( m_rbNetProtoGPSD->GetValue() ) {
+        if ( m_tNetPort->GetValue().IsEmpty() )
+            m_tNetPort->SetValue( _T( "2947" ));
+    } else if ( m_rbNetProtoUDP->GetValue() ) {
+        if ( m_tNetPort->GetValue().IsEmpty() )
+            m_tNetPort->SetValue( _T( "10110" ) );
+        if ( m_tNetAddress->GetValue().IsEmpty() )
+            m_tNetAddress->SetValue( _T( "0.0.0.0" ) );
+    } else if ( m_rbNetProtoTCP->GetValue() ) {
+        if (m_tNetPort->GetValue().IsEmpty())
+            m_tNetPort->SetValue( _T( "10110" ) );
     }
 
     SetDSFormRWStates();
-    OnConnValChange(event);
+    OnConnValChange( event );
 }
 
 void options::OnRbAcceptInput( wxCommandEvent& event )
 {
-    OnConnValChange(event);
+    OnConnValChange( event );
 }
 void options::OnRbIgnoreInput( wxCommandEvent& event )
 {
-    OnConnValChange(event);
+    OnConnValChange( event );
 }
 
 void options::OnRbOutput( wxCommandEvent& event )
 {
-    OnConnValChange(event);
+    OnConnValChange( event );
 }
 
 void options::OnCbInput( wxCommandEvent& event )
 {
-    OnConnValChange(event);
+    OnConnValChange( event );
 }
 
 void options::OnCbOutput( wxCommandEvent& event )
 {
-    OnConnValChange(event);
+    OnConnValChange( event );
     const bool checked = m_cbOutput->IsChecked();
     m_stPrecision->Enable( checked );
     m_choicePrecision->Enable( checked );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -480,8 +480,8 @@ BEGIN_EVENT_TABLE( MMSIListCtrl, wxListCtrl )
 END_EVENT_TABLE()
 
 MMSIListCtrl::MMSIListCtrl( wxWindow* parent, wxWindowID id, const wxPoint& pos,
-        const wxSize& size, long style ) :
-        wxListCtrl( parent, id, pos, size, style )
+                            const wxSize& size, long style ) :
+    wxListCtrl( parent, id, pos, size, style )
 {
     m_parent = parent;
 }
@@ -490,43 +490,42 @@ MMSIListCtrl::~MMSIListCtrl() {}
 
 wxString MMSIListCtrl::OnGetItemText( long item, long column ) const
 {
-    wxString ret = _T( "" );
+    wxString ret;
     MMSIProperties *props = g_MMSI_Props_Array.Item( item );
 
-    if ( props ) {
-        switch( column ){
-            case mlMMSI:
-                if ( props->MMSI > 0 )
-                    ret.Printf( _T( "%d" ), props->MMSI );
-                break;
-            case mlTrackMode:
-                if ( TRACKTYPE_DEFAULT == props->TrackType )
-                    ret = _( "Default" );
-                else if ( TRACKTYPE_ALWAYS == props->TrackType )
-                    ret = _( "Always" );
-                else if ( TRACKTYPE_NEVER == props->TrackType )
-                    ret = _( "Never" );
-                else
-                    ret = _T( "???" );
-                if ( props->m_bPersistentTrack )
-                    ret.Append( _T( ", " ) ).Append( _( "Persistent" ) );
-                break;
-            case mlIgnore:
-                if ( props->m_bignore )
-                    ret = _T( "X" );
-                break;
-            case mlMOB:
-                if ( props->m_bMOB )
-                    ret = _T( "X" );
-                break;
-            case mlVDM:
-                if ( props->m_bVDM )
-                    ret = _T( "X" );
-                break;
-            default:
-                ret = _T( "??" );
-                break;
-        }
+    if ( !props ) return ret;
+    switch ( column ) {
+        case mlMMSI:
+            if ( props->MMSI > 0 )
+                ret = wxString::Format( _T( "%d" ), props->MMSI );
+            break;
+        case mlTrackMode:
+            if ( TRACKTYPE_DEFAULT == props->TrackType )
+                ret = _( "Default" );
+            else if ( TRACKTYPE_ALWAYS == props->TrackType )
+                ret = _( "Always" );
+            else if ( TRACKTYPE_NEVER == props->TrackType )
+                ret = _( "Never" );
+            else
+                ret = _T( "???" );
+            if ( props->m_bPersistentTrack )
+                ret.Append( _T( ", " ) + _( "Persistent" ) );
+            break;
+        case mlIgnore:
+            if ( props->m_bignore )
+                ret = _T( "X" );
+            break;
+        case mlMOB:
+            if ( props->m_bMOB )
+                ret = _T( "X" );
+            break;
+        case mlVDM:
+            if ( props->m_bVDM )
+                ret = _T( "X" );
+            break;
+        default:
+            ret = _T( "??" );
+            break;
     }
     return ret;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -5955,29 +5955,33 @@ void options::OnUploadFormatChange( wxCommandEvent& event )
 
 void options::ShowNMEACommon( bool visible )
 {
-    if ( visible )
-    {
-        m_rbTypeSerial->Show();
-        m_rbTypeNet->Show();
-        if(m_rbTypeInternalGPS) m_rbTypeInternalGPS->Show();
-        if(m_rbTypeInternalBT) m_rbTypeInternalBT->Show();
-
-        m_rbIAccept->Show();
-        m_rbIIgnore->Show();
-        m_rbOAccept->Show();
-        m_rbOIgnore->Show();
-        m_tcInputStc->Show();
-        m_btnInputStcList->Show();
-        m_tcOutputStc->Show();
-        m_btnOutputStcList->Show();
-        m_cbInput->Show();
-        m_cbOutput->Show();
-        m_stPrecision->Show();
-        m_choicePrecision->Show();
-        if (m_cbOutput->IsChecked()) {
-            m_stPrecision->Enable(TRUE);
-            m_choicePrecision->Enable(TRUE);
-            m_stTalkerIdText->Enable(TRUE);
+    m_rbTypeSerial->Show( visible );
+    m_rbTypeNet->Show( visible );
+    if ( m_rbTypeInternalGPS ) m_rbTypeInternalGPS->Show( visible );
+    if ( m_rbTypeInternalBT ) m_rbTypeInternalBT->Show( visible );
+    m_rbIAccept->Show( visible );
+    m_rbIIgnore->Show( visible );
+    m_rbOAccept->Show( visible );
+    m_rbOIgnore->Show( visible );
+    m_tcInputStc->Show( visible );
+    m_btnInputStcList->Show( visible );
+    m_tcOutputStc->Show( visible );
+    m_btnOutputStcList->Show( visible );
+    m_cbInput->Show( visible );
+    m_cbOutput->Show( visible );
+    m_stPrecision->Show( visible );
+    m_choicePrecision->Show( visible );
+    m_choicePriority->Show( visible );
+    m_stPriority->Show( visible );
+    m_stPrecision->Show( visible );
+    m_stTalkerIdText->Show( visible );
+    m_TalkerIdText->Show( visible );
+    m_cbCheckCRC->Show( visible );
+    if ( visible ) {
+        if ( m_cbOutput->IsChecked() ) {
+            m_stPrecision->Enable( TRUE );
+            m_choicePrecision->Enable( TRUE );
+            m_stTalkerIdText->Enable( TRUE );
             m_TalkerIdText->Enable( TRUE );
         } else {
             m_stPrecision->Enable( FALSE );
@@ -5985,95 +5989,32 @@ void options::ShowNMEACommon( bool visible )
             m_stTalkerIdText->Enable( FALSE );
             m_TalkerIdText->Enable( FALSE );
         }
-        m_choicePriority->Show();
-        m_stPriority->Show();
-        m_stPrecision->Show();
-        m_stTalkerIdText->Show();
-        m_TalkerIdText->Show();
-        m_cbCheckCRC->Show();
     }
-    else
-    {
-        m_rbTypeSerial->Hide();
-        m_rbTypeNet->Hide();
-        if(m_rbTypeInternalGPS) m_rbTypeInternalGPS->Hide();
-        if(m_rbTypeInternalBT) m_rbTypeInternalBT->Hide();
-
-        m_rbIAccept->Hide();
-        m_rbIIgnore->Hide();
-        m_rbOAccept->Hide();
-        m_rbOIgnore->Hide();
-        m_tcInputStc->Hide();
-        m_btnInputStcList->Hide();
-        m_tcOutputStc->Hide();
-        m_btnOutputStcList->Hide();
-        m_cbInput->Hide();
-        m_cbOutput->Hide();
-        m_choicePriority->Hide();
-        m_stPrecision->Hide();
-        m_stTalkerIdText->Hide();
-        m_TalkerIdText->Hide();
-        m_choicePrecision->Hide();
-        m_stPriority->Hide();
-        m_cbCheckCRC->Hide();
-        sbSizerOutFilter->SetDimension(0,0,0,0);
-        sbSizerInFilter->SetDimension(0,0,0,0);
-        sbSizerConnectionProps->SetDimension(0,0,0,0);
-    }
-
     m_bNMEAParams_shown = visible;
 }
 
 void options::ShowNMEANet( bool visible )
 {
-    if ( visible )
-    {
-        m_stNetAddr->Show();
-        m_tNetAddress->Show();
-        m_stNetPort->Show();
-        m_tNetPort->Show();
-        m_stNetProto->Show();
-        m_rbNetProtoGPSD->Show();
-        m_rbNetProtoTCP->Show();
-        m_rbNetProtoUDP->Show();
-    }
-    else
-    {
-        m_stNetAddr->Hide();
-        m_tNetAddress->Hide();
-        m_stNetPort->Hide();
-        m_tNetPort->Hide();
-        m_stNetProto->Hide();
-        m_rbNetProtoGPSD->Hide();
-        m_rbNetProtoTCP->Hide();
-        m_rbNetProtoUDP->Hide();
-    }
+    m_stNetAddr->Show( visible );
+    m_tNetAddress->Show( visible );
+    m_stNetPort->Show( visible );
+    m_tNetPort->Show( visible );
+    m_stNetProto->Show( visible );
+    m_rbNetProtoGPSD->Show( visible );
+    m_rbNetProtoTCP->Show( visible );
+    m_rbNetProtoUDP->Show( visible );
 }
 
 void options::ShowNMEASerial( bool visible )
 {
-    if ( visible )
-    {
-        m_stSerBaudrate->Show();
-        m_choiceBaudRate->Show();
-        m_stSerPort->Show();
-        m_comboPort->Show();
-        m_stSerProtocol->Show();
-        m_choiceSerialProtocol->Show();
-        m_cbGarminHost->Show();
-        ///gSizerNetProps->SetDimension(0,0,0,0);
-    }
-    else
-    {
-        m_stSerBaudrate->Hide();
-        m_choiceBaudRate->Hide();
-        m_stSerPort->Hide();
-        m_comboPort->Hide();
-        m_stSerProtocol->Hide();
-        m_choiceSerialProtocol->Hide();
-        m_cbGarminHost->Hide();
-        ///gSizerSerProps->SetDimension(0,0,0,0);
-    }
+    m_stSerBaudrate->Show( visible );
+    m_choiceBaudRate->Show( visible );
+    m_stSerPort->Show( visible );
+    m_comboPort->Show( visible );
+    m_stSerProtocol->Show( visible );
+    m_choiceSerialProtocol->Show( visible );
+    m_cbGarminHost->Show( visible );
+    ///gSizerNetProps->SetDimension(0,0,0,0);
 }
 
 void options::ShowNMEAGPS( bool visible ) {}

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4279,7 +4279,7 @@ void options::OnApplyClick( wxCommandEvent& event )
 
     // Start with the stuff that requires intelligent validation.
 
-    if( m_pShipIconType->GetSelection() > 0 ) {
+    if ( m_pShipIconType->GetSelection() > 0 ) {
         double n_ownship_length_meters;
         double n_ownship_beam_meters;
         double n_gps_antenna_offset_y;
@@ -4291,19 +4291,19 @@ void options::OnApplyClick( wxCommandEvent& event )
         m_pOSGPSOffsetY->GetValue().ToDouble( &n_gps_antenna_offset_y );
         m_pOSMinSize->GetValue().ToLong( &n_ownship_min_mm );
         wxString msg;
-        if( n_ownship_length_meters <= 0 )
-            msg += _("\n - your ship's length must be > 0");
-        if( n_ownship_beam_meters <= 0 )
-            msg += _("\n - your ship's beam must be > 0");
-        if( fabs(n_gps_antenna_offset_x) > n_ownship_beam_meters/2.0 )
-            msg += _("\n - your GPS offset from midship must be within your ship's beam");
-        if( n_gps_antenna_offset_y < 0 || n_gps_antenna_offset_y > n_ownship_length_meters )
-            msg += _("\n - your GPS offset from bow must be within your ship's length");
+        if ( n_ownship_length_meters <= 0 )
+            msg += _( "\n - your ship's length must be > 0" );
+        if ( n_ownship_beam_meters <= 0 )
+            msg += _( "\n - your ship's beam must be > 0" );
+        if ( fabs( n_gps_antenna_offset_x ) > n_ownship_beam_meters / 2.0 )
+            msg += _( "\n - your GPS offset from midship must be within your ship's beam" );
+        if ( n_gps_antenna_offset_y < 0 || n_gps_antenna_offset_y > n_ownship_length_meters )
+            msg += _( "\n - your GPS offset from bow must be within your ship's length" );
         if( n_ownship_min_mm <= 0 || n_ownship_min_mm > 100 )
-            msg += _("\n - your minimum ship icon size must be between 1 and 100 mm");
-        if( ! msg.IsEmpty() ) {
-            msg.Prepend( _("The settings for own ship real size are not correct:") );
-            OCPNMessageBox( this, msg, _("OpenCPN info"), wxICON_ERROR );
+            msg += _( "\n - your minimum ship icon size must be between 1 and 100 mm" );
+        if( !msg.IsEmpty() ) {
+            msg.Prepend( _( "The settings for own ship real size are not correct:" ) );
+            OCPNMessageBox( this, msg, _( "OpenCPN info" ), wxICON_ERROR );
             ::wxEndBusyCursor();
             event.SetInt( wxID_STOP );
             return;
@@ -4312,22 +4312,20 @@ void options::OnApplyClick( wxCommandEvent& event )
         g_n_ownship_beam_meters = n_ownship_beam_meters;
         g_n_gps_antenna_offset_y = n_gps_antenna_offset_y;
         g_n_gps_antenna_offset_x = n_gps_antenna_offset_x;
-        g_n_ownship_min_mm = (int)n_ownship_min_mm;
+        g_n_ownship_min_mm = static_cast<int>( n_ownship_min_mm );
     }
     g_OwnShipIconType = m_pShipIconType->GetSelection();
 
     m_pText_ACRadius->GetValue().ToDouble( &g_n_arrival_circle_radius );
 
-    //    Handle Chart Tab
-    wxString dirname;
-
-    if( pActiveChartsList ) {
+    // Handle Chart Tab
+    if ( pActiveChartsList ) {
         UpdateWorkArrayFromTextCtl();
     } else {
         m_pWorkDirList->Clear();
         int nDir = m_CurrentDirList.GetCount();
 
-        for( int i = 0; i < nDir; i++ ) {
+        for ( int i = 0; i < nDir; i++ ) {
             ChartDirInfo cdi = m_CurrentDirList.Item( i );
             m_pWorkDirList->Add( cdi );
         }
@@ -4336,7 +4334,7 @@ void options::OnApplyClick( wxCommandEvent& event )
     groupsPanel->m_treespopulated = FALSE;
 
     int k_force = FORCE_UPDATE;
-    if( pUpdateCheckBox ) {
+    if ( pUpdateCheckBox ) {
         if( !pUpdateCheckBox->GetValue() ) k_force = 0;
         pUpdateCheckBox->Enable();
         pUpdateCheckBox->SetValue( FALSE );
@@ -4347,8 +4345,8 @@ void options::OnApplyClick( wxCommandEvent& event )
     m_returnChanges |= k_force;
 
     int k_scan = SCAN_UPDATE;
-    if( pScanCheckBox ) {
-        if( !pScanCheckBox->GetValue() ) k_scan = 0;
+    if ( pScanCheckBox ) {
+        if ( !pScanCheckBox->GetValue() ) k_scan = 0;
         pScanCheckBox->Enable();
         pScanCheckBox->SetValue( FALSE );
     } else {
@@ -4359,7 +4357,7 @@ void options::OnApplyClick( wxCommandEvent& event )
 
     // Chart Groups
 
-    if( groupsPanel->modified ) {
+    if ( groupsPanel->modified ) {
         groupsPanel->EmptyChartGroupArray( g_pGroupArray );
         delete g_pGroupArray;
         g_pGroupArray = groupsPanel->CloneChartGroupArray( m_pGroupArray );
@@ -4367,7 +4365,6 @@ void options::OnApplyClick( wxCommandEvent& event )
     }
 
     // Handle Settings Tab
-
     if( m_pConfig ) {
         g_bShowStatusBar = pShowStatusBar->GetValue();
 #ifndef __WXOSX__
@@ -4381,14 +4378,7 @@ void options::OnApplyClick( wxCommandEvent& event )
     wxString screenmm = pScreenMM->GetValue();
     long mm = -1;
     screenmm.ToLong(&mm);
-
-    if(mm >0){
-        g_config_display_size_mm = mm;
-    }
-    else{
-        g_config_display_size_mm = -1;
-    }
-
+    g_config_display_size_mm = mm > 0 ? mm : -1;
     g_config_display_size_manual = pRBSizeManual->GetValue();
 
     // Connections page.
@@ -4396,8 +4386,8 @@ void options::OnApplyClick( wxCommandEvent& event )
 
     long filter_val = 1;
     m_tFilterSec->GetValue().ToLong( &filter_val );
-    g_COGFilterSec = wxMin((int)filter_val, MAX_COGSOG_FILTER_SECONDS);
-    g_COGFilterSec = wxMax(g_COGFilterSec, 1);
+    g_COGFilterSec = wxMin( static_cast<int>( filter_val ), MAX_COGSOG_FILTER_SECONDS );
+    g_COGFilterSec = wxMax( g_COGFilterSec, 1 );
     g_SOGFilterSec = g_COGFilterSec;
 
     g_bMagneticAPB = m_cbAPBMagnetic->GetValue();
@@ -4410,29 +4400,24 @@ void options::OnApplyClick( wxCommandEvent& event )
     //  to facility identification and allow stop and restart of the stream
     wxString lastAddr;
     int lastPort = 0;
-    if(itemIndex >=0){
+    if ( itemIndex >= 0 ) {
         int params_index = m_lcSources->GetItemData( itemIndex );
-        ConnectionParams *cpo = g_pConnectionParams->Item(params_index);
-        if(cpo){
+        ConnectionParams *cpo = g_pConnectionParams->Item( params_index );
+        if ( cpo ) {
             lastAddr = cpo->NetworkAddress;
             lastPort = cpo->NetworkPort;
         }
     }
 
-    if(!connectionsaved)
-    {
+    if ( !connectionsaved ) {
         ConnectionParams * cp = CreateConnectionParamsFromSelectedItem();
-        if(cp != NULL)
-        {
-            if (itemIndex >= 0)
-            {
+        if ( cp != NULL ) {
+            if ( itemIndex >= 0 ) {
                 int params_index = m_lcSources->GetItemData( itemIndex );
-                g_pConnectionParams->RemoveAt(params_index);
-                g_pConnectionParams->Insert(cp, params_index);
-            }
-            else
-            {
-                g_pConnectionParams->Add(cp);
+                g_pConnectionParams->RemoveAt( params_index );
+                g_pConnectionParams->Insert( cp, params_index );
+            } else {
+                g_pConnectionParams->Add( cp );
                 itemIndex = g_pConnectionParams->Count() - 1;
             }
 
@@ -4441,73 +4426,57 @@ void options::OnApplyClick( wxCommandEvent& event )
             cp->LastNetworkPort = lastPort;
 
             FillSourceList();
-            m_lcSources->SetItemState(itemIndex, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
+            m_lcSources->SetItemState( itemIndex, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED );
             m_lcSources->Refresh();
             connectionsaved = TRUE;
         } else {
             ::wxEndBusyCursor();
-            if( m_bNMEAParams_shown )
-                event.SetInt (wxID_STOP );
+            if ( m_bNMEAParams_shown ) event.SetInt(wxID_STOP );
         }
     }
 
     //Recreate datastreams that are new, or have been edited
-    for ( size_t i = 0; i < g_pConnectionParams->Count(); i++ )
-    {
-        ConnectionParams *cp = g_pConnectionParams->Item(i);
-        if( !cp->b_IsSetup ) {                  // Stream is new, or edited
+    for ( size_t i = 0; i < g_pConnectionParams->Count(); i++ ) {
+        ConnectionParams *cp = g_pConnectionParams->Item( i );
+        // Stream is new, or edited
+        if ( cp->b_IsSetup ) continue;
+        // Terminate and remove any existing stream with the same port name
+        DataStream *pds_existing = g_pMUX->FindStream( cp->GetDSPort() );
+        if ( pds_existing ) g_pMUX->StopAndRemoveStream( pds_existing );
 
-            // Terminate and remove any existing stream with the same port name
-            DataStream *pds_existing = g_pMUX->FindStream( cp->GetDSPort() );
-            if(pds_existing)
-                g_pMUX->StopAndRemoveStream( pds_existing );
+        //  Try to stop any previous stream to avoid orphans
+        pds_existing = g_pMUX->FindStream( cp->GetLastDSPort() );
+        if ( pds_existing ) g_pMUX->StopAndRemoveStream( pds_existing );
 
-            //  Try to stop any previous stream to avoid orphans
-            pds_existing = g_pMUX->FindStream( cp->GetLastDSPort() );
-            if(pds_existing)
-                g_pMUX->StopAndRemoveStream( pds_existing );
+        //  This for Bluetooth, which has strange parameters
+        pds_existing = g_pMUX->FindStream( cp->GetPortStr() );
+        if ( pds_existing ) g_pMUX->StopAndRemoveStream( pds_existing );
 
-            //  This for Bluetooth, which has strange parameters
-            pds_existing = g_pMUX->FindStream( cp->GetPortStr() );
-            if(pds_existing)
-                g_pMUX->StopAndRemoveStream( pds_existing );
+        if ( !cp->bEnabled ) continue;
+        dsPortType port_type = cp->IOSelect;
+        DataStream *dstr = new DataStream( g_pMUX, cp->Type, cp->GetDSPort(),
+                                           wxString::Format(wxT("%i"),
+                                           cp->Baudrate), port_type,
+                                           cp->Priority, cp->Garmin );
+        dstr->SetInputFilter( cp->InputSentenceList );
+        dstr->SetInputFilterType( cp->InputSentenceListType );
+        dstr->SetOutputFilter( cp->OutputSentenceList );
+        dstr->SetOutputFilterType( cp->OutputSentenceListType );
+        dstr->SetChecksumCheck( cp->ChecksumCheck );
+        g_pMUX->AddStream( dstr );
 
-           if( cp->bEnabled ) {
-           dsPortType port_type = cp->IOSelect;
-                DataStream *dstr = new DataStream( g_pMUX,
-                                            cp->Type,
-                                            cp->GetDSPort(),
-                                            wxString::Format(wxT("%i"), cp->Baudrate),
-                                            port_type,
-                                            cp->Priority,
-                                            cp->Garmin
-                                            );
-                dstr->SetInputFilter(cp->InputSentenceList);
-                dstr->SetInputFilterType(cp->InputSentenceListType);
-                dstr->SetOutputFilter(cp->OutputSentenceList);
-                dstr->SetOutputFilterType(cp->OutputSentenceListType);
-                dstr->SetChecksumCheck(cp->ChecksumCheck);
-
-                g_pMUX->AddStream(dstr);
-
-                cp->b_IsSetup = TRUE;
-            }
-        }
+        cp->b_IsSetup = TRUE;
     }
 
     g_bGarminHostUpload = m_cbGarminUploadHost->GetValue();
-    if( m_cbFurunoGP3X->GetValue() )
-        g_GPS_Ident = _T("FurunoGP3X");
-    else
-        g_GPS_Ident = _T("Generic");
+    g_GPS_Ident = m_cbFurunoGP3X->GetValue() ? _T( "FurunoGP3X" ) : _T( "Generic" );
 
     // End of Connections page
-
     g_bShowOutlines = pCDOOutlines->GetValue();
     g_bDisplayGrid = pSDisplayGrid->GetValue();
 
     bool temp_bquilting = pCDOQuilting->GetValue();
-    if(!g_bQuiltEnable && temp_bquilting)
+    if ( !g_bQuiltEnable && temp_bquilting )
         cc1->ReloadVP(); /* compose the quilt */
     g_bQuiltEnable = temp_bquilting;
 
@@ -4522,23 +4491,21 @@ void options::OnApplyClick( wxCommandEvent& event )
 
     long hide_val = 10;
     pToolbarHideSecs->GetValue().ToLong( &hide_val );
-    g_nAutoHideToolbar = wxMin((int)hide_val, 100);
-    g_nAutoHideToolbar = wxMax(g_nAutoHideToolbar, 2);
+    g_nAutoHideToolbar = wxMin( static_cast<int>( hide_val ), 100 );
+    g_nAutoHideToolbar = wxMax( g_nAutoHideToolbar, 2 );
 
     g_fog_overzoom = !pOverzoomEmphasis->GetValue();
     g_oz_vector_scale = !pOZScaleVector->GetValue();
 
-    bool bopengl_changed = g_bopengl != pOpenGL->GetValue();
     g_bopengl = pOpenGL->GetValue();
 
     g_bsmoothpanzoom = pSmoothPanZoom->GetValue();
 
     long update_val = 1;
     pCOGUPUpdateSecs->GetValue().ToLong( &update_val );
-    g_COGAvgSec = wxMin((int)update_val, MAX_COG_AVERAGE_SECONDS);
+    g_COGAvgSec = wxMin( static_cast<int>( update_val ), MAX_COG_AVERAGE_SECONDS);
 
-    if(g_bCourseUp != pCBCourseUp->GetValue())
-        gFrame->ToggleCourseUp();
+    if ( g_bCourseUp != pCBCourseUp->GetValue() ) gFrame->ToggleCourseUp();
 
     g_bLookAhead = pCBLookAhead->GetValue();
 
@@ -4548,11 +4515,14 @@ void options::OnApplyClick( wxCommandEvent& event )
     m_pText_OSCOG_Predictor->GetValue().ToDouble( &g_ownship_predictor_minutes );
     m_pText_OSHDT_Predictor->GetValue().ToDouble( &g_ownship_HDTpredictor_miles );
 
+    double temp_dbl;
     g_iNavAidRadarRingsNumberVisible = pNavAidRadarRingsNumberVisible->GetSelection();
-    g_fNavAidRadarRingsStep = atof( pNavAidRadarRingsStep->GetValue().mb_str() );
+    if ( pNavAidRadarRingsStep->GetValue().ToDouble( &temp_dbl ) )
+        g_fNavAidRadarRingsStep = temp_dbl;
     g_pNavAidRadarRingsStepUnits = m_itemRadarRingsUnits->GetSelection();
     g_iWaypointRangeRingsNumber = pWaypointRangeRingsNumber->GetSelection();
-    g_fWaypointRangeRingsStep = atof( pWaypointRangeRingsStep->GetValue().mb_str() );
+    if ( pWaypointRangeRingsStep->GetValue().ToDouble( &temp_dbl ) )
+        g_fWaypointRangeRingsStep = temp_dbl;
     g_iWaypointRangeRingsStepUnits = m_itemWaypointRangeRingsUnits->GetSelection();
     g_colourWaypointRangeRingsColour = m_colourWaypointRangeRingsColour->GetColour();
     g_bWayPointPreventDragging = pWayPointPreventDragging->GetValue();
@@ -4576,8 +4546,8 @@ void options::OnApplyClick( wxCommandEvent& event )
 
     g_bEnableZoomToCursor = pEnableZoomToCursor->GetValue();
 
-    //    AIS Parameters
-    //      CPA Box
+    // AIS Parameters
+    //   CPA Box
     g_bCPAMax = m_pCheck_CPA_Max->GetValue();
     m_pText_CPA_Max->GetValue().ToDouble( &g_CPAMax_NM );
     g_bCPAWarn = m_pCheck_CPA_Warn->GetValue();
@@ -4585,28 +4555,27 @@ void options::OnApplyClick( wxCommandEvent& event )
     g_bTCPA_Max = m_pCheck_CPA_WarnT->GetValue();
     m_pText_CPA_WarnT->GetValue().ToDouble( &g_TCPA_Max );
 
-    //      Lost Targets
+    //   Lost Targets
     g_bMarkLost = m_pCheck_Mark_Lost->GetValue();
     m_pText_Mark_Lost->GetValue().ToDouble( &g_MarkLost_Mins );
     g_bRemoveLost = m_pCheck_Remove_Lost->GetValue();
     m_pText_Remove_Lost->GetValue().ToDouble( &g_RemoveLost_Mins );
 
-    //      Display
+    //   Display
     g_bShowCOG = m_pCheck_Show_COG->GetValue();
     m_pText_COG_Predictor->GetValue().ToDouble( &g_ShowCOG_Mins );
 
     g_bAISShowTracks = m_pCheck_Show_Tracks->GetValue();
     m_pText_Track_Length->GetValue().ToDouble( &g_AISShowTracks_Mins );
 
-    //  Update all the current targets
-    if( g_pAIS ){
+    //   Update all the current targets
+    if ( g_pAIS ) {
         AIS_Target_Hash::iterator it;
         AIS_Target_Hash *current_targets = g_pAIS->GetTargetList();
-        for( it = ( *current_targets ).begin(); it != ( *current_targets ).end(); ++it ) {
+        for ( it = current_targets->begin(); it != current_targets->end(); ++it ) {
             AIS_Target_Data *pAISTarget = it->second;
-            if( NULL != pAISTarget ) {
+            if ( NULL != pAISTarget )
                 pAISTarget->b_show_track = g_bAISShowTracks;
-            }
         }
     }
 
@@ -4622,7 +4591,7 @@ void options::OnApplyClick( wxCommandEvent& event )
 
     g_bWplIsAprsPosition = m_pCheck_Wpl_Aprs->GetValue();
 
-    //      Alert
+    //   Alert
     g_bAIS_CPA_Alert = m_pCheck_AlertDialog->GetValue();
     g_bAIS_CPA_Alert_Audio = m_pCheck_AlertAudio->GetValue();
     g_bAIS_CPA_Alert_Suppress_Moored = m_pCheck_Alert_Moored->GetValue();
@@ -4630,7 +4599,7 @@ void options::OnApplyClick( wxCommandEvent& event )
     g_bAIS_ACK_Timeout = m_pCheck_Ack_Timout->GetValue();
     m_pText_ACK_Timeout->GetValue().ToDouble( &g_AckTimeout_Mins );
 
-    // Rollover
+    //   Rollover
     g_bAISRolloverShowClass = m_pCheck_Rollover_Class->GetValue();
     g_bAISRolloverShowCOG = m_pCheck_Rollover_COG->GetValue();
     g_bAISRolloverShowCPA = m_pCheck_Rollover_CPA->GetValue();
@@ -4645,16 +4614,14 @@ void options::OnApplyClick( wxCommandEvent& event )
     g_TalkerIdText = m_TalkerIdText->GetValue().MakeUpper();
 
 #ifdef USE_S57
-    //    Handle Vector Charts Tab
-
+    //   Handle Vector Charts Tab
     g_cm93_zoom_factor = m_pSlider_CM93_Zoom->GetValue();
-
     int nOBJL = ps57CtlListBox->GetCount();
 
-    for( int iPtr = 0; iPtr < nOBJL; iPtr++ ) {
+    for ( int iPtr = 0; iPtr < nOBJL; iPtr++ ) {
         int itemIndex = -1;
-        for( size_t i=0; i<marinersStdXref.size(); i++ ) {
-            if( marinersStdXref[ i ] == iPtr ) {
+        for ( size_t i = 0; i < marinersStdXref.size(); i++ ) {
+            if ( marinersStdXref[ i ] == iPtr ) {
                 itemIndex = i;
                 break;
             }
@@ -4663,19 +4630,20 @@ void options::OnApplyClick( wxCommandEvent& event )
         pOLE->nViz = ps57CtlListBox->IsChecked( iPtr );
     }
 
-    if( ps52plib ) {
-        if( bopengl_changed ) {
-            //    We need to do this now to handle the screen refresh that
-            //    is automatically generated on Windows at closure of the options dialog...
+    if ( ps52plib ) {
+        if ( g_bopengl != pOpenGL->GetValue() ) {
+            // Do this now to handle the screen refresh that is automatically
+            // generated on Windows at closure of the options dialog...
             ps52plib->FlushSymbolCaches();
-            ps52plib->ClearCNSYLUPArray();      // some CNSY depends on renderer (e.g. CARC)
+            // some CNSY depends on renderer (e.g. CARC)
+            ps52plib->ClearCNSYLUPArray();
             ps52plib->GenerateStateHash();
 
             m_returnChanges |= GL_CHANGED;
         }
 
         enum _DisCat nset = OTHER;
-        switch( pDispCat->GetSelection() ){
+        switch ( pDispCat->GetSelection() ) {
             case 0:
                 nset = DISPLAYBASE;
                 break;
@@ -4701,63 +4669,55 @@ void options::OnApplyClick( wxCommandEvent& event )
         ps52plib->m_bDeClutterText = pCheck_DECLTEXT->GetValue();
         ps52plib->m_bShowNationalTexts = pCheck_NATIONALTEXT->GetValue();
 
-        if( 0 == pPointStyle->GetSelection() )
-            ps52plib->m_nSymbolStyle = PAPER_CHART;
-        else
-            ps52plib->m_nSymbolStyle = SIMPLIFIED;
+        ps52plib->m_nSymbolStyle =
+            pPointStyle->GetSelection() == 0 ? PAPER_CHART : SIMPLIFIED;
 
-        if( 0 == pBoundStyle->GetSelection() )
-            ps52plib->m_nBoundaryStyle = PLAIN_BOUNDARIES;
-        else
-            ps52plib->m_nBoundaryStyle = SYMBOLIZED_BOUNDARIES;
+        ps52plib->m_nBoundaryStyle =
+            pBoundStyle->GetSelection() == 0 ? PLAIN_BOUNDARIES :
+                                               SYMBOLIZED_BOUNDARIES;
 
-        if( 0 == p24Color->GetSelection() )
-            S52_setMarinerParam( S52_MAR_TWO_SHADES, 1.0 );
-        else
-            S52_setMarinerParam( S52_MAR_TWO_SHADES, 0.0 );
+        S52_setMarinerParam( S52_MAR_TWO_SHADES, p24Color->GetSelection() ? 1.0 : 0.0 );
 
         // Depths
         double dval;
         int depthUnit = pDepthUnitSelect->GetSelection();
-
         float conv = 1;
+
         if ( depthUnit == 0 ) // feet
             conv = 0.3048f; // international definiton of 1 foot is 0.3048 metres
         else if ( depthUnit == 2 ) // fathoms
             conv = 0.3048f * 6; // 1 fathom is 6 feet
 
-        if( ( m_SafetyCtl->GetValue() ).ToDouble( &dval ) ) {
+        if ( m_SafetyCtl->GetValue().ToDouble( &dval ) ) {
             S52_setMarinerParam( S52_MAR_SAFETY_DEPTH, dval * conv );   // controls sounding display
             S52_setMarinerParam( S52_MAR_SAFETY_CONTOUR, dval * conv ); // controls colour
         }
 
-        if( ( m_ShallowCtl->GetValue() ).ToDouble( &dval ) )
+        if ( m_ShallowCtl->GetValue().ToDouble( &dval ) )
             S52_setMarinerParam( S52_MAR_SHALLOW_CONTOUR, dval * conv );
 
-        if( ( m_DeepCtl->GetValue() ).ToDouble( &dval ) )
+        if ( m_DeepCtl->GetValue().ToDouble( &dval ) )
             S52_setMarinerParam( S52_MAR_DEEP_CONTOUR, dval * conv );
 
         ps52plib->UpdateMarinerParams();
-
         ps52plib->m_nDepthUnitDisplay = depthUnit;
-
         ps52plib->GenerateStateHash();
     }
 #endif
 
-//    User Interface Panel
+    // User Interface Panel
 #if wxUSE_XLOCALE || !wxCHECK_VERSION(3,0,0)
-    if( m_bVisitLang ) {
+    if ( m_bVisitLang ) {
         wxString new_canon = _T("en_US");
         wxString lang_sel = m_itemLangListBox->GetStringSelection();
 
-        int nLang = sizeof( lang_list ) / sizeof(int);
-        for( int it = 0; it < nLang; it++ ) {
+        int nLang = sizeof( lang_list ) / sizeof( int );
+        for ( int it = 0; it < nLang; it++ ) {
             const wxLanguageInfo * pli = wxLocale::GetLanguageInfo( lang_list[it] );
-            if(pli){
+            if ( pli ) {
                 wxString lang_canonical = pli->CanonicalName;
                 wxString test_string = GetOCPNKnownLanguage( lang_canonical );
-                if( lang_sel == test_string ) {
+                if ( lang_sel == test_string ) {
                     new_canon = lang_canonical;
                     break;
                 }
@@ -4767,7 +4727,7 @@ void options::OnApplyClick( wxCommandEvent& event )
         wxString locale_old = g_locale;
         g_locale = new_canon;
 
-        if( g_locale != locale_old ) m_returnChanges |= LOCALE_CHANGED;
+        if ( g_locale != locale_old ) m_returnChanges |= LOCALE_CHANGED;
 
         wxString oldStyle = g_StyleManager->GetCurrentStyle()->name;
         g_StyleManager->SetStyleNextInvocation( m_itemStyleListBox->GetStringSelection() );
@@ -4778,39 +4738,30 @@ void options::OnApplyClick( wxCommandEvent& event )
         gFrame->OnSize( nullEvent );
     }
 #endif
-    //      PlugIn Manager Panel
+    // PlugIn Manager Panel
 
-    //      Pick up any changes to selections
-    bool bnew_settings = g_pi_manager->UpdatePlugIns();
-    if( bnew_settings ) m_returnChanges |= TOOLBAR_CHANGED;
+    // Pick up any changes to selections
+    if ( g_pi_manager->UpdatePlugIns() ) m_returnChanges |= TOOLBAR_CHANGED;
 
-    //      And keep config in sync
-    if( m_pPlugInCtrl )
-        m_pPlugInCtrl->UpdatePluginsOrder();
+    // And keep config in sync
+    if ( m_pPlugInCtrl ) m_pPlugInCtrl->UpdatePluginsOrder();
     g_pi_manager->UpdateConfig();
 
-    //      PlugIns may have added panels
-    if( g_pi_manager ) g_pi_manager->CloseAllPlugInPanels( (int) wxOK );
+    // PlugIns may have added panels
+    if ( g_pi_manager ) g_pi_manager->CloseAllPlugInPanels( (int) wxOK );
 
-    //      Could be a lot smarter here
-    m_returnChanges |= GENERIC_CHANGED;
-    m_returnChanges |= k_vectorcharts;
-    m_returnChanges |= k_charts;
-    m_returnChanges |= m_groups_changed;
-    m_returnChanges |= k_plugins;
-    m_returnChanges |= k_tides;
+    m_returnChanges |= GENERIC_CHANGED | k_vectorcharts | k_charts |
+        m_groups_changed | k_plugins |k_tides;
 
-    //  Pick up all the entries in the DataSelected control
-    //  and update the global static array
+    // Pick up all the entries in the DataSelected control
+    // and update the global static array
     TideCurrentDataSet.Clear();
     int nEntry = tcDataSelected->GetCount();
 
-    for( int i = 0; i < nEntry; i++ ) {
-        wxString s = tcDataSelected->GetString( i );
-        TideCurrentDataSet.Add( s );
-    }
+    for ( int i = 0; i < nEntry; i++ )
+        TideCurrentDataSet.Add( tcDataSelected->GetString( i ) );
 
-    if( event.GetId() == ID_APPLY ) {
+    if ( event.GetId() == ID_APPLY ) {
         gFrame->ProcessOptionsDialog( m_returnChanges, m_pWorkDirList );
         cc1->ReloadVP();
     }
@@ -4821,10 +4772,10 @@ void options::OnApplyClick( wxCommandEvent& event )
 void options::OnXidOkClick( wxCommandEvent& event )
 {
     // When closing the form with Ctrl-Enter sometimes we get double events, the second is empty??
-    if( event.GetEventObject() == NULL ) return;
+    if ( event.GetEventObject() == NULL ) return;
 
     OnApplyClick( event );
-    if( event.GetInt() == wxID_STOP ) return;
+    if ( event.GetInt() == wxID_STOP ) return;
 
     Finish();
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6596,90 +6596,49 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked ) :
               ),
     m_brebuild_cache( FALSE )
 {
-    extern PFNGLCOMPRESSEDTEXIMAGE2DPROC s_glCompressedTexImage2D;
-    extern bool  b_glEntryPointsSet;
     wxBoxSizer* mainSizer = new wxBoxSizer( wxVERTICAL );
     wxFlexGridSizer *flexSizer = new wxFlexGridSizer( 2 );
-
-    flexSizer->Add( new wxStaticText(this, wxID_ANY, _( "Texture Settings" )), 0,
-                    wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL, 5 );
 
     m_cbTextureCompression = new wxCheckBox( this, wxID_ANY,
                                              g_bexpert ?
                                              _("Texture Compression") :
                                              _( "Texture Compression with Caching" ) );
-    m_cbTextureCompression->SetValue( g_GLOptions.m_bTextureCompression );
-    /* disable caching if unsupported */
-    if ( b_glEntryPointsSet && !s_glCompressedTexImage2D ) {
-        g_GLOptions.m_bTextureCompressionCaching = FALSE;
-        m_cbTextureCompression->Disable();
-        m_cbTextureCompression->SetValue(FALSE);
-    }
-
-    flexSizer->Add( m_cbTextureCompression, 0, wxALL | wxEXPAND, 5 );
-
-    if ( g_bexpert ) {
-        m_cbTextureCompressionCaching = new wxCheckBox( this, wxID_ANY, _("Texture Compression Caching") );
-        m_cbTextureCompressionCaching->SetValue( g_GLOptions.m_bTextureCompressionCaching );
-
-        flexSizer->AddSpacer( 0 );
-        flexSizer->Add( m_cbTextureCompressionCaching, 0, wxALL | wxEXPAND, 5 );
-
-        flexSizer->Add( new wxStaticText( this, wxID_ANY, _("Texture Memory Size (MB)") ),
-                        0, wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL, 5 );
-
-        m_sTextureMemorySize = new wxSpinCtrl( this );
-        m_sTextureMemorySize->SetRange( 1, 16384 );
-        m_sTextureMemorySize->SetValue( g_GLOptions.m_iTextureMemorySize );
-        flexSizer->Add( m_sTextureMemorySize, 0, wxALL | wxEXPAND, 5) ;
-    }
-
-    flexSizer->Add( new wxStaticText(this, wxID_ANY, _( "Texture Cache" )), 0,
-                    wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL, 5 );
+    m_cbTextureCompressionCaching = new wxCheckBox( this, wxID_ANY, _("Texture Compression Caching") );
+    m_memorySize = new wxStaticText( this, wxID_ANY, _("Texture Memory Size (MB)") );
+    m_sTextureMemorySize = new wxSpinCtrl( this );
+    m_sTextureMemorySize->SetRange( 1, 16384 );
     m_cacheSize = new wxStaticText(this, wxID_ANY, _("Size: ") + TextureCacheSize());
-    flexSizer->Add( m_cacheSize, 0, wxALIGN_CENTER | wxALIGN_CENTER_VERTICAL, 5 );
-    flexSizer->AddSpacer( 0 );
-
     wxButton *btnRebuild = new wxButton( this, ID_BUTTON_REBUILD, _( "Rebuild Texture Cache" ) );
+    wxButton *btnClear = new wxButton(this, ID_BUTTON_CLEAR, _( "Clear Texture Cache" ) );
     btnRebuild->Enable( g_GLOptions.m_bTextureCompressionCaching );
     if ( !g_bopengl || g_raster_format == GL_RGB )
         btnRebuild->Disable();
+    btnClear->Enable( g_GLOptions.m_bTextureCompressionCaching );
+    m_cbShowFPS = new wxCheckBox( this, wxID_ANY, _( "Show FPS" ) );
+    m_cbSoftwareGL = new wxCheckBox( this, wxID_ANY, _( "Software OpenGL (restart OpenCPN)" ) );
+    m_cbUseAcceleratedPanning = new wxCheckBox( this, wxID_ANY, _( "Use Accelerated Panning" ) );
+
+    flexSizer->Add( new wxStaticText(this, wxID_ANY, _( "Texture Settings" )), 0,
+                    wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL, 5 );
+    flexSizer->Add( m_cbTextureCompression, 0, wxALL | wxEXPAND, 5 );
+    flexSizer->AddSpacer( 0 );
+    flexSizer->Add( m_cbTextureCompressionCaching, 0, wxALL | wxEXPAND, 5 );
+    flexSizer->Add( m_memorySize, 0, wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL, 5 );
+    flexSizer->Add( m_sTextureMemorySize, 0, wxALL | wxEXPAND, 5) ;
+    flexSizer->Add( new wxStaticText(this, wxID_ANY, _( "Texture Cache" )), 0,
+                    wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL, 5 );
+    flexSizer->Add( m_cacheSize, 0, wxALIGN_CENTER | wxALIGN_CENTER_VERTICAL, 5 );
+    flexSizer->AddSpacer( 0 );
     flexSizer->Add( btnRebuild, 0, wxALL | wxEXPAND, 5 );
     flexSizer->AddSpacer( 0 );
-
-    wxButton *btnClear = new wxButton(this, ID_BUTTON_CLEAR, _( "Clear Texture Cache" ) );
-    btnClear->Enable( g_GLOptions.m_bTextureCompressionCaching );
     flexSizer->Add( btnClear, 0, wxALL | wxEXPAND, 5 );
-
     flexSizer->Add( new wxStaticText(this, wxID_ANY, _( "Miscellaneous" )), 0,
                     wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL, 5 );
-
-    m_cbShowFPS = new wxCheckBox( this, wxID_ANY, _( "Show FPS" ) );
-    m_cbShowFPS->SetValue( g_bShowFPS );
     flexSizer->Add( m_cbShowFPS, 0,  wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
-
-    m_cbSoftwareGL = NULL;
-#if defined(__UNIX__) && !defined(__OCPN__ANDROID__) && !defined(__WXOSX__)
-    if ( cc1->GetglCanvas()->GetVersionString().Upper().Find( _T( "MESA" ) ) != wxNOT_FOUND ) {
-        flexSizer->AddSpacer( 0 );
-        m_cbSoftwareGL = new wxCheckBox( this, wxID_ANY, _( "Software OpenGL (restart OpenCPN)" ) );
-        flexSizer->Add( m_cbSoftwareGL, 0,  wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
-        m_cbSoftwareGL->SetValue(g_bSoftwareGL);
-    }
-#endif
-    if ( g_bexpert ) {
-        flexSizer->AddSpacer( 0 );
-        m_cbUseAcceleratedPanning = new wxCheckBox( this, wxID_ANY, _( "Use Accelerated Panning" ) );
-        if ( cc1->GetglCanvas()->CanAcceleratePanning() ) {
-            m_cbUseAcceleratedPanning->Enable();
-            m_cbUseAcceleratedPanning->SetValue( g_GLOptions.m_bUseAcceleratedPanning );
-        } else {
-            m_cbUseAcceleratedPanning->SetValue( FALSE );
-            m_cbUseAcceleratedPanning->Disable();
-        }
-        flexSizer->Add( m_cbUseAcceleratedPanning, 0, wxALL | wxEXPAND, 5 );
-    }
-
+    flexSizer->AddSpacer( 0 );
+    flexSizer->Add( m_cbSoftwareGL, 0,  wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
+    flexSizer->AddSpacer( 0 );
+    flexSizer->Add( m_cbUseAcceleratedPanning, 0, wxALL | wxEXPAND, 5 );
     flexSizer->AddGrowableCol( 1 );
     mainSizer->Add( flexSizer, 0, wxALL | wxEXPAND, 5 );
 
@@ -6688,12 +6647,55 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked ) :
     btnSizer->AddButton( new wxButton( this, wxID_CANCEL ) );
     btnSizer->Realize();
 
-    mainSizer->AddStretchSpacer( );
+    mainSizer->AddStretchSpacer();
     mainSizer->Add( btnSizer, 0, wxALL | wxEXPAND, 5 );
+
+    Populate();
 
     SetSizer( mainSizer );
     mainSizer->SetSizeHints( this );
     Centre();
+}
+
+void OpenGLOptionsDlg::Populate( void )
+{
+    extern PFNGLCOMPRESSEDTEXIMAGE2DPROC s_glCompressedTexImage2D;
+    extern bool  b_glEntryPointsSet;
+
+    m_cbTextureCompression->SetValue( g_GLOptions.m_bTextureCompression );
+    /* disable caching if unsupported */
+    if ( b_glEntryPointsSet && !s_glCompressedTexImage2D ) {
+        g_GLOptions.m_bTextureCompressionCaching = FALSE;
+        m_cbTextureCompression->Disable();
+        m_cbTextureCompression->SetValue(FALSE);
+    }
+
+    m_cbTextureCompressionCaching->Show(g_bexpert);
+    m_memorySize->Show(g_bexpert);
+    m_sTextureMemorySize->Show(g_bexpert);
+    if ( g_bexpert ) {
+        m_cbTextureCompressionCaching->SetValue( g_GLOptions.m_bTextureCompressionCaching );
+        m_sTextureMemorySize->SetValue( g_GLOptions.m_iTextureMemorySize );
+    }
+    m_cbShowFPS->SetValue( g_bShowFPS );
+
+#if defined(__UNIX__) && !defined(__OCPN__ANDROID__) && !defined(__WXOSX__)
+    if ( cc1->GetglCanvas()->GetVersionString().Upper().Find( _T( "MESA" ) ) != wxNOT_FOUND ) {
+        m_cbSoftwareGL->SetValue(g_bSoftwareGL);
+    }
+#else
+    m_cbSoftwareGL->Hide();
+#endif
+
+    if ( g_bexpert ) {
+        if ( cc1->GetglCanvas()->CanAcceleratePanning() ) {
+            m_cbUseAcceleratedPanning->Enable();
+            m_cbUseAcceleratedPanning->SetValue( g_GLOptions.m_bUseAcceleratedPanning );
+        } else {
+            m_cbUseAcceleratedPanning->SetValue( FALSE );
+            m_cbUseAcceleratedPanning->Disable();
+        }
+    }
 }
 
 void OpenGLOptionsDlg::OnButtonRebuild( wxCommandEvent& event )

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6486,7 +6486,7 @@ SentenceListDlg::SentenceListDlg( wxWindow* parent, FilterDirection dir,
     Populate( list );
 }
 
-const wxString SentenceListDlg::GetBoxLabel( void )
+const wxString SentenceListDlg::GetBoxLabel( void ) const
 {
     if ( m_dir == FILTER_OUTPUT )
         return m_type == WHITELIST ? _( "Transmit Sentences" ) :

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1980,7 +1980,7 @@ void options::OnConnectionToggleEnable( wxMouseEvent &event )
 {
     int flags;
     long index = m_lcSources->HitTest( event.GetPosition(), flags );
-    if ( index > -1 && event.GetX() < m_lcSources->GetColumnWidth( 0 ) )
+    if ( index == wxNOT_FOUND || event.GetX() < m_lcSources->GetColumnWidth( 0 ) )
         EnableItem( index );
 
     // Allow wx to process...

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6586,20 +6586,19 @@ BEGIN_EVENT_TABLE( OpenGLOptionsDlg, wxDialog )
     EVT_BUTTON( ID_BUTTON_CLEAR, OpenGLOptionsDlg::OnButtonClear )
 END_EVENT_TABLE()
 
-OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
-{
-    long style = wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER;
+OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked ) :
+    wxDialog( parent, wxID_ANY, _T( "OpenGL Options" ),
+              wxDefaultPosition, wxDefaultSize,
+              wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER
 #ifdef __WXOSX__
-    style |= wxSTAY_ON_TOP;
+              | wxSTAY_ON_TOP
 #endif
-
-    wxDialog::Create( parent, wxID_ANY, _T( "OpenGL Options" ),
-                      wxDefaultPosition, wxDefaultSize, style );
-
+              ),
+    m_brebuild_cache( FALSE )
+{
     wxFont *qFont = GetOCPNScaledFont( _( "Dialog" ) );
     SetFont( *qFont );
 
-    m_brebuild_cache = FALSE;
 
 #ifdef ocpnUSE_GL
     m_bSizer1 = new wxFlexGridSizer( 3 );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1482,10 +1482,6 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     m_lcSources->AssignImageList( imglist, wxIMAGE_LIST_SMALL );
 
     m_lcSources->Refresh();
-
-    m_stcdialog_in = new SentenceListDlg( FILTER_INPUT, this );
-    m_stcdialog_out = new SentenceListDlg( FILTER_OUTPUT, this );
-
     FillSourceList();
 
     if ( m_pSerialArray ) {
@@ -1934,10 +1930,6 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     m_lcSources->AssignImageList( imglist, wxIMAGE_LIST_SMALL );
 
     m_lcSources->Refresh();
-
-    m_stcdialog_in = new SentenceListDlg( FILTER_INPUT, this );
-    m_stcdialog_out = new SentenceListDlg( FILTER_OUTPUT, this );
-
     FillSourceList();
 
     if ( m_pSerialArray ) {
@@ -6376,26 +6368,26 @@ void options::OnSelectDatasource( wxListEvent& event )
 
 void options::OnBtnIStcs( wxCommandEvent& event )
 {
-    m_stcdialog_in->SetSentenceList(
+    SentenceListDlg dlg( FILTER_INPUT, this );
+    dlg.SetSentenceList(
         wxStringTokenize( m_tcInputStc->GetValue(), _T( "," ) )
     );
-    m_stcdialog_in->SetType( 0, m_rbIAccept->GetValue() ? WHITELIST :
-                                                          BLACKLIST);
+    dlg.SetType( 0, m_rbIAccept->GetValue() ? WHITELIST : BLACKLIST);
 
-    if ( m_stcdialog_in->ShowModal() == wxID_OK )
-        m_tcInputStc->SetValue( m_stcdialog_in->GetSentencesAsText() );
+    if ( dlg.ShowModal() == wxID_OK )
+        m_tcInputStc->SetValue( dlg.GetSentencesAsText() );
 }
 
 void options::OnBtnOStcs( wxCommandEvent& event )
 {
-    m_stcdialog_out->SetSentenceList(
+    SentenceListDlg dlg( FILTER_OUTPUT, this );
+    dlg.SetSentenceList(
         wxStringTokenize( m_tcOutputStc->GetValue(), _T( "," ) )
     );
-    m_stcdialog_out->SetType( 1, m_rbOAccept->GetValue() ? WHITELIST :
-                                                           BLACKLIST );
+    dlg.SetType( 1, m_rbOAccept->GetValue() ? WHITELIST : BLACKLIST );
 
-    if ( m_stcdialog_out->ShowModal() == wxID_OK )
-        m_tcOutputStc->SetValue( m_stcdialog_out->GetSentencesAsText() );
+    if ( dlg.ShowModal() == wxID_OK )
+        m_tcOutputStc->SetValue( dlg.GetSentencesAsText() );
 }
 
 void options::OnNetProtocolSelected( wxCommandEvent& event )

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -84,7 +84,8 @@ extern GLuint g_raster_format;
 
 #include "OCPNPlatform.h"
 
-wxString GetOCPNKnownLanguage(wxString lang_canonical, wxString *lang_dir);
+wxString GetOCPNKnownLanguage(const wxString lang_canonical, wxString &lang_dir);
+wxString GetOCPNKnownLanguage(const wxString lang_canonical);
 
 extern OCPNPlatform     *g_Platform;
 
@@ -4756,7 +4757,7 @@ void options::OnApplyClick( wxCommandEvent& event )
             const wxLanguageInfo * pli = wxLocale::GetLanguageInfo( lang_list[it] );
             if(pli){
                 wxString lang_canonical = pli->CanonicalName;
-                wxString test_string = GetOCPNKnownLanguage( lang_canonical, NULL );
+                wxString test_string = GetOCPNKnownLanguage( lang_canonical );
                 if( lang_sel == test_string ) {
                     new_canon = lang_canonical;
                     break;
@@ -5073,7 +5074,7 @@ void options::DoOnPageChange( size_t page )
             int current_language = plocale_def_lang->GetLanguage();
             wxString current_sel = wxLocale::GetLanguageName( current_language );
 
-            current_sel = GetOCPNKnownLanguage( g_locale, NULL );
+            current_sel = GetOCPNKnownLanguage( g_locale );
 
             int nLang = sizeof( lang_list ) / sizeof(int);
 
@@ -5096,7 +5097,7 @@ void options::DoOnPageChange( size_t page )
 
                     //  Make opencpn substitutions
                     wxString lang_suffix;
-                    loc_lang_name = GetOCPNKnownLanguage( lang_canonical, &lang_suffix );
+                    loc_lang_name = GetOCPNKnownLanguage( lang_canonical, lang_suffix );
 
                     //  Look explicitely to see if .mo is available
                     wxString test_dir = lang_dir + lang_suffix;
@@ -5135,7 +5136,7 @@ void options::DoOnPageChange( size_t page )
             for(unsigned int i=0; i < lang_array.GetCount(); i++)
             {
                 //  Make opencpn substitutions
-                wxString loc_lang_name = GetOCPNKnownLanguage(lang_array[i], NULL);
+                wxString loc_lang_name = GetOCPNKnownLanguage( lang_array[i] );
                 m_itemLangListBox->Append( loc_lang_name );
             }
 #endif
@@ -5302,7 +5303,7 @@ void options::OnButtonTestSound( wxCommandEvent& event )
 
 }
 
-wxString GetOCPNKnownLanguage( wxString lang_canonical, wxString *lang_dir )
+wxString GetOCPNKnownLanguage( wxString lang_canonical, wxString &lang_dir )
 {
     wxString return_string;
     wxString dir_suffix;
@@ -5381,9 +5382,15 @@ wxString GetOCPNKnownLanguage( wxString lang_canonical, wxString *lang_dir )
         return_string = info->Description;
     }
 
-    if( NULL != lang_dir ) *lang_dir = dir_suffix;
+    lang_dir = dir_suffix;
 #endif
     return return_string;
+}
+
+wxString GetOCPNKnownLanguage( const wxString lang_canonical )
+{
+    wxString lang_dir;
+    return GetOCPNKnownLanguage( lang_canonical, lang_dir );
 }
 
 ChartGroupArray* ChartGroupsUI::CloneChartGroupArray( ChartGroupArray* s )

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6498,17 +6498,11 @@ void options::OnCbInput( wxCommandEvent& event )
 void options::OnCbOutput( wxCommandEvent& event )
 {
     OnConnValChange(event);
-    if (m_cbOutput->IsChecked()) {
-        m_stPrecision->Enable(TRUE);
-        m_choicePrecision->Enable(TRUE);
-        m_stTalkerIdText->Enable(TRUE);
-        m_TalkerIdText->Enable( TRUE );
-    } else {
-        m_stPrecision->Enable(FALSE);
-        m_choicePrecision->Enable(FALSE);
-        m_stTalkerIdText->Enable( FALSE );
-        m_TalkerIdText->Enable( FALSE );
-    }
+    const bool checked = m_cbOutput->IsChecked();
+    m_stPrecision->Enable( checked );
+    m_choicePrecision->Enable( checked );
+    m_stTalkerIdText->Enable( checked );
+    m_TalkerIdText->Enable( checked );
 }
 
 SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent,

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6599,12 +6599,12 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked ) :
     wxFont *qFont = GetOCPNScaledFont( _( "Dialog" ) );
     SetFont( *qFont );
 
-    m_bSizer1 = new wxFlexGridSizer( 3 );
+    wxFlexGridSizer *mainSizer = new wxFlexGridSizer( 3 );
     this->SetSizeHints( wxDefaultSize, wxDefaultSize );
 
     if ( g_bexpert ) {
         m_cbUseAcceleratedPanning = new wxCheckBox( this, wxID_ANY, _( "Use Accelerated Panning" ) );
-        m_bSizer1->Add( m_cbUseAcceleratedPanning, 0, wxALL | wxEXPAND, 5 );
+        mainSizer->Add( m_cbUseAcceleratedPanning, 0, wxALL | wxEXPAND, 5 );
         if ( cc1->GetglCanvas()->CanAcceleratePanning() ) {
             m_cbUseAcceleratedPanning->Enable();
             m_cbUseAcceleratedPanning->SetValue( g_GLOptions.m_bUseAcceleratedPanning );
@@ -6615,7 +6615,7 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked ) :
 
         m_cbTextureCompression = new wxCheckBox(this, wxID_ANY, _("Texture Compression") );
         m_cbTextureCompression->SetValue( g_GLOptions.m_bTextureCompression );
-        m_bSizer1->Add( m_cbTextureCompression, 0, wxALL | wxEXPAND, 5 );
+        mainSizer->Add( m_cbTextureCompression, 0, wxALL | wxEXPAND, 5 );
 
         m_cbTextureCompressionCaching = new wxCheckBox( this, wxID_ANY, _("Texture Compression Caching") );
         m_cbTextureCompressionCaching->SetValue( g_GLOptions.m_bTextureCompressionCaching );
@@ -6627,11 +6627,11 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked ) :
             m_cbTextureCompressionCaching->Disable();
         }
 
-        m_bSizer1->Add( m_cbTextureCompressionCaching, 0, wxALL | wxEXPAND, 5 );
+        mainSizer->Add( m_cbTextureCompressionCaching, 0, wxALL | wxEXPAND, 5 );
     } else {
         m_cbTextureCompression = new wxCheckBox( this, wxID_ANY, _( "Texture Compression with Caching" ) );
         m_cbTextureCompression->SetValue( g_GLOptions.m_bTextureCompression );
-        m_bSizer1->Add( m_cbTextureCompression, 0, wxALL | wxEXPAND, 5 );
+        mainSizer->Add( m_cbTextureCompression, 0, wxALL | wxEXPAND, 5 );
     }
 
     /* disable caching if unsupported */
@@ -6647,56 +6647,55 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked ) :
     if ( g_bexpert ) {
         wxStaticText* stTextureMemorySize =
             new wxStaticText( this, wxID_STATIC, _("Texture Memory Size (MB)") );
-        m_bSizer1->Add( stTextureMemorySize, 0, wxLEFT | wxRIGHT | wxTOP, 5 );
+        mainSizer->Add( stTextureMemorySize, 0, wxLEFT | wxRIGHT | wxTOP, 5 );
 
         m_sTextureMemorySize = new wxSpinCtrl( this );
         m_sTextureMemorySize->SetRange( 1, 16384 );
         m_sTextureMemorySize->SetValue( g_GLOptions.m_iTextureMemorySize );
-        m_bSizer1->Add( m_sTextureMemorySize, 0, wxALL | wxEXPAND, 5) ;
+        mainSizer->Add( m_sTextureMemorySize, 0, wxALL | wxEXPAND, 5) ;
     } else
-        m_bSizer1->AddSpacer(0);
+        mainSizer->AddSpacer(0);
 
-    m_bSizer1->AddSpacer(0);
+    mainSizer->AddSpacer(0);
 
-    m_bRebuildTextureCache = new wxButton( this, ID_BUTTON_REBUILD, _( "Rebuild Texture Cache" ) );
-    m_bSizer1->Add( m_bRebuildTextureCache, 0, wxALL | wxEXPAND, 5 );
-    m_bRebuildTextureCache->Enable( g_GLOptions.m_bTextureCompressionCaching );
-
+    wxButton *btnRebuild = new wxButton( this, ID_BUTTON_REBUILD, _( "Rebuild Texture Cache" ) );
+    mainSizer->Add( btnRebuild, 0, wxALL | wxEXPAND, 5 );
+    btnRebuild->Enable( g_GLOptions.m_bTextureCompressionCaching );
     if ( !g_bopengl || g_raster_format == GL_RGB )
-        m_bRebuildTextureCache->Disable();
+        btnRebuild->Disable();
 
-    m_bClearTextureCache = new wxButton(this, ID_BUTTON_CLEAR, _( "Clear Texture Cache" ) );
-    m_bSizer1->Add( m_bClearTextureCache, 0, wxALL | wxEXPAND, 5 );
-    m_bClearTextureCache->Enable( g_GLOptions.m_bTextureCompressionCaching );
+    wxButton *btnClear = new wxButton(this, ID_BUTTON_CLEAR, _( "Clear Texture Cache" ) );
+    mainSizer->Add( btnClear, 0, wxALL | wxEXPAND, 5 );
+    btnClear->Enable( g_GLOptions.m_bTextureCompressionCaching );
 
-    m_stTextureCacheSize = new wxStaticText(this, wxID_STATIC, TextureCacheSize());
-    m_bSizer1->Add( m_stTextureCacheSize, 0,
+    m_cacheSize = new wxStaticText(this, wxID_STATIC, TextureCacheSize());
+    mainSizer->Add( m_cacheSize, 0,
                     wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
 
     m_cbShowFPS = new wxCheckBox( this, wxID_ANY, _( "Show FPS" ) );
-    m_bSizer1->Add( m_cbShowFPS, 0,  wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
+    mainSizer->Add( m_cbShowFPS, 0,  wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
     m_cbShowFPS->SetValue( g_bShowFPS );
 
     m_cbSoftwareGL = NULL;
 #if defined(__UNIX__) && !defined(__OCPN__ANDROID__) && !defined(__WXOSX__)
     if ( cc1->GetglCanvas()->GetVersionString().Upper().Find( _T( "MESA" ) ) != wxNOT_FOUND ) {
         m_cbSoftwareGL = new wxCheckBox( this, wxID_ANY, _( "Software OpenGL (restart OpenCPN)" ) );
-        m_bSizer1->Add( m_cbSoftwareGL, 0,  wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
+        mainSizer->Add( m_cbSoftwareGL, 0,  wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
         m_cbSoftwareGL->SetValue(g_bSoftwareGL);
     } else
 #endif
-        m_bSizer1->AddSpacer(0);
+        mainSizer->AddSpacer(0);
 
-    m_bSizer1->AddSpacer(0);
+    mainSizer->AddSpacer(0);
 
     wxStdDialogButtonSizer * btnSizer = new wxStdDialogButtonSizer();
     btnSizer->AddButton( new wxButton( this, wxID_OK ) );
     btnSizer->AddButton( new wxButton( this, wxID_CANCEL ) );
     btnSizer->Realize();
 
-    m_bSizer1->Add( btnSizer, 0, wxALL | wxEXPAND, 5 );
+    mainSizer->Add( btnSizer, 0, wxALL | wxEXPAND, 5 );
 
-    SetSizer( m_bSizer1 );
+    SetSizer( mainSizer );
     Layout();
     Centre( wxBOTH );
     Fit();
@@ -6704,17 +6703,14 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked ) :
 
 void OpenGLOptionsDlg::OnButtonRebuild( wxCommandEvent& event )
 {
-#ifdef ocpnUSE_GL
     if ( g_GLOptions.m_bTextureCompressionCaching ) {
         m_brebuild_cache = TRUE;
         EndModal(wxID_CANCEL);
     }
-#endif
 }
 
 void OpenGLOptionsDlg::OnButtonClear( wxCommandEvent& event )
 {
-#ifdef ocpnUSE_GL
     ::wxBeginBusyCursor();
     if ( g_bopengl )
         cc1->GetglCanvas()->ClearAllRasterTextures();
@@ -6728,9 +6724,8 @@ void OpenGLOptionsDlg::OnButtonClear( wxCommandEvent& event )
             ::wxRemoveFile(files[i]);
     }
 
-    m_stTextureCacheSize->SetLabel( TextureCacheSize() );
+    m_cacheSize->SetLabel( TextureCacheSize() );
     ::wxEndBusyCursor();
-#endif
 }
 
 wxString OpenGLOptionsDlg::TextureCacheSize( void )

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6613,9 +6613,14 @@ void SentenceListDlg::OnCLBToggle( wxCommandEvent& event )
 
 void SentenceListDlg::OnAddClick( wxCommandEvent& event )
 {
-    wxString stc =
-        wxGetTextFromUser( _( "Enter the NMEA sentence (2, 3 or 5 characters) " ),
-                           _( "Enter the NMEA sentence" ) );
+    wxTextEntryDialog textdlg( this, _( "Enter the NMEA sentence (2, 3 or 5 characters) " ),
+                               _( "Enter the NMEA sentence" ) );
+    textdlg.SetMaxLength( 5 );
+    textdlg.SetTextValidator( wxFILTER_ALPHANUMERIC );
+    if ( textdlg.ShowModal() == wxID_CANCEL )
+        return;
+    wxString stc = textdlg.GetValue();
+
     if ( stc.Length() == 2 || stc.Length() == 3 || stc.Length() == 5 ) {
         m_sentences.Add( stc );
         m_clbSentences->Append( stc );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -442,12 +442,12 @@ void MMSIEditDialog::OnMMSIEditCancelClick( wxCommandEvent& event )
 void MMSIEditDialog::OnMMSIEditOKClick( wxCommandEvent& event )
 {
     // Update the MMSIProperties by the passed pointer
-    if ( m_props ){
+    if ( m_props ) {
         long nmmsi;
         m_MMSICtl->GetValue().ToLong( &nmmsi );
         m_props->MMSI = nmmsi;
 
-        if( m_rbTypeTrackDefault->GetValue() )
+        if ( m_rbTypeTrackDefault->GetValue() )
             m_props->TrackType = TRACKTYPE_DEFAULT;
         else if ( m_rbTypeTrackAlways->GetValue() )
             m_props->TrackType = TRACKTYPE_ALWAYS;
@@ -726,14 +726,14 @@ void MMSI_Props_Panel::UpdateMMSIList( void )
     long item_sel = wxNOT_FOUND;
     if ( selItemID != wxNOT_FOUND && selMMSI != wxNOT_FOUND ) {
         for ( unsigned int i = 0; i < g_MMSI_Props_Array.GetCount(); i++ ) {
-            if( g_MMSI_Props_Array.Item( i )->MMSI == selMMSI ) {
+            if ( g_MMSI_Props_Array.Item( i )->MMSI == selMMSI ) {
                 item_sel = i;
                 break;
             }
         }
     }
 
-    if( g_MMSI_Props_Array.GetCount() > 0 )
+    if ( g_MMSI_Props_Array.GetCount() > 0 )
         m_pListCtrlMMSI->SetItemState(
             item_sel, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED,
             wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED
@@ -868,24 +868,25 @@ void options::RecalculateSize()
         SetSize( fitted_size );
 
         Fit();
-    } else {
-        wxSize esize;
-        esize.x = GetCharWidth() * 110;
-        esize.y = GetCharHeight() * 40;
-
-        wxSize dsize = GetParent()->GetSize(); // GetClientSize();
-        esize.y = wxMin( esize.y, dsize.y - 0 /*(2 * GetCharHeight())*/ );
-        esize.x = wxMin( esize.x, dsize.x - 0 /*(2 * GetCharHeight())*/ );
-        SetSize(esize);
-
-        wxSize fsize = GetSize();
-        wxSize canvas_size = GetParent()->GetSize();
-        wxPoint canvas_pos = GetParent()->GetPosition();
-        int xp = (canvas_size.x - fsize.x)/2;
-        int yp = (canvas_size.y - fsize.y)/2;
-        wxPoint xxp = GetParent()->ClientToScreen( canvas_pos );
-        Move( xxp.x + xp, xxp.y + yp );
+        return;
     }
+
+    wxSize esize;
+    esize.x = GetCharWidth() * 110;
+    esize.y = GetCharHeight() * 40;
+
+    wxSize dsize = GetParent()->GetSize(); // GetClientSize();
+    esize.y = wxMin( esize.y, dsize.y - 0 /*(2 * GetCharHeight())*/ );
+    esize.x = wxMin( esize.x, dsize.x - 0 /*(2 * GetCharHeight())*/ );
+    SetSize(esize);
+
+    wxSize fsize = GetSize();
+    wxSize canvas_size = GetParent()->GetSize();
+    wxPoint canvas_pos = GetParent()->GetPosition();
+    int xp = (canvas_size.x - fsize.x)/2;
+    int yp = (canvas_size.y - fsize.y)/2;
+    wxPoint xxp = GetParent()->ClientToScreen( canvas_pos );
+    Move( xxp.x + xp, xxp.y + yp );
 }
 
 void options::Init()
@@ -1030,7 +1031,7 @@ bool options::DeletePage( wxScrolledWindow *page  )
     for ( size_t i = 0; i < m_pListbook->GetPageCount(); i++ ) {
         wxNotebookPage* pg = m_pListbook->GetPage( i );
 
-        if( pg->IsKindOf( CLASSINFO( wxNotebook ) ) ) {
+        if ( pg->IsKindOf( CLASSINFO( wxNotebook ) ) ) {
             wxNotebook *nb = dynamic_cast<wxNotebook *>( pg );
             for ( size_t j = 0; j < nb->GetPageCount(); j++ ) {
                 wxNotebookPage* spg = nb->GetPage( j );
@@ -3253,12 +3254,10 @@ void options::CreateControls()
     int width, height;
     ::wxDisplaySize( &width, &height );
 
-    if(!g_bresponsive){
-        if( height <= 800 ) {
-            border_size = 2;
-            check_spacing = 2;
-            group_item_spacing = 1;
-        }
+    if ( !g_bresponsive && height <= 800 ) {
+        border_size = 2;
+        check_spacing = 2;
+        group_item_spacing = 1;
     }
 
     labelFlags = wxSizerFlags(0).Align(wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL).Border(wxALL, group_item_spacing);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1470,24 +1470,25 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     }
 
     //  Build the image list
-    wxBitmap unchecked_bmp(16, 16), checked_bmp(16, 16);
-    {
-        wxMemoryDC renderer_dc;
-
-        // Unchecked
-        renderer_dc.SelectObject( unchecked_bmp );
-        renderer_dc.SetBackground( *wxTheBrushList->FindOrCreateBrush( GetBackgroundColour(), wxBRUSHSTYLE_SOLID ) );
-        renderer_dc.Clear();
-        wxRendererNative::Get().DrawCheckBox( this, renderer_dc, wxRect( 0, 0, 16, 16 ), 0 );
-
-        // Checked
-        renderer_dc.SelectObject( checked_bmp );
-        renderer_dc.SetBackground( *wxTheBrushList->FindOrCreateBrush( GetBackgroundColour(), wxBRUSHSTYLE_SOLID ) );
-        renderer_dc.Clear();
-        wxRendererNative::Get().DrawCheckBox( this, renderer_dc, wxRect( 0, 0, 16, 16 ), wxCONTROL_CHECKED );
-    }
-
     wxImageList *imglist = new wxImageList( 16, 16, TRUE, 1 );
+    wxBitmap unchecked_bmp( 16, 16 ), checked_bmp( 16, 16 );
+    wxMemoryDC renderer_dc;
+
+    // Unchecked
+    renderer_dc.SelectObject( unchecked_bmp );
+    renderer_dc.SetBackground( *wxTheBrushList->FindOrCreateBrush( GetBackgroundColour(), wxBRUSHSTYLE_SOLID ) );
+    renderer_dc.Clear();
+    wxRendererNative::Get().DrawCheckBox( this, renderer_dc, wxRect( 0, 0, 16, 16 ), 0 );
+
+    // Checked
+    renderer_dc.SelectObject( checked_bmp );
+    renderer_dc.SetBackground( *wxTheBrushList->FindOrCreateBrush( GetBackgroundColour(), wxBRUSHSTYLE_SOLID ) );
+    renderer_dc.Clear();
+    wxRendererNative::Get().DrawCheckBox( this, renderer_dc, wxRect( 0, 0, 16, 16 ), wxCONTROL_CHECKED );
+
+    // Deselect the renderer Object
+    renderer_dc.SelectObject( wxNullBitmap );
+
     imglist->Add( unchecked_bmp );
     imglist->Add( checked_bmp );
     m_lcSources->AssignImageList( imglist, wxIMAGE_LIST_SMALL );
@@ -1922,24 +1923,25 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     }
 
     //  Build the image list
-    wxBitmap unchecked_bmp( 16, 16 ), checked_bmp( 16, 16 );
-    {
-        wxMemoryDC renderer_dc;
-
-        // Unchecked
-        renderer_dc.SelectObject( unchecked_bmp );
-        renderer_dc.SetBackground( *wxTheBrushList->FindOrCreateBrush( GetBackgroundColour(), wxBRUSHSTYLE_SOLID ) );
-        renderer_dc.Clear();
-        wxRendererNative::Get().DrawCheckBox( this, renderer_dc, wxRect( 0, 0, 16, 16 ), 0 );
-
-        // Checked
-        renderer_dc.SelectObject( checked_bmp );
-        renderer_dc.SetBackground( *wxTheBrushList->FindOrCreateBrush( GetBackgroundColour(), wxBRUSHSTYLE_SOLID ) );
-        renderer_dc.Clear();
-        wxRendererNative::Get().DrawCheckBox( this, renderer_dc, wxRect( 0, 0, 16, 16 ), wxCONTROL_CHECKED );
-    }
-
     wxImageList *imglist = new wxImageList( 16, 16, TRUE, 1 );
+    wxBitmap unchecked_bmp( 16, 16 ), checked_bmp( 16, 16 );
+    wxMemoryDC renderer_dc;
+
+    // Unchecked
+    renderer_dc.SelectObject( unchecked_bmp );
+    renderer_dc.SetBackground( *wxTheBrushList->FindOrCreateBrush( GetBackgroundColour(), wxBRUSHSTYLE_SOLID ) );
+    renderer_dc.Clear();
+    wxRendererNative::Get().DrawCheckBox( this, renderer_dc, wxRect( 0, 0, 16, 16 ), 0 );
+
+    // Checked
+    renderer_dc.SelectObject( checked_bmp );
+    renderer_dc.SetBackground( *wxTheBrushList->FindOrCreateBrush( GetBackgroundColour(), wxBRUSHSTYLE_SOLID ) );
+    renderer_dc.Clear();
+    wxRendererNative::Get().DrawCheckBox( this, renderer_dc, wxRect( 0, 0, 16, 16 ), wxCONTROL_CHECKED );
+
+    // Deselect the renderer Object
+    renderer_dc.SelectObject( wxNullBitmap );
+
     imglist->Add( unchecked_bmp );
     imglist->Add( checked_bmp );
     m_lcSources->AssignImageList( imglist, wxIMAGE_LIST_SMALL );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -291,9 +291,9 @@ int wxCALLBACK SortConnectionOnPriority(long item1, long item2, long list)
     lc->GetItem(it2);
 
 #ifdef __WXOSX__
-    return it1.GetText().CmpNoCase(it2.GetText());
+    return it1.GetText().CmpNoCase( it2.GetText() );
 #else
-    return it2.GetText().CmpNoCase(it1.GetText());
+    return it2.GetText().CmpNoCase( it1.GetText() );
 #endif
 }
 
@@ -310,7 +310,7 @@ EVT_BUTTON( ID_MMSIEDIT_CANCEL, MMSIEditDialog::OnMMSIEditCancelClick )
 EVT_BUTTON( ID_MMSIEDIT_OK, MMSIEditDialog::OnMMSIEditOKClick )
 END_EVENT_TABLE()
 
-MMSIEditDialog::MMSIEditDialog() {}
+MMSIEditDialog::MMSIEditDialog( void ) {}
 
 MMSIEditDialog::MMSIEditDialog( MMSIProperties *props, wxWindow* parent, wxWindowID id, const wxString& caption,
                                 const wxPoint& pos, const wxSize& size, long style ) :
@@ -324,7 +324,7 @@ MMSIEditDialog::MMSIEditDialog( MMSIProperties *props, wxWindow* parent, wxWindo
     Centre();
 }
 
-MMSIEditDialog::~MMSIEditDialog()
+MMSIEditDialog::~MMSIEditDialog( void )
 {
     delete m_MMSICtl;
 }
@@ -344,7 +344,7 @@ bool MMSIEditDialog::Create( MMSIProperties *props, wxWindow* parent, wxWindowID
     return TRUE;
 }
 
-void MMSIEditDialog::CreateControls()
+void MMSIEditDialog::CreateControls( void )
 {
     wxBoxSizer* mainSizer = new wxBoxSizer( wxVERTICAL );
     SetSizer( mainSizer );
@@ -464,13 +464,7 @@ void MMSIEditDialog::OnMMSIEditOKClick( wxCommandEvent& event )
     EndModal(wxID_OK);
 }
 
-void MMSIEditDialog::OnCtlUpdated( wxCommandEvent& event )
-{
-}
-
- ///////////////////////////////////////////////////////////////////////////////
- /// Class MMSIListCtrl
- ///////////////////////////////////////////////////////////////////////////////
+void MMSIEditDialog::OnCtlUpdated( wxCommandEvent& event ) {}
 
 BEGIN_EVENT_TABLE( MMSIListCtrl, wxListCtrl )
  EVT_LIST_ITEM_SELECTED( ID_MMSI_PROPS_LIST,    MMSIListCtrl::OnListItemClick )
@@ -487,7 +481,7 @@ MMSIListCtrl::MMSIListCtrl( wxWindow* parent, wxWindowID id, const wxPoint& pos,
     m_parent = parent;
 }
 
-MMSIListCtrl::~MMSIListCtrl() {}
+MMSIListCtrl::~MMSIListCtrl( void ) {}
 
 wxString MMSIListCtrl::OnGetItemText( long item, long column ) const
 {
@@ -554,15 +548,11 @@ void MMSIListCtrl::OnListItemActivated( wxListEvent &event )
 void MMSIListCtrl::OnListItemRightClick( wxListEvent &event )
 {
     m_context_item = GetNextItem( -1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED );
-
     if ( m_context_item ==wxNOT_FOUND ) return;
-
     wxMenu* menu = new wxMenu( _("MMSI Properties") );
-
     wxMenuItem *item_edit = new wxMenuItem( menu, ID_DEF_MENU_MMSI_EDIT,
                                             _( "Edit..." ) );
     menu->Append( item_edit );
-
     wxMenuItem *item_delete = new wxMenuItem( menu, ID_DEF_MENU_MMSI_DELETE,
                                               _( "Delete" ) );
     menu->Append( item_delete );
@@ -604,10 +594,6 @@ void MMSIListCtrl::PopupMenuHandler( wxCommandEvent& event )
             break;
     }
 }
-
-///////////////////////////////////////////////////////////////////////////////
-/// Class MMSI_Props_Panel
-///////////////////////////////////////////////////////////////////////////////
 
 MMSI_Props_Panel::MMSI_Props_Panel( wxWindow *parent ):
     wxPanel( parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE )
@@ -694,7 +680,7 @@ MMSI_Props_Panel::MMSI_Props_Panel( wxWindow *parent ):
     SetColorScheme( GLOBAL_COLOR_SCHEME_RGB );
 }
 
-MMSI_Props_Panel::~MMSI_Props_Panel() {}
+MMSI_Props_Panel::~MMSI_Props_Panel( void ) {}
 
 void MMSI_Props_Panel::OnNewButton( wxCommandEvent &event )
 {
@@ -781,7 +767,7 @@ BEGIN_EVENT_TABLE( options, wxDialog )
     EVT_TIMER ( ID_BT_SCANTIMER, options::onBTScanTimer )
 END_EVENT_TABLE()
 
-options::options()
+options::options( void )
 {
     Init();
 }
@@ -809,7 +795,7 @@ options::options( MyFrame* parent, wxWindowID id, const wxString& caption,
     Center();
 }
 
-options::~options()
+options::~options( void )
 {
     // Disconnect Connection page Events
     if ( m_pNMEAForm ) {
@@ -857,7 +843,7 @@ options::~options()
     delete smallFont;
 }
 
-void options::RecalculateSize()
+void options::RecalculateSize( void )
 {
     if ( !g_bresponsive ) {
         wxSize canvas_size = cc1->GetSize();
@@ -890,7 +876,7 @@ void options::RecalculateSize()
     Move( xxp.x + xp, xxp.y + yp );
 }
 
-void options::Init()
+void options::Init( void )
 {
     m_pWorkDirList = NULL;
 
@@ -965,7 +951,7 @@ bool options::Create( MyFrame* parent, wxWindowID id, const wxString& caption, c
     return TRUE;
 }
 
-wxWindow* options::GetContentWindow() const
+wxWindow* options::GetContentWindow( void ) const
 {
     return NULL;
 }
@@ -1513,7 +1499,6 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     connectionsaved = TRUE;
 }
 
-
 void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_spacing, wxSize small_button_size )
 {
     m_pNMEAForm = AddPage( parent, _( "NMEA" ) );
@@ -1913,7 +1898,6 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     m_tFilterSec->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
     m_cbAPBMagnetic->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnValChange ), NULL, this );
     m_lcSources->Connect( wxEVT_LEFT_DOWN, wxMouseEventHandler(options::OnConnectionToggleEnable), NULL, this );
-
 
     wxString columns[] = { _( "Enable" ), _( "Type" ), _( "DataPort" ), _("Priority"), _( "Parameters" ), _( "Connection" ), _( "Filters" ) };
     for ( int i = 0; i < 7; ++i ) {
@@ -3231,7 +3215,7 @@ void options::CreatePanel_UI( size_t parent, int border_size, int group_item_spa
 //#endif
 }
 
-void options::CreateControls()
+void options::CreateControls( void )
 {
     int border_size = 4;
     // use for items within one group, with Add(...wxALL)
@@ -3447,7 +3431,7 @@ void options::CreateControls()
     vectorPanel->SetSizeHints( ps57Ctl );
 }
 
-void options::SetInitialPage( int page_sel)
+void options::SetInitialPage( int page_sel )
 {
     m_pListbook->SetSelection( page_sel );
 
@@ -3469,7 +3453,7 @@ void options::SetColorScheme( ColorScheme cs )
 #endif
 }
 
-void options::SetInitialSettings()
+void options::SetInitialSettings( void )
 {
     wxString s;
     wxString dirname;
@@ -3790,7 +3774,7 @@ void options::SetInitialSettings()
     pToolbarHideSecs->SetValue( s );
 }
 
-void options::UpdateOptionsUnits()
+void options::UpdateOptionsUnits( void )
 {
     int depthUnit = pDepthUnitSelect->GetSelection();
 
@@ -4024,7 +4008,7 @@ void options::OnButtonSelectClick( wxCommandEvent& event )
     event.Skip();
 }
 
-bool options::ShowToolTips()
+bool options::ShowToolTips( void )
 {
     return TRUE;
 }
@@ -4094,7 +4078,7 @@ void options::AddChartDir( wxString &dir )
     pScanCheckBox->Disable();
 }
 
-void options::UpdateDisplayedChartDirList(ArrayOfCDI p)
+void options::UpdateDisplayedChartDirList( ArrayOfCDI p )
 {
     wxString dirname;
     if( pActiveChartsList ) {
@@ -4108,7 +4092,7 @@ void options::UpdateDisplayedChartDirList(ArrayOfCDI p)
     }
 }
 
-void options::UpdateWorkArrayFromTextCtl()
+void options::UpdateWorkArrayFromTextCtl( void )
 {
     wxString dirname;
 
@@ -4150,7 +4134,7 @@ void options::UpdateWorkArrayFromTextCtl()
     }
 }
 
-ConnectionParams *options::CreateConnectionParamsFromSelectedItem()
+ConnectionParams *options::CreateConnectionParamsFromSelectedItem( void )
 {
     if( !m_bNMEAParams_shown )
         return NULL;
@@ -4780,7 +4764,7 @@ void options::OnXidOkClick( wxCommandEvent& event )
     Finish();
 }
 
-void options::Finish()
+void options::Finish( void )
 {
     //  Required to avoid intermittent crash on wxGTK
     m_pListbook->ChangeSelection(0);
@@ -4804,11 +4788,9 @@ void options::Finish()
 
 void options::OnButtondeleteClick( wxCommandEvent& event )
 {
-
     wxString dirname;
 
 #ifndef __WXQT__                // Multi selection is not implemented in wxQT
-
     wxArrayInt pListBoxSelections;
     pActiveChartsList->GetSelections( pListBoxSelections );
     int nSelections = pListBoxSelections.GetCount();
@@ -5241,7 +5223,6 @@ void options::OnButtonTestSound( wxCommandEvent& event )
 #endif
 #endif
     }
-
 }
 
 wxString GetOCPNKnownLanguage( wxString lang_canonical, wxString &lang_dir )
@@ -5415,19 +5396,19 @@ ChartGroupsUI::ChartGroupsUI( wxWindow* parent )
     m_treespopulated = FALSE;
 }
 
-ChartGroupsUI::~ChartGroupsUI()
+ChartGroupsUI::~ChartGroupsUI( void )
 {
     m_DirCtrlArray.Clear();
     delete iFont;
 }
 
-void ChartGroupsUI::SetInitialSettings()
+void ChartGroupsUI::SetInitialSettings( void )
 {
     m_settingscomplete = FALSE;
     m_treespopulated = FALSE;
 }
 
-void ChartGroupsUI::PopulateTrees()
+void ChartGroupsUI::PopulateTrees( void )
 {
     //    Fill in the "Active chart" tree control
     //    from the options dialog "Active Chart Directories" list
@@ -5453,7 +5434,7 @@ void ChartGroupsUI::PopulateTrees()
                       iFont );
 }
 
-void ChartGroupsUI::CompleteInitialSettings()
+void ChartGroupsUI::CompleteInitialSettings( void )
 {
     PopulateTrees();
 
@@ -5867,7 +5848,7 @@ void options::OnScanBTClick( wxCommandEvent& event )
     }
 }
 
-void options::onBTScanTimer(wxTimerEvent &event)
+void options::onBTScanTimer( wxTimerEvent &event )
 {
     if(m_BTscanning){
         m_BTscanning++;
@@ -5911,7 +5892,7 @@ void options::onBTScanTimer(wxTimerEvent &event)
     return;
 }
 
-void options::StopBTScan()
+void options::StopBTScan( void )
 {
     m_BTScanTimer.Stop();
 
@@ -5972,7 +5953,7 @@ void options::OnUploadFormatChange( wxCommandEvent& event )
     event.Skip();
 }
 
-void options::ShowNMEACommon(bool visible)
+void options::ShowNMEACommon( bool visible )
 {
     if ( visible )
     {
@@ -6043,7 +6024,7 @@ void options::ShowNMEACommon(bool visible)
     m_bNMEAParams_shown = visible;
 }
 
-void options::ShowNMEANet(bool visible)
+void options::ShowNMEANet( bool visible )
 {
     if ( visible )
     {
@@ -6069,7 +6050,7 @@ void options::ShowNMEANet(bool visible)
     }
 }
 
-void options::ShowNMEASerial(bool visible)
+void options::ShowNMEASerial( bool visible )
 {
     if ( visible )
     {
@@ -6114,7 +6095,7 @@ void options::ShowNMEABT( bool visible )
     }
 }
 
-void options::SetNMEAFormToSerial()
+void options::SetNMEAFormToSerial( void )
 {
     ShowNMEACommon( TRUE );
     ShowNMEANet( FALSE );
@@ -6130,7 +6111,7 @@ void options::SetNMEAFormToSerial()
     SetDSFormRWStates();
 }
 
-void options::SetNMEAFormToNet()
+void options::SetNMEAFormToNet( void )
 {
     ShowNMEACommon( TRUE );
     ShowNMEANet( TRUE );
@@ -6145,7 +6126,7 @@ void options::SetNMEAFormToNet()
     SetDSFormRWStates();
 }
 
-void options::SetNMEAFormToGPS()
+void options::SetNMEAFormToGPS( void )
 {
     ShowNMEACommon( TRUE );
     ShowNMEANet( FALSE );
@@ -6160,7 +6141,7 @@ void options::SetNMEAFormToGPS()
     SetDSFormRWStates();
 }
 
-void options::SetNMEAFormToBT()
+void options::SetNMEAFormToBT( void )
 {
     ShowNMEACommon( TRUE );
     ShowNMEANet( FALSE );
@@ -6175,7 +6156,7 @@ void options::SetNMEAFormToBT()
     SetDSFormRWStates();
 }
 
-void options::ClearNMEAForm()
+void options::ClearNMEAForm( void )
 {
     ShowNMEACommon( FALSE );
     ShowNMEANet( FALSE );
@@ -6190,7 +6171,7 @@ void options::ClearNMEAForm()
 
 }
 
-wxString StringArrayToString(wxArrayString arr)
+wxString StringArrayToString( wxArrayString arr )
 {
     wxString ret = wxEmptyString;
     for (size_t i = 0; i < arr.Count(); i++)
@@ -6202,7 +6183,7 @@ wxString StringArrayToString(wxArrayString arr)
     return ret;
 }
 
-void options::SetDSFormRWStates()
+void options::SetDSFormRWStates( void )
 {
     if (m_rbTypeSerial->GetValue())
     {
@@ -6236,7 +6217,7 @@ void options::SetDSFormRWStates()
     }
 }
 
-void options::SetConnectionParams(ConnectionParams *cp)
+void options::SetConnectionParams( ConnectionParams *cp )
 {
     m_comboPort->Select(m_comboPort->FindString(cp->Port));
     m_comboPort->SetValue(cp->Port);
@@ -6305,7 +6286,7 @@ void options::SetConnectionParams(ConnectionParams *cp)
     m_connection_enabled = cp->bEnabled;
 }
 
-void options::SetDefaultConnectionParams()
+void options::SetDefaultConnectionParams( void )
 {
     m_comboPort->Select(0);
     m_comboPort->SetValue(_T(""));
@@ -6356,7 +6337,7 @@ void options::OnAddDatasourceClick( wxCommandEvent& event )
     RecalculateSize();
 }
 
-void options::FillSourceList()
+void options::FillSourceList( void )
 {
     m_buttonRemove->Enable(FALSE);
     m_lcSources->DeleteAllItems();
@@ -6614,7 +6595,7 @@ SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent, wxWindo
 
 }
 
-SentenceListDlg::~SentenceListDlg()
+SentenceListDlg::~SentenceListDlg( void )
 {
     // Disconnect Events
     m_btnAdd->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnAddClick ), NULL, this );
@@ -6643,12 +6624,12 @@ void SentenceListDlg::SetSentenceList(wxArrayString sentences)
     FillSentences();
 }
 
-wxString SentenceListDlg::GetSentencesAsText()
+wxString SentenceListDlg::GetSentencesAsText( void )
 {
     return StringArrayToString(m_sentences);
 }
 
-void SentenceListDlg::BuildSentenceArray()
+void SentenceListDlg::BuildSentenceArray( void )
 {
     m_sentences.Clear();
     wxString s;
@@ -6658,7 +6639,7 @@ void SentenceListDlg::BuildSentenceArray()
     }
 }
 
-void SentenceListDlg::FillSentences()
+void SentenceListDlg::FillSentences( void )
 {
     if(m_sentences.Count() == 0)
         return;
@@ -6957,7 +6938,7 @@ void OpenGLOptionsDlg::OnButtonClear( wxCommandEvent& event )
 #endif
 }
 
-wxString OpenGLOptionsDlg::TextureCacheSize()
+wxString OpenGLOptionsDlg::TextureCacheSize( void )
 {
     wxString path =  g_Platform->GetPrivateDataDir() + wxFileName::GetPathSeparator() + _T("raster_texture_cache");
     long long total = 0;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -26,7 +26,6 @@
 // For compilers that support precompilation, includes "wx/wx.h".
 #include "wx/wxprec.h"
 
-
 #ifndef WX_PRECOMP
 #include <wx/wx.h>
 #endif
@@ -299,17 +298,7 @@ int wxCALLBACK SortConnectionOnPriority(long item1, long item2, long list)
 #endif
 }
 
-    
-
-
-
-
-
 extern ArrayOfMMSIProperties   g_MMSI_Props_Array;
-
-
-
-
 
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -322,204 +311,190 @@ BEGIN_EVENT_TABLE( MMSIEditDialog, wxDialog )
 EVT_BUTTON( ID_MMSIEDIT_CANCEL, MMSIEditDialog::OnMMSIEditCancelClick )
 EVT_BUTTON( ID_MMSIEDIT_OK, MMSIEditDialog::OnMMSIEditOKClick )
 END_EVENT_TABLE()
- 
- MMSIEditDialog::MMSIEditDialog()
- {
- }
- 
- MMSIEditDialog::MMSIEditDialog( MMSIProperties *props, wxWindow* parent, wxWindowID id, const wxString& caption,
-                                         const wxPoint& pos, const wxSize& size, long style )
- {
-     m_props = props;
-     
-     long wstyle = wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER;
-     wxDialog::Create( parent, id, caption, pos, size, wstyle );
-     
-     CreateControls();
-     GetSizer()->SetSizeHints( this );
-     Centre();
-     
- }
- 
- MMSIEditDialog::~MMSIEditDialog()
- {
-     delete m_MMSICtl;
- }
- 
- 
- bool MMSIEditDialog::Create( MMSIProperties *props, wxWindow* parent, wxWindowID id, const wxString& caption,
-                                  const wxPoint& pos, const wxSize& size, long style )
+
+MMSIEditDialog::MMSIEditDialog()
+{
+}
+
+MMSIEditDialog::MMSIEditDialog( MMSIProperties *props, wxWindow* parent, wxWindowID id, const wxString& caption,
+                                const wxPoint& pos, const wxSize& size, long style )
 {
     m_props = props;
-    
+
+    long wstyle = wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER;
+    wxDialog::Create( parent, id, caption, pos, size, wstyle );
+
+    CreateControls();
+    GetSizer()->SetSizeHints( this );
+    Centre();
+}
+
+MMSIEditDialog::~MMSIEditDialog()
+{
+    delete m_MMSICtl;
+}
+
+
+bool MMSIEditDialog::Create( MMSIProperties *props, wxWindow* parent, wxWindowID id, const wxString& caption,
+                             const wxPoint& pos, const wxSize& size, long style )
+{
+    m_props = props;
+
     SetExtraStyle( GetExtraStyle() | wxWS_EX_BLOCK_EVENTS );
     wxDialog::Create( parent, id, caption, pos, size, style );
-     
-     CreateControls();
-     GetSizer()->SetSizeHints( this );
-     Centre();
-     
-     return TRUE;
+
+    CreateControls();
+    GetSizer()->SetSizeHints( this );
+    Centre();
+
+    return TRUE;
 }
- 
+
 void MMSIEditDialog::CreateControls()
 {
-     MMSIEditDialog* itemDialog1 = this;
-     
-     wxBoxSizer* itemBoxSizer2 = new wxBoxSizer( wxVERTICAL );
-     itemDialog1->SetSizer( itemBoxSizer2 );
-     
-     wxStaticBox* itemStaticBoxSizer4Static = new wxStaticBox( itemDialog1, wxID_ANY,
-                                                               _("MMSI Extended Properties") );
-     
-     wxStaticBoxSizer* itemStaticBoxSizer4 = new wxStaticBoxSizer( itemStaticBoxSizer4Static,
-                                                                   wxVERTICAL );
-     itemBoxSizer2->Add( itemStaticBoxSizer4, 0, wxEXPAND | wxALL, 5 );
-     
-     wxStaticText* itemStaticText5 = new wxStaticText( itemDialog1, wxID_STATIC, _("MMSI") );
-     itemStaticBoxSizer4->Add( itemStaticText5, 0,
-                               wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
-     
-     m_MMSICtl = new wxTextCtrl( itemDialog1, ID_MMSI_CTL, _T(""), wxDefaultPosition, wxSize( 180, -1 ), 0 );
-     itemStaticBoxSizer4->Add( m_MMSICtl, 0,
-                               wxALIGN_LEFT | wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 5 );
-     
-     
-     wxStaticBoxSizer *sbSizerPropsTrack = new wxStaticBoxSizer( new wxStaticBox( itemDialog1, wxID_ANY, _("Tracking") ), wxVERTICAL );
-     
-     wxGridSizer* bSizer15;
-     bSizer15 = new wxGridSizer( 0, 3, 0, 0 );
-     
-     m_rbTypeTrackDefault = new wxRadioButton( itemDialog1, wxID_ANY, _("Default tracking"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
-     m_rbTypeTrackDefault->SetValue( true );
-     bSizer15->Add( m_rbTypeTrackDefault, 0, wxALL, 5 );
+    MMSIEditDialog* itemDialog1 = this;
+    wxBoxSizer* itemBoxSizer2 = new wxBoxSizer( wxVERTICAL );
+    itemDialog1->SetSizer( itemBoxSizer2 );
 
-     m_rbTypeTrackAlways = new wxRadioButton( itemDialog1, wxID_ANY, _("Always track"), wxDefaultPosition, wxDefaultSize, 0 );
-     bSizer15->Add( m_rbTypeTrackAlways, 0, wxALL, 5 );
-     
-     m_rbTypeTrackNever = new wxRadioButton( itemDialog1, wxID_ANY, _("Never track"), wxDefaultPosition, wxDefaultSize, 0 );
-     bSizer15->Add( m_rbTypeTrackNever, 0, wxALL, 5 );
-     
-     m_cbTrackPersist = new wxCheckBox( itemDialog1, wxID_ANY, _("Persistent") );
-     bSizer15->Add( m_cbTrackPersist, 0, wxALL, 5 );
-     
-     sbSizerPropsTrack->Add( bSizer15, 0, wxEXPAND, 0 );
-     itemStaticBoxSizer4->Add(sbSizerPropsTrack, 0, wxEXPAND, 0);
-     
+    wxStaticBox* itemStaticBoxSizer4Static = new wxStaticBox( itemDialog1, wxID_ANY,
+                                                              _("MMSI Extended Properties") );
 
-     m_IgnoreButton = new wxCheckBox( itemDialog1, wxID_ANY, _("Ignore this MMSI") );
-     itemStaticBoxSizer4->Add( m_IgnoreButton, 0, wxEXPAND, 5 );
-     
-     m_MOBButton = new wxCheckBox( itemDialog1, wxID_ANY, _("Handle this MMSI as SART/PLB(AIS) MOB.") );
-     itemStaticBoxSizer4->Add( m_MOBButton, 0, wxEXPAND, 5 );
-     
-     m_VDMButton = new wxCheckBox( itemDialog1, wxID_ANY, _("Convert AIVDM to AIVDO for this MMSI") );
-     itemStaticBoxSizer4->Add( m_VDMButton, 0, wxEXPAND, 5 );
-     
-     
-     wxBoxSizer* itemBoxSizer16 = new wxBoxSizer( wxHORIZONTAL );
-     itemBoxSizer2->Add( itemBoxSizer16, 0, wxALIGN_RIGHT | wxALL, 5 );
-     
-     m_CancelButton = new wxButton( itemDialog1, ID_MMSIEDIT_CANCEL, _("Cancel"), wxDefaultPosition,
-     wxDefaultSize, 0 );
-     itemBoxSizer16->Add( m_CancelButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5 );
-     
-     m_OKButton = new wxButton( itemDialog1, ID_MMSIEDIT_OK, _("OK"), wxDefaultPosition,
-     wxDefaultSize, 0 );
-     itemBoxSizer16->Add( m_OKButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5 );
-     m_OKButton->SetDefault();
+    wxStaticBoxSizer* itemStaticBoxSizer4 = new wxStaticBoxSizer( itemStaticBoxSizer4Static,
+                                                                  wxVERTICAL );
+    itemBoxSizer2->Add( itemStaticBoxSizer4, 0, wxEXPAND | wxALL, 5 );
 
-     //  Set initial values...
-     wxString sMMSI;
-     if(m_props->MMSI > 0)
-        sMMSI.Printf(_T("%d"), m_props->MMSI);
-     else
-         sMMSI = _T("");
-     m_MMSICtl->AppendText(sMMSI);
+    wxStaticText* itemStaticText5 = new wxStaticText( itemDialog1, wxID_STATIC, _("MMSI") );
+    itemStaticBoxSizer4->Add( itemStaticText5, 0,
+                              wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
 
-     switch(m_props->TrackType){
-         case TRACKTYPE_DEFAULT:
-             break;
-         case TRACKTYPE_ALWAYS:
-             m_rbTypeTrackAlways->SetValue(true);
-             break;
-         case TRACKTYPE_NEVER:
-             m_rbTypeTrackNever->SetValue(true);
-             break;
-         default:
-             break;
-     }
-     
-     m_cbTrackPersist->SetValue(m_props->m_bPersistentTrack);
-     
-     m_IgnoreButton->SetValue(m_props->m_bignore);
-     m_MOBButton->SetValue(m_props->m_bMOB);
-     m_VDMButton->SetValue(m_props->m_bVDM);
-     
-     
-     SetColorScheme( (ColorScheme) 0 );
- }
- 
- void MMSIEditDialog::SetColorScheme( ColorScheme cs )
- {
-     DimeControl( this );
- }
- 
- 
- void MMSIEditDialog::OnMMSIEditCancelClick( wxCommandEvent& event )
- {
-     EndModal(wxID_CANCEL);
- }
- 
- void MMSIEditDialog::OnMMSIEditOKClick( wxCommandEvent& event )
- {
-
-     // Update the MMSIProperties by the passed pointer
-     if(m_props){
-         long nmmsi;
-         m_MMSICtl->GetValue().ToLong(&nmmsi);
-         m_props->MMSI = nmmsi;
-         
-         if( m_rbTypeTrackDefault->GetValue() )
-             m_props->TrackType = TRACKTYPE_DEFAULT;
-         else if ( m_rbTypeTrackAlways->GetValue() )
-             m_props->TrackType = TRACKTYPE_ALWAYS;
-         else 
-             m_props->TrackType = TRACKTYPE_NEVER;
-        
-         
-         m_props->m_bignore = m_IgnoreButton->GetValue();
-         m_props->m_bMOB = m_MOBButton->GetValue();
-         m_props->m_bVDM = m_VDMButton->GetValue();
-         m_props->m_bPersistentTrack = m_cbTrackPersist->GetValue();
-     }
-     
-     EndModal(wxID_OK);
- }
- 
- 
- void MMSIEditDialog::OnCtlUpdated( wxCommandEvent& event )
- {
- }
- 
+    m_MMSICtl = new wxTextCtrl( itemDialog1, ID_MMSI_CTL, _T(""), wxDefaultPosition, wxSize( 180, -1 ), 0 );
+    itemStaticBoxSizer4->Add( m_MMSICtl, 0,
+                              wxALIGN_LEFT | wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 5 );
 
 
+    wxStaticBoxSizer *sbSizerPropsTrack = new wxStaticBoxSizer( new wxStaticBox( itemDialog1, wxID_ANY, _("Tracking") ), wxVERTICAL );
 
+    wxGridSizer* bSizer15;
+    bSizer15 = new wxGridSizer( 0, 3, 0, 0 );
+
+    m_rbTypeTrackDefault = new wxRadioButton( itemDialog1, wxID_ANY, _("Default tracking"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
+    m_rbTypeTrackDefault->SetValue( true );
+    bSizer15->Add( m_rbTypeTrackDefault, 0, wxALL, 5 );
+
+    m_rbTypeTrackAlways = new wxRadioButton( itemDialog1, wxID_ANY, _("Always track"), wxDefaultPosition, wxDefaultSize, 0 );
+    bSizer15->Add( m_rbTypeTrackAlways, 0, wxALL, 5 );
+
+    m_rbTypeTrackNever = new wxRadioButton( itemDialog1, wxID_ANY, _("Never track"), wxDefaultPosition, wxDefaultSize, 0 );
+    bSizer15->Add( m_rbTypeTrackNever, 0, wxALL, 5 );
+
+    m_cbTrackPersist = new wxCheckBox( itemDialog1, wxID_ANY, _("Persistent") );
+    bSizer15->Add( m_cbTrackPersist, 0, wxALL, 5 );
+
+    sbSizerPropsTrack->Add( bSizer15, 0, wxEXPAND, 0 );
+    itemStaticBoxSizer4->Add(sbSizerPropsTrack, 0, wxEXPAND, 0);
+
+
+    m_IgnoreButton = new wxCheckBox( itemDialog1, wxID_ANY, _("Ignore this MMSI") );
+    itemStaticBoxSizer4->Add( m_IgnoreButton, 0, wxEXPAND, 5 );
+
+    m_MOBButton = new wxCheckBox( itemDialog1, wxID_ANY, _("Handle this MMSI as SART/PLB(AIS) MOB.") );
+    itemStaticBoxSizer4->Add( m_MOBButton, 0, wxEXPAND, 5 );
+
+    m_VDMButton = new wxCheckBox( itemDialog1, wxID_ANY, _("Convert AIVDM to AIVDO for this MMSI") );
+    itemStaticBoxSizer4->Add( m_VDMButton, 0, wxEXPAND, 5 );
+
+
+    wxBoxSizer* itemBoxSizer16 = new wxBoxSizer( wxHORIZONTAL );
+    itemBoxSizer2->Add( itemBoxSizer16, 0, wxALIGN_RIGHT | wxALL, 5 );
+
+    m_CancelButton = new wxButton( itemDialog1, ID_MMSIEDIT_CANCEL, _("Cancel"), wxDefaultPosition,
+    wxDefaultSize, 0 );
+    itemBoxSizer16->Add( m_CancelButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5 );
+
+    m_OKButton = new wxButton( itemDialog1, ID_MMSIEDIT_OK, _("OK"), wxDefaultPosition,
+    wxDefaultSize, 0 );
+    itemBoxSizer16->Add( m_OKButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5 );
+    m_OKButton->SetDefault();
+
+    //  Set initial values...
+    wxString sMMSI;
+    if ( m_props->MMSI > 0 )
+       sMMSI.Printf( _T( "%d" ), m_props->MMSI );
+    else
+        sMMSI = _T( "" );
+    m_MMSICtl->AppendText(sMMSI);
+
+    switch ( m_props->TrackType ){
+        case TRACKTYPE_DEFAULT:
+            break;
+        case TRACKTYPE_ALWAYS:
+            m_rbTypeTrackAlways->SetValue(true);
+            break;
+        case TRACKTYPE_NEVER:
+            m_rbTypeTrackNever->SetValue(true);
+            break;
+        default:
+            break;
+    }
+
+    m_cbTrackPersist->SetValue( m_props->m_bPersistentTrack );
+    m_IgnoreButton->SetValue( m_props->m_bignore );
+    m_MOBButton->SetValue( m_props->m_bMOB );
+    m_VDMButton->SetValue( m_props->m_bVDM );
+
+    SetColorScheme( (ColorScheme) 0 );
+}
+
+void MMSIEditDialog::SetColorScheme( ColorScheme cs )
+{
+    DimeControl( this );
+}
+
+
+void MMSIEditDialog::OnMMSIEditCancelClick( wxCommandEvent& event )
+{
+    EndModal( wxID_CANCEL );
+}
+
+void MMSIEditDialog::OnMMSIEditOKClick( wxCommandEvent& event )
+{
+    // Update the MMSIProperties by the passed pointer
+    if ( m_props ){
+        long nmmsi;
+        m_MMSICtl->GetValue().ToLong( &nmmsi );
+        m_props->MMSI = nmmsi;
+
+        if( m_rbTypeTrackDefault->GetValue() )
+            m_props->TrackType = TRACKTYPE_DEFAULT;
+        else if ( m_rbTypeTrackAlways->GetValue() )
+            m_props->TrackType = TRACKTYPE_ALWAYS;
+        else
+            m_props->TrackType = TRACKTYPE_NEVER;
+
+        m_props->m_bignore = m_IgnoreButton->GetValue();
+        m_props->m_bMOB = m_MOBButton->GetValue();
+        m_props->m_bVDM = m_VDMButton->GetValue();
+        m_props->m_bPersistentTrack = m_cbTrackPersist->GetValue();
+    }
+
+    EndModal(wxID_OK);
+}
+
+void MMSIEditDialog::OnCtlUpdated( wxCommandEvent& event )
+{
+}
 
  ///////////////////////////////////////////////////////////////////////////////
  /// Class MMSIListCtrl
  ///////////////////////////////////////////////////////////////////////////////
- 
 
 BEGIN_EVENT_TABLE( MMSIListCtrl, wxListCtrl )
- EVT_LIST_ITEM_SELECTED( ID_MMSI_PROPS_LIST, MMSIListCtrl::OnListItemClick )
- EVT_LIST_ITEM_ACTIVATED( ID_MMSI_PROPS_LIST, MMSIListCtrl::OnListItemActivated )
+ EVT_LIST_ITEM_SELECTED( ID_MMSI_PROPS_LIST,    MMSIListCtrl::OnListItemClick )
+ EVT_LIST_ITEM_ACTIVATED( ID_MMSI_PROPS_LIST,   MMSIListCtrl::OnListItemActivated )
  EVT_LIST_ITEM_RIGHT_CLICK( ID_MMSI_PROPS_LIST, MMSIListCtrl::OnListItemRightClick )
- EVT_MENU ( ID_DEF_MENU_MMSI_EDIT,             MMSIListCtrl::PopupMenuHandler )
- EVT_MENU ( ID_DEF_MENU_MMSI_DELETE,           MMSIListCtrl::PopupMenuHandler )
- 
+ EVT_MENU ( ID_DEF_MENU_MMSI_EDIT,              MMSIListCtrl::PopupMenuHandler )
+ EVT_MENU ( ID_DEF_MENU_MMSI_DELETE,            MMSIListCtrl::PopupMenuHandler )
 END_EVENT_TABLE()
-
 
 MMSIListCtrl::MMSIListCtrl( wxWindow* parent, wxWindowID id, const wxPoint& pos,
         const wxSize& size, long style ) :
@@ -528,109 +503,97 @@ MMSIListCtrl::MMSIListCtrl( wxWindow* parent, wxWindowID id, const wxPoint& pos,
     m_parent = parent;
 }
 
-MMSIListCtrl::~MMSIListCtrl()
-{
-}
+MMSIListCtrl::~MMSIListCtrl() {}
 
 wxString MMSIListCtrl::OnGetItemText( long item, long column ) const
 {
-    wxString ret = _T("");
-    
+    wxString ret = _T( "" );
     MMSIProperties *props = g_MMSI_Props_Array.Item( item );
-    
-    if(props){
+
+    if ( props ) {
         switch( column ){
             case mlMMSI:
-                if(props->MMSI > 0)
-                    ret.Printf(_T("%d"), props->MMSI );
-                
+                if ( props->MMSI > 0 )
+                    ret.Printf( _T( "%d" ), props->MMSI );
                 break;
-                
             case mlTrackMode:
-                if(TRACKTYPE_DEFAULT == props->TrackType)
-                    ret = _("Default");
-                else if(TRACKTYPE_ALWAYS == props->TrackType)
-                    ret = _("Always");
-                else if(TRACKTYPE_NEVER == props->TrackType)
-                    ret = _("Never");
+                if ( TRACKTYPE_DEFAULT == props->TrackType )
+                    ret = _( "Default" );
+                else if ( TRACKTYPE_ALWAYS == props->TrackType )
+                    ret = _( "Always" );
+                else if ( TRACKTYPE_NEVER == props->TrackType )
+                    ret = _( "Never" );
                 else
-                    ret = _T("???");
-                if( props->m_bPersistentTrack )
-                    ret.Append(_T(", ")).Append(_("Persistent"));
+                    ret = _T( "???" );
+                if ( props->m_bPersistentTrack )
+                    ret.Append( _T( ", " ) ).Append( _( "Persistent" ) );
                 break;
-                
             case mlIgnore:
-                if( props->m_bignore)
-                    ret = _T("X");
+                if ( props->m_bignore )
+                    ret = _T( "X" );
                 break;
-                
             case mlMOB:
-                if( props->m_bMOB)
-                    ret = _T("X");
+                if ( props->m_bMOB )
+                    ret = _T( "X" );
                 break;
-                
             case mlVDM:
-                if( props->m_bVDM)
-                    ret = _T("X");
+                if ( props->m_bVDM )
+                    ret = _T( "X" );
                 break;
-                
             default:
-                ret = _T("??");
+                ret = _T( "??" );
                 break;
         }
     }
-            
 
     return ret;
 }
 
-void MMSIListCtrl::OnListItemClick( wxListEvent &event)
-{
-}
+void MMSIListCtrl::OnListItemClick( wxListEvent &event) {}
 
-void MMSIListCtrl::OnListItemActivated( wxListEvent &event)
+void MMSIListCtrl::OnListItemActivated( wxListEvent &event )
 {
     MMSIProperties *props = g_MMSI_Props_Array.Item( event.GetIndex() );
-    MMSIProperties *props_new = new MMSIProperties( *props);
-    
+    MMSIProperties *props_new = new MMSIProperties( *props );
+
     MMSIEditDialog *pd = new MMSIEditDialog( props_new, m_parent, -1, _("Edit MMSI Properties"),
-                                             wxDefaultPosition, wxSize(200,200) );
-    
+                                             wxDefaultPosition, wxSize( 200, 200 ) );
+
     if ( pd->ShowModal() == wxID_OK ){
         g_MMSI_Props_Array.RemoveAt( event.GetIndex() );
-        g_MMSI_Props_Array.Insert(props_new, event.GetIndex());
+        g_MMSI_Props_Array.Insert( props_new, event.GetIndex() );
     }
-    
-    pd->Destroy();    
+
+    pd->Destroy();
 }
 
-void MMSIListCtrl::OnListItemRightClick( wxListEvent &event)
+void MMSIListCtrl::OnListItemRightClick( wxListEvent &event )
 {
     m_context_item = GetNextItem( -1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED );
-    
-    if(-1 == m_context_item)
+
+    if ( -1 == m_context_item )
         return;
-    
+
     wxMenu* menu = new wxMenu( _("MMSI Properties") );
 
-    wxMenuItem *item_edit = new wxMenuItem(menu, ID_DEF_MENU_MMSI_EDIT, _("Edit..."));
-    menu->Append(item_edit);
-    
-    wxMenuItem *item_delete = new wxMenuItem(menu, ID_DEF_MENU_MMSI_DELETE, _("Delete"));
-    menu->Append(item_delete);
+    wxMenuItem *item_edit = new wxMenuItem( menu, ID_DEF_MENU_MMSI_EDIT, _( "Edit..." ) );
+    menu->Append( item_edit );
+
+    wxMenuItem *item_delete = new wxMenuItem( menu, ID_DEF_MENU_MMSI_DELETE, _( "Delete" ) );
+    menu->Append( item_delete );
 
 #ifdef __WXMSW__
-    wxFont *qFont = GetOCPNScaledFont(_("Menu"));
-    item_edit->SetFont(*qFont);
-    item_delete->SetFont(*qFont);
+    wxFont *qFont = GetOCPNScaledFont( _( "Menu" ) );
+    item_edit->SetFont( *qFont );
+    item_delete->SetFont( *qFont );
 #endif
-    
-    wxPoint p = ScreenToClient(wxGetMousePosition());
+
+    wxPoint p = ScreenToClient( wxGetMousePosition() );
     PopupMenu( menu, p.x, p.y );
-    
+
     SetItemCount( g_MMSI_Props_Array.GetCount() );
-    Refresh(true);
-    
+    Refresh( TRUE );
+
 }
 
 
@@ -638,186 +601,170 @@ void MMSIListCtrl::PopupMenuHandler( wxCommandEvent& event )
 {
     MMSIProperties *props = g_MMSI_Props_Array.Item( m_context_item );
     MMSIProperties *props_new = new MMSIProperties( *props);
-    
     MMSIEditDialog *pd;
-    
-   switch( event.GetId() ) {
-       case ID_DEF_MENU_MMSI_EDIT:
-           if(props){
-            pd = new MMSIEditDialog( props_new, m_parent, -1, _("Edit MMSI Properties"), wxDefaultPosition, wxSize(200,200) );
-           
-            if ( pd->ShowModal() == wxID_OK ){
-                g_MMSI_Props_Array.RemoveAt( m_context_item );
-                g_MMSI_Props_Array.Insert(props_new, m_context_item);
-            }
-            
-            pd->Destroy();    
+
+    switch ( event.GetId() ) {
+        case ID_DEF_MENU_MMSI_EDIT:
+            if ( props ) {
+                pd = new MMSIEditDialog( props_new, m_parent, -1, _( "Edit MMSI Properties" ), wxDefaultPosition, wxSize( 200, 200 ) );
+
+                if ( pd->ShowModal() == wxID_OK ) {
+                    g_MMSI_Props_Array.RemoveAt( m_context_item );
+                    g_MMSI_Props_Array.Insert( props_new, m_context_item );
+                }
+            pd->Destroy();
            }
            break;
-           
+
        case ID_DEF_MENU_MMSI_DELETE:
-           if(props){
+           if ( props ) {
                g_MMSI_Props_Array.RemoveAt( m_context_item );
            }
            break;
    }
-   
 }
-            
-
-
-
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Class MMSI_Props_Panel
 ///////////////////////////////////////////////////////////////////////////////
 
-
 MMSI_Props_Panel::MMSI_Props_Panel( wxWindow *parent ):
-        wxPanel( parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE )
+    wxPanel( parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE )
 {
     m_pparent = parent;
-    
-    wxFont *qFont = GetOCPNScaledFont(_("Dialog"));
+
+    wxFont *qFont = GetOCPNScaledFont( _( "Dialog" ) );
     SetFont( *qFont );
 
     wxBoxSizer* topSizer = new wxBoxSizer( wxVERTICAL );
     SetSizer( topSizer );
 
-    wxString MMSI_props_column_spec = _T("120;120;100;100;100;100;100");
+    wxString MMSI_props_column_spec = _T( "120;120;100;100;100;100;100" );
     //  Parse the global column width string as read from config file
     wxStringTokenizer tkz( MMSI_props_column_spec, _T(";") );
     wxString s_width = tkz.GetNextToken();
     int width;
     long lwidth;
-    
-    m_pListCtrlMMSI = new MMSIListCtrl( this, ID_MMSI_PROPS_LIST, wxDefaultPosition,  wxSize(-1, 400),
+
+    m_pListCtrlMMSI = new MMSIListCtrl( this, ID_MMSI_PROPS_LIST, wxDefaultPosition,  wxSize( -1, 400 ),
             wxLC_REPORT | wxLC_SINGLE_SEL | wxLC_HRULES | wxLC_VRULES | wxBORDER_SUNKEN  | wxLC_VIRTUAL );
     wxImageList *imglist = new wxImageList( 16, 16, true, 2 );
 
     ocpnStyle::Style* style = g_StyleManager->GetCurrentStyle();
-    imglist->Add( style->GetIcon( _T("sort_asc") ) );
-    imglist->Add( style->GetIcon( _T("sort_desc") ) );
+    imglist->Add( style->GetIcon( _T( "sort_asc" ) ) );
+    imglist->Add( style->GetIcon( _T( "sort_desc" ) ) );
 
- //   m_pListCtrlMMSI->AssignImageList( imglist, wxIMAGE_LIST_SMALL );
-
+    // m_pListCtrlMMSI->AssignImageList( imglist, wxIMAGE_LIST_SMALL );
     int dx = GetCharWidth();
-    
-    
-    width = dx * 12;
-    if( s_width.ToLong( &lwidth ) ) {
-        width = wxMax(dx * 2, lwidth);
-        width = wxMin(width, dx * 30);
-    }
-    m_pListCtrlMMSI->InsertColumn( tlMMSI, _("MMSI"), wxLIST_FORMAT_LEFT, width );
-    s_width = tkz.GetNextToken();
+
 
     width = dx * 12;
-    if( s_width.ToLong( &lwidth ) ) {
+    if ( s_width.ToLong( &lwidth ) ) {
         width = wxMax(dx * 2, lwidth);
         width = wxMin(width, dx * 30);
     }
-    m_pListCtrlMMSI->InsertColumn( tlCLASS, _("Track Mode"), wxLIST_FORMAT_CENTER, width );
+    m_pListCtrlMMSI->InsertColumn( tlMMSI, _( "MMSI" ), wxLIST_FORMAT_LEFT, width );
+    s_width = tkz.GetNextToken();
+
+    width = dx * 12;
+    if ( s_width.ToLong( &lwidth ) ) {
+        width = wxMax( dx * 2, lwidth );
+        width = wxMin( width, dx * 30 );
+    }
+    m_pListCtrlMMSI->InsertColumn( tlCLASS, _( "Track Mode" ), wxLIST_FORMAT_CENTER, width );
     s_width = tkz.GetNextToken();
 
     width = dx * 8;
-    if( s_width.ToLong( &lwidth ) ) {
-        width = wxMax(dx * 2, lwidth);
-        width = wxMin(width, dx * 30);
+    if ( s_width.ToLong( &lwidth ) ) {
+        width = wxMax( dx * 2, lwidth );
+        width = wxMin( width, dx * 30 );
     }
-    m_pListCtrlMMSI->InsertColumn( tlTYPE, _("Ignore"), wxLIST_FORMAT_CENTER, width );
+    m_pListCtrlMMSI->InsertColumn( tlTYPE, _( "Ignore" ), wxLIST_FORMAT_CENTER, width );
     s_width = tkz.GetNextToken();
 
     width = dx * 8;
-    if( s_width.ToLong( &lwidth ) ) {
-        width = wxMax(dx * 2, lwidth);
-        width = wxMin(width, dx * 30);
+    if ( s_width.ToLong( &lwidth ) ) {
+        width = wxMax( dx * 2, lwidth );
+        width = wxMin( width, dx * 30 );
     }
-    m_pListCtrlMMSI->InsertColumn( tlTYPE, _("MOB"), wxLIST_FORMAT_CENTER, width );
+    m_pListCtrlMMSI->InsertColumn( tlTYPE, _( "MOB" ), wxLIST_FORMAT_CENTER, width );
     s_width = tkz.GetNextToken();
-    
+
     width = dx * 8;
-    if( s_width.ToLong( &lwidth ) ) {
-        width = wxMax(dx * 2, lwidth);
-        width = wxMin(width, dx * 30);
+    if ( s_width.ToLong( &lwidth ) ) {
+        width = wxMax( dx * 2, lwidth );
+        width = wxMin( width, dx * 30 );
     }
-    m_pListCtrlMMSI->InsertColumn( tlTYPE, _("VDM->VDO"), wxLIST_FORMAT_CENTER, width );
+    m_pListCtrlMMSI->InsertColumn( tlTYPE, _( "VDM->VDO" ), wxLIST_FORMAT_CENTER, width );
     s_width = tkz.GetNextToken();
-    
 
     topSizer->Add( m_pListCtrlMMSI, 1, wxEXPAND | wxALL, 0 );
 
-    m_pButtonNew = new wxButton( this, wxID_ANY, _("New..."), wxDefaultPosition, wxSize( 200, -1));
+    m_pButtonNew = new wxButton( this, wxID_ANY, _( "New..." ), wxDefaultPosition, wxSize( 200, -1 ) );
     m_pButtonNew->Connect( wxEVT_COMMAND_BUTTON_CLICKED,
                            wxCommandEventHandler( MMSI_Props_Panel::OnNewButton ), NULL, this );
     topSizer->Add( m_pButtonNew, 0, wxALIGN_RIGHT | wxALL, 0 );
-    
-    
+
     topSizer->Layout();
 
-    //    This is silly, but seems to be required for __WXMSW__ build
-    //    If not done, the SECOND invocation of the panel fails to expand the list to the full wxSizer size....
+    //  This is silly, but seems to be required for __WXMSW__ build
+    //  If not done, the SECOND invocation of the panel fails to expand the list to the full wxSizer size....
     SetSize( GetSize().x, GetSize().y - 1 );
 
     SetColorScheme( (ColorScheme) 0 );
 }
 
-MMSI_Props_Panel::~MMSI_Props_Panel()
-{
-}
+MMSI_Props_Panel::~MMSI_Props_Panel() {}
 
 void MMSI_Props_Panel::OnNewButton( wxCommandEvent &event )
 {
-    MMSIProperties *props = new MMSIProperties(-1);
-    
-    MMSIEditDialog *pd = new MMSIEditDialog( props, m_parent, -1, _("Add MMSI Properties"), wxDefaultPosition, wxSize(200,200) );
-    
+    MMSIProperties *props = new MMSIProperties( -1 );
+
+    MMSIEditDialog *pd = new MMSIEditDialog( props, m_parent, -1, _( "Add MMSI Properties" ), wxDefaultPosition, wxSize( 200,200 ) );
+
     if ( pd->ShowModal() == wxID_OK )
         g_MMSI_Props_Array.Add( props );
-   
-    pd->Destroy();    
-    
+
+    pd->Destroy();
+
     UpdateMMSIList();
 }
 
 
 void MMSI_Props_Panel::UpdateMMSIList( void )
 {
-        //    Capture the MMSI of the curently selected list item
-        long selItemID = -1;
-        selItemID = m_pListCtrlMMSI->GetNextItem( selItemID, wxLIST_NEXT_ALL,
-                                                        wxLIST_STATE_SELECTED );
-        
-        int selMMSI = -1;
-        if( selItemID != -1 )
-            selMMSI = g_MMSI_Props_Array.Item( selItemID )->MMSI;
- 
-        
-        m_pListCtrlMMSI->SetItemCount( g_MMSI_Props_Array.GetCount() );
-        
-                
-        //    Restore selected item
-        long item_sel = 0;
-        if( ( selItemID != -1 ) && ( selMMSI != -1 ) ) {
-            for( unsigned int i = 0; i < g_MMSI_Props_Array.GetCount(); i++ ) {
-                if( g_MMSI_Props_Array.Item( i )->MMSI == selMMSI ) {
-                    item_sel = i;
-                    break;
-                    }
-                }
-            }
-                
-        if( g_MMSI_Props_Array.GetCount() != 0 ) 
-            m_pListCtrlMMSI->SetItemState( item_sel,
-                    wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED,
-                    wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED );
+    // Capture the MMSI of the curently selected list item
+    long selItemID = -1;
+    selItemID = m_pListCtrlMMSI->GetNextItem( selItemID, wxLIST_NEXT_ALL,
+                                              wxLIST_STATE_SELECTED );
 
-                
+    int selMMSI = -1;
+    if( selItemID != -1 )
+        selMMSI = g_MMSI_Props_Array.Item( selItemID )->MMSI;
+
+    m_pListCtrlMMSI->SetItemCount( g_MMSI_Props_Array.GetCount() );
+
+    // Restore selected item
+    long item_sel = 0;
+    if( ( selItemID != -1 ) && ( selMMSI != -1 ) ) {
+        for( unsigned int i = 0; i < g_MMSI_Props_Array.GetCount(); i++ ) {
+            if( g_MMSI_Props_Array.Item( i )->MMSI == selMMSI ) {
+                item_sel = i;
+                break;
+            }
+        }
+    }
+
+    if( g_MMSI_Props_Array.GetCount() != 0 )
+        m_pListCtrlMMSI->SetItemState( item_sel,
+                                       wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED,
+                                       wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED );
+
 #ifdef __WXMSW__
-        m_pListCtrlMMSI->Refresh( false );
+    m_pListCtrlMMSI->Refresh( false );
 #endif
 }
-        
+
 void MMSI_Props_Panel::SetColorScheme( ColorScheme cs )
 {
     DimeControl( this );
@@ -834,7 +781,7 @@ BEGIN_EVENT_TABLE( options, wxDialog )
     EVT_BUTTON( wxID_CANCEL, options::OnCancelClick )
     EVT_BUTTON( ID_BUTTONFONTCHOOSE, options::OnChooseFont )
     EVT_CLOSE( options::OnClose)
-    
+
 #ifdef __WXGTK__
     EVT_BUTTON( ID_BUTTONFONTCOLOR, options::OnChooseFontColor )
 #endif
@@ -852,7 +799,6 @@ BEGIN_EVENT_TABLE( options, wxDialog )
     EVT_CHOICE( ID_OPWAYPOINTRANGERINGS, options::OnWaypointRangeRingSelect )
     EVT_CHAR_HOOK( options::OnCharHook )
     EVT_TIMER ( ID_BT_SCANTIMER, options::onBTScanTimer )
-    
 END_EVENT_TABLE()
 
 options::options()
@@ -861,12 +807,12 @@ options::options()
 }
 
 options::options( MyFrame* parent, wxWindowID id, const wxString& caption, const wxPoint& pos,
-        const wxSize& size, long style )
+                  const wxSize& size, long style )
 {
     Init();
+    // Need to load S52 Options
+    LoadS57();
 
-    LoadS57();                  // Need to load S52 Options
-    
     pParent = parent;
 
     long wstyle = wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER;
@@ -874,9 +820,9 @@ options::options( MyFrame* parent, wxWindowID id, const wxString& caption, const
 
     wxDialog::Create( parent, id, caption, pos, size, wstyle );
 
-    wxFont *qFont = GetOCPNScaledFont(_("Dialog"));
+    wxFont *qFont = GetOCPNScaledFont( _("Dialog") );
     SetFont( *qFont );
-    
+
     CreateControls();
     RecalculateSize();
 
@@ -886,86 +832,83 @@ options::options( MyFrame* parent, wxWindowID id, const wxString& caption, const
 options::~options()
 {
     // Disconnect Connection page Events
-    if(m_pNMEAForm){
-    m_lcSources->Disconnect( wxEVT_COMMAND_LIST_ITEM_SELECTED, wxListEventHandler( options::OnSelectDatasource ), NULL, this );
-    m_buttonAdd->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnAddDatasourceClick ), NULL, this );
-    m_buttonRemove->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnRemoveDatasourceClick ), NULL, this );
-    m_tFilterSec->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-    m_rbTypeSerial->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnTypeSerialSelected ), NULL, this );
-    m_rbTypeNet->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnTypeNetSelected ), NULL, this );
-    m_rbNetProtoTCP->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
-    m_rbNetProtoUDP->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
-    m_rbNetProtoGPSD->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
-    m_tNetAddress->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-    m_tNetPort->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-    m_comboPort->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-    m_comboPort->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-    m_choiceBaudRate->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( options::OnBaudrateChoice ), NULL, this );
-    m_choiceSerialProtocol->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( options::OnProtocolChoice ), NULL, this );
-    m_choicePriority->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-    m_cbCheckCRC->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnCrcCheck ), NULL, this );
-    m_cbGarminHost->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnUploadFormatChange ), NULL, this );
-    m_cbGarminUploadHost->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnUploadFormatChange ), NULL, this );
-    m_cbFurunoGP3X->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnUploadFormatChange ), NULL, this );
-    m_rbIAccept->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnRbAcceptInput ), NULL, this );
-    m_rbIIgnore->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnRbIgnoreInput ), NULL, this );
-    m_tcInputStc->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-    m_btnInputStcList->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnBtnIStcs ), NULL, this );
-    m_cbInput->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnCbInput ), NULL, this );
-    m_cbOutput->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnCbOutput ), NULL, this );
-    m_rbOAccept->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnRbOutput ), NULL, this );
-    m_rbOIgnore->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnRbOutput ), NULL, this );
-    m_tcOutputStc->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
-    m_btnOutputStcList->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnBtnOStcs ), NULL, this );
-    m_cbNMEADebug->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnShowGpsWindowCheckboxClick ), NULL, this );
-    pOpenGL->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnGLClicked ), NULL, this );
-    
+    if ( m_pNMEAForm ) {
+        m_lcSources->Disconnect( wxEVT_COMMAND_LIST_ITEM_SELECTED, wxListEventHandler( options::OnSelectDatasource ), NULL, this );
+        m_buttonAdd->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnAddDatasourceClick ), NULL, this );
+        m_buttonRemove->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnRemoveDatasourceClick ), NULL, this );
+        m_tFilterSec->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
+        m_rbTypeSerial->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnTypeSerialSelected ), NULL, this );
+        m_rbTypeNet->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnTypeNetSelected ), NULL, this );
+        m_rbNetProtoTCP->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
+        m_rbNetProtoUDP->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
+        m_rbNetProtoGPSD->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
+        m_tNetAddress->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
+        m_tNetPort->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
+        m_comboPort->Disconnect( wxEVT_COMMAND_COMBOBOX_SELECTED, wxCommandEventHandler( options::OnValChange ), NULL, this );
+        m_comboPort->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
+        m_choiceBaudRate->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( options::OnBaudrateChoice ), NULL, this );
+        m_choiceSerialProtocol->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( options::OnProtocolChoice ), NULL, this );
+        m_choicePriority->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( options::OnValChange ), NULL, this );
+        m_cbCheckCRC->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnCrcCheck ), NULL, this );
+        m_cbGarminHost->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnUploadFormatChange ), NULL, this );
+        m_cbGarminUploadHost->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnUploadFormatChange ), NULL, this );
+        m_cbFurunoGP3X->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnUploadFormatChange ), NULL, this );
+        m_rbIAccept->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnRbAcceptInput ), NULL, this );
+        m_rbIIgnore->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnRbIgnoreInput ), NULL, this );
+        m_tcInputStc->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
+        m_btnInputStcList->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnBtnIStcs ), NULL, this );
+        m_cbInput->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnCbInput ), NULL, this );
+        m_cbOutput->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnCbOutput ), NULL, this );
+        m_rbOAccept->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnRbOutput ), NULL, this );
+        m_rbOIgnore->Disconnect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnRbOutput ), NULL, this );
+        m_tcOutputStc->Disconnect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
+        m_btnOutputStcList->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnBtnOStcs ), NULL, this );
+        m_cbNMEADebug->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnShowGpsWindowCheckboxClick ), NULL, this );
+        pOpenGL->Disconnect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnGLClicked ), NULL, this );
     }
-    
+
     delete m_pSerialArray;
     groupsPanel->EmptyChartGroupArray( m_pGroupArray );
     delete m_pGroupArray;
     m_pGroupArray = NULL;
     m_groupsPage = NULL;
     g_pOptions = NULL;
-    if( m_topImgList ) delete m_topImgList;
+    if ( m_topImgList ) delete m_topImgList;
     delete smallFont;
 }
 
 void options::RecalculateSize()
 {
-    if(!g_bresponsive){
+    if ( !g_bresponsive ) {
         wxSize canvas_size = cc1->GetSize();
         wxSize fitted_size = GetSize();
-    
-        fitted_size.x = wxMin(fitted_size.x, canvas_size.x);
-        fitted_size.y = wxMin(fitted_size.y, canvas_size.y);
-    
+
+        fitted_size.x = wxMin( fitted_size.x, canvas_size.x );
+        fitted_size.y = wxMin( fitted_size.y, canvas_size.y );
+
         SetSize( fitted_size );
-        
+
         Fit();
-    }
-    else {
+    } else {
         wxSize esize;
         esize.x = GetCharWidth() * 110;
         esize.y = GetCharHeight() * 40;
-        
-        wxSize dsize = GetParent()->GetSize();//GetClientSize();
-        esize.y = wxMin(esize.y, dsize.y - 0/*(2 * GetCharHeight())*/);
-        esize.x = wxMin(esize.x, dsize.x - 0/*(2 * GetCharHeight())*/);
+
+        wxSize dsize = GetParent()->GetSize(); // GetClientSize();
+        esize.y = wxMin( esize.y, dsize.y - 0 /*(2 * GetCharHeight())*/ );
+        esize.x = wxMin( esize.x, dsize.x - 0 /*(2 * GetCharHeight())*/ );
         SetSize(esize);
-        
+
         wxSize fsize = GetSize();
         wxSize canvas_size = GetParent()->GetSize();
         wxPoint canvas_pos = GetParent()->GetPosition();
         int xp = (canvas_size.x - fsize.x)/2;
         int yp = (canvas_size.y - fsize.y)/2;
-        wxPoint xxp = GetParent()->ClientToScreen(canvas_pos);
-        Move(xxp.x + xp, xxp.y + yp);
-        
+        wxPoint xxp = GetParent()->ClientToScreen( canvas_pos );
+        Move( xxp.x + xp, xxp.y + yp );
     }
 }
-    
+
 void options::Init()
 {
     m_pWorkDirList = NULL;
@@ -1008,34 +951,35 @@ void options::Init()
     m_buttonScanBT = 0;
     m_stBTPairs = 0;
     m_choiceBTDataSources = 0;
-    
+
     lastPage = 0;
-    
-    m_pPlugInCtrl = NULL;       // for deferred loading
+
+    // for deferred loading
+    m_pPlugInCtrl = NULL;
     m_pNMEAForm = NULL;
 
 #ifdef __OCPN__ANDROID__
     m_scrollRate = 1;
 #else
     m_scrollRate = 15;
-#endif    
-    
+#endif
+
     m_BTScanTimer.SetOwner(this, ID_BT_SCANTIMER);
     m_BTscanning = 0;
-    
+
     // This variable is used by plugin callback function AddOptionsPage
     g_pOptions = this;
 }
 
 bool options::Create( MyFrame* parent, wxWindowID id, const wxString& caption, const wxPoint& pos,
-        const wxSize& size, long style )
+                      const wxSize& size, long style )
 {
     SetExtraStyle( GetExtraStyle() | wxWS_EX_BLOCK_EVENTS );
     wxDialog::Create( parent, id, caption, pos, size, style );
 
     CreateControls();
     Fit();
-    if( lastWindowPos == wxPoint(0,0) ) {
+    if ( lastWindowPos == wxPoint( 0, 0 ) ) {
         Centre();
     } else {
         Move( lastWindowPos );
@@ -1061,7 +1005,7 @@ size_t options::CreatePanel(const wxString & title)
 
 wxScrolledWindow *options::AddPage( size_t parent, const wxString & title)
 {
-    if( parent > m_pListbook->GetPageCount() - 1 ) {
+    if ( parent > m_pListbook->GetPageCount() - 1 ) {
         wxLogMessage(
                 wxString::Format( _T("Warning: invalid parent in options::AddPage( %d, "),
                         parent ) + title + _T(" )") );
@@ -1071,11 +1015,11 @@ wxScrolledWindow *options::AddPage( size_t parent, const wxString & title)
 
     wxScrolledWindow *window;
     int style = wxVSCROLL | wxTAB_TRAVERSAL;
-    if( page->IsKindOf( CLASSINFO(wxNotebook))) {
+    if ( page->IsKindOf( CLASSINFO( wxNotebook ) ) ) {
         window = new wxScrolledWindow( page, wxID_ANY, wxDefaultPosition, wxDefaultSize, style );
         window->SetScrollRate(m_scrollRate, m_scrollRate);
-        ((wxNotebook *)page)->AddPage( window, title );
-    } else if (page->IsKindOf(CLASSINFO(wxScrolledWindow))) {
+        ( ( wxNotebook * ) page )->AddPage( window, title );
+    } else if ( page->IsKindOf( CLASSINFO( wxScrolledWindow ) ) ) {
         wxString toptitle = m_pListbook->GetPageText( parent );
         wxNotebook *nb = new wxNotebook( m_pListbook, wxID_ANY, wxDefaultPosition, wxDefaultSize,wxNB_TOP );
         /* Only remove the tab from listbook, we still have original content in {page} */
@@ -1088,41 +1032,37 @@ wxScrolledWindow *options::AddPage( size_t parent, const wxString & title)
          * we must explicitely Show() it */
         page->Show();
         window = new wxScrolledWindow( nb, wxID_ANY, wxDefaultPosition, wxDefaultSize, style );
-        window->SetScrollRate(m_scrollRate, m_scrollRate);
+        window->SetScrollRate( m_scrollRate, m_scrollRate );
         nb->AddPage( window, title );
         nb->ChangeSelection( 0 );
     } else { // This is the default content, we can replace it now
         window = new wxScrolledWindow( m_pListbook, wxID_ANY, wxDefaultPosition, wxDefaultSize, style, title );
-        window->SetScrollRate(m_scrollRate, m_scrollRate);
+        window->SetScrollRate( m_scrollRate, m_scrollRate );
         wxString toptitle = m_pListbook->GetPageText( parent );
         m_pListbook->InsertPage( parent, window, toptitle, false, parent );
         m_pListbook->DeletePage( parent + 1 );
-        
+
     }
 
-#ifdef __OCPN__ANDROID__    
+#ifdef __OCPN__ANDROID__
 //    window->GetHandle()->setStyleSheet(getQtStyleSheet());
-#endif    
-    
+#endif
+
     return window;
 }
 
 bool options::DeletePage( wxScrolledWindow *page  )
 {
-    for (size_t i = 0; i < m_pListbook->GetPageCount(); i++)
-    {
+    for ( size_t i = 0; i < m_pListbook->GetPageCount(); i++ ) {
         wxNotebookPage* pg = m_pListbook->GetPage( i );
 
-        if( pg->IsKindOf( CLASSINFO(wxNotebook))) {
+        if( pg->IsKindOf( CLASSINFO( wxNotebook ) ) ) {
             wxNotebook *nb = ((wxNotebook *)pg);
-            for (size_t j = 0; j < nb->GetPageCount(); j++)
-            {
+            for ( size_t j = 0; j < nb->GetPageCount(); j++ ) {
                 wxNotebookPage* spg = nb->GetPage( j );
-                if ( spg == page )
-                {
+                if ( spg == page ) {
                     nb->DeletePage( j );
-                    if (nb->GetPageCount()==1)
-                    {
+                    if ( nb->GetPageCount() == 1 ) {
                         /* There's only one page, remove inner notebook */
                         spg = nb->GetPage( 0 );
                         spg->Reparent( m_pListbook );
@@ -1134,10 +1074,10 @@ bool options::DeletePage( wxScrolledWindow *page  )
                     return true;
                 }
             }
-        } else if (pg->IsKindOf(CLASSINFO(wxScrolledWindow)) && pg == page) {
+        } else if ( pg->IsKindOf( CLASSINFO( wxScrolledWindow ) ) && pg == page ) {
             /* There's only one page, replace it with empty panel */
             m_pListbook->DeletePage( i );
-            wxPanel *panel = new wxPanel( m_pListbook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T("") );
+            wxPanel *panel = new wxPanel( m_pListbook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T( "" ) );
             wxString toptitle = m_pListbook->GetPageText( i );
             m_pListbook->InsertPage( i, panel, toptitle, false, i );
             return true;
@@ -1148,7 +1088,7 @@ bool options::DeletePage( wxScrolledWindow *page  )
 
 void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int group_item_spacing, wxSize small_button_size )
 {
-    m_pNMEAForm = AddPage( parent, _("NMEA") );
+    m_pNMEAForm = AddPage( parent, _( "NMEA" ) );
 
     wxBoxSizer* bSizer4 = new wxBoxSizer( wxVERTICAL );
     m_pNMEAForm->SetSizer( bSizer4 );
@@ -1166,7 +1106,6 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     wxBoxSizer* bSizer161;
     bSizer161 = new wxBoxSizer( wxVERTICAL );
 
-
     m_cbFilterSogCog = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Filter NMEA COG/SOG"), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbFilterSogCog->SetValue( g_bfilter_cogsog );
     bSizer161->Add( m_cbFilterSogCog, 0, wxALL, 5 );
@@ -1174,7 +1113,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     wxFlexGridSizer* bSizer171 = new wxFlexGridSizer( 0, 2, 0, 0 );
     bSizer171->SetFlexibleDirection( wxBOTH );
     bSizer171->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-    
+
     m_stFilterSec = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Filter period (sec)"), wxDefaultPosition, wxDefaultSize, 0 );
     //m_stFilterSec->Wrap( -1 );
 
@@ -1219,21 +1158,21 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
 
     wxBoxSizer* bSizer17;
     bSizer17 = new wxBoxSizer( wxVERTICAL );
-    
+
     m_lcSources = new wxListCtrl( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxSize(300, 200), wxLC_REPORT|wxLC_SINGLE_SEL);
     bSizer17->Add( m_lcSources, 1, wxALL|wxEXPAND, 5 );
-    
+
     wxBoxSizer* bSizer18;
     bSizer18 = new wxBoxSizer( wxHORIZONTAL );
     bSizer17->Add( bSizer18, 0, wxEXPAND, 5 );
-    
+
     m_buttonAdd = new wxButton( m_pNMEAForm, wxID_ANY, _("Add..."), wxDefaultPosition, wxDefaultSize, 0 );
     bSizer18->Add( m_buttonAdd, 0, wxALL, 5 );
-    
+
     m_buttonRemove = new wxButton( m_pNMEAForm, wxID_ANY, _("Remove"), wxDefaultPosition, wxDefaultSize, 0 );
     m_buttonRemove->Enable( false );
     bSizer18->Add( m_buttonRemove, 0, wxALL, 5 );
-    
+
     sbSizerLB->Add( bSizer17, 1, wxEXPAND, 5 );
     bSizerOuterContainer->Add( sbSizerLB, 0, wxEXPAND, 5 );
 
@@ -1241,87 +1180,87 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
 
     sbSizerConnectionProps = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("Properties") ), wxVERTICAL );
 
-    
-       
+
+
         wxFlexGridSizer* bSizer15 = new wxFlexGridSizer( 0, 2, 0, 0 );
         bSizer15->SetFlexibleDirection( wxBOTH );
         bSizer15->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-        
+
         sbSizerConnectionProps->Add( bSizer15, 0, wxEXPAND, 0 );
-        
+
         m_rbTypeSerial = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Serial"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
         m_rbTypeSerial->SetValue( true );
         bSizer15->Add( m_rbTypeSerial, 0, wxALL, 5 );
-        
+
         m_rbTypeNet = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Network"), wxDefaultPosition, wxDefaultSize, 0 );
         bSizer15->Add( m_rbTypeNet, 0, wxALL, 5 );
-        
+
         if(OCPNPlatform::hasInternalGPS()){      // has internal GPS
         m_rbTypeInternalGPS = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Built-in GPS"), wxDefaultPosition, wxDefaultSize, 0 );
         bSizer15->Add( m_rbTypeInternalGPS, 0, wxALL, 5 );
         }
         else
             m_rbTypeInternalGPS = NULL;
-        
-        
+
+
         if(OCPNPlatform::hasInternalBT()){      // has built-in Bluetooth
         m_rbTypeInternalBT = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Built-in Bluetooth"), wxDefaultPosition, wxDefaultSize, 0 );
         bSizer15->Add( m_rbTypeInternalBT, 0, wxALL, 5 );
-        
+
         m_buttonScanBT = new wxButton( m_pNMEAForm, wxID_ANY, _("BT Scan..."), wxDefaultPosition, wxDefaultSize );
         m_buttonScanBT->Hide();
         sbSizerConnectionProps->Add( m_buttonScanBT, 0, wxALL, 5 );
-        
-        
+
+
         wxBoxSizer* bSizer15a = new wxBoxSizer( wxHORIZONTAL );
         sbSizerConnectionProps->Add( bSizer15a, 0, wxEXPAND, 5 );
-        
-        
+
+
         m_stBTPairs = new wxStaticText( m_pNMEAForm, wxID_ANY, _("BT Sources"), wxDefaultPosition, wxDefaultSize, 0 );
         //m_stBTPairs->Wrap( -1 );
         //m_stBTPairs->Hide();
         bSizer15a->Add( m_stBTPairs, 0, wxALL, 5 );
-        
+
         wxArrayString mt;
         mt.Add(_T("unscanned"));
         m_choiceBTDataSources = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, mt);
         bSizer15a->Add( m_choiceBTDataSources, 1, wxEXPAND|wxTOP, 5 );
-        
-        #if 0        
+
+        #if 0
         m_BTscan_results.Clear();
         m_BTscan_results.Add(_T("None"));
-        
+
         m_BTscan_results = g_Platform->getBluetoothScanResults();
         m_choiceBTDataSources->Clear();
         m_choiceBTDataSources->Append(m_BTscan_results.Item(0));  // scan status
-        
+
         unsigned int i=1;
         while( (i+1) < m_BTscan_results.GetCount()){
             wxString item1 = m_BTscan_results.Item(i) + _T(";");
             wxString item2 = m_BTscan_results.Item(i+1);
             m_choiceBTDataSources->Append(item1 + item2);
-            
+
             i += 2;
         }
-        
+
         if( m_BTscan_results.GetCount() > 1){
             m_choiceBTDataSources->SetSelection( 1 );
         }
-        
-        #endif        
+
+        #endif
         m_choiceBTDataSources->Hide();
-        
-        
+
+
         m_buttonScanBT->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnScanBTClick ), NULL, this );
-        
+
         }
         else
             m_rbTypeInternalBT = NULL;
-        
+
 
     wxBoxSizer *gSizerNetPropsV = new wxBoxSizer( wxVERTICAL );
     sbSizerConnectionProps->Add( gSizerNetPropsV, 0, wxEXPAND, 5 );
-    
+
     m_stNetProto = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Protocol"), wxDefaultPosition, wxDefaultSize, 0 );
     //m_stNetProto->Wrap( -1 );
     gSizerNetPropsV->Add( m_stNetProto, 0, wxALL, 5 );
@@ -1329,7 +1268,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     wxBoxSizer* bSizer16;
     bSizer16 = new wxBoxSizer( wxHORIZONTAL );
     gSizerNetPropsV->Add( bSizer16, 1, wxEXPAND, 5 );
-    
+
     m_rbNetProtoTCP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("TCP"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
     m_rbNetProtoTCP->Enable( true );
 
@@ -1349,7 +1288,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     fgSizer1a->SetFlexibleDirection( wxBOTH );
     fgSizer1a->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
     gSizerNetPropsV->Add( fgSizer1a, 0, wxEXPAND, 5 );
-    
+
     m_stNetAddr = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Address"), wxDefaultPosition, wxDefaultSize, 0 );
     fgSizer1a->Add( m_stNetAddr, 0, wxALL, 5 );
 
@@ -1364,16 +1303,16 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
 
 
 
-    
-    
-    
-    
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
+
+
+
+
     gSizerSerProps = new wxGridSizer( 0, 1, 0, 0 );
 
 
@@ -1381,7 +1320,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     fgSizer1->SetFlexibleDirection( wxBOTH );
     fgSizer1->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
     gSizerSerProps->Add( fgSizer1, 0, wxEXPAND, 5 );
-    
+
     m_stSerPort = new wxStaticText( m_pNMEAForm, wxID_ANY, _("DataPort"), wxDefaultPosition, wxDefaultSize, 0 );
     //m_stSerPort->Wrap( -1 );
     fgSizer1->Add( m_stSerPort, 0, wxALL, 5 );
@@ -1434,7 +1373,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     fgSizer5->Add( m_cbGarminHost, 0, wxALL, 5 );
     #ifndef USE_GARMINHOST
     //m_cbGarminHost->Hide();
-    #endif    
+    #endif
 
     m_cbInput = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Receive Input on this Port"), wxDefaultPosition, wxDefaultSize, 0 );
     fgSizer5->Add( m_cbInput, 0, wxALL, 5 );
@@ -1445,7 +1384,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     wxFlexGridSizer* fgSizer5a = new wxFlexGridSizer( 0, 2, 0, 0 );
     fgSizer5a->SetFlexibleDirection( wxBOTH );
     fgSizer5a->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-    
+
     m_stTalkerIdText = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Talker ID"), wxDefaultPosition, wxDefaultSize, 0 );
     //m_stTalkerIdText->Wrap( -1 );
     fgSizer5a->Add( m_stTalkerIdText, 0, wxALL, 5 );
@@ -1468,13 +1407,13 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     sbSizerConnectionProps->Add( gSizerSerProps, 0, wxEXPAND, 5 );
     sbSizerConnectionProps->Add( fgSizer5, 0, wxEXPAND, 5 );
     sbSizerConnectionProps->Add( fgSizer5a, 0, wxEXPAND, 5 );
-    
-    
-    
-    
-    
-    
-    
+
+
+
+
+
+
+
     sbSizerInFilter = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("Input filtering") ), wxVERTICAL );
 
     wxBoxSizer* bSizer9;
@@ -1537,15 +1476,15 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     m_lcSources->Connect( wxEVT_COMMAND_LIST_ITEM_SELECTED, wxListEventHandler( options::OnSelectDatasource ), NULL, this );
     m_buttonAdd->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnAddDatasourceClick ), NULL, this );
     m_buttonRemove->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnRemoveDatasourceClick ), NULL, this );
-    
+
     m_rbTypeSerial->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnTypeSerialSelected ), NULL, this );
     m_rbTypeNet->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnTypeNetSelected ), NULL, this );
-    
+
     if(m_rbTypeInternalGPS)
         m_rbTypeInternalGPS->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnTypeGPSSelected ), NULL, this );
     if(m_rbTypeInternalBT)
         m_rbTypeInternalBT->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnTypeBTSelected ), NULL, this );
-    
+
     m_rbNetProtoTCP->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
     m_rbNetProtoUDP->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
     m_rbNetProtoGPSD->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
@@ -1571,7 +1510,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     m_tcOutputStc->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnConnValChange ), NULL, this );
     m_btnOutputStcList->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnBtnOStcs ), NULL, this );
     pOpenGL->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnGLClicked ), NULL, this );
-    
+
     m_cbNMEADebug->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnShowGpsWindowCheckboxClick ), NULL, this );
     m_cbFilterSogCog->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnValChange ), NULL, this );
     m_tFilterSec->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
@@ -1649,7 +1588,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
             m_comboPort->Append(m_pSerialArray->Item(i));
         }
     }
-    
+
     ShowNMEACommon( false );
     ShowNMEASerial( false );
     ShowNMEANet( false );
@@ -1660,382 +1599,382 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
 void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_spacing, wxSize small_button_size )
 {
     m_pNMEAForm = AddPage( parent, _("NMEA") );
-    
+
     wxBoxSizer* bSizer4 = new wxBoxSizer( wxVERTICAL );
     m_pNMEAForm->SetSizer( bSizer4 );
     m_pNMEAForm->SetSizeHints( wxDefaultSize, wxDefaultSize );
-    
+
     wxBoxSizer* bSizerOuterContainer = new wxBoxSizer( wxVERTICAL );
-    
-    
+
+
     wxStaticBoxSizer* sbSizerGeneral;
     sbSizerGeneral = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("General") ), wxVERTICAL );
-    
+
     wxBoxSizer* bSizer151;
     bSizer151 = new wxBoxSizer( wxVERTICAL );
-    
+
     wxBoxSizer* bSizer161;
     bSizer161 = new wxBoxSizer( wxVERTICAL );
-    
+
     wxBoxSizer* bSizer171;
     bSizer171 = new wxBoxSizer( wxHORIZONTAL );
-    
+
     m_cbFilterSogCog = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Filter NMEA Course and Speed data"), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbFilterSogCog->SetValue( g_bfilter_cogsog );
     bSizer171->Add( m_cbFilterSogCog, 0, wxALL, 5 );
-    
+
     m_stFilterSec = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Filter period (sec)"), wxDefaultPosition, wxDefaultSize, 0 );
     m_stFilterSec->Wrap( -1 );
-    
+
     int nspace = 5;
     #ifdef __WXGTK__
     nspace = 9;
     #endif
     bSizer171->Add( m_stFilterSec, 0, wxALL, nspace );
-    
+
     m_tFilterSec = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
     wxString sfilt;
     sfilt.Printf( _T("%d"), g_COGFilterSec );
     m_tFilterSec->SetValue( sfilt );
     bSizer171->Add( m_tFilterSec, 0, wxALL, 4 );
-    
+
     bSizer161->Add( bSizer171, 1, wxEXPAND, 5 );
-    
+
     int cb_space = 2;
     m_cbNMEADebug = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Show NMEA Debug Window"), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbNMEADebug->SetValue(NMEALogWindow::Get().Active());
     bSizer161->Add( m_cbNMEADebug, 0, wxALL, cb_space );
-    
+
     m_cbFurunoGP3X = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Format uploads for Furuno GP3X"), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbFurunoGP3X->SetValue(g_GPS_Ident == _T("FurunoGP3X"));
     bSizer161->Add( m_cbFurunoGP3X, 0, wxALL, cb_space );
-    
+
     m_cbGarminUploadHost = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Use Garmin GRMN (Host) mode for uploads"), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbGarminUploadHost->SetValue(g_bGarminHostUpload);
     bSizer161->Add( m_cbGarminUploadHost, 0, wxALL, cb_space );
-    
+
     m_cbAPBMagnetic = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Use magnetic bearings in output sentence ECAPB"), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbAPBMagnetic->SetValue(g_bMagneticAPB);
     bSizer161->Add( m_cbAPBMagnetic, 0, wxALL, cb_space );
-    
+
     bSizer151->Add( bSizer161, 1, wxEXPAND, 5 );
     sbSizerGeneral->Add( bSizer151, 1, wxEXPAND, 5 );
     bSizerOuterContainer->Add( sbSizerGeneral, 0, wxALL|wxEXPAND, 5 );
-    
-    
+
+
     //  Connections listbox, etc
     wxStaticBoxSizer* sbSizerLB= new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("Data Connections") ), wxVERTICAL );
-    
-    
+
+
     wxBoxSizer* bSizer17;
     bSizer17 = new wxBoxSizer( wxVERTICAL );
-    
+
     m_lcSources = new wxListCtrl( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxSize(-1, 150), wxLC_REPORT|wxLC_SINGLE_SEL);
     bSizer17->Add( m_lcSources, 1, wxALL|wxEXPAND, 5 );
-    
+
     wxBoxSizer* bSizer18;
     bSizer18 = new wxBoxSizer( wxHORIZONTAL );
-    
+
     m_buttonAdd = new wxButton( m_pNMEAForm, wxID_ANY, _("Add Connection"), wxDefaultPosition, wxDefaultSize, 0 );
     bSizer18->Add( m_buttonAdd, 0, wxALL, 5 );
-    
+
     m_buttonRemove = new wxButton( m_pNMEAForm, wxID_ANY, _("Remove Connection"), wxDefaultPosition, wxDefaultSize, 0 );
     m_buttonRemove->Enable( false );
     bSizer18->Add( m_buttonRemove, 0, wxALL, 5 );
-    
+
     bSizer17->Add( bSizer18, 0, wxEXPAND, 5 );
     sbSizerLB->Add( bSizer17, 1, wxEXPAND, 5 );
     bSizerOuterContainer->Add( sbSizerLB, 0, wxEXPAND, 5 );
-    
-    
+
+
     //  Connections Properties
-    
+
     sbSizerConnectionProps = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("Properties") ), wxVERTICAL );
-    
+
     wxBoxSizer* bSizer15;
     bSizer15 = new wxBoxSizer( wxHORIZONTAL );
-    
+
     sbSizerConnectionProps->Add( bSizer15, 0, wxEXPAND, 0 );
-    
+
     m_rbTypeSerial = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Serial"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
     m_rbTypeSerial->SetValue( true );
     bSizer15->Add( m_rbTypeSerial, 0, wxALL, 5 );
-    
+
     m_rbTypeNet = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Network"), wxDefaultPosition, wxDefaultSize, 0 );
     bSizer15->Add( m_rbTypeNet, 0, wxALL, 5 );
-    
+
     if(OCPNPlatform::hasInternalGPS()){      // has internal GPS
         m_rbTypeInternalGPS = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Built-in GPS"), wxDefaultPosition, wxDefaultSize, 0 );
         bSizer15->Add( m_rbTypeInternalGPS, 0, wxALL, 5 );
     }
     else
         m_rbTypeInternalGPS = NULL;
-    
-    
+
+
     if(OCPNPlatform::hasInternalBT()){      // has built-in Bluetooth
         m_rbTypeInternalBT = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Built-in Bluetooth SPP"), wxDefaultPosition, wxDefaultSize, 0 );
         bSizer15->Add( m_rbTypeInternalBT, 0, wxALL, 5 );
-        
+
         m_buttonScanBT = new wxButton( m_pNMEAForm, wxID_ANY, _("BT Scan"), wxDefaultPosition, wxDefaultSize );
         m_buttonScanBT->Hide();
-        
+
         wxBoxSizer* bSizer15a = new wxBoxSizer( wxHORIZONTAL );
         sbSizerConnectionProps->Add( bSizer15a, 0, wxEXPAND, 5 );
-        
+
         bSizer15a->Add( m_buttonScanBT, 0, wxALL, 5 );
-        
+
         m_stBTPairs = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Bluetooth Data Sources"), wxDefaultPosition, wxDefaultSize, 0 );
         m_stBTPairs->Wrap( -1 );
         m_stBTPairs->Hide();
         bSizer15a->Add( m_stBTPairs, 0, wxALL, 5 );
-        
+
         wxArrayString mt;
         mt.Add(_T("unscanned"));
         m_choiceBTDataSources = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, mt);
-        
-        #if 0        
+
+        #if 0
         m_BTscan_results.Clear();
         m_BTscan_results.Add(_T("None"));
-        
+
         m_BTscan_results = g_Platform->getBluetoothScanResults();
         m_choiceBTDataSources->Clear();
         m_choiceBTDataSources->Append(m_BTscan_results.Item(0));  // scan status
-        
+
         unsigned int i=1;
         while( (i+1) < m_BTscan_results.GetCount()){
             wxString item1 = m_BTscan_results.Item(i) + _T(";");
             wxString item2 = m_BTscan_results.Item(i+1);
             m_choiceBTDataSources->Append(item1 + item2);
-            
+
             i += 2;
     }
-    
+
     if( m_BTscan_results.GetCount() > 1){
         m_choiceBTDataSources->SetSelection( 1 );
     }
-    
-    #endif        
+
+    #endif
     m_choiceBTDataSources->Hide();
     bSizer15a->Add( m_choiceBTDataSources, 1, wxEXPAND|wxTOP, 5 );
-    
-    
+
+
     m_buttonScanBT->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnScanBTClick ), NULL, this );
-    
+
     }
     else
         m_rbTypeInternalBT = NULL;
-    
-    
-    
+
+
+
     gSizerNetProps = new wxGridSizer( 0, 2, 0, 0 );
-    
+
     m_stNetProto = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Protocol"), wxDefaultPosition, wxDefaultSize, 0 );
     m_stNetProto->Wrap( -1 );
     gSizerNetProps->Add( m_stNetProto, 0, wxALL, 5 );
-    
+
     wxBoxSizer* bSizer16;
     bSizer16 = new wxBoxSizer( wxHORIZONTAL );
-    
+
     m_rbNetProtoTCP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("TCP"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
     m_rbNetProtoTCP->Enable( true );
-    
+
     bSizer16->Add( m_rbNetProtoTCP, 0, wxALL, 5 );
-    
+
     m_rbNetProtoUDP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("UDP"), wxDefaultPosition, wxDefaultSize, 0 );
     m_rbNetProtoUDP->Enable( true );
-    
+
     bSizer16->Add( m_rbNetProtoUDP, 0, wxALL, 5 );
-    
+
     m_rbNetProtoGPSD = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("GPSD"), wxDefaultPosition, wxDefaultSize, 0 );
     m_rbNetProtoGPSD->SetValue( true );
     bSizer16->Add( m_rbNetProtoGPSD, 0, wxALL, 5 );
-    
-    
+
+
     gSizerNetProps->Add( bSizer16, 1, wxEXPAND, 5 );
-    
+
     m_stNetAddr = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Address"), wxDefaultPosition, wxDefaultSize, 0 );
     m_stNetAddr->Wrap( -1 );
     gSizerNetProps->Add( m_stNetAddr, 0, wxALL, 5 );
-    
+
     m_tNetAddress = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
     gSizerNetProps->Add( m_tNetAddress, 0, wxEXPAND|wxTOP, 5 );
-    
+
     m_stNetPort = new wxStaticText( m_pNMEAForm, wxID_ANY, _("DataPort"), wxDefaultPosition, wxDefaultSize, 0 );
     m_stNetPort->Wrap( -1 );
     gSizerNetProps->Add( m_stNetPort, 0, wxALL, 5 );
-    
+
     m_tNetPort = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
     gSizerNetProps->Add( m_tNetPort, 1, wxEXPAND|wxTOP, 5 );
-    
-    
+
+
     sbSizerConnectionProps->Add( gSizerNetProps, 0, wxEXPAND, 5 );
-    
+
     gSizerSerProps = new wxGridSizer( 0, 1, 0, 0 );
-    
+
     wxFlexGridSizer* fgSizer1;
     fgSizer1 = new wxFlexGridSizer( 0, 4, 0, 0 );
     fgSizer1->SetFlexibleDirection( wxBOTH );
     fgSizer1->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-    
+
     m_stSerPort = new wxStaticText( m_pNMEAForm, wxID_ANY, _("DataPort"), wxDefaultPosition, wxDefaultSize, 0 );
     m_stSerPort->Wrap( -1 );
     fgSizer1->Add( m_stSerPort, 0, wxALL, 5 );
-    
+
     m_comboPort = new wxComboBox( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 );
     fgSizer1->Add( m_comboPort, 0, wxEXPAND|wxTOP, 5 );
-    
+
     m_stSerBaudrate = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Baudrate"), wxDefaultPosition, wxDefaultSize, 0 );
     m_stSerBaudrate->Wrap( -1 );
     fgSizer1->Add( m_stSerBaudrate, 0, wxALL, 5 );
-    
+
     wxString m_choiceBaudRateChoices[] = { _("150"), _("300"), _("600"), _("1200"), _("2400"), _("4800"), _("9600"), _("19200"), _("38400"), _("57600"), _("115200"), _("230400"), _("460800"), _("921600") };
     int m_choiceBaudRateNChoices = sizeof( m_choiceBaudRateChoices ) / sizeof( wxString );
     m_choiceBaudRate = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choiceBaudRateNChoices, m_choiceBaudRateChoices, 0 );
     m_choiceBaudRate->SetSelection( 0 );
     fgSizer1->Add( m_choiceBaudRate, 1, wxEXPAND|wxTOP, 5 );
-    
+
     m_stSerProtocol = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Protocol"), wxDefaultPosition, wxDefaultSize, 0 );
     m_stSerProtocol->Wrap( -1 );
     fgSizer1->Add( m_stSerProtocol, 0, wxALL, 5 );
-    
+
     wxString m_choiceSerialProtocolChoices[] = { _("NMEA 0183"), _("NMEA 2000"), _("Seatalk") };
     int m_choiceSerialProtocolNChoices = sizeof( m_choiceSerialProtocolChoices ) / sizeof( wxString );
     m_choiceSerialProtocol = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choiceSerialProtocolNChoices, m_choiceSerialProtocolChoices, 0 );
     m_choiceSerialProtocol->SetSelection( 0 );
     m_choiceSerialProtocol->Enable( false );
-    
+
     fgSizer1->Add( m_choiceSerialProtocol, 1, wxEXPAND|wxTOP, 5 );
     m_stPriority = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Priority"), wxDefaultPosition, wxDefaultSize, 0 );
     m_stPriority->Wrap( -1 );
     fgSizer1->Add( m_stPriority, 0, wxALL, 5 );
-    
+
     wxString m_choicePriorityChoices[] = { _("0"), _("1"), _("2"), _("3"), _("4"), _("5"), _("6"), _("7"), _("8"), _("9") };
     int m_choicePriorityNChoices = sizeof( m_choicePriorityChoices ) / sizeof( wxString );
     m_choicePriority = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choicePriorityNChoices, m_choicePriorityChoices, 0 );
     m_choicePriority->SetSelection( 9 );
     fgSizer1->Add( m_choicePriority, 0, wxEXPAND|wxTOP, 5 );
-    
-    
+
+
     gSizerSerProps->Add( fgSizer1, 0, wxEXPAND, 5 );
-    
+
     wxFlexGridSizer* fgSizer5;
     fgSizer5 = new wxFlexGridSizer( 0, 2, 0, 0 );
     fgSizer5->SetFlexibleDirection( wxBOTH );
     fgSizer5->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
-    
+
     m_cbCheckCRC = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Control checksum"), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbCheckCRC->SetValue(true);
     m_cbCheckCRC->SetToolTip( _("If checked, only the sentences with a valid checksum are passed through") );
     fgSizer5->Add( m_cbCheckCRC, 0, wxALL, 5 );
-    
+
     m_cbGarminHost = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Use Garmin (GRMN) mode for input"), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbGarminHost->SetValue(false);
     fgSizer5->Add( m_cbGarminHost, 0, wxALL, 5 );
     #ifndef USE_GARMINHOST
     m_cbGarminHost->Hide();
-    #endif    
-    
+    #endif
+
     m_cbInput = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Receive Input on this Port"), wxDefaultPosition, wxDefaultSize, 0 );
     fgSizer5->Add( m_cbInput, 0, wxALL, 5 );
-    
+
     m_cbOutput = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Output on this port ( as Autopilot or NMEA Repeater)"), wxDefaultPosition, wxDefaultSize, 0 );
     fgSizer5->Add( m_cbOutput, 0, wxALL, 5 );
-    
-    
+
+
     m_stTalkerIdText = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Talker ID (blank = default ID)"), wxDefaultPosition, wxDefaultSize, 0 );
     m_stTalkerIdText->Wrap( -1 );
     fgSizer5->Add( m_stTalkerIdText, 0, wxALL, 5 );
-    
+
     m_TalkerIdText = new wxTextCtrl( m_pNMEAForm, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize( 50, -1 ), 0 );
     m_TalkerIdText->SetMaxLength( 2 );
     fgSizer5->Add( m_TalkerIdText, 0, wxALIGN_LEFT | wxALL, group_item_spacing );
-    
+
     m_stPrecision = new wxStaticText( m_pNMEAForm, wxID_ANY, _("APB bearing precision"), wxDefaultPosition, wxDefaultSize, 0 );
-    
+
     m_stPrecision->Wrap( -1 );
     fgSizer5->Add( m_stPrecision, 0, wxALL, 5 );
-    
+
     wxString m_choicePrecisionChoices[] = { _("x"), _("x.x"), _("x.xx"), _("x.xxx"), _("x.xxxx") };
     int m_choicePrecisionNChoices = sizeof( m_choicePrecisionChoices ) / sizeof( wxString );
     m_choicePrecision = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choicePrecisionNChoices, m_choicePrecisionChoices, 0 );
     m_choicePrecision->SetSelection( g_NMEAAPBPrecision );
     fgSizer5->Add( m_choicePrecision, 0, wxALL, 5 );
-    
+
     sbSizerConnectionProps->Add( gSizerSerProps, 0, wxEXPAND, 5 );
     sbSizerConnectionProps->Add( fgSizer5, 0, wxEXPAND, 5 );
-    
+
     sbSizerInFilter = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("Input filtering") ), wxVERTICAL );
-    
+
     wxBoxSizer* bSizer9;
     bSizer9 = new wxBoxSizer( wxHORIZONTAL );
-    
+
     m_rbIAccept = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Accept only sentences"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
     bSizer9->Add( m_rbIAccept, 0, wxALL, 5 );
-    
+
     m_rbIIgnore = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Ignore sentences"), wxDefaultPosition, wxDefaultSize, 0 );
     bSizer9->Add( m_rbIIgnore, 0, wxALL, 5 );
-    
-    
+
+
     sbSizerInFilter->Add( bSizer9, 0, wxEXPAND, 5 );
-    
+
     wxBoxSizer* bSizer11;
     bSizer11 = new wxBoxSizer( wxHORIZONTAL );
-    
+
     m_tcInputStc = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY );
     bSizer11->Add( m_tcInputStc, 1, wxALL|wxEXPAND, 5 );
-    
+
     m_btnInputStcList = new wxButton( m_pNMEAForm, wxID_ANY, _("..."), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT );
     bSizer11->Add( m_btnInputStcList, 0, wxALL, 5 );
-    
+
     sbSizerInFilter->Add( bSizer11, 0, wxEXPAND, 5 );
-    
+
     sbSizerConnectionProps->Add( sbSizerInFilter, 0, wxEXPAND, 5 );
-    
+
     sbSizerOutFilter = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("Output filtering") ), wxVERTICAL );
-    
+
     wxBoxSizer* bSizer10;
     bSizer10 = new wxBoxSizer( wxHORIZONTAL );
-    
+
     m_rbOAccept = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Transmit sentences"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
     bSizer10->Add( m_rbOAccept, 0, wxALL, 5 );
-    
+
     m_rbOIgnore = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Drop sentences"), wxDefaultPosition, wxDefaultSize, 0 );
     bSizer10->Add( m_rbOIgnore, 0, wxALL, 5 );
-    
-    
+
+
     sbSizerOutFilter->Add( bSizer10, 0, wxEXPAND, 5 );
-    
+
     wxBoxSizer* bSizer12;
     bSizer12 = new wxBoxSizer( wxHORIZONTAL );
-    
+
     m_tcOutputStc = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY );
     bSizer12->Add( m_tcOutputStc, 1, wxALL|wxEXPAND, 5 );
-    
+
     m_btnOutputStcList = new wxButton( m_pNMEAForm, wxID_ANY, _("..."), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT );
     bSizer12->Add( m_btnOutputStcList, 0, wxALL, 5 );
-    
-    
+
+
     sbSizerOutFilter->Add( bSizer12, 0, wxEXPAND, 5 );
     sbSizerConnectionProps->Add( sbSizerOutFilter, 0, wxEXPAND, 5 );
-    
-    
+
+
     bSizerOuterContainer->Add( sbSizerConnectionProps, 1, wxALL|wxEXPAND, 5 );
-    
+
     bSizer4->Add( bSizerOuterContainer, 1, wxEXPAND, 5 );
-    
+
     // Connect Events
     m_lcSources->Connect( wxEVT_COMMAND_LIST_ITEM_SELECTED, wxListEventHandler( options::OnSelectDatasource ), NULL, this );
     m_buttonAdd->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnAddDatasourceClick ), NULL, this );
     m_buttonRemove->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnRemoveDatasourceClick ), NULL, this );
-    
+
     m_rbTypeSerial->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnTypeSerialSelected ), NULL, this );
     m_rbTypeNet->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnTypeNetSelected ), NULL, this );
-    
+
     if(m_rbTypeInternalGPS)
         m_rbTypeInternalGPS->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnTypeGPSSelected ), NULL, this );
     if(m_rbTypeInternalBT)
         m_rbTypeInternalBT->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnTypeBTSelected ), NULL, this );
-    
+
     m_rbNetProtoTCP->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
     m_rbNetProtoUDP->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
     m_rbNetProtoGPSD->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED, wxCommandEventHandler( options::OnNetProtocolSelected ), NULL, this );
@@ -2061,85 +2000,85 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     m_tcOutputStc->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnConnValChange ), NULL, this );
     m_btnOutputStcList->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnBtnOStcs ), NULL, this );
     pOpenGL->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnGLClicked ), NULL, this );
-    
+
     m_cbNMEADebug->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnShowGpsWindowCheckboxClick ), NULL, this );
     m_cbFilterSogCog->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnValChange ), NULL, this );
     m_tFilterSec->Connect( wxEVT_COMMAND_TEXT_UPDATED, wxCommandEventHandler( options::OnValChange ), NULL, this );
     m_cbAPBMagnetic->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnValChange ), NULL, this );
     m_lcSources->Connect( wxEVT_LEFT_DOWN, wxMouseEventHandler(options::OnConnectionToggleEnable), NULL, this );
-    
+
     wxListItem col0;
     col0.SetId(0);
     col0.SetText( _("Enable") );
     m_lcSources->InsertColumn(0, col0);
-    
+
     wxListItem col1;
     col1.SetId(1);
     col1.SetText( _("Type") );
     m_lcSources->InsertColumn(1, col1);
-    
+
     wxListItem col2;
     col2.SetId(2);
     col2.SetText( _("DataPort") );
     m_lcSources->InsertColumn(2, col2);
-    
+
     wxListItem col3;
     col3.SetId(3);
     col3.SetText( _("Priority") );
     m_lcSources->InsertColumn(3, col3);
-    
+
     wxListItem col4;
     col4.SetId(4);
     col4.SetText( _("Parameters") );
     m_lcSources->InsertColumn(4, col4);
-    
+
     wxListItem col5;
     col5.SetId(5);
     col5.SetText( _("Connection") );
     m_lcSources->InsertColumn(5, col5);
-    
+
     wxListItem col6;
     col6.SetId(6);
     col6.SetText( _("Filters") );
     m_lcSources->InsertColumn(6, col6);
-    
+
     //  Build the image list
     wxBitmap unchecked_bmp(16, 16), checked_bmp(16, 16);
-    
+
     {
         wxMemoryDC renderer_dc;
-        
+
         // Unchecked
         renderer_dc.SelectObject(unchecked_bmp);
         renderer_dc.SetBackground(*wxTheBrushList->FindOrCreateBrush(GetBackgroundColour(), wxBRUSHSTYLE_SOLID));
         renderer_dc.Clear();
         wxRendererNative::Get().DrawCheckBox(this, renderer_dc, wxRect(0, 0, 16, 16), 0);
-        
+
         // Checked
         renderer_dc.SelectObject(checked_bmp);
         renderer_dc.SetBackground(*wxTheBrushList->FindOrCreateBrush(GetBackgroundColour(), wxBRUSHSTYLE_SOLID));
         renderer_dc.Clear();
         wxRendererNative::Get().DrawCheckBox(this, renderer_dc, wxRect(0, 0, 16, 16), wxCONTROL_CHECKED);
     }
-    
+
     wxImageList *imglist = new wxImageList( 16, 16, true, 1 );
     imglist->Add( unchecked_bmp );
     imglist->Add( checked_bmp );
     m_lcSources->AssignImageList( imglist, wxIMAGE_LIST_SMALL );
-    
+
     m_lcSources->Refresh();
-    
+
     m_stcdialog_in = new SentenceListDlg(FILTER_INPUT, this);
     m_stcdialog_out = new SentenceListDlg(FILTER_OUTPUT, this);
-    
+
     FillSourceList();
-    
+
     if(m_pSerialArray){
         for(size_t i = 0; i < m_pSerialArray->Count() ; i++){
             m_comboPort->Append(m_pSerialArray->Item(i));
         }
     }
-    
+
     ShowNMEACommon( false );
     ShowNMEASerial( false );
     ShowNMEANet( false );
@@ -2166,7 +2105,7 @@ void options::OnConnectionToggleEnable( wxMouseEvent &event )
     int flags = 0;
     long ptrSubItem = -1;
     long clicked_index = m_lcSources->HitTest( pos, flags, &ptrSubItem );
-    
+
     //    Clicking Enable Checkbox (full column)?
     if( clicked_index > -1 && event.GetX() < m_lcSources->GetColumnWidth( 0 ) ) {
         // Process the clicked item
@@ -2175,7 +2114,7 @@ void options::OnConnectionToggleEnable( wxMouseEvent &event )
             conn->bEnabled = !conn->bEnabled;
             m_connection_enabled = conn->bEnabled;
             conn->b_IsSetup = false;            // Mark as changed
-        
+
             m_lcSources->SetItemImage( clicked_index, conn->bEnabled ? 1 : 0 );
         }
 
@@ -2216,10 +2155,10 @@ void options::CreatePanel_Ownship( size_t parent, int border_size, int group_ite
 
     wxStaticText *pStatic_OSHDT_Predictor = new wxStaticText( itemPanelShip, wxID_ANY, _("Heading Predictor Length (NMi)") );
     dispOptionsGrid->Add( pStatic_OSHDT_Predictor, 0 );
-    
+
     m_pText_OSHDT_Predictor = new wxTextCtrl( itemPanelShip, wxID_ANY );
     dispOptionsGrid->Add( m_pText_OSHDT_Predictor, 0, wxALIGN_RIGHT );
-    
+
     wxStaticText *iconTypeTxt = new wxStaticText( itemPanelShip, wxID_ANY, _("Ship Icon Type") );
     dispOptionsGrid->Add( iconTypeTxt, 0 );
 
@@ -2308,7 +2247,7 @@ void options::CreatePanel_Ownship( size_t parent, int border_size, int group_ite
     wxStaticBox* routeText = new wxStaticBox( itemPanelShip, wxID_ANY, _("Routes") );
     wxStaticBoxSizer* routeSizer = new wxStaticBoxSizer( routeText, wxVERTICAL );
     ownShip->Add( routeSizer, 0, wxGROW | wxALL, border_size );
-    
+
     wxFlexGridSizer *pRouteGrid = new wxFlexGridSizer( 1, 2, group_item_spacing, group_item_spacing );
     pRouteGrid->AddGrowableCol( 1 );
     routeSizer->Add( pRouteGrid, 0, wxALL | wxEXPAND, border_size );
@@ -2318,18 +2257,18 @@ void options::CreatePanel_Ownship( size_t parent, int border_size, int group_ite
 
     m_pText_ACRadius = new wxTextCtrl( itemPanelShip, -1 );
     pRouteGrid->Add( m_pText_ACRadius, 0, wxALL | wxALIGN_RIGHT, group_item_spacing );
-    
+
     pAdvanceRouteWaypointOnArrivalOnly = new wxCheckBox( itemPanelShip, ID_DAILYCHECKBOX, _("Advance route waypoint on arrival only") );
     routeSizer->Add( pAdvanceRouteWaypointOnArrivalOnly, 0 );
-    
+
     //  Waypoints
     wxStaticBox* waypointText = new wxStaticBox( itemPanelShip, wxID_ANY, _("Waypoints") );
     wxStaticBoxSizer* waypointSizer = new wxStaticBoxSizer( waypointText, wxVERTICAL );
     ownShip->Add( waypointSizer, 0, wxTOP | wxALL | wxEXPAND, border_size );
-    
+
     wxFlexGridSizer* dispWaypointOptionsGrid = new wxFlexGridSizer( 2, 2, group_item_spacing, group_item_spacing );
     dispWaypointOptionsGrid->AddGrowableCol( 1 );
-    
+
     wxFlexGridSizer* waypointrrSelect = new wxFlexGridSizer( 1, 2, group_item_spacing, group_item_spacing );
     waypointrrSelect->AddGrowableCol( 1 );
     waypointSizer->Add( waypointrrSelect, 0, wxLEFT|wxRIGHT | wxEXPAND, border_size );
@@ -2358,12 +2297,12 @@ void options::CreatePanel_Ownship( size_t parent, int border_size, int group_ite
 
     wxStaticText* waypointrangeringsColour = new wxStaticText( itemPanelShip, wxID_STATIC, _("Waypoint Range Ring Colours") );
     waypointradarGrid->Add( waypointrangeringsColour, 1, wxEXPAND | wxALL, 1 );
-    
+
     m_colourWaypointRangeRingsColour = new wxColourPickerCtrl( itemPanelShip, wxID_ANY, *wxRED, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_COLOURWAYPOINTRANGERINGSCOLOUR") );
     waypointradarGrid->Add( m_colourWaypointRangeRingsColour, 0, wxALIGN_RIGHT | wxALL, 1);
 
 
-   
+
     DimeControl( itemPanelShip );
 }
 
@@ -2380,14 +2319,14 @@ void options::CreatePanel_ChartsLoad( size_t parent, int border_size, int group_
     chartPanel->Add( activeSizer, 1, wxALL | wxEXPAND, border_size );
 
     wxString* pListBoxStrings = NULL;
-    
+
     pActiveChartsList = new wxListBox( chartPanelWin, ID_LISTBOX, wxDefaultPosition,
                                        wxDefaultSize, 0, pListBoxStrings, wxLB_MULTIPLE );
 
     activeSizer->Add( pActiveChartsList, 1, wxALL | wxEXPAND, border_size );
 
     pActiveChartsList->Connect(  wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( options::OnChartDirListSelect ), NULL, this );
-    
+
     wxBoxSizer* cmdButtonSizer = new wxBoxSizer( wxVERTICAL );
     activeSizer->Add( cmdButtonSizer, 0, wxALL, border_size );
 
@@ -2408,7 +2347,7 @@ void options::CreatePanel_ChartsLoad( size_t parent, int border_size, int group_
     m_removeBtn = new wxButton( chartPanelWin, ID_BUTTONDELETE, _("Remove Selected") );
     cmdButtonSizer->Add( m_removeBtn, 1, wxALL | wxEXPAND, group_item_spacing );
     m_removeBtn->Disable();
-    
+
 
     wxStaticBox* itemStaticBoxUpdateStatic = new wxStaticBox( chartPanelWin, wxID_ANY,
             _("Update Control") );
@@ -2431,7 +2370,7 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
                                         wxSize small_button_size )
 {
     m_ChartDisplayPage = AddPage( parent, _("Advanced") );
-    
+
     wxFlexGridSizer* itemBoxSizerUI = new wxFlexGridSizer( 2 );
     itemBoxSizerUI->SetHGap(border_size);
 //    itemBoxSizerUI->AddGrowableCol( 0, 1 );
@@ -2448,7 +2387,7 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
     itemBoxSizerUI->Add( 0, border_size*3 );
     itemBoxSizerUI->Add( 0, border_size*3 );
 
-    
+
     // Chart Display Options
     itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Chart Display") ), groupLabelFlags );
     wxBoxSizer* boxCharts = new wxBoxSizer( wxVERTICAL );
@@ -2456,21 +2395,21 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
 
     pSkewComp = new wxCheckBox( m_ChartDisplayPage, ID_SKEWCOMPBOX, _("Show Skewed Raster Charts as North-Up") );
     boxCharts->Add( pSkewComp, inputFlags );
-    
+
     pFullScreenQuilt = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _("Disable Full Screen Quilting") );
     boxCharts->Add( pFullScreenQuilt, inputFlags );
 
     pOverzoomEmphasis = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _("Suppress blur/fog effects on overzoom") );
     boxCharts->Add( pOverzoomEmphasis, inputFlags );
-    
+
     pOZScaleVector = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _("Suppress scaled vector charts on overzoom") );
     boxCharts->Add( pOZScaleVector, inputFlags );
-    
+
     // spacer
     itemBoxSizerUI->Add( 0, border_size*3 );
     itemBoxSizerUI->Add( 0, border_size*3 );
 
-    
+
     //  Course Up display update period
     itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Course-Up Update Period") ), labelFlags );
     wxBoxSizer *pCOGUPFilterRow = new wxBoxSizer( wxHORIZONTAL );
@@ -2478,7 +2417,7 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
 
     pCOGUPUpdateSecs = new wxTextCtrl( m_ChartDisplayPage, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize( 50, -1 ), wxTE_RIGHT  );
     pCOGUPFilterRow->Add( pCOGUPUpdateSecs, 0, wxALIGN_RIGHT | wxALL, group_item_spacing );
-    
+
     pCOGUPFilterRow->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("seconds") ), inputFlags );
 
 
@@ -2492,24 +2431,24 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
     m_pSlider_Zoom = new wxSlider( m_ChartDisplayPage, ID_CM93ZOOM, 0, -5,
                                   5, wxDefaultPosition, wxSize( 300, 50),
                                   wxSL_HORIZONTAL | wxSL_AUTOTICKS | wxSL_LABELS );
-    
+
 #ifdef __OCPN__ANDROID__
     m_pSlider_Zoom->GetHandle()->setStyleSheet( getQtStyleSheet());
-#endif    
-    
+#endif
+
     itemBoxSizerUI->Add( m_pSlider_Zoom, inputFlags );
 
     itemBoxSizerUI->Add( 0, border_size*3 );
     wxStaticText* zoomText = new wxStaticText( m_ChartDisplayPage, wxID_ANY,
         _("With a lower value, the same zoom level shows a less detailed chart.\nWith a higher value, the same zoom level shows a more detailed chart.") );
-    
+
     wxFont *dialogFont = GetOCPNScaledFont(_("Dialog"));
     smallFont = new wxFont( * dialogFont ); // we can't use Smaller() because wx2.8 doesn't support it
     smallFont->SetPointSize( (smallFont->GetPointSize() / 1.2) + 0.5 ); // + 0.5 to round instead of truncate
     zoomText->SetFont( * smallFont );
     itemBoxSizerUI->Add( zoomText, 0, wxALL | wxEXPAND, group_item_spacing );
-    
-    
+
+
     // spacer
     itemBoxSizerUI->Add( 0, border_size*3 );
     itemBoxSizerUI->Add( 0, border_size*3 );
@@ -2538,7 +2477,7 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
     itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Physical Screen Width") ), labelFlags );
     wxBoxSizer *pDPIRow = new wxBoxSizer( wxHORIZONTAL );
     itemBoxSizerUI->Add( pDPIRow, 0, wxEXPAND );
-    
+
     pRBSizeAuto = new wxRadioButton( m_ChartDisplayPage, wxID_ANY, _("Auto") );
     pDPIRow->Add( pRBSizeAuto, inputFlags );
     pDPIRow->AddSpacer( 10 );
@@ -2555,11 +2494,11 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
                            wxCommandEventHandler( options::OnSizeAutoButton ), NULL, this );
     pRBSizeManual->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED,
                           wxCommandEventHandler( options::OnSizeManualButton ), NULL, this );
-    
+
     // spacer
     itemBoxSizerUI->Add( 0, border_size*3 );
     itemBoxSizerUI->Add( 0, border_size*3 );
-    
+
     // OpenGL Options
     itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Graphics") ), labelFlags );
     wxBoxSizer* OpenGLSizer = new wxBoxSizer( wxHORIZONTAL );
@@ -2571,13 +2510,13 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
 
 #ifdef __OCPN__ANDROID__
     pOpenGL->Disable();
-#endif    
-    
+#endif
+
     wxButton *bOpenGL = new wxButton( m_ChartDisplayPage, ID_OPENGLOPTIONS, _("Options...") );
     OpenGLSizer->Add( bOpenGL, inputFlags );
     bOpenGL->Enable(!g_bdisable_opengl);
-    
- 
+
+
     itemBoxSizerUI->Add( 0, border_size*3 );
     pTransparentToolbar = new wxCheckBox( m_ChartDisplayPage, ID_TRANSTOOLBARCHECKBOX,
                                           _("Enable Transparent Toolbar") );
@@ -2640,7 +2579,7 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
 
     wxBoxSizer* lightSizer = new wxBoxSizer( wxVERTICAL );
     optionsColumn->Add( lightSizer, groupInputFlags );
-    
+
     pCheck_ATONTEXT = new wxCheckBox( ps57Ctl, ID_ATONTEXTCHECKBOX, _("Buoy/Light Labels") );
     pCheck_ATONTEXT->SetValue( FALSE );
     lightSizer->Add( pCheck_ATONTEXT, inputFlags );
@@ -2739,17 +2678,17 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
 
 #ifdef USE_S57
     int slider_width = wxMax(m_fontHeight * 4, 150);
-   
+
     optionsColumn->Add( new wxStaticText(ps57Ctl, wxID_ANY, _("CM93 Detail Level")), labelFlags );
     m_pSlider_CM93_Zoom = new wxSlider( ps57Ctl, ID_CM93ZOOM, 0, -CM93_ZOOM_FACTOR_MAX_RANGE,
                                         CM93_ZOOM_FACTOR_MAX_RANGE, wxDefaultPosition, wxSize( slider_width, 50),
                                        wxSL_HORIZONTAL | wxSL_AUTOTICKS | wxSL_LABELS );
     optionsColumn->Add( m_pSlider_CM93_Zoom, 0, wxALL/* | wxEXPAND*/, border_size );
-    
+
 #ifdef __OCPN__ANDROID__
     m_pSlider_CM93_Zoom->GetHandle()->setStyleSheet( getQtStyleSheet());
-#endif    
-    
+#endif
+
 //    cm93Sizer->SetSizeHints(cm93DetailBox);
 #endif
 
@@ -2764,7 +2703,7 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
     dispSizer->Add( marinersSizer, 1, wxALL | wxEXPAND, border_size );
 
     wxString* ps57CtlListBoxStrings = NULL;
-    
+
 #ifndef __OCPN__ANDROID__
     ps57CtlListBox = new wxCheckListBox( ps57Ctl, ID_CHECKLISTBOX, wxDefaultPosition,
                                          wxSize( 250, 350 ), 0, ps57CtlListBoxStrings, wxLB_SINGLE | wxLB_HSCROLL | wxLB_SORT );
@@ -2773,23 +2712,23 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
     wxScrolledWindow *marinersWindow = new wxScrolledWindow( ps57Ctl, wxID_ANY, wxDefaultPosition, wxSize(250, 350), wxHSCROLL | wxVSCROLL);
     marinersWindow->SetScrollRate(m_scrollRate, m_scrollRate);
     marinersSizer->Add( marinersWindow, 1, wxALL | wxEXPAND, group_item_spacing );
-    
+
     wxBoxSizer* bSizerScrollMariners = new wxBoxSizer( wxVERTICAL );
     marinersWindow->SetSizer( bSizerScrollMariners );
-    
+
     ps57CtlListBox = new wxCheckListBox( marinersWindow, ID_CHECKLISTBOX, wxDefaultPosition,
                                          wxSize(200, 8000), 0, ps57CtlListBoxStrings, wxLB_SINGLE | wxLB_SORT );
     bSizerScrollMariners->Add( ps57CtlListBox, 1, wxALL | wxEXPAND, group_item_spacing );
 #endif
-    
-    
+
+
      wxBoxSizer* btnRow = new wxBoxSizer( wxHORIZONTAL );
     itemButtonSelectList = new wxButton( ps57Ctl, ID_SELECTLIST, _("Select All") );
     btnRow->Add( itemButtonSelectList, 1, wxALL | wxEXPAND, group_item_spacing );
     itemButtonClearList = new wxButton( ps57Ctl, ID_CLEARLIST, _("Clear All") );
     btnRow->Add( itemButtonClearList, 1, wxALL | wxEXPAND, group_item_spacing );
     marinersSizer->Add( btnRow );
-    
+
 
 //    m_choicePrecision->SetSelection( g_NMEAAPBPrecision );
 }
@@ -2974,13 +2913,13 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
 
     pCBLookAhead = new wxCheckBox( pDisplayPanel, ID_CHECK_LOOKAHEAD, _("Look Ahead Mode") );
     boxNavMode->Add( pCBLookAhead, inputFlags );
-    
-    
+
+
     // spacer
     generalSizer->Add( 0, border_size*4 );
     generalSizer->Add( 0, border_size*4 );
 
-    
+
     // Control Options
     generalSizer->Add( new wxStaticText( pDisplayPanel, wxID_ANY, _("Chart Display") ), groupLabelFlags );
     wxBoxSizer* boxCharts = new wxBoxSizer( wxVERTICAL );
@@ -2997,25 +2936,25 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
     generalSizer->Add( 0, border_size*4 );
     generalSizer->Add( 0, border_size*4 );
 
-    
+
     // Control Options
     generalSizer->Add( new wxStaticText( pDisplayPanel, wxID_ANY, _("Controls") ), groupLabelFlags );
     wxBoxSizer* boxCtrls = new wxBoxSizer( wxVERTICAL );
     generalSizer->Add( boxCtrls, groupInputFlags );
-    
+
     pSmoothPanZoom = new wxCheckBox( pDisplayPanel, ID_SMOOTHPANZOOMBOX, _("Smooth Panning / Zooming") );
     boxCtrls->Add( pSmoothPanZoom, inputFlags );
-    
+
     pEnableZoomToCursor = new wxCheckBox( pDisplayPanel, ID_ZTCCHECKBOX, _("Zoom to Cursor") );
     pEnableZoomToCursor->SetValue( FALSE );
     boxCtrls->Add( pEnableZoomToCursor, inputFlags );
-    
+
 
     // spacer
     generalSizer->Add( 0, border_size*4 );
     generalSizer->Add( 0, border_size*4 );
 
-    
+
     // Display Options
     generalSizer->Add( new wxStaticText( pDisplayPanel, wxID_ANY, _("Display Features") ), groupLabelFlags );
     wxBoxSizer* boxDisp = new wxBoxSizer( wxVERTICAL );
@@ -3029,7 +2968,7 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
 
     pSDepthUnits = new wxCheckBox( pDisplayPanel, ID_SHOWDEPTHUNITSBOX1, _("Show Depth Units") );
     boxDisp->Add( pSDepthUnits, inputFlags );
-    
+
 }
 
 void options::CreatePanel_Units( size_t parent, int border_size, int group_item_spacing,
@@ -3078,13 +3017,13 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
     pDepthUnitSelect = new wxChoice( panelUnits, ID_DEPTHUNITSCHOICE, wxDefaultPosition,
                                     wxDefaultSize, 3, pDepthUnitStrings );
     unitsSizer->Add( pDepthUnitSelect, inputFlags );
-    
+
 
     // spacer
     unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
     unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
 
-    
+
     // lat/long units
     unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Lat/Long")), labelFlags );
     wxString pSDMMFormats[] = { _("Degrees, Decimal Minutes"), _("Decimal Degrees"), _("Degrees, Minutes, Seconds") };
@@ -3137,11 +3076,11 @@ void options::CreatePanel_MMSI( size_t parent, int border_size, int group_item_s
     MMSISizer->Add( itemStaticBoxSizerMMSI, 0, wxALL | wxEXPAND, border_size );
 
     MMSI_Props_Panel *pPropsPanel = new MMSI_Props_Panel( panelMMSI );
-    
+
     pPropsPanel->UpdateMMSIList( );
-    
+
     itemStaticBoxSizerMMSI->Add( pPropsPanel, 0, wxALL | wxEXPAND, border_size );
-    
+
     panelMMSI->Layout();
 }
 
@@ -3177,8 +3116,8 @@ void options::CreatePanel_AIS( size_t parent, int border_size, int group_item_sp
 
     m_pCheck_CPA_Warn->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED,
                                 wxCommandEventHandler( options::OnCPAWarnClick ), NULL, this );
-    
-    
+
+
     m_pCheck_CPA_WarnT = new wxCheckBox( panelAIS, -1,
             _("...and TCPA is less than (min)") );
     pCPAGrid->Add( m_pCheck_CPA_WarnT, 0, wxALL, group_item_spacing );
@@ -3408,65 +3347,65 @@ void options::CreatePanel_UI( size_t parent, int border_size, int group_item_spa
     pShowChartBar = new wxCheckBox( itemPanelFont, wxID_ANY, _("Show Chart Bar") );
     pShowChartBar->SetValue( g_bShowChartBar );
     miscOptions->Add( pShowChartBar, 0, wxALL, border_size );
-    
+
     pShowCompassWin = new wxCheckBox( itemPanelFont, wxID_ANY, _("Show Compass/GPS Status Window") );
     pShowCompassWin->SetValue( FALSE );
     miscOptions->Add( pShowCompassWin, 0, wxALL, border_size );
-    
+
     wxBoxSizer *pToolbarAutoHide = new wxBoxSizer( wxHORIZONTAL );
     miscOptions->Add( pToolbarAutoHide, 0, wxALL | wxEXPAND, group_item_spacing );
-    
+
     pToolbarAutoHideCB = new wxCheckBox( itemPanelFont, ID_REPONSIVEBOX, _("Enable Toolbar auto-hide") );
     pToolbarAutoHide->Add( pToolbarAutoHideCB, 0, wxALL, group_item_spacing );
-    
+
     pToolbarHideSecs = new wxTextCtrl( itemPanelFont, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize( 50, -1 ), wxTE_RIGHT  );
     pToolbarAutoHide->Add( pToolbarHideSecs, 0, wxALIGN_RIGHT | wxALL, group_item_spacing );
-    
+
     pToolbarAutoHide->Add( new wxStaticText( itemPanelFont, wxID_ANY, _("seconds") ),group_item_spacing );
-    
+
     // Sound options
     pPlayShipsBells = new wxCheckBox( itemPanelFont, ID_BELLSCHECKBOX, _("Play Ships Bells"));
     miscOptions->Add( pPlayShipsBells, 0, wxALL, border_size );
-    
+
     pSoundDeviceIndex = new wxSpinCtrl( itemPanelFont, wxID_ANY );
     pSoundDeviceIndex->SetValue( g_iSoundDeviceIndex );
     pSoundDeviceIndex->Hide();
-    
+
     if(OCPN_Sound::DeviceCount() > 1){
         pSoundDeviceIndex->Show();
-        
+
         wxFlexGridSizer *pSoundDeviceIndexGrid = new wxFlexGridSizer( 2 );
         miscOptions->Add( pSoundDeviceIndexGrid, 0, wxALL | wxEXPAND, group_item_spacing );
-    
+
         wxStaticText* stSoundDeviceIndex = new wxStaticText( itemPanelFont, wxID_STATIC, _("Sound Device Index") );
         pSoundDeviceIndexGrid->Add( stSoundDeviceIndex, 0,  wxALL, 5 );
         pSoundDeviceIndex->SetRange(-1, OCPN_Sound::DeviceCount() - 1);
         pSoundDeviceIndexGrid->Add( pSoundDeviceIndex, 0, wxALL, border_size);
     }
-    
+
     //  Mobile/Touchscreen checkboxes
     pMobile = new wxCheckBox( itemPanelFont, ID_MOBILEBOX, _("Enable Touchscreen interface") );
     miscOptions->Add( pMobile, 0, wxALL, border_size );
-    
+
     pResponsive = new wxCheckBox( itemPanelFont, ID_REPONSIVEBOX, _("Enable Tablet Scaled Graphics interface") );
     miscOptions->Add( pResponsive, 0, wxALL, border_size );
 
     int slider_width = wxMax(m_fontHeight * 4, 150);
- 
+
     m_pSlider_GUI_Factor = new wxSlider( itemPanelFont, wxID_ANY, 0, -5, 5,
                                         wxDefaultPosition, wxSize( slider_width, 50),
                                         wxSL_HORIZONTAL | wxSL_AUTOTICKS | wxSL_LABELS );
     m_pSlider_GUI_Factor->Hide();
-//#ifdef __OCPN__ANDROID__    
+//#ifdef __OCPN__ANDROID__
     miscOptions->Add( new wxStaticText(itemPanelFont, wxID_ANY, _("User Interface scale factor")), inputFlags );
     miscOptions->Add( m_pSlider_GUI_Factor, 0, wxALL, border_size );
     m_pSlider_GUI_Factor->Show();
-    
+
 #ifdef __WXQT__
     m_pSlider_GUI_Factor->GetHandle()->setStyleSheet( getQtStyleSheet());
 #endif
 //#endif
-    
+
 
 
     m_pSlider_Chart_Factor = new wxSlider( itemPanelFont, wxID_ANY, 0, -5, 5,
@@ -3477,12 +3416,12 @@ void options::CreatePanel_UI( size_t parent, int border_size, int group_item_spa
     miscOptions->Add( new wxStaticText(itemPanelFont, wxID_ANY, _("Chart Object scale factor")), inputFlags );
     miscOptions->Add( m_pSlider_Chart_Factor, 0, wxALL, border_size );
     m_pSlider_Chart_Factor->Show();
-    
+
 #ifdef __WXQT__
     m_pSlider_Chart_Factor->GetHandle()->setStyleSheet( getQtStyleSheet());
 #endif
-//#endif    
-    
+//#endif
+
 }
 
 void options::CreateControls()
@@ -3494,9 +3433,9 @@ void options::CreateControls()
     int font_size_y, font_descent, font_lead;
     GetTextExtent( _T("0"), NULL, &font_size_y, &font_descent, &font_lead );
     m_fontHeight =  font_size_y + font_descent + font_lead;
-    
+
     m_small_button_size = wxSize( -1, (int) ( 1.4 * ( font_size_y + font_descent + font_lead ) ) );
-    
+
     //      Some members (pointers to controls) need to initialized
     pEnableZoomToCursor = NULL;
     pSmoothPanZoom = NULL;
@@ -3535,45 +3474,45 @@ void options::CreateControls()
     wxString wqs = getFontQtStylesheet(qFont);
     wxCharBuffer sbuf = wqs.ToUTF8();
     QString qsb = QString(sbuf.data());
-    
+
     QString qsbq = getQtStyleSheet();           // basic scrollbars, etc
 
     itemDialog1->GetHandle()->setStyleSheet( qsb + qsbq );      // Concatenated style sheets
-    
+
     #endif
- 
+
     int flags = 0;
-    
-#ifdef __OCPN__OPTIONS_USE_LISTBOOK__    
+
+#ifdef __OCPN__OPTIONS_USE_LISTBOOK__
     flags = wxLB_TOP;
     m_pListbook = new wxListbook( itemDialog1, ID_NOTEBOOK, wxDefaultPosition, wxSize(-1, -1), flags);
     m_pListbook->Connect( wxEVT_COMMAND_LISTBOOK_PAGE_CHANGED, wxListbookEventHandler( options::OnPageChange ), NULL, this );
-#else    
+#else
     flags = wxNB_TOP;
     m_pListbook = new wxNotebook( itemDialog1, ID_NOTEBOOK, wxDefaultPosition, wxSize(-1, -1), flags);
     m_pListbook->Connect( wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED, wxNotebookEventHandler( options::OnNBPageChange ), NULL, this );
-#endif    
+#endif
 
-#ifdef __OCPN__ANDROID__    
+#ifdef __OCPN__ANDROID__
     //  In wxQT, we can dynamically style the little scroll buttons on a small display, to make them bigger
     wxString qtstyle;
     qtstyle.Printf(_T("QTabBar::scroller { width: %dpx; }"), m_fontHeight * 3 / 4);
     wxCharBuffer buf = qtstyle.ToUTF8();
     m_pListbook->GetHandle()->setStyleSheet( buf.data() );
-    
+
 //     QTabBar QToolButton::right-arrow { /* the arrow mark in the tool buttons */
 //     image: url(rightarrow.png);
 //     }
-//     
+//
 //     QTabBar QToolButton::left-arrow {
 //         image: url(leftarrow.png);
 //     }
-#endif    
-    
+#endif
+
 #ifdef __WXMSW__
     //  Windows clips the width of listbook selectors to about twice icon size
     //  This makes the text render with ellipses if too large
-    
+
     //  So, Measure and reduce the Font size on ListBook(ListView) selectors
     //  to allow text layout without ellipsis...
     wxBitmap tbmp = g_StyleManager->GetCurrentStyle()->GetIcon( _T("Display") );
@@ -3585,19 +3524,19 @@ void options::CreateControls()
     if(text_width > tbmp.GetWidth() * 2 ){
         wxListView* lv = m_pListbook->GetListView();
         wxFont *qFont = GetOCPNScaledFont(_("Dialog"));         // to get type, weight, etc...
-        
+
         wxFont *sFont = wxTheFontList->FindOrCreateFont( 10, qFont->GetFamily(), qFont->GetStyle(), qFont->GetWeight());
         lv->SetFont( *sFont );
     }
 #endif
 
-    
+
     m_topImgList = new wxImageList( 40, 40, true, 1 );
     ocpnStyle::Style* style = g_StyleManager->GetCurrentStyle();
 
 #ifndef __OCPN__ANDROID__
     m_topImgList = new wxImageList( 40, 40, true, 1 );
-    
+
 #if wxCHECK_VERSION(2, 8, 12)
     m_topImgList->Add( style->GetIcon( _T("Display") ) );
     m_topImgList->Add( style->GetIcon( _T("Charts") ) );
@@ -3624,7 +3563,7 @@ void options::CreateControls()
 
 #else
     m_topImgList = new wxImageList( 80, 80, true, 1 );
-    
+
     wxBitmap bmp;
     wxImage img, simg;
     bmp = style->GetIcon( _T("Display") ); img = bmp.ConvertToImage();
@@ -3640,7 +3579,7 @@ void options::CreateControls()
     bmp = style->GetIcon( _T("Plugins") ); img = bmp.ConvertToImage();
     simg = img.Scale(80,80); bmp = wxBitmap( simg ); m_topImgList->Add( bmp );
 #endif
-    
+
     m_pListbook->SetImageList( m_topImgList );
     itemBoxSizer2->Add( m_pListbook, 1,
             wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL | wxALL | wxEXPAND, border_size );
@@ -3671,14 +3610,14 @@ void options::CreateControls()
     CreatePanel_TidesCurrents( m_pageCharts, border_size, group_item_spacing, m_small_button_size );
 
     m_pageConnections = CreatePanel( _("Connections") );
-#ifndef __OCPN__ANDROID__    
+#ifndef __OCPN__ANDROID__
     CreatePanel_NMEA( m_pageConnections, border_size, group_item_spacing, m_small_button_size );
 #else
     CreatePanel_NMEA_Compact( m_pageConnections, border_size, group_item_spacing, m_small_button_size );
 #endif
-    
+
 //    SetDefaultConnectionParams();
-    
+
     m_pageShips = CreatePanel( _("Ships") );
     CreatePanel_Ownship( m_pageShips, border_size, group_item_spacing, m_small_button_size );
     CreatePanel_AIS( m_pageShips, border_size, group_item_spacing, m_small_button_size );
@@ -3697,7 +3636,7 @@ void options::CreateControls()
     if( g_pi_manager ) g_pi_manager->NotifySetupOptions();
 
     SetColorScheme( (ColorScheme) 0 );
-    
+
     //Set the maximum size of the entire settings dialog
     SetSizeHints( -1, -1, width-100, height-100 );
 
@@ -3709,11 +3648,11 @@ void options::CreateControls()
 void options::SetInitialPage( int page_sel)
 {
     m_pListbook->SetSelection( page_sel );
-    
+
     for (size_t i = 0; i < m_pListbook->GetPageCount(); i++)
     {
         wxNotebookPage* pg = m_pListbook->GetPage( i );
-        
+
         if( pg->IsKindOf( CLASSINFO(wxNotebook))) {
             wxNotebook *nb = ((wxNotebook *)pg);
             nb->ChangeSelection(0);
@@ -3729,7 +3668,7 @@ void options::SetColorScheme( ColorScheme cs )
 #ifdef __OCPN__OPTIONS_USE_LISTBOOK__
     wxListView* lv = m_pListbook->GetListView();
     lv->SetBackgroundColour(this->GetBackgroundColour());
-#endif    
+#endif
 }
 
 void options::SetInitialSettings()
@@ -3784,7 +3723,7 @@ void options::SetInitialSettings()
     pResponsive->SetValue( g_bresponsive );
     pOverzoomEmphasis->SetValue( !g_fog_overzoom );
     pOZScaleVector->SetValue( !g_oz_vector_scale );
-    
+
     pOpenGL->SetValue( g_bopengl );
     pSmoothPanZoom->SetValue( g_bsmoothpanzoom );
 #if 0
@@ -3794,10 +3733,10 @@ void options::SetInitialSettings()
     }
 #endif
     pCBMagShow->SetValue( g_bShowMag );
-    
+
     s.Printf( _T("%4.1f"), g_UserVar );
     pMagVar->SetValue(s);
-    
+
     pSDisplayGrid->SetValue( g_bDisplayGrid );
 
     pCBCourseUp->SetValue( g_bCourseUp );
@@ -3815,7 +3754,7 @@ void options::SetInitialSettings()
     else
         s.Printf( _T("%4.0f"), g_ownship_HDTpredictor_miles );
     m_pText_OSHDT_Predictor->SetValue( s );
-    
+
     m_pShipIconType->SetSelection( g_OwnShipIconType );
     wxCommandEvent eDummy;
     OnShipTypeSelect( eDummy );
@@ -3825,7 +3764,7 @@ void options::SetInitialSettings()
     m_pOSGPSOffsetY->SetValue( wxString::Format( _T("%.1f"), g_n_gps_antenna_offset_y ) );
     m_pOSMinSize->SetValue( wxString::Format( _T("%d"), g_n_ownship_min_mm ) );
     m_pText_ACRadius->SetValue( wxString::Format( _T("%.2f"), g_n_arrival_circle_radius ) );
-    
+
     wxString buf;
     if( g_iNavAidRadarRingsNumberVisible > 10 ) g_iNavAidRadarRingsNumberVisible = 10;
     pNavAidRadarRingsNumberVisible->SetSelection( g_iNavAidRadarRingsNumberVisible );
@@ -3862,7 +3801,7 @@ void options::SetInitialSettings()
     pSDMMFormat->Select( g_iSDMMFormat );
     pDistanceFormat->Select( g_iDistanceFormat );
     pSpeedFormat->Select( g_iSpeedFormat );
-    
+
     pAdvanceRouteWaypointOnArrivalOnly->SetValue( g_bAdvanceRouteWaypointOnArrivalOnly );
 
     pTrackDaily->SetValue( g_bTrackDaily );
@@ -3888,10 +3827,10 @@ void options::SetInitialSettings()
     }
     else
         m_pCheck_CPA_WarnT->Disable();
-    
+
     s.Printf( _T("%4.0f"), g_TCPA_Max );
     m_pText_CPA_WarnT->SetValue( s );
-    
+
     //      Lost Targets
     m_pCheck_Mark_Lost->SetValue( g_bMarkLost );
 
@@ -3945,12 +3884,12 @@ void options::SetInitialSettings()
     m_pCheck_Rollover_CPA->SetValue( g_bAISRolloverShowCPA );
 
     m_pSlider_Zoom->SetValue( g_chart_zoom_modifier );
- 
+
     m_pSlider_GUI_Factor->SetValue(g_GUIScaleFactor);
     m_pSlider_Chart_Factor->SetValue(g_ChartScaleFactor);
-                                           
+
     wxString screenmm;
-    
+
     if( !g_config_display_size_manual ){
         pRBSizeAuto->SetValue( true );
         screenmm.Printf(_T("%d"), int(g_Platform->GetDisplaySizeMM()));
@@ -3960,11 +3899,11 @@ void options::SetInitialSettings()
         screenmm.Printf(_T("%d"), int(g_config_display_size_mm));
         pRBSizeManual->SetValue( true );
     }
-    
+
     pScreenMM->SetValue(screenmm);
 
      m_TalkerIdText->SetValue( g_TalkerIdText.MakeUpper() );
-    
+
 #ifdef USE_S57
     m_pSlider_CM93_Zoom->SetValue( g_cm93_zoom_factor );
 
@@ -4051,7 +3990,7 @@ void options::SetInitialSettings()
 #endif
 
     pToolbarAutoHideCB->SetValue(g_bAutoHideToolbar);
-    
+
     s.Printf( _T("%d"), g_nAutoHideToolbar );
     pToolbarHideSecs->SetValue( s );
 
@@ -4098,7 +4037,7 @@ void options::OnSizeAutoButton( wxCommandEvent& event )
     pScreenMM->SetValue(screenmm);
     pScreenMM->Disable();
     g_config_display_size_manual = false;
-    
+
 }
 
 void options::OnSizeManualButton( wxCommandEvent& event )
@@ -4110,11 +4049,11 @@ void options::OnSizeManualButton( wxCommandEvent& event )
     else {
         screenmm.Printf(_T("%d"), int(g_Platform->GetDisplaySizeMM()));
     }
-    
+
     pScreenMM->SetValue(screenmm);
     pScreenMM->Enable();
     g_config_display_size_manual = true;
-    
+
 }
 
 void options::OnUnitsChoice( wxCommandEvent& event )
@@ -4213,11 +4152,11 @@ void options::OnOpenGLOptions( wxCommandEvent& event )
             g_GLOptions.m_bUseAcceleratedPanning = cc1->GetglCanvas()->CanAcceleratePanning();
 
         g_GLOptions.m_bTextureCompression = dlg.m_cbTextureCompression->GetValue();
-        
+
         g_bShowFPS = dlg.m_cbShowFPS->GetValue();
         if(dlg.m_cbSoftwareGL)
             g_bSoftwareGL = dlg.m_cbSoftwareGL->GetValue();
-        
+
         if(g_bexpert){
             g_GLOptions.m_bTextureCompressionCaching = dlg.m_cbTextureCompressionCaching->GetValue();
             g_GLOptions.m_iTextureMemorySize = dlg.m_sTextureMemorySize->GetValue();
@@ -4225,16 +4164,16 @@ void options::OnOpenGLOptions( wxCommandEvent& event )
         else{
             g_GLOptions.m_bTextureCompressionCaching = g_GLOptions.m_bTextureCompression;
         }
-    
+
         if(g_bopengl &&
            g_GLOptions.m_bTextureCompression != dlg.m_cbTextureCompression->GetValue()) {
             g_GLOptions.m_bTextureCompression = dlg.m_cbTextureCompression->GetValue();
             cc1->GetglCanvas()->SetupCompression();
-            
+
             ::wxBeginBusyCursor();
             cc1->GetglCanvas()->ClearAllRasterTextures();
             ::wxEndBusyCursor();
-            
+
         }
     }
 
@@ -4257,7 +4196,7 @@ void options::OnChartDirListSelect( wxCommandEvent& event )
         else
             m_removeBtn->Disable();
     }
-    
+
 }
 
 void options::OnDisplayCategoryRadioButton( wxCommandEvent& event )
@@ -4317,14 +4256,14 @@ void options::OnCharHook( wxKeyEvent& event ) {
 void options::OnButtonaddClick( wxCommandEvent& event )
 {
     wxString selDir;
-    
+
     int dresult = g_Platform->DoDirSelectorDialog( this, &selDir, _("Add a directory containing chart files"),
                                                    *pInit_Chart_Dir);
-    
+
     if(wxID_CANCEL == dresult)
         goto done;
-        
-#if 0    
+
+#if 0
     wxDirDialog *dirSelector = new wxDirDialog( this, _("Add a directory containing chart files"),
             *pInit_Chart_Dir, wxDD_DEFAULT_STYLE | wxDD_DIR_MUST_EXIST );
 
@@ -4333,14 +4272,14 @@ void options::OnButtonaddClick( wxCommandEvent& event )
 
     if(g_bresponsive)
         dirSelector = g_Platform->AdjustDirDialogFont(this, dirSelector);
-    
+
     if( dirSelector->ShowModal() == wxID_CANCEL )
         goto done;
 
     selDir = dirSelector->GetPath();
 #endif
 
-    
+
     AddChartDir( selDir );
 
 done:
@@ -4352,7 +4291,7 @@ done:
 void options::AddChartDir( wxString &dir )
 {
     wxFileName dirname = wxFileName( dir );
-    
+
     pInit_Chart_Dir->Empty();
     if( !g_bportable )
         pInit_Chart_Dir->Append( dirname.GetPath() );
@@ -4437,7 +4376,7 @@ ConnectionParams *options::CreateConnectionParamsFromSelectedItem()
     //  DataStreams should be Input, Output, or Both
     if (!(m_cbInput->GetValue() || m_cbOutput->GetValue())) {
         OCPNMessageBox( NULL, _("Data connection must be input, output or both"), _("OpenCPN Info"), wxICON_HAND );
-        
+
         return NULL;
     }
 
@@ -4477,11 +4416,11 @@ ConnectionParams *options::CreateConnectionParamsFromSelectedItem()
         pConnectionParams->Type = INTERNAL_GPS;
     else if ( m_rbTypeInternalBT && m_rbTypeInternalBT->GetValue() )
         pConnectionParams->Type = INTERNAL_BT;
-    
+
     //  Save the existing addr/port to allow closing of existing port
     pConnectionParams->LastNetworkAddress = pConnectionParams->NetworkAddress;
     pConnectionParams->LastNetworkPort = pConnectionParams->NetworkPort;
-        
+
     pConnectionParams->NetworkAddress = m_tNetAddress->GetValue();
     pConnectionParams->NetworkPort = wxAtoi(m_tNetPort->GetValue());
     if ( m_rbNetProtoTCP->GetValue() )
@@ -4519,7 +4458,7 @@ ConnectionParams *options::CreateConnectionParamsFromSelectedItem()
 
     pConnectionParams->bEnabled = m_connection_enabled;
     pConnectionParams->b_IsSetup = false;
- 
+
     if(pConnectionParams->Type == INTERNAL_GPS){
         pConnectionParams->NetworkAddress = _T("");
         pConnectionParams->NetworkPort = 0;
@@ -4532,7 +4471,7 @@ ConnectionParams *options::CreateConnectionParamsFromSelectedItem()
         wxStringTokenizer tkz( parms, _T(";") );
         wxString name = tkz.GetNextToken();
         wxString mac = tkz.GetNextToken();
-        
+
         pConnectionParams->NetworkAddress = name;
         pConnectionParams->Port = mac;
         pConnectionParams->NetworkPort = 0;
@@ -4540,7 +4479,7 @@ ConnectionParams *options::CreateConnectionParamsFromSelectedItem()
         pConnectionParams->Baudrate = 0;
 //        pConnectionParams->SetAuxParameterStr(m_choiceBTDataSources->GetStringSelection());
     }
-    
+
     return pConnectionParams;
 }
 
@@ -4549,7 +4488,7 @@ void options::OnApplyClick( wxCommandEvent& event )
     ::wxBeginBusyCursor();
 
     StopBTScan();
-    
+
     m_returnChanges = 0;
 
     // Start with the stuff that requires intelligent validation.
@@ -4592,7 +4531,7 @@ void options::OnApplyClick( wxCommandEvent& event )
     g_OwnShipIconType = m_pShipIconType->GetSelection();
 
     m_pText_ACRadius->GetValue().ToDouble( &g_n_arrival_circle_radius );
-    
+
     //    Handle Chart Tab
     wxString dirname;
 
@@ -4650,23 +4589,23 @@ void options::OnApplyClick( wxCommandEvent& event )
 #endif
         m_pConfig->m_bShowCompassWin = pShowCompassWin->GetValue();
     }
-    
+
     g_bShowChartBar = pShowChartBar->GetValue();
 
     wxString screenmm = pScreenMM->GetValue();
     long mm = -1;
     screenmm.ToLong(&mm);
-    
+
     if(mm >0){
         g_config_display_size_mm = mm;
     }
     else{
         g_config_display_size_mm = -1;
     }
-    
+
     g_config_display_size_manual = pRBSizeManual->GetValue();
-    
-        
+
+
 // Connections page.
     g_bfilter_cogsog = m_cbFilterSogCog->GetValue();
 
@@ -4678,11 +4617,11 @@ void options::OnApplyClick( wxCommandEvent& event )
 
     g_bMagneticAPB = m_cbAPBMagnetic->GetValue();
     g_NMEAAPBPrecision = m_choicePrecision->GetCurrentSelection();
-    
-    
+
+
         // NMEA Source
     long itemIndex = m_lcSources->GetNextItem( -1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED );
-    
+
     //  If the stream selected exists, capture some of its existing parameters
     //  to facility identification and allow stop and restart of the stream
     wxString lastAddr;
@@ -4712,11 +4651,11 @@ void options::OnApplyClick( wxCommandEvent& event )
                 g_pConnectionParams->Add(cp);
                 itemIndex = g_pConnectionParams->Count() - 1;
             }
-            
+
             //  Record the previous parameters, if any
             cp->LastNetworkAddress = lastAddr;
             cp->LastNetworkPort = lastPort;
-            
+
             FillSourceList();
             m_lcSources->SetItemState(itemIndex, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
             m_lcSources->Refresh();
@@ -4728,7 +4667,7 @@ void options::OnApplyClick( wxCommandEvent& event )
         }
     }
 
-    
+
     //Recreate datastreams that are new, or have been edited
     for ( size_t i = 0; i < g_pConnectionParams->Count(); i++ )
     {
@@ -4737,23 +4676,23 @@ void options::OnApplyClick( wxCommandEvent& event )
 
             // Terminate and remove any existing stream with the same port name
             DataStream *pds_existing = g_pMUX->FindStream( cp->GetDSPort() );
-            if(pds_existing) 
+            if(pds_existing)
                 g_pMUX->StopAndRemoveStream( pds_existing );
 
             //  Try to stop any previous stream to avoid orphans
             pds_existing = g_pMUX->FindStream( cp->GetLastDSPort() );
-            if(pds_existing) 
+            if(pds_existing)
                 g_pMUX->StopAndRemoveStream( pds_existing );
- 
+
             //  This for Bluetooth, which has strange parameters
             pds_existing = g_pMUX->FindStream( cp->GetPortStr() );
-            if(pds_existing) 
+            if(pds_existing)
                 g_pMUX->StopAndRemoveStream( pds_existing );
-            
+
            if( cp->bEnabled ) {
            dsPortType port_type = cp->IOSelect;
                 DataStream *dstr = new DataStream( g_pMUX,
-                                            cp->Type,       
+                                            cp->Type,
                                             cp->GetDSPort(),
                                             wxString::Format(wxT("%i"), cp->Baudrate),
                                             port_type,
@@ -4767,7 +4706,7 @@ void options::OnApplyClick( wxCommandEvent& event )
                 dstr->SetChecksumCheck(cp->ChecksumCheck);
 
                 g_pMUX->AddStream(dstr);
-                
+
                 cp->b_IsSetup = true;
             }
         }
@@ -4780,7 +4719,7 @@ void options::OnApplyClick( wxCommandEvent& event )
         g_GPS_Ident = _T("Generic");
 
 
-// End of Connections page    
+// End of Connections page
 
     g_bShowOutlines = pCDOOutlines->GetValue();
     g_bDisplayGrid = pSDisplayGrid->GetValue();
@@ -4798,15 +4737,15 @@ void options::OnApplyClick( wxCommandEvent& event )
     g_bresponsive = pResponsive->GetValue();
 
     g_bAutoHideToolbar = pToolbarAutoHideCB->GetValue();
- 
+
     long hide_val = 10;
     pToolbarHideSecs->GetValue().ToLong( &hide_val );
     g_nAutoHideToolbar = wxMin((int)hide_val, 100);
     g_nAutoHideToolbar = wxMax(g_nAutoHideToolbar, 2);
-    
+
     g_fog_overzoom = !pOverzoomEmphasis->GetValue();
     g_oz_vector_scale = !pOZScaleVector->GetValue();
-    
+
     bool bopengl_changed = g_bopengl != pOpenGL->GetValue();
     g_bopengl = pOpenGL->GetValue();
 
@@ -4818,15 +4757,15 @@ void options::OnApplyClick( wxCommandEvent& event )
 
     if(g_bCourseUp != pCBCourseUp->GetValue())
         gFrame->ToggleCourseUp();
-        
+
     g_bLookAhead = pCBLookAhead->GetValue();
 
     g_bShowMag = pCBMagShow->GetValue();
     pMagVar->GetValue().ToDouble( &g_UserVar );
-    
+
     m_pText_OSCOG_Predictor->GetValue().ToDouble( &g_ownship_predictor_minutes );
     m_pText_OSHDT_Predictor->GetValue().ToDouble( &g_ownship_HDTpredictor_miles );
-    
+
     g_iNavAidRadarRingsNumberVisible = pNavAidRadarRingsNumberVisible->GetSelection();
     g_fNavAidRadarRingsStep = atof( pNavAidRadarRingsStep->GetValue().mb_str() );
     g_pNavAidRadarRingsStepUnits = m_itemRadarRingsUnits->GetSelection();
@@ -4845,7 +4784,7 @@ void options::OnApplyClick( wxCommandEvent& event )
     g_iSDMMFormat = pSDMMFormat->GetSelection();
     g_iDistanceFormat = pDistanceFormat->GetSelection();
     g_iSpeedFormat = pSpeedFormat->GetSelection();
-    
+
     g_bAdvanceRouteWaypointOnArrivalOnly = pAdvanceRouteWaypointOnArrivalOnly->GetValue();
 
     g_nTrackPrecision = pTrackPrecision->GetSelection();
@@ -4876,7 +4815,7 @@ void options::OnApplyClick( wxCommandEvent& event )
 
     g_bAISShowTracks = m_pCheck_Show_Tracks->GetValue();
     m_pText_Track_Length->GetValue().ToDouble( &g_AISShowTracks_Mins );
-    
+
     //  Update all the current targets
     if( g_pAIS ){
         AIS_Target_Hash::iterator it;
@@ -4888,7 +4827,7 @@ void options::OnApplyClick( wxCommandEvent& event )
             }
         }
     }
-    
+
 
     g_bShowMoored = !m_pCheck_Show_Moored->GetValue();
     m_pText_Moored_Speed->GetValue().ToDouble( &g_ShowMoored_Kts );
@@ -4919,11 +4858,11 @@ void options::OnApplyClick( wxCommandEvent& event )
     g_GUIScaleFactor = m_pSlider_GUI_Factor->GetValue();
     g_ChartScaleFactor = m_pSlider_Chart_Factor->GetValue();
     g_ChartScaleFactorExp = g_Platform->getChartScaleFactorExp( g_ChartScaleFactor );
-    
+
     g_NMEAAPBPrecision = m_choicePrecision->GetCurrentSelection();
-    
+
     g_TalkerIdText = m_TalkerIdText->GetValue().MakeUpper();
-    
+
 #ifdef USE_S57
     //    Handle Vector Charts Tab
 
@@ -5094,7 +5033,7 @@ void options::OnApplyClick( wxCommandEvent& event )
         gFrame->ProcessOptionsDialog( m_returnChanges, m_pWorkDirList );
         cc1->ReloadVP();
     }
-    
+
     ::wxEndBusyCursor();
 }
 
@@ -5116,22 +5055,22 @@ void options::Finish()
     for (size_t i = 0; i < m_pListbook->GetPageCount(); i++)
     {
         wxNotebookPage* pg = m_pListbook->GetPage( i );
-        
+
         if( pg->IsKindOf( CLASSINFO(wxNotebook))) {
             wxNotebook *nb = ((wxNotebook *)pg);
             nb->ChangeSelection(0);
         }
     }
-    
+
     delete pActiveChartsList;
     delete ps57CtlListBox;
     delete tcDataSelected;
-    
+
     lastWindowPos = GetPosition();
     lastWindowSize = GetSize();
     SetReturnCode( m_returnChanges );
     EndModal( m_returnChanges );
-    
+
 }
 
 
@@ -5141,7 +5080,7 @@ void options::OnButtondeleteClick( wxCommandEvent& event )
     wxString dirname;
 
 #ifndef __WXQT__                // Multi selection is not implemented in wxQT
-    
+
     wxArrayInt pListBoxSelections;
     pActiveChartsList->GetSelections( pListBoxSelections );
     int nSelections = pListBoxSelections.GetCount();
@@ -5150,7 +5089,7 @@ void options::OnButtondeleteClick( wxCommandEvent& event )
     }
 #else
     int n = pActiveChartsList->GetSelection();
-    pActiveChartsList->Delete( n );    
+    pActiveChartsList->Delete( n );
 #endif
 
     UpdateWorkArrayFromTextCtl();
@@ -5184,7 +5123,7 @@ void options::OnCancelClick( wxCommandEvent& event )
     //  Required to avoid intermittent crash on wxGTK
     if(m_groupsPage)
         m_groupsPage->Disconnect( wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED, wxListbookEventHandler( options::OnChartsPageChange ), NULL, this );
-    
+
     m_pListbook->ChangeSelection(0);
     delete pActiveChartsList;
     delete ps57CtlListBox;
@@ -5199,18 +5138,18 @@ void options::OnClose( wxCloseEvent& event )
     //      PlugIns may have added panels
     if( g_pi_manager )
         g_pi_manager->CloseAllPlugInPanels( (int) wxOK );
-    
+
     //  Required to avoid intermittent crash on wxGTK
     if(m_groupsPage)
         m_groupsPage->Disconnect( wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED, wxListbookEventHandler( options::OnChartsPageChange ), NULL, this );
-    
+
     m_pListbook->ChangeSelection(0);
     delete pActiveChartsList;
     delete ps57CtlListBox;
-    
+
     lastWindowPos = GetPosition();
     lastWindowSize = GetSize();
-    
+
     EndModal(0);
 }
 
@@ -5237,30 +5176,30 @@ void options::OnChooseFont( wxCommandEvent& event )
 
     wxFont *qFont = GetOCPNScaledFont(_("Dialog"));
     dg.SetFont(*qFont);
-    
-#ifdef __WXQT__    
+
+#ifdef __WXQT__
     // Make sure that font dialog will fit on the screen without scrolling
     // We do this by setting the dialog font size "small enough" to show "n" lines
     wxSize proposed_size = GetSize();
     float n_lines = 30;
-    
+
     wxFont *dialogFont = GetOCPNScaledFont(_("Dialog"));
     float font_size = dialogFont->GetPointSize();
-    
+
     if( (proposed_size.y / font_size) < n_lines){
         float new_font_size = proposed_size.y / n_lines;
-        wxFont *smallFont = new wxFont( * dialogFont ); 
-        smallFont->SetPointSize( new_font_size ); 
+        wxFont *smallFont = new wxFont( * dialogFont );
+        smallFont->SetPointSize( new_font_size );
         dg.SetFont( *smallFont );
     }
 #endif
 
-    
+
     if(g_bresponsive){
         dg.SetSize(GetSize());
         dg.Centre();
     }
-    
+
     int retval = dg.ShowModal();
     if( wxID_CANCEL != retval ) {
         font_data = dg.GetFontData();
@@ -5289,7 +5228,7 @@ void options::OnChooseFontColor( wxCommandEvent& event )
     init_colour_data.SetColour( init_color );
 
     wxColourDialog dg( this, &init_colour_data );
-    
+
     int retval = dg.ShowModal();
     if( wxID_CANCEL != retval ) {
         colour_data = dg.GetColourData();
@@ -5454,10 +5393,10 @@ void options::DoOnPageChange( size_t page )
 
             ::wxEndBusyCursor();
         }
-#endif        
+#endif
     }
 
- 
+
     else if( m_pagePlugins == i ) {                    // 7 is the index of "Plugins" page
 
         // load the disabled plugins finally because the user might want to enable them
@@ -5469,21 +5408,21 @@ void options::DoOnPageChange( size_t page )
         if( !m_pPlugInCtrl){
     //      Build the PlugIn Manager Panel
             ::wxBeginBusyCursor();
-     
+
             m_pPlugInCtrl = new PluginListPanel( itemPanelPlugins, ID_PANELPIM, wxDefaultPosition,
                                          wxDefaultSize, g_pi_manager->GetPlugInArray() );
             m_pPlugInCtrl->SetScrollRate( m_scrollRate, m_scrollRate );
-    
+
             itemBoxSizerPanelPlugins->Add( m_pPlugInCtrl, 1, wxEXPAND|wxALL, 4 );
-            
+
             itemBoxSizerPanelPlugins->Layout();
-            
+
             //  Update the PlugIn page to reflect the state of individual selections
             m_pPlugInCtrl->UpdateSelections();
-            
+
             ::wxEndBusyCursor();
         }
-    
+
         k_plugins = TOOLBAR_CHANGED;
     }
 }
@@ -5526,33 +5465,33 @@ void options::OnButtonSelectSound( wxCommandEvent& event )
 /*
     wxFileDialog *openDialog = new wxFileDialog( NULL, _("Select Sound File"), sound_dir, wxT(""),
             _("WAV files (*.wav)|*.wav|All files (*.*)|*.*"), wxFD_OPEN );
-    
+
     if(g_bresponsive)
         openDialog = g_Platform->AdjustFileDialogFont(this, openDialog);
-    
+
     int response = openDialog->ShowModal();*/
-    
+
     wxString sel_file;
     int response = wxID_CANCEL;
-    
-#ifndef __OCPN__ANDROID__    
+
+#ifndef __OCPN__ANDROID__
     wxFileDialog *popenDialog = new wxFileDialog( NULL, _( "Select Sound File" ), sound_dir, wxT ( "" ),
                                                   _T("WAV files (*.wav)|*.wav|All files (*.*)|*.*"), wxFD_OPEN );
     if(g_bresponsive)
         popenDialog = g_Platform->AdjustFileDialogFont(this, popenDialog);
-                                                  
+
     response = popenDialog->ShowModal();
     sel_file = popenDialog->GetPath();
     delete popenDialog;
-                                                  
+
 #else
     wxString path;
     response = g_Platform->DoFileSelectorDialog( NULL, &path, _( "Select Sound File" ),
                                                  sound_dir, _T(""), wxT ( "*.*" ) );
     sel_file = path;
 #endif
-                                                  
-    
+
+
     if( response == wxID_OK ) {
         if( g_bportable ) {
             wxFileName f( sel_file );
@@ -5563,7 +5502,7 @@ void options::OnButtonSelectSound( wxCommandEvent& event )
 
         g_anchorwatch_sound.UnLoad();
     }
-    
+
 }
 
 void options::OnButtonTestSound( wxCommandEvent& event )
@@ -5588,7 +5527,7 @@ void options::OnButtonTestSound( wxCommandEvent& event )
         }
         if( AIS_Sound.IsPlaying() )
             AIS_Sound.Stop();
-#endif 
+#endif
 #endif
     }
 
@@ -5600,7 +5539,7 @@ wxString GetOCPNKnownLanguage( wxString lang_canonical, wxString *lang_dir )
     wxString dir_suffix;
 
 #if wxUSE_XLOCALE || !wxCHECK_VERSION(3,0,0)
-    
+
     if( lang_canonical == _T("en_US") ) {
         dir_suffix = _T("en");
         return_string = wxString( "English (U.S.)", wxConvUTF8 );
@@ -5740,10 +5679,10 @@ ChartGroupsUI::ChartGroupsUI( wxWindow* parent )
     int scrollRate = 5;
 #ifdef __OCPN__ANDROID__
     scrollRate = 1;
-#endif    
-    
+#endif
+
     SetScrollRate(scrollRate, scrollRate);
-    
+
     m_GroupSelectedPage = -1;
     m_pActiveChartsTree = 0;
     pParent = parent;
@@ -6129,24 +6068,24 @@ void options::OnInsertTideDataLocation( wxCommandEvent &event )
     wxString sel_file;
     int response = wxID_CANCEL;
 
-#ifndef __OCPN__ANDROID__    
+#ifndef __OCPN__ANDROID__
     wxFileDialog *popenDialog = new wxFileDialog( NULL, _( "Select Tide/Current Data" ), g_TCData_Dir, wxT ( "" ),
                              wxT ( "Tide/Current Data files (*.IDX; *.TCD)|*.IDX;*.idx;*.TCD;*.tcd|All files (*.*)|*.*" ),
                                     wxFD_OPEN  );
     if(g_bresponsive)
         popenDialog = g_Platform->AdjustFileDialogFont(this, popenDialog);
-    
+
     response = popenDialog->ShowModal();
     sel_file = popenDialog->GetPath();
     delete popenDialog;
-    
+
 #else
     wxString path;
     response = g_Platform->DoFileSelectorDialog( NULL, &path, _( "Select Tide/Current Data" ),
                                                  g_TCData_Dir, _T(""), wxT ( "*.*" ) );
     sel_file = path;
 #endif
-    
+
     if( response == wxID_OK ) {
 
         if( g_bportable ) {
@@ -6167,7 +6106,7 @@ void options::OnInsertTideDataLocation( wxCommandEvent &event )
         else
             g_TCData_Dir = data_dir;
     }
-    
+
 
 }
 
@@ -6183,7 +6122,7 @@ void options::OnRemoveTideDataLocation( wxCommandEvent &event )
     }
 
     for (unsigned int i=0 ; i < a.Count() ; i++) {
-        
+
         int b = tcDataSelected->FindString(a.Item(i));
         wxCharBuffer buf = a.Item(i).ToUTF8();
         tcDataSelected->Delete( b );
@@ -6192,7 +6131,7 @@ void options::OnRemoveTideDataLocation( wxCommandEvent &event )
     int iSel = tcDataSelected->GetSelection();
     tcDataSelected->Delete( iSel );
 #endif
-    
+
 }
 
 void options::OnValChange( wxCommandEvent& event )
@@ -6207,8 +6146,8 @@ void options::OnScanBTClick( wxCommandEvent& event )
         StopBTScan();
     else {
         m_btNoChangeCounter = 0;
-        m_btlastResultCount =  0;   
-        
+        m_btlastResultCount =  0;
+
         m_BTScanTimer.Start(1000, wxTIMER_CONTINUOUS);
         g_Platform->startBluetoothScan();
         m_BTscanning = 1;
@@ -6222,61 +6161,61 @@ void options::onBTScanTimer(wxTimerEvent &event)
 {
     if(m_BTscanning){
         m_BTscanning++;
-        
+
         m_BTscan_results = g_Platform->getBluetoothScanResults();
-        
+
         m_choiceBTDataSources->Clear();
         m_choiceBTDataSources->Append(m_BTscan_results.Item(0));  // scan status
-        
+
         unsigned int i=1;
         while( (i+1) < m_BTscan_results.GetCount()){
             wxString item1 = m_BTscan_results.Item(i) + _T(";");
             wxString item2 = m_BTscan_results.Item(i+1);
             m_choiceBTDataSources->Append(item1 + item2);
-            
+
             i += 2;
         }
-        
+
         if( m_BTscan_results.GetCount() > 1){
             m_choiceBTDataSources->SetSelection( 1 );
         }
 
-        
+
         //  Watch for changes.  When no changes occur after n seconds, stop the scan
         if(m_btNoChangeCounter > 5)
             StopBTScan();
-        
+
         if((int)m_BTscan_results.GetCount() == m_btlastResultCount)
             m_btNoChangeCounter++;
         else
             m_btNoChangeCounter = 0;
-        
-        m_btlastResultCount =  m_BTscan_results.GetCount();   
-                
-        // Absolute fallback    
+
+        m_btlastResultCount =  m_BTscan_results.GetCount();
+
+        // Absolute fallback
         if(m_BTscanning >= 15){
             StopBTScan();
         }
     }
     else{
     }
-    
+
     return;
 }
 
 void options::StopBTScan()
-{ 
+{
     m_BTScanTimer.Stop();
 
     g_Platform->stopBluetoothScan();
-    
+
     m_BTscanning = 0;
-    
+
     if(m_buttonScanBT){
         m_buttonScanBT->SetLabel(_("BT Scan"));
         m_buttonScanBT->Enable();
     }
-    
+
 }
 
 
@@ -6294,8 +6233,8 @@ void options::OnTypeSerialSelected( wxCommandEvent& event )
         }
         g_bserial_access_checked = true;
     }
-#endif    
-    
+#endif
+
     OnConnValChange(event);
     SetNMEAFormToSerial();
 }
@@ -6336,7 +6275,7 @@ void options::ShowNMEACommon(bool visible)
         m_rbTypeNet->Show();
         if(m_rbTypeInternalGPS) m_rbTypeInternalGPS->Show();
         if(m_rbTypeInternalBT) m_rbTypeInternalBT->Show();
-        
+
         m_rbIAccept->Show();
         m_rbIIgnore->Show();
         m_rbOAccept->Show();
@@ -6373,7 +6312,7 @@ void options::ShowNMEACommon(bool visible)
         m_rbTypeNet->Hide();
         if(m_rbTypeInternalGPS) m_rbTypeInternalGPS->Hide();
         if(m_rbTypeInternalBT) m_rbTypeInternalBT->Hide();
-        
+
         m_rbIAccept->Hide();
         m_rbIIgnore->Hide();
         m_rbOAccept->Hide();
@@ -6472,7 +6411,7 @@ void options::ShowNMEABT(bool visible)
                 m_choiceBTDataSources->SetSelection(1);
             m_choiceBTDataSources->Show();
         }
-        
+
     }
     else
     {
@@ -6485,12 +6424,12 @@ void options::ShowNMEABT(bool visible)
 void options::SetNMEAFormToSerial()
 {
     ShowNMEACommon( true );
-    
+
     ShowNMEANet( false );
     ShowNMEAGPS( false );
     ShowNMEABT( false );
     ShowNMEASerial( true );
-    
+
     m_pNMEAForm->FitInside();
     m_pNMEAForm->Layout();
     Fit();
@@ -6556,7 +6495,7 @@ void options::ClearNMEAForm()
     Fit();
     Layout();
     RecalculateSize();
-    
+
 }
 
 wxString StringArrayToString(wxArrayString arr)
@@ -6662,20 +6601,20 @@ void options::SetConnectionParams(ConnectionParams *cp)
         if(m_rbTypeInternalBT)
             m_rbTypeInternalBT->SetValue( true );
         SetNMEAFormToBT();
-        
+
         // Preset the source selector
         wxString bts = cp->NetworkAddress + _T(";") + cp->GetPortStr();
         m_choiceBTDataSources->Clear();
         m_choiceBTDataSources->Append(bts);
         m_choiceBTDataSources->SetSelection( 0 );
-        
-        
-        
+
+
+
     }
-    
+
     else
         ClearNMEAForm();
-    
+
     m_connection_enabled = cp->bEnabled;
 }
 
@@ -6700,15 +6639,15 @@ void options::SetDefaultConnectionParams()
     if(!g_bserial_access_checked)
         bserial = false;
 #endif
-    
+
     m_rbTypeSerial->SetValue( bserial );
     m_rbTypeNet->SetValue( !bserial );
-    
+
     if(bserial)
         SetNMEAFormToSerial();
     else
         SetNMEAFormToNet();
-    
+
     m_connection_enabled = true;
 }
 
@@ -6727,7 +6666,7 @@ void options::OnAddDatasourceClick( wxCommandEvent& event )
         m_lcSources->SetItemState( itemIndex, 0, wxLIST_STATE_SELECTED|wxLIST_STATE_FOCUSED );
     }
     m_buttonRemove->Enable( false );
-    
+
     RecalculateSize();
 }
 
@@ -6758,7 +6697,7 @@ void options::FillSourceList()
         m_lcSources->SetItem(itemIndex, 6, g_pConnectionParams->Item(i)->GetFiltersStr());
     }
 
-#ifndef __OCPN__ANDROID__    
+#ifndef __OCPN__ANDROID__
     #ifdef __WXOSX__
     m_lcSources->SetColumnWidth( 0, wxLIST_AUTOSIZE );
     m_lcSources->SetColumnWidth( 1, wxLIST_AUTOSIZE );
@@ -6776,7 +6715,7 @@ void options::FillSourceList()
     m_lcSources->SetColumnWidth( 5, wxLIST_AUTOSIZE_USEHEADER );
     m_lcSources->SetColumnWidth( 6, wxLIST_AUTOSIZE );
     #endif
-#else    
+#else
     m_lcSources->SetColumnWidth( 0, 60 );
     m_lcSources->SetColumnWidth( 1, 90 );
     m_lcSources->SetColumnWidth( 2, 90 );
@@ -6784,7 +6723,7 @@ void options::FillSourceList()
     m_lcSources->SetColumnWidth( 4, 90 );
     m_lcSources->SetColumnWidth( 5, 90 );
     m_lcSources->SetColumnWidth( 6, 90 );
-#endif    
+#endif
 
     m_lcSources->SortItems( SortConnectionOnPriority, (long) m_lcSources );
 }
@@ -6804,10 +6743,10 @@ void options::OnRemoveDatasourceClick( wxCommandEvent& event )
             g_pConnectionParams->RemoveAt( params_index );
 
             DataStream *pds_existing = g_pMUX->FindStream( cp->GetDSPort() );
-            if(pds_existing) 
+            if(pds_existing)
                 g_pMUX->StopAndRemoveStream( pds_existing );
         }
-            
+
         //  Mark connection deleted
         m_rbTypeSerial->SetValue(true);
         m_comboPort->SetValue( _T("Deleted") );
@@ -6856,10 +6795,10 @@ void options::OnNetProtocolSelected( wxCommandEvent& event )
     {
         if (m_tNetPort->GetValue() == wxEmptyString)
             m_tNetPort->SetValue(_T("10110"));
-        
+
         if (m_tNetAddress->GetValue() == wxEmptyString)
             m_tNetAddress->SetValue(_T("0.0.0.0"));
-        
+
     }
     else if (m_rbNetProtoTCP->GetValue())
     {
@@ -7173,7 +7112,7 @@ void SentenceListDlg::SetType(int io, ListType type)
 
 void SentenceListDlg::OnCancelClick( wxCommandEvent& event ) { event.Skip(); }
 void SentenceListDlg::OnOkClick( wxCommandEvent& event ) { event.Skip(); }
- 
+
 //OpenGLOptionsDlg
 enum { ID_BUTTON_REBUILD, ID_BUTTON_CLEAR };
 
@@ -7189,15 +7128,15 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
 #ifdef __WXOSX__
     style |= wxSTAY_ON_TOP;
 #endif
-    
+
     wxDialog::Create( parent, wxID_ANY, _T("OpenGL Options"), wxDefaultPosition, wxDefaultSize,
                       style );
-    
+
     wxFont *qFont = GetOCPNScaledFont(_("Dialog"));
     SetFont( *qFont );
 
     m_brebuild_cache = false;
-    
+
 #ifdef ocpnUSE_GL
     m_bSizer1 = new wxFlexGridSizer( 3 );
     this->SetSizeHints( wxDefaultSize, wxDefaultSize );
@@ -7219,14 +7158,14 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
 
         m_cbTextureCompressionCaching = new wxCheckBox(this, wxID_ANY, _("Texture Compression Caching") );
         m_cbTextureCompressionCaching->SetValue(g_GLOptions.m_bTextureCompressionCaching);
-    
+
         /* disable caching if unsupported */
         extern PFNGLCOMPRESSEDTEXIMAGE2DPROC s_glCompressedTexImage2D;
         if(!s_glCompressedTexImage2D) {
             g_GLOptions.m_bTextureCompression = false;
             m_cbTextureCompressionCaching->Disable();
         }
-        
+
         m_bSizer1->Add(m_cbTextureCompressionCaching, 0, wxALL | wxEXPAND, 5);
     }
     else {
@@ -7234,12 +7173,12 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
         m_cbTextureCompression->SetValue(g_GLOptions.m_bTextureCompression);
         m_bSizer1->Add(m_cbTextureCompression, 0, wxALL | wxEXPAND, 5);
     }
-        
+
 
         /* disable caching if unsupported */
     extern PFNGLCOMPRESSEDTEXIMAGE2DPROC s_glCompressedTexImage2D;
     extern bool  b_glEntryPointsSet;
-    
+
     if(b_glEntryPointsSet){
         if(!s_glCompressedTexImage2D) {
             g_GLOptions.m_bTextureCompressionCaching = false;
@@ -7247,7 +7186,7 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
             m_cbTextureCompression->SetValue(false);
         }
     }
-        
+
     if(g_bexpert){
         wxStaticText* stTextureMemorySize =
             new wxStaticText( this, wxID_STATIC, _("Texture Memory Size (MB)") );
@@ -7263,14 +7202,14 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
         m_bSizer1->AddSpacer(0);
 
     m_bSizer1->AddSpacer(0);
-    
+
     m_bRebuildTextureCache = new wxButton(this, ID_BUTTON_REBUILD, _("Rebuild Texture Cache") );
     m_bSizer1->Add(m_bRebuildTextureCache, 0, wxALL | wxEXPAND, 5);
     m_bRebuildTextureCache->Enable(g_GLOptions.m_bTextureCompressionCaching);
-    
+
     if(!g_bopengl || g_raster_format == GL_RGB)
         m_bRebuildTextureCache->Disable();
-    
+
     m_bClearTextureCache = new wxButton(this, ID_BUTTON_CLEAR, _("Clear Texture Cache") );
     m_bSizer1->Add(m_bClearTextureCache, 0, wxALL | wxEXPAND, 5);
     m_bClearTextureCache->Enable(g_GLOptions.m_bTextureCompressionCaching);
@@ -7294,7 +7233,7 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
         m_bSizer1->AddSpacer(0);
 
     m_bSizer1->AddSpacer(0);
-    
+
     wxStdDialogButtonSizer * m_sdbSizer4 = new wxStdDialogButtonSizer();
     wxButton *bOK = new wxButton( this, wxID_OK );
     m_sdbSizer4->AddButton( bOK );
@@ -7336,9 +7275,9 @@ void OpenGLOptionsDlg::OnButtonClear( wxCommandEvent& event )
         size_t nfiles = wxDir::GetAllFiles(path, &files);
         for(unsigned int i=0 ; i < files.GetCount() ; i++){
             ::wxRemoveFile(files[i]);
-        }                
+        }
     }
-    
+
     m_stTextureCacheSize->SetLabel(TextureCacheSize());
     ::wxEndBusyCursor();
 #endif
@@ -7356,9 +7295,9 @@ wxString OpenGLOptionsDlg::TextureCacheSize()
         }
     }
     double mb = total/1024.0/1024.0;
-    if (mb < 10000.0) 
+    if (mb < 10000.0)
         return wxString::Format(_T("%.1f MB"), mb);
     mb = mb / 1024.0;
     return wxString::Format(_T("%.1f GB"), mb);
-    
+
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -537,8 +537,10 @@ void MMSIListCtrl::OnListItemActivated( wxListEvent &event )
     MMSIProperties *props = g_MMSI_Props_Array.Item( event.GetIndex() );
     MMSIProperties *props_new = new MMSIProperties( *props );
 
-    MMSIEditDialog *pd = new MMSIEditDialog( props_new, m_parent, -1, _("Edit MMSI Properties"),
-                                             wxDefaultPosition, wxSize( 200, 200 ) );
+    MMSIEditDialog *pd = new MMSIEditDialog(
+        props_new, m_parent, -1, _("Edit MMSI Properties"),
+        wxDefaultPosition, wxSize( 200, 200 )
+    );
 
     if ( pd->ShowModal() == wxID_OK ){
         g_MMSI_Props_Array.RemoveAt( event.GetIndex() );
@@ -552,15 +554,16 @@ void MMSIListCtrl::OnListItemRightClick( wxListEvent &event )
 {
     m_context_item = GetNextItem( -1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED );
 
-    if ( -1 == m_context_item )
-        return;
+    if ( m_context_item ==wxNOT_FOUND ) return;
 
     wxMenu* menu = new wxMenu( _("MMSI Properties") );
 
-    wxMenuItem *item_edit = new wxMenuItem( menu, ID_DEF_MENU_MMSI_EDIT, _( "Edit..." ) );
+    wxMenuItem *item_edit = new wxMenuItem( menu, ID_DEF_MENU_MMSI_EDIT,
+                                            _( "Edit..." ) );
     menu->Append( item_edit );
 
-    wxMenuItem *item_delete = new wxMenuItem( menu, ID_DEF_MENU_MMSI_DELETE, _( "Delete" ) );
+    wxMenuItem *item_delete = new wxMenuItem( menu, ID_DEF_MENU_MMSI_DELETE,
+                                              _( "Delete" ) );
     menu->Append( item_delete );
 
 #ifdef __WXMSW__
@@ -579,28 +582,26 @@ void MMSIListCtrl::OnListItemRightClick( wxListEvent &event )
 void MMSIListCtrl::PopupMenuHandler( wxCommandEvent& event )
 {
     MMSIProperties *props = g_MMSI_Props_Array.Item( m_context_item );
+    if ( !props ) return;
     MMSIProperties *props_new = new MMSIProperties( *props);
     MMSIEditDialog *pd;
 
     switch ( event.GetId() ) {
         case ID_DEF_MENU_MMSI_EDIT:
-            if ( props ) {
-                pd = new MMSIEditDialog( props_new, m_parent, -1, _( "Edit MMSI Properties" ), wxDefaultPosition, wxSize( 200, 200 ) );
-
-                if ( pd->ShowModal() == wxID_OK ) {
-                    g_MMSI_Props_Array.RemoveAt( m_context_item );
-                    g_MMSI_Props_Array.Insert( props_new, m_context_item );
-                }
+            pd = new MMSIEditDialog(
+                props_new, m_parent, -1, _( "Edit MMSI Properties" ),
+                wxDefaultPosition, wxSize( 200, 200 )
+            );
+            if ( pd->ShowModal() == wxID_OK ) {
+                g_MMSI_Props_Array.RemoveAt( m_context_item );
+                g_MMSI_Props_Array.Insert( props_new, m_context_item );
+            }
             pd->Destroy();
-           }
-           break;
-
+            break;
        case ID_DEF_MENU_MMSI_DELETE:
-           if ( props ) {
-               g_MMSI_Props_Array.RemoveAt( m_context_item );
-           }
-           break;
-   }
+            g_MMSI_Props_Array.RemoveAt( m_context_item );
+            break;
+    }
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4298,7 +4298,7 @@ void options::OnApplyClick( wxCommandEvent& event )
             msg += _( "\n - your minimum ship icon size must be between 1 and 100 mm" );
         if( !msg.IsEmpty() ) {
             msg.Prepend( _( "The settings for own ship real size are not correct:" ) );
-            OCPNMessageBox( this, msg, _( "OpenCPN info" ), wxICON_ERROR );
+            OCPNMessageBox( this, msg, _( "OpenCPN info" ), wxICON_ERROR | wxOK );
             ::wxEndBusyCursor();
             event.SetInt( wxID_STOP );
             return;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -300,7 +300,6 @@ int wxCALLBACK SortConnectionOnPriority(long item1, long item2, long list)
 
 extern ArrayOfMMSIProperties   g_MMSI_Props_Array;
 
-
 ///////////////////////////////////////////////////////////////////////////////
 /// Class MMSIEditDialog
 ///////////////////////////////////////////////////////////////////////////////
@@ -333,7 +332,6 @@ MMSIEditDialog::~MMSIEditDialog()
 {
     delete m_MMSICtl;
 }
-
 
 bool MMSIEditDialog::Create( MMSIProperties *props, wxWindow* parent, wxWindowID id, const wxString& caption,
                              const wxPoint& pos, const wxSize& size, long style )
@@ -450,7 +448,6 @@ void MMSIEditDialog::SetColorScheme( ColorScheme cs )
     DimeControl( this );
 }
 
-
 void MMSIEditDialog::OnMMSIEditCancelClick( wxCommandEvent& event )
 {
     EndModal( wxID_CANCEL );
@@ -545,7 +542,6 @@ wxString MMSIListCtrl::OnGetItemText( long item, long column ) const
                 break;
         }
     }
-
     return ret;
 }
 
@@ -593,9 +589,7 @@ void MMSIListCtrl::OnListItemRightClick( wxListEvent &event )
 
     SetItemCount( g_MMSI_Props_Array.GetCount() );
     Refresh( TRUE );
-
 }
-
 
 void MMSIListCtrl::PopupMenuHandler( wxCommandEvent& event )
 {
@@ -656,7 +650,6 @@ MMSI_Props_Panel::MMSI_Props_Panel( wxWindow *parent ):
 
     // m_pListCtrlMMSI->AssignImageList( imglist, wxIMAGE_LIST_SMALL );
     int dx = GetCharWidth();
-
 
     width = dx * 12;
     if ( s_width.ToLong( &lwidth ) ) {
@@ -729,7 +722,6 @@ void MMSI_Props_Panel::OnNewButton( wxCommandEvent &event )
 
     UpdateMMSIList();
 }
-
 
 void MMSI_Props_Panel::UpdateMMSIList( void )
 {
@@ -1096,9 +1088,8 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
 
     wxBoxSizer* bSizerOuterContainer = new wxBoxSizer( wxVERTICAL );
 
-
     wxStaticBoxSizer* sbSizerGeneral;
-    sbSizerGeneral = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("General") ), wxVERTICAL );
+    sbSizerGeneral = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _( "General" ) ), wxVERTICAL );
 
     wxBoxSizer* bSizer151;
     bSizer151 = new wxBoxSizer( wxVERTICAL );
@@ -1106,7 +1097,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     wxBoxSizer* bSizer161;
     bSizer161 = new wxBoxSizer( wxVERTICAL );
 
-    m_cbFilterSogCog = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Filter NMEA COG/SOG"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbFilterSogCog = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Filter NMEA COG/SOG" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbFilterSogCog->SetValue( g_bfilter_cogsog );
     bSizer161->Add( m_cbFilterSogCog, 0, wxALL, 5 );
 
@@ -1114,7 +1105,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     bSizer171->SetFlexibleDirection( wxBOTH );
     bSizer171->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 
-    m_stFilterSec = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Filter period (sec)"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stFilterSec = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "Filter period (sec)" ), wxDefaultPosition, wxDefaultSize, 0 );
     //m_stFilterSec->Wrap( -1 );
 
     int nspace = 5;
@@ -1123,53 +1114,52 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     #endif
     bSizer171->Add( m_stFilterSec, 1, wxALL, nspace );
 
-    m_tFilterSec = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(100, -1), 0 );
+    m_tFilterSec = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 100, -1 ), 0 );
     wxString sfilt;
-    sfilt.Printf( _T("%d"), g_COGFilterSec );
+    sfilt.Printf( _T( "%d" ), g_COGFilterSec );
     m_tFilterSec->SetValue( sfilt );
     bSizer171->Add( m_tFilterSec, 1, wxALL, 4 );
 
     bSizer161->Add( bSizer171, 1, wxEXPAND, 5 );
 
     int cb_space = 2;
-    m_cbNMEADebug = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Show NMEA Debug Window"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbNMEADebug = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Show NMEA Debug Window" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbNMEADebug->SetValue(NMEALogWindow::Get().Active());
     bSizer161->Add( m_cbNMEADebug, 0, wxALL, cb_space );
 
-    m_cbFurunoGP3X = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Use Furuno GP3X for uploads"), wxDefaultPosition, wxDefaultSize, 0 );
-    m_cbFurunoGP3X->SetValue(g_GPS_Ident == _T("FurunoGP3X"));
+    m_cbFurunoGP3X = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Use Furuno GP3X for uploads" ), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbFurunoGP3X->SetValue( g_GPS_Ident == _T( "FurunoGP3X" ) );
     bSizer161->Add( m_cbFurunoGP3X, 0, wxALL, cb_space );
 
-    m_cbGarminUploadHost = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Use GRMN for uploads"), wxDefaultPosition, wxDefaultSize, 0 );
-    m_cbGarminUploadHost->SetValue(g_bGarminHostUpload);
+    m_cbGarminUploadHost = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Use GRMN for uploads" ), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbGarminUploadHost->SetValue( g_bGarminHostUpload );
     bSizer161->Add( m_cbGarminUploadHost, 0, wxALL, cb_space );
 
-    m_cbAPBMagnetic = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Use mag bearings in ECAPB"), wxDefaultPosition, wxDefaultSize, 0 );
-    m_cbAPBMagnetic->SetValue(g_bMagneticAPB);
+    m_cbAPBMagnetic = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Use mag bearings in ECAPB" ), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbAPBMagnetic->SetValue( g_bMagneticAPB );
     bSizer161->Add( m_cbAPBMagnetic, 0, wxALL, cb_space );
 
     bSizer151->Add( bSizer161, 1, wxEXPAND, 5 );
     sbSizerGeneral->Add( bSizer151, 1, wxEXPAND, 5 );
     bSizerOuterContainer->Add( sbSizerGeneral, 0, wxALL|wxEXPAND, 5 );
 
-
     //  Connections listbox, etc
-    wxStaticBoxSizer* sbSizerLB= new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("Data Connections") ), wxVERTICAL );
+    wxStaticBoxSizer* sbSizerLB= new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _( "Data Connections" ) ), wxVERTICAL );
 
     wxBoxSizer* bSizer17;
     bSizer17 = new wxBoxSizer( wxVERTICAL );
 
-    m_lcSources = new wxListCtrl( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxSize(300, 200), wxLC_REPORT|wxLC_SINGLE_SEL);
+    m_lcSources = new wxListCtrl( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxSize( 300, 200 ), wxLC_REPORT | wxLC_SINGLE_SEL);
     bSizer17->Add( m_lcSources, 1, wxALL|wxEXPAND, 5 );
 
     wxBoxSizer* bSizer18;
     bSizer18 = new wxBoxSizer( wxHORIZONTAL );
     bSizer17->Add( bSizer18, 0, wxEXPAND, 5 );
 
-    m_buttonAdd = new wxButton( m_pNMEAForm, wxID_ANY, _("Add..."), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonAdd = new wxButton( m_pNMEAForm, wxID_ANY, _( "Add..." ), wxDefaultPosition, wxDefaultSize, 0 );
     bSizer18->Add( m_buttonAdd, 0, wxALL, 5 );
 
-    m_buttonRemove = new wxButton( m_pNMEAForm, wxID_ANY, _("Remove"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonRemove = new wxButton( m_pNMEAForm, wxID_ANY, _( "Remove" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_buttonRemove->Enable( false );
     bSizer18->Add( m_buttonRemove, 0, wxALL, 5 );
 
@@ -1177,53 +1167,47 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     bSizerOuterContainer->Add( sbSizerLB, 0, wxEXPAND, 5 );
 
     //  Connections Properties
+    sbSizerConnectionProps = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _( "Properties" ) ), wxVERTICAL );
 
-    sbSizerConnectionProps = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("Properties") ), wxVERTICAL );
+    wxFlexGridSizer* bSizer15 = new wxFlexGridSizer( 0, 2, 0, 0 );
+    bSizer15->SetFlexibleDirection( wxBOTH );
+    bSizer15->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 
+    sbSizerConnectionProps->Add( bSizer15, 0, wxEXPAND, 0 );
 
+    m_rbTypeSerial = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Serial" ), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
+    m_rbTypeSerial->SetValue( true );
+    bSizer15->Add( m_rbTypeSerial, 0, wxALL, 5 );
 
-        wxFlexGridSizer* bSizer15 = new wxFlexGridSizer( 0, 2, 0, 0 );
-        bSizer15->SetFlexibleDirection( wxBOTH );
-        bSizer15->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
+    m_rbTypeNet = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Network" ), wxDefaultPosition, wxDefaultSize, 0 );
+    bSizer15->Add( m_rbTypeNet, 0, wxALL, 5 );
 
-        sbSizerConnectionProps->Add( bSizer15, 0, wxEXPAND, 0 );
-
-        m_rbTypeSerial = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Serial"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
-        m_rbTypeSerial->SetValue( true );
-        bSizer15->Add( m_rbTypeSerial, 0, wxALL, 5 );
-
-        m_rbTypeNet = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Network"), wxDefaultPosition, wxDefaultSize, 0 );
-        bSizer15->Add( m_rbTypeNet, 0, wxALL, 5 );
-
-        if(OCPNPlatform::hasInternalGPS()){      // has internal GPS
-        m_rbTypeInternalGPS = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Built-in GPS"), wxDefaultPosition, wxDefaultSize, 0 );
+    if ( OCPNPlatform::hasInternalGPS() ) {
+        m_rbTypeInternalGPS = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Built-in GPS" ), wxDefaultPosition, wxDefaultSize, 0 );
         bSizer15->Add( m_rbTypeInternalGPS, 0, wxALL, 5 );
-        }
-        else
-            m_rbTypeInternalGPS = NULL;
+    } else
+        m_rbTypeInternalGPS = NULL;
 
-
-        if(OCPNPlatform::hasInternalBT()){      // has built-in Bluetooth
-        m_rbTypeInternalBT = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Built-in Bluetooth"), wxDefaultPosition, wxDefaultSize, 0 );
+    // has built-in Bluetooth
+    if ( OCPNPlatform::hasInternalBT() ) {
+        m_rbTypeInternalBT = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Built-in Bluetooth" ), wxDefaultPosition, wxDefaultSize, 0 );
         bSizer15->Add( m_rbTypeInternalBT, 0, wxALL, 5 );
 
-        m_buttonScanBT = new wxButton( m_pNMEAForm, wxID_ANY, _("BT Scan..."), wxDefaultPosition, wxDefaultSize );
+        m_buttonScanBT = new wxButton( m_pNMEAForm, wxID_ANY, _( "BT Scan..." ), wxDefaultPosition, wxDefaultSize );
         m_buttonScanBT->Hide();
         sbSizerConnectionProps->Add( m_buttonScanBT, 0, wxALL, 5 );
-
 
         wxBoxSizer* bSizer15a = new wxBoxSizer( wxHORIZONTAL );
         sbSizerConnectionProps->Add( bSizer15a, 0, wxEXPAND, 5 );
 
-
-        m_stBTPairs = new wxStaticText( m_pNMEAForm, wxID_ANY, _("BT Sources"), wxDefaultPosition, wxDefaultSize, 0 );
+        m_stBTPairs = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "BT Sources" ), wxDefaultPosition, wxDefaultSize, 0 );
         //m_stBTPairs->Wrap( -1 );
         //m_stBTPairs->Hide();
         bSizer15a->Add( m_stBTPairs, 0, wxALL, 5 );
 
         wxArrayString mt;
-        mt.Add(_T("unscanned"));
-        m_choiceBTDataSources = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, mt);
+        mt.Add( _T( "unscanned" ) );
+        m_choiceBTDataSources = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, mt );
         bSizer15a->Add( m_choiceBTDataSources, 1, wxEXPAND|wxTOP, 5 );
 
         #if 0
@@ -1246,22 +1230,17 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
         if( m_BTscan_results.GetCount() > 1){
             m_choiceBTDataSources->SetSelection( 1 );
         }
-
         #endif
+
         m_choiceBTDataSources->Hide();
-
-
         m_buttonScanBT->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnScanBTClick ), NULL, this );
-
-        }
-        else
-            m_rbTypeInternalBT = NULL;
-
+    } else
+        m_rbTypeInternalBT = NULL;
 
     wxBoxSizer *gSizerNetPropsV = new wxBoxSizer( wxVERTICAL );
     sbSizerConnectionProps->Add( gSizerNetPropsV, 0, wxEXPAND, 5 );
 
-    m_stNetProto = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Protocol"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stNetProto = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "Protocol" ), wxDefaultPosition, wxDefaultSize, 0 );
     //m_stNetProto->Wrap( -1 );
     gSizerNetPropsV->Add( m_stNetProto, 0, wxALL, 5 );
 
@@ -1269,113 +1248,104 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     bSizer16 = new wxBoxSizer( wxHORIZONTAL );
     gSizerNetPropsV->Add( bSizer16, 1, wxEXPAND, 5 );
 
-    m_rbNetProtoTCP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("TCP"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
+    m_rbNetProtoTCP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "TCP" ), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
     m_rbNetProtoTCP->Enable( true );
 
     bSizer16->Add( m_rbNetProtoTCP, 0, wxALL, 5 );
 
-    m_rbNetProtoUDP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("UDP"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_rbNetProtoUDP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "UDP" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_rbNetProtoUDP->Enable( true );
 
     bSizer16->Add( m_rbNetProtoUDP, 0, wxALL, 5 );
 
-    m_rbNetProtoGPSD = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("GPSD"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_rbNetProtoGPSD = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "GPSD" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_rbNetProtoGPSD->SetValue( true );
     bSizer16->Add( m_rbNetProtoGPSD, 0, wxALL, 5 );
-
 
     wxFlexGridSizer* fgSizer1a = new wxFlexGridSizer( 0, 2, 0, 0 );
     fgSizer1a->SetFlexibleDirection( wxBOTH );
     fgSizer1a->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
     gSizerNetPropsV->Add( fgSizer1a, 0, wxEXPAND, 5 );
 
-    m_stNetAddr = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Address"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stNetAddr = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "Address" ), wxDefaultPosition, wxDefaultSize, 0 );
     fgSizer1a->Add( m_stNetAddr, 0, wxALL, 5 );
 
-    m_tNetAddress = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(200, -1), 0 );
+    m_tNetAddress = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 200, -1 ), 0 );
     fgSizer1a->Add( m_tNetAddress, 1, wxTOP | wxALIGN_RIGHT, 5 );
 
-    m_stNetPort = new wxStaticText( m_pNMEAForm, wxID_ANY, _("DataPort"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stNetPort = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "DataPort" ), wxDefaultPosition, wxDefaultSize, 0 );
     fgSizer1a->Add( m_stNetPort, 1, wxALL, 5 );
 
-    m_tNetPort = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(200, -1), 0 );
+    m_tNetPort = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( 200, -1 ), 0 );
     fgSizer1a->Add( m_tNetPort, 1, wxTOP  | wxALIGN_RIGHT, 5 );
 
-
-
-
-
-
-
-
-
-
-
-
-
     gSizerSerProps = new wxGridSizer( 0, 1, 0, 0 );
-
 
     wxFlexGridSizer* fgSizer1 = new wxFlexGridSizer( 0, 2, 0, 0 );
     fgSizer1->SetFlexibleDirection( wxBOTH );
     fgSizer1->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
     gSizerSerProps->Add( fgSizer1, 0, wxEXPAND, 5 );
 
-    m_stSerPort = new wxStaticText( m_pNMEAForm, wxID_ANY, _("DataPort"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stSerPort = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "DataPort" ), wxDefaultPosition, wxDefaultSize, 0 );
     //m_stSerPort->Wrap( -1 );
     fgSizer1->Add( m_stSerPort, 0, wxALL, 5 );
 
     m_comboPort = new wxComboBox( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 );
     fgSizer1->Add( m_comboPort, 0, wxEXPAND|wxTOP, 5 );
 
-    m_stSerBaudrate = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Baudrate"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stSerBaudrate = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "Baudrate" ), wxDefaultPosition, wxDefaultSize, 0 );
    // m_stSerBaudrate->Wrap( -1 );
     fgSizer1->Add( m_stSerBaudrate, 0, wxALL, 5 );
 
-    wxString m_choiceBaudRateChoices[] = { _("150"), _("300"), _("600"), _("1200"), _("2400"), _("4800"), _("9600"), _("19200"), _("38400"), _("57600"), _("115200"), _("230400"), _("460800"), _("921600") };
+    wxString m_choiceBaudRateChoices[] = {
+        _( "150" ), _( "300" ), _( "600" ), _( "1200" ), _( "2400" ),
+        _( "4800" ), _( "9600" ), _( "19200" ), _( "38400" ), _( "57600" ),
+        _( "115200" ), _( "230400" ), _( "460800" ), _( "921600" )
+    };
     int m_choiceBaudRateNChoices = sizeof( m_choiceBaudRateChoices ) / sizeof( wxString );
     m_choiceBaudRate = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choiceBaudRateNChoices, m_choiceBaudRateChoices, 0 );
     m_choiceBaudRate->SetSelection( 0 );
-    fgSizer1->Add( m_choiceBaudRate, 1, wxEXPAND|wxTOP, 5 );
+    fgSizer1->Add( m_choiceBaudRate, 1, wxEXPAND | wxTOP, 5 );
 
     m_stSerProtocol = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Protocol"), wxDefaultPosition, wxDefaultSize, 0 );
     //m_stSerProtocol->Wrap( -1 );
     fgSizer1->Add( m_stSerProtocol, 0, wxALL, 5 );
 
-    wxString m_choiceSerialProtocolChoices[] = { _("NMEA 0183"), _("NMEA 2000"), _("Seatalk") };
+    wxString m_choiceSerialProtocolChoices[] = { _( "NMEA 0183" ), _( "NMEA 2000" ), _( "Seatalk" ) };
     int m_choiceSerialProtocolNChoices = sizeof( m_choiceSerialProtocolChoices ) / sizeof( wxString );
     m_choiceSerialProtocol = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choiceSerialProtocolNChoices, m_choiceSerialProtocolChoices, 0 );
     m_choiceSerialProtocol->SetSelection( 0 );
     m_choiceSerialProtocol->Enable( false );
 
     fgSizer1->Add( m_choiceSerialProtocol, 1, wxEXPAND|wxTOP, 5 );
-    m_stPriority = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Priority"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stPriority = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "Priority" ), wxDefaultPosition, wxDefaultSize, 0 );
     //m_stPriority->Wrap( -1 );
     fgSizer1->Add( m_stPriority, 0, wxALL, 5 );
 
-    wxString m_choicePriorityChoices[] = { _("0"), _("1"), _("2"), _("3"), _("4"), _("5"), _("6"), _("7"), _("8"), _("9") };
+    wxString m_choicePriorityChoices[] = {
+        _( "0" ), _( "1" ), _( "2" ), _( "3" ), _( "4" ),
+        _( "5" ), _( "6" ), _( "7" ), _( "8" ), _( "9" )
+    };
     int m_choicePriorityNChoices = sizeof( m_choicePriorityChoices ) / sizeof( wxString );
     m_choicePriority = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choicePriorityNChoices, m_choicePriorityChoices, 0 );
     m_choicePriority->SetSelection( 9 );
-    fgSizer1->Add( m_choicePriority, 0, wxEXPAND|wxTOP, 5 );
-
-
+    fgSizer1->Add( m_choicePriority, 0, wxEXPAND | wxTOP, 5 );
 
     wxBoxSizer* fgSizer5 = new wxBoxSizer( wxVERTICAL );
 
-    m_cbCheckCRC = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Control checksum"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbCheckCRC = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Control checksum" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbCheckCRC->SetValue(true);
-    m_cbCheckCRC->SetToolTip( _("If checked, only the sentences with a valid checksum are passed through") );
+    m_cbCheckCRC->SetToolTip( _( "If checked, only the sentences with a valid checksum are passed through" ) );
     fgSizer5->Add( m_cbCheckCRC, 0, wxALL, 5 );
 
-    m_cbGarminHost = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Use GRMN mode for input"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbGarminHost = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Use GRMN mode for input" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbGarminHost->SetValue(false);
     fgSizer5->Add( m_cbGarminHost, 0, wxALL, 5 );
     #ifndef USE_GARMINHOST
     //m_cbGarminHost->Hide();
     #endif
 
-    m_cbInput = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Receive Input on this Port"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbInput = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Receive Input on this Port" ), wxDefaultPosition, wxDefaultSize, 0 );
     fgSizer5->Add( m_cbInput, 0, wxALL, 5 );
 
     m_cbOutput = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Output on this port"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1385,7 +1355,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     fgSizer5a->SetFlexibleDirection( wxBOTH );
     fgSizer5a->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 
-    m_stTalkerIdText = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Talker ID"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stTalkerIdText = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "Talker ID" ), wxDefaultPosition, wxDefaultSize, 0 );
     //m_stTalkerIdText->Wrap( -1 );
     fgSizer5a->Add( m_stTalkerIdText, 0, wxALL, 5 );
 
@@ -1393,12 +1363,14 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     m_TalkerIdText->SetMaxLength( 2 );
     fgSizer5a->Add( m_TalkerIdText, 0, wxALIGN_LEFT | wxALL, group_item_spacing );
 
-    m_stPrecision = new wxStaticText( m_pNMEAForm, wxID_ANY, _("APB bearing precision"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stPrecision = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "APB bearing precision" ), wxDefaultPosition, wxDefaultSize, 0 );
 
     //m_stPrecision->Wrap( -1 );
     fgSizer5a->Add( m_stPrecision, 0, wxALL, 5 );
 
-    wxString m_choicePrecisionChoices[] = { _("x"), _("x.x"), _("x.xx"), _("x.xxx"), _("x.xxxx") };
+    wxString m_choicePrecisionChoices[] = {
+        _( "x" ), _( "x.x" ), _( "x.xx" ), _( "x.xxx" ), _( "x.xxxx" )
+    };
     int m_choicePrecisionNChoices = sizeof( m_choicePrecisionChoices ) / sizeof( wxString );
     m_choicePrecision = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choicePrecisionNChoices, m_choicePrecisionChoices, 0 );
     m_choicePrecision->SetSelection( g_NMEAAPBPrecision );
@@ -1408,23 +1380,16 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     sbSizerConnectionProps->Add( fgSizer5, 0, wxEXPAND, 5 );
     sbSizerConnectionProps->Add( fgSizer5a, 0, wxEXPAND, 5 );
 
-
-
-
-
-
-
-    sbSizerInFilter = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("Input filtering") ), wxVERTICAL );
+    sbSizerInFilter = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _( "Input filtering" ) ), wxVERTICAL );
 
     wxBoxSizer* bSizer9;
     bSizer9 = new wxBoxSizer( wxVERTICAL );
 
-    m_rbIAccept = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Accept only sentences"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
+    m_rbIAccept = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Accept only sentences" ), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
     bSizer9->Add( m_rbIAccept, 0, wxALL, 5 );
 
-    m_rbIIgnore = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Ignore sentences"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_rbIIgnore = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Ignore sentences" ), wxDefaultPosition, wxDefaultSize, 0 );
     bSizer9->Add( m_rbIIgnore, 0, wxALL, 5 );
-
 
     sbSizerInFilter->Add( bSizer9, 0, wxEXPAND, 5 );
 
@@ -1440,33 +1405,30 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     sbSizerInFilter->Add( bSizer11, 0, wxEXPAND, 5 );
     sbSizerConnectionProps->Add( sbSizerInFilter, 0, wxEXPAND, 5 );
 
-    sbSizerOutFilter = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("Output filtering") ), wxVERTICAL );
+    sbSizerOutFilter = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _( "Output filtering" ) ), wxVERTICAL );
 
     wxBoxSizer* bSizer10;
     bSizer10 = new wxBoxSizer( wxVERTICAL );
 
-    m_rbOAccept = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Transmit sentences"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
+    m_rbOAccept = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Transmit sentences" ), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
     bSizer10->Add( m_rbOAccept, 0, wxALL, 5 );
 
-    m_rbOIgnore = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Drop sentences"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_rbOIgnore = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Drop sentences" ), wxDefaultPosition, wxDefaultSize, 0 );
     bSizer10->Add( m_rbOIgnore, 0, wxALL, 5 );
-
 
     sbSizerOutFilter->Add( bSizer10, 0, wxEXPAND, 5 );
 
     wxBoxSizer* bSizer12;
     bSizer12 = new wxBoxSizer( wxHORIZONTAL );
 
-    m_tcOutputStc = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize(-1, -1), wxTE_READONLY );
+    m_tcOutputStc = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxSize( -1, -1 ), wxTE_READONLY );
     bSizer12->Add( m_tcOutputStc, 1, wxALL, 5 );
 
     m_btnOutputStcList = new wxButton( m_pNMEAForm, wxID_ANY, _("..."), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT );
     bSizer12->Add( m_btnOutputStcList, 0, wxALL, 5 );
 
-
     sbSizerOutFilter->Add( bSizer12, 0, wxEXPAND, 5 );
     sbSizerConnectionProps->Add( sbSizerOutFilter, 0, wxEXPAND, 5 );
-
 
     bSizerOuterContainer->Add( sbSizerConnectionProps, 1, wxALL|wxEXPAND, 5 );
 
@@ -1518,57 +1480,56 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     m_lcSources->Connect( wxEVT_LEFT_DOWN, wxMouseEventHandler(options::OnConnectionToggleEnable), NULL, this );
 
     wxListItem col0;
-    col0.SetId(0);
-    col0.SetText( _("On") );
-    m_lcSources->InsertColumn(0, col0);
+    col0.SetId( 0 );
+    col0.SetText( _( "On" ) );
+    m_lcSources->InsertColumn( 0, col0 );
 
     wxListItem col1;
-    col1.SetId(1);
-    col1.SetText( _("Type") );
-    m_lcSources->InsertColumn(1, col1);
+    col1.SetId( 1 );
+    col1.SetText( _( "Type" ) );
+    m_lcSources->InsertColumn( 1, col1 );
 
     wxListItem col2;
-    col2.SetId(2);
-    col2.SetText( _("Port") );
-    m_lcSources->InsertColumn(2, col2);
+    col2.SetId( 2 );
+    col2.SetText( _( "Port" ) );
+    m_lcSources->InsertColumn( 2, col2 );
 
     wxListItem col3;
-    col3.SetId(3);
+    col3.SetId( 3 );
     col3.SetText( _("Prio") );
-    m_lcSources->InsertColumn(3, col3);
+    m_lcSources->InsertColumn( 3, col3 );
 
     wxListItem col4;
-    col4.SetId(4);
-    col4.SetText( _("Parm") );
-    m_lcSources->InsertColumn(4, col4);
+    col4.SetId( 4 );
+    col4.SetText( _( "Parm" ) );
+    m_lcSources->InsertColumn( 4, col4 );
 
     wxListItem col5;
-    col5.SetId(5);
-    col5.SetText( _("I/O") );
-    m_lcSources->InsertColumn(5, col5);
+    col5.SetId( 5 );
+    col5.SetText( _( "I/O" ) );
+    m_lcSources->InsertColumn( 5, col5 );
 
     wxListItem col6;
-    col6.SetId(6);
-    col6.SetText( _("Filters") );
-    m_lcSources->InsertColumn(6, col6);
+    col6.SetId( 6 );
+    col6.SetText( _( "Filters" ) );
+    m_lcSources->InsertColumn( 6, col6 );
 
     //  Build the image list
     wxBitmap unchecked_bmp(16, 16), checked_bmp(16, 16);
-
     {
         wxMemoryDC renderer_dc;
 
         // Unchecked
-        renderer_dc.SelectObject(unchecked_bmp);
-        renderer_dc.SetBackground(*wxTheBrushList->FindOrCreateBrush(GetBackgroundColour(), wxBRUSHSTYLE_SOLID));
+        renderer_dc.SelectObject( unchecked_bmp );
+        renderer_dc.SetBackground( *wxTheBrushList->FindOrCreateBrush( GetBackgroundColour(), wxBRUSHSTYLE_SOLID ) );
         renderer_dc.Clear();
-        wxRendererNative::Get().DrawCheckBox(this, renderer_dc, wxRect(0, 0, 16, 16), 0);
+        wxRendererNative::Get().DrawCheckBox( this, renderer_dc, wxRect( 0, 0, 16, 16 ), 0 );
 
         // Checked
-        renderer_dc.SelectObject(checked_bmp);
-        renderer_dc.SetBackground(*wxTheBrushList->FindOrCreateBrush(GetBackgroundColour(), wxBRUSHSTYLE_SOLID));
+        renderer_dc.SelectObject( checked_bmp );
+        renderer_dc.SetBackground( *wxTheBrushList->FindOrCreateBrush( GetBackgroundColour(), wxBRUSHSTYLE_SOLID ) );
         renderer_dc.Clear();
-        wxRendererNative::Get().DrawCheckBox(this, renderer_dc, wxRect(0, 0, 16, 16), wxCONTROL_CHECKED);
+        wxRendererNative::Get().DrawCheckBox( this, renderer_dc, wxRect( 0, 0, 16, 16 ), wxCONTROL_CHECKED );
     }
 
     wxImageList *imglist = new wxImageList( 16, 16, true, 1 );
@@ -1578,14 +1539,14 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
 
     m_lcSources->Refresh();
 
-    m_stcdialog_in = new SentenceListDlg(FILTER_INPUT, this);
-    m_stcdialog_out = new SentenceListDlg(FILTER_OUTPUT, this);
+    m_stcdialog_in = new SentenceListDlg( FILTER_INPUT, this );
+    m_stcdialog_out = new SentenceListDlg( FILTER_OUTPUT, this );
 
     FillSourceList();
 
-    if(m_pSerialArray){
-        for(size_t i = 0; i < m_pSerialArray->Count() ; i++){
-            m_comboPort->Append(m_pSerialArray->Item(i));
+    if ( m_pSerialArray ) {
+        for ( size_t i = 0; i < m_pSerialArray->Count() ; i++ ) {
+            m_comboPort->Append( m_pSerialArray->Item( i ) );
         }
     }
 
@@ -1598,7 +1559,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
 
 void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_spacing, wxSize small_button_size )
 {
-    m_pNMEAForm = AddPage( parent, _("NMEA") );
+    m_pNMEAForm = AddPage( parent, _( "NMEA" ) );
 
     wxBoxSizer* bSizer4 = new wxBoxSizer( wxVERTICAL );
     m_pNMEAForm->SetSizer( bSizer4 );
@@ -1606,9 +1567,8 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
 
     wxBoxSizer* bSizerOuterContainer = new wxBoxSizer( wxVERTICAL );
 
-
     wxStaticBoxSizer* sbSizerGeneral;
-    sbSizerGeneral = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("General") ), wxVERTICAL );
+    sbSizerGeneral = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _( "General" ) ), wxVERTICAL );
 
     wxBoxSizer* bSizer151;
     bSizer151 = new wxBoxSizer( wxVERTICAL );
@@ -1619,11 +1579,11 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     wxBoxSizer* bSizer171;
     bSizer171 = new wxBoxSizer( wxHORIZONTAL );
 
-    m_cbFilterSogCog = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Filter NMEA Course and Speed data"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbFilterSogCog = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Filter NMEA Course and Speed data" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbFilterSogCog->SetValue( g_bfilter_cogsog );
     bSizer171->Add( m_cbFilterSogCog, 0, wxALL, 5 );
 
-    m_stFilterSec = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Filter period (sec)"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stFilterSec = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "Filter period (sec)" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_stFilterSec->Wrap( -1 );
 
     int nspace = 5;
@@ -1637,23 +1597,22 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     sfilt.Printf( _T("%d"), g_COGFilterSec );
     m_tFilterSec->SetValue( sfilt );
     bSizer171->Add( m_tFilterSec, 0, wxALL, 4 );
-
     bSizer161->Add( bSizer171, 1, wxEXPAND, 5 );
 
     int cb_space = 2;
-    m_cbNMEADebug = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Show NMEA Debug Window"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbNMEADebug = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Show NMEA Debug Window" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbNMEADebug->SetValue(NMEALogWindow::Get().Active());
     bSizer161->Add( m_cbNMEADebug, 0, wxALL, cb_space );
 
-    m_cbFurunoGP3X = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Format uploads for Furuno GP3X"), wxDefaultPosition, wxDefaultSize, 0 );
-    m_cbFurunoGP3X->SetValue(g_GPS_Ident == _T("FurunoGP3X"));
+    m_cbFurunoGP3X = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Format uploads for Furuno GP3X" ), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbFurunoGP3X->SetValue( g_GPS_Ident == _T( "FurunoGP3X" ) );
     bSizer161->Add( m_cbFurunoGP3X, 0, wxALL, cb_space );
 
-    m_cbGarminUploadHost = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Use Garmin GRMN (Host) mode for uploads"), wxDefaultPosition, wxDefaultSize, 0 );
-    m_cbGarminUploadHost->SetValue(g_bGarminHostUpload);
+    m_cbGarminUploadHost = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Use Garmin GRMN (Host) mode for uploads" ), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbGarminUploadHost->SetValue( g_bGarminHostUpload );
     bSizer161->Add( m_cbGarminUploadHost, 0, wxALL, cb_space );
 
-    m_cbAPBMagnetic = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Use magnetic bearings in output sentence ECAPB"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbAPBMagnetic = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Use magnetic bearings in output sentence ECAPB" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_cbAPBMagnetic->SetValue(g_bMagneticAPB);
     bSizer161->Add( m_cbAPBMagnetic, 0, wxALL, cb_space );
 
@@ -1661,24 +1620,22 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     sbSizerGeneral->Add( bSizer151, 1, wxEXPAND, 5 );
     bSizerOuterContainer->Add( sbSizerGeneral, 0, wxALL|wxEXPAND, 5 );
 
-
     //  Connections listbox, etc
-    wxStaticBoxSizer* sbSizerLB= new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("Data Connections") ), wxVERTICAL );
-
+    wxStaticBoxSizer* sbSizerLB= new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _( "Data Connections" ) ), wxVERTICAL );
 
     wxBoxSizer* bSizer17;
     bSizer17 = new wxBoxSizer( wxVERTICAL );
 
-    m_lcSources = new wxListCtrl( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxSize(-1, 150), wxLC_REPORT|wxLC_SINGLE_SEL);
-    bSizer17->Add( m_lcSources, 1, wxALL|wxEXPAND, 5 );
+    m_lcSources = new wxListCtrl( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxSize( -1, 150 ), wxLC_REPORT | wxLC_SINGLE_SEL );
+    bSizer17->Add( m_lcSources, 1, wxALL | wxEXPAND, 5 );
 
     wxBoxSizer* bSizer18;
     bSizer18 = new wxBoxSizer( wxHORIZONTAL );
 
-    m_buttonAdd = new wxButton( m_pNMEAForm, wxID_ANY, _("Add Connection"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonAdd = new wxButton( m_pNMEAForm, wxID_ANY, _( "Add Connection" ), wxDefaultPosition, wxDefaultSize, 0 );
     bSizer18->Add( m_buttonAdd, 0, wxALL, 5 );
 
-    m_buttonRemove = new wxButton( m_pNMEAForm, wxID_ANY, _("Remove Connection"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_buttonRemove = new wxButton( m_pNMEAForm, wxID_ANY, _( "Remove Connection" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_buttonRemove->Enable( false );
     bSizer18->Add( m_buttonRemove, 0, wxALL, 5 );
 
@@ -1686,36 +1643,33 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     sbSizerLB->Add( bSizer17, 1, wxEXPAND, 5 );
     bSizerOuterContainer->Add( sbSizerLB, 0, wxEXPAND, 5 );
 
-
     //  Connections Properties
-
-    sbSizerConnectionProps = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("Properties") ), wxVERTICAL );
+    sbSizerConnectionProps = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _( "Properties" ) ), wxVERTICAL );
 
     wxBoxSizer* bSizer15;
     bSizer15 = new wxBoxSizer( wxHORIZONTAL );
 
     sbSizerConnectionProps->Add( bSizer15, 0, wxEXPAND, 0 );
 
-    m_rbTypeSerial = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Serial"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
+    m_rbTypeSerial = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Serial" ), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
     m_rbTypeSerial->SetValue( true );
     bSizer15->Add( m_rbTypeSerial, 0, wxALL, 5 );
 
-    m_rbTypeNet = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Network"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_rbTypeNet = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Network" ), wxDefaultPosition, wxDefaultSize, 0 );
     bSizer15->Add( m_rbTypeNet, 0, wxALL, 5 );
 
-    if(OCPNPlatform::hasInternalGPS()){      // has internal GPS
-        m_rbTypeInternalGPS = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Built-in GPS"), wxDefaultPosition, wxDefaultSize, 0 );
+    if ( OCPNPlatform::hasInternalGPS() ) {
+        m_rbTypeInternalGPS = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Built-in GPS" ), wxDefaultPosition, wxDefaultSize, 0 );
         bSizer15->Add( m_rbTypeInternalGPS, 0, wxALL, 5 );
-    }
-    else
+    } else
         m_rbTypeInternalGPS = NULL;
 
-
-    if(OCPNPlatform::hasInternalBT()){      // has built-in Bluetooth
-        m_rbTypeInternalBT = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Built-in Bluetooth SPP"), wxDefaultPosition, wxDefaultSize, 0 );
+    // has built-in Bluetooth
+    if ( OCPNPlatform::hasInternalBT() ) {
+        m_rbTypeInternalBT = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Built-in Bluetooth SPP" ), wxDefaultPosition, wxDefaultSize, 0 );
         bSizer15->Add( m_rbTypeInternalBT, 0, wxALL, 5 );
 
-        m_buttonScanBT = new wxButton( m_pNMEAForm, wxID_ANY, _("BT Scan"), wxDefaultPosition, wxDefaultSize );
+        m_buttonScanBT = new wxButton( m_pNMEAForm, wxID_ANY, _( "BT Scan" ), wxDefaultPosition, wxDefaultSize );
         m_buttonScanBT->Hide();
 
         wxBoxSizer* bSizer15a = new wxBoxSizer( wxHORIZONTAL );
@@ -1723,14 +1677,14 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
 
         bSizer15a->Add( m_buttonScanBT, 0, wxALL, 5 );
 
-        m_stBTPairs = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Bluetooth Data Sources"), wxDefaultPosition, wxDefaultSize, 0 );
+        m_stBTPairs = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "Bluetooth Data Sources" ), wxDefaultPosition, wxDefaultSize, 0 );
         m_stBTPairs->Wrap( -1 );
         m_stBTPairs->Hide();
         bSizer15a->Add( m_stBTPairs, 0, wxALL, 5 );
 
         wxArrayString mt;
-        mt.Add(_T("unscanned"));
-        m_choiceBTDataSources = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, mt);
+        mt.Add( _T( "unscanned" ) );
+        m_choiceBTDataSources = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, mt );
 
         #if 0
         m_BTscan_results.Clear();
@@ -1752,60 +1706,53 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     if( m_BTscan_results.GetCount() > 1){
         m_choiceBTDataSources->SetSelection( 1 );
     }
+        #endif
 
-    #endif
-    m_choiceBTDataSources->Hide();
-    bSizer15a->Add( m_choiceBTDataSources, 1, wxEXPAND|wxTOP, 5 );
+        m_choiceBTDataSources->Hide();
+        bSizer15a->Add( m_choiceBTDataSources, 1, wxEXPAND|wxTOP, 5 );
 
-
-    m_buttonScanBT->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnScanBTClick ), NULL, this );
-
-    }
-    else
+        m_buttonScanBT->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( options::OnScanBTClick ), NULL, this );
+    } else
         m_rbTypeInternalBT = NULL;
-
-
 
     gSizerNetProps = new wxGridSizer( 0, 2, 0, 0 );
 
-    m_stNetProto = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Protocol"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stNetProto = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "Protocol" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_stNetProto->Wrap( -1 );
     gSizerNetProps->Add( m_stNetProto, 0, wxALL, 5 );
 
     wxBoxSizer* bSizer16;
     bSizer16 = new wxBoxSizer( wxHORIZONTAL );
 
-    m_rbNetProtoTCP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("TCP"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
+    m_rbNetProtoTCP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "TCP" ), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
     m_rbNetProtoTCP->Enable( true );
 
     bSizer16->Add( m_rbNetProtoTCP, 0, wxALL, 5 );
 
-    m_rbNetProtoUDP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("UDP"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_rbNetProtoUDP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "UDP" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_rbNetProtoUDP->Enable( true );
 
     bSizer16->Add( m_rbNetProtoUDP, 0, wxALL, 5 );
 
-    m_rbNetProtoGPSD = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("GPSD"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_rbNetProtoGPSD = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "GPSD" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_rbNetProtoGPSD->SetValue( true );
     bSizer16->Add( m_rbNetProtoGPSD, 0, wxALL, 5 );
 
-
     gSizerNetProps->Add( bSizer16, 1, wxEXPAND, 5 );
 
-    m_stNetAddr = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Address"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stNetAddr = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "Address" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_stNetAddr->Wrap( -1 );
     gSizerNetProps->Add( m_stNetAddr, 0, wxALL, 5 );
 
     m_tNetAddress = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-    gSizerNetProps->Add( m_tNetAddress, 0, wxEXPAND|wxTOP, 5 );
+    gSizerNetProps->Add( m_tNetAddress, 0, wxEXPAND | wxTOP, 5 );
 
-    m_stNetPort = new wxStaticText( m_pNMEAForm, wxID_ANY, _("DataPort"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stNetPort = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "DataPort" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_stNetPort->Wrap( -1 );
     gSizerNetProps->Add( m_stNetPort, 0, wxALL, 5 );
 
     m_tNetPort = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0 );
-    gSizerNetProps->Add( m_tNetPort, 1, wxEXPAND|wxTOP, 5 );
-
+    gSizerNetProps->Add( m_tNetPort, 1, wxEXPAND | wxTOP, 5 );
 
     sbSizerConnectionProps->Add( gSizerNetProps, 0, wxEXPAND, 5 );
 
@@ -1816,44 +1763,50 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     fgSizer1->SetFlexibleDirection( wxBOTH );
     fgSizer1->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 
-    m_stSerPort = new wxStaticText( m_pNMEAForm, wxID_ANY, _("DataPort"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stSerPort = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "DataPort" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_stSerPort->Wrap( -1 );
     fgSizer1->Add( m_stSerPort, 0, wxALL, 5 );
 
     m_comboPort = new wxComboBox( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0, NULL, 0 );
-    fgSizer1->Add( m_comboPort, 0, wxEXPAND|wxTOP, 5 );
+    fgSizer1->Add( m_comboPort, 0, wxEXPAND | wxTOP, 5 );
 
-    m_stSerBaudrate = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Baudrate"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stSerBaudrate = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "Baudrate" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_stSerBaudrate->Wrap( -1 );
     fgSizer1->Add( m_stSerBaudrate, 0, wxALL, 5 );
 
-    wxString m_choiceBaudRateChoices[] = { _("150"), _("300"), _("600"), _("1200"), _("2400"), _("4800"), _("9600"), _("19200"), _("38400"), _("57600"), _("115200"), _("230400"), _("460800"), _("921600") };
+    wxString m_choiceBaudRateChoices[] = {
+        _( "150" ), _( "300" ), _( "600" ), _( "1200" ), _( "2400" ),
+        _( "4800" ), _( "9600" ), _( "19200" ), _( "38400" ), _( "57600" ),
+        _( "115200" ), _( "230400" ), _( "460800" ), _( "921600" )
+    };
     int m_choiceBaudRateNChoices = sizeof( m_choiceBaudRateChoices ) / sizeof( wxString );
     m_choiceBaudRate = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choiceBaudRateNChoices, m_choiceBaudRateChoices, 0 );
     m_choiceBaudRate->SetSelection( 0 );
-    fgSizer1->Add( m_choiceBaudRate, 1, wxEXPAND|wxTOP, 5 );
+    fgSizer1->Add( m_choiceBaudRate, 1, wxEXPAND | wxTOP, 5 );
 
-    m_stSerProtocol = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Protocol"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stSerProtocol = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "Protocol" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_stSerProtocol->Wrap( -1 );
     fgSizer1->Add( m_stSerProtocol, 0, wxALL, 5 );
 
-    wxString m_choiceSerialProtocolChoices[] = { _("NMEA 0183"), _("NMEA 2000"), _("Seatalk") };
+    wxString m_choiceSerialProtocolChoices[] = { _( "NMEA 0183" ), _( "NMEA 2000" ), _( "Seatalk" ) };
     int m_choiceSerialProtocolNChoices = sizeof( m_choiceSerialProtocolChoices ) / sizeof( wxString );
     m_choiceSerialProtocol = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choiceSerialProtocolNChoices, m_choiceSerialProtocolChoices, 0 );
     m_choiceSerialProtocol->SetSelection( 0 );
     m_choiceSerialProtocol->Enable( false );
 
-    fgSizer1->Add( m_choiceSerialProtocol, 1, wxEXPAND|wxTOP, 5 );
+    fgSizer1->Add( m_choiceSerialProtocol, 1, wxEXPAND | wxTOP, 5 );
     m_stPriority = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Priority"), wxDefaultPosition, wxDefaultSize, 0 );
     m_stPriority->Wrap( -1 );
     fgSizer1->Add( m_stPriority, 0, wxALL, 5 );
 
-    wxString m_choicePriorityChoices[] = { _("0"), _("1"), _("2"), _("3"), _("4"), _("5"), _("6"), _("7"), _("8"), _("9") };
+    wxString m_choicePriorityChoices[] = {
+        _( "0" ), _( "1" ), _( "2" ), _( "3" ), _( "4" ),
+        _( "5" ), _( "6" ), _( "7" ), _( "8" ), _( "9" )
+    };
     int m_choicePriorityNChoices = sizeof( m_choicePriorityChoices ) / sizeof( wxString );
     m_choicePriority = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choicePriorityNChoices, m_choicePriorityChoices, 0 );
     m_choicePriority->SetSelection( 9 );
-    fgSizer1->Add( m_choicePriority, 0, wxEXPAND|wxTOP, 5 );
-
+    fgSizer1->Add( m_choicePriority, 0, wxEXPAND | wxTOP, 5 );
 
     gSizerSerProps->Add( fgSizer1, 0, wxEXPAND, 5 );
 
@@ -1862,39 +1815,40 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     fgSizer5->SetFlexibleDirection( wxBOTH );
     fgSizer5->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 
-    m_cbCheckCRC = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Control checksum"), wxDefaultPosition, wxDefaultSize, 0 );
-    m_cbCheckCRC->SetValue(true);
-    m_cbCheckCRC->SetToolTip( _("If checked, only the sentences with a valid checksum are passed through") );
+    m_cbCheckCRC = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Control checksum" ), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbCheckCRC->SetValue( true );
+    m_cbCheckCRC->SetToolTip( _( "If checked, only the sentences with a valid checksum are passed through" ) );
     fgSizer5->Add( m_cbCheckCRC, 0, wxALL, 5 );
 
-    m_cbGarminHost = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Use Garmin (GRMN) mode for input"), wxDefaultPosition, wxDefaultSize, 0 );
-    m_cbGarminHost->SetValue(false);
+    m_cbGarminHost = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Use Garmin (GRMN) mode for input" ), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbGarminHost->SetValue( false );
     fgSizer5->Add( m_cbGarminHost, 0, wxALL, 5 );
     #ifndef USE_GARMINHOST
     m_cbGarminHost->Hide();
     #endif
 
-    m_cbInput = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Receive Input on this Port"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbInput = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Receive Input on this Port" ), wxDefaultPosition, wxDefaultSize, 0 );
     fgSizer5->Add( m_cbInput, 0, wxALL, 5 );
 
-    m_cbOutput = new wxCheckBox( m_pNMEAForm, wxID_ANY, _("Output on this port ( as Autopilot or NMEA Repeater)"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_cbOutput = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Output on this port ( as Autopilot or NMEA Repeater)" ), wxDefaultPosition, wxDefaultSize, 0 );
     fgSizer5->Add( m_cbOutput, 0, wxALL, 5 );
 
-
-    m_stTalkerIdText = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Talker ID (blank = default ID)"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stTalkerIdText = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "Talker ID (blank = default ID)" ), wxDefaultPosition, wxDefaultSize, 0 );
     m_stTalkerIdText->Wrap( -1 );
     fgSizer5->Add( m_stTalkerIdText, 0, wxALL, 5 );
 
-    m_TalkerIdText = new wxTextCtrl( m_pNMEAForm, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize( 50, -1 ), 0 );
+    m_TalkerIdText = new wxTextCtrl( m_pNMEAForm, ID_OPTEXTCTRL, _T( "" ), wxDefaultPosition, wxSize( 50, -1 ), 0 );
     m_TalkerIdText->SetMaxLength( 2 );
     fgSizer5->Add( m_TalkerIdText, 0, wxALIGN_LEFT | wxALL, group_item_spacing );
 
-    m_stPrecision = new wxStaticText( m_pNMEAForm, wxID_ANY, _("APB bearing precision"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_stPrecision = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "APB bearing precision" ), wxDefaultPosition, wxDefaultSize, 0 );
 
     m_stPrecision->Wrap( -1 );
     fgSizer5->Add( m_stPrecision, 0, wxALL, 5 );
 
-    wxString m_choicePrecisionChoices[] = { _("x"), _("x.x"), _("x.xx"), _("x.xxx"), _("x.xxxx") };
+    wxString m_choicePrecisionChoices[] = {
+        _( "x" ), _( "x.x" ), _( "x.xx" ), _( "x.xxx" ), _( "x.xxxx" )
+    };
     int m_choicePrecisionNChoices = sizeof( m_choicePrecisionChoices ) / sizeof( wxString );
     m_choicePrecision = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choicePrecisionNChoices, m_choicePrecisionChoices, 0 );
     m_choicePrecision->SetSelection( g_NMEAAPBPrecision );
@@ -1903,17 +1857,16 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     sbSizerConnectionProps->Add( gSizerSerProps, 0, wxEXPAND, 5 );
     sbSizerConnectionProps->Add( fgSizer5, 0, wxEXPAND, 5 );
 
-    sbSizerInFilter = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("Input filtering") ), wxVERTICAL );
+    sbSizerInFilter = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _( "Input filtering" ) ), wxVERTICAL );
 
     wxBoxSizer* bSizer9;
     bSizer9 = new wxBoxSizer( wxHORIZONTAL );
 
-    m_rbIAccept = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Accept only sentences"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
+    m_rbIAccept = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Accept only sentences" ), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
     bSizer9->Add( m_rbIAccept, 0, wxALL, 5 );
 
-    m_rbIIgnore = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Ignore sentences"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_rbIIgnore = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Ignore sentences" ), wxDefaultPosition, wxDefaultSize, 0 );
     bSizer9->Add( m_rbIIgnore, 0, wxALL, 5 );
-
 
     sbSizerInFilter->Add( bSizer9, 0, wxEXPAND, 5 );
 
@@ -1921,26 +1874,25 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     bSizer11 = new wxBoxSizer( wxHORIZONTAL );
 
     m_tcInputStc = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY );
-    bSizer11->Add( m_tcInputStc, 1, wxALL|wxEXPAND, 5 );
+    bSizer11->Add( m_tcInputStc, 1, wxALL | wxEXPAND, 5 );
 
-    m_btnInputStcList = new wxButton( m_pNMEAForm, wxID_ANY, _("..."), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT );
+    m_btnInputStcList = new wxButton( m_pNMEAForm, wxID_ANY, _( "..." ), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT );
     bSizer11->Add( m_btnInputStcList, 0, wxALL, 5 );
 
     sbSizerInFilter->Add( bSizer11, 0, wxEXPAND, 5 );
 
     sbSizerConnectionProps->Add( sbSizerInFilter, 0, wxEXPAND, 5 );
 
-    sbSizerOutFilter = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _("Output filtering") ), wxVERTICAL );
+    sbSizerOutFilter = new wxStaticBoxSizer( new wxStaticBox( m_pNMEAForm, wxID_ANY, _( "Output filtering" ) ), wxVERTICAL );
 
     wxBoxSizer* bSizer10;
     bSizer10 = new wxBoxSizer( wxHORIZONTAL );
 
-    m_rbOAccept = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Transmit sentences"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
+    m_rbOAccept = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Transmit sentences" ), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
     bSizer10->Add( m_rbOAccept, 0, wxALL, 5 );
 
-    m_rbOIgnore = new wxRadioButton( m_pNMEAForm, wxID_ANY, _("Drop sentences"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_rbOIgnore = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Drop sentences" ), wxDefaultPosition, wxDefaultSize, 0 );
     bSizer10->Add( m_rbOIgnore, 0, wxALL, 5 );
-
 
     sbSizerOutFilter->Add( bSizer10, 0, wxEXPAND, 5 );
 
@@ -1948,17 +1900,15 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     bSizer12 = new wxBoxSizer( wxHORIZONTAL );
 
     m_tcOutputStc = new wxTextCtrl( m_pNMEAForm, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxTE_READONLY );
-    bSizer12->Add( m_tcOutputStc, 1, wxALL|wxEXPAND, 5 );
+    bSizer12->Add( m_tcOutputStc, 1, wxALL | wxEXPAND, 5 );
 
-    m_btnOutputStcList = new wxButton( m_pNMEAForm, wxID_ANY, _("..."), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT );
+    m_btnOutputStcList = new wxButton( m_pNMEAForm, wxID_ANY, _( "..." ), wxDefaultPosition, wxDefaultSize, wxBU_EXACTFIT );
     bSizer12->Add( m_btnOutputStcList, 0, wxALL, 5 );
-
 
     sbSizerOutFilter->Add( bSizer12, 0, wxEXPAND, 5 );
     sbSizerConnectionProps->Add( sbSizerOutFilter, 0, wxEXPAND, 5 );
 
-
-    bSizerOuterContainer->Add( sbSizerConnectionProps, 1, wxALL|wxEXPAND, 5 );
+    bSizerOuterContainer->Add( sbSizerConnectionProps, 1, wxALL | wxEXPAND, 5 );
 
     bSizer4->Add( bSizerOuterContainer, 1, wxEXPAND, 5 );
 
@@ -2008,57 +1958,56 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     m_lcSources->Connect( wxEVT_LEFT_DOWN, wxMouseEventHandler(options::OnConnectionToggleEnable), NULL, this );
 
     wxListItem col0;
-    col0.SetId(0);
-    col0.SetText( _("Enable") );
-    m_lcSources->InsertColumn(0, col0);
+    col0.SetId( 0 );
+    col0.SetText( _( "Enable" ) );
+    m_lcSources->InsertColumn( 0, col0 );
 
     wxListItem col1;
-    col1.SetId(1);
-    col1.SetText( _("Type") );
-    m_lcSources->InsertColumn(1, col1);
+    col1.SetId( 1 );
+    col1.SetText( _( "Type" ) );
+    m_lcSources->InsertColumn( 1, col1 );
 
     wxListItem col2;
-    col2.SetId(2);
-    col2.SetText( _("DataPort") );
-    m_lcSources->InsertColumn(2, col2);
+    col2.SetId( 2 );
+    col2.SetText( _( "DataPort" ) );
+    m_lcSources->InsertColumn( 2, col2 );
 
     wxListItem col3;
-    col3.SetId(3);
-    col3.SetText( _("Priority") );
-    m_lcSources->InsertColumn(3, col3);
+    col3.SetId( 3 );
+    col3.SetText( _( "Priority" ) );
+    m_lcSources->InsertColumn( 3, col3 );
 
     wxListItem col4;
-    col4.SetId(4);
-    col4.SetText( _("Parameters") );
-    m_lcSources->InsertColumn(4, col4);
+    col4.SetId( 4 );
+    col4.SetText( _( "Parameters" ) );
+    m_lcSources->InsertColumn( 4, col4 );
 
     wxListItem col5;
-    col5.SetId(5);
-    col5.SetText( _("Connection") );
-    m_lcSources->InsertColumn(5, col5);
+    col5.SetId( 5 );
+    col5.SetText( _( "Connection" ) );
+    m_lcSources->InsertColumn( 5, col5 );
 
     wxListItem col6;
-    col6.SetId(6);
-    col6.SetText( _("Filters") );
-    m_lcSources->InsertColumn(6, col6);
+    col6.SetId( 6 );
+    col6.SetText( _( "Filters" ) );
+    m_lcSources->InsertColumn( 6, col6 );
 
     //  Build the image list
-    wxBitmap unchecked_bmp(16, 16), checked_bmp(16, 16);
-
+    wxBitmap unchecked_bmp( 16, 16 ), checked_bmp( 16, 16 );
     {
         wxMemoryDC renderer_dc;
 
         // Unchecked
-        renderer_dc.SelectObject(unchecked_bmp);
-        renderer_dc.SetBackground(*wxTheBrushList->FindOrCreateBrush(GetBackgroundColour(), wxBRUSHSTYLE_SOLID));
+        renderer_dc.SelectObject( unchecked_bmp );
+        renderer_dc.SetBackground( *wxTheBrushList->FindOrCreateBrush( GetBackgroundColour(), wxBRUSHSTYLE_SOLID ) );
         renderer_dc.Clear();
-        wxRendererNative::Get().DrawCheckBox(this, renderer_dc, wxRect(0, 0, 16, 16), 0);
+        wxRendererNative::Get().DrawCheckBox( this, renderer_dc, wxRect( 0, 0, 16, 16 ), 0 );
 
         // Checked
-        renderer_dc.SelectObject(checked_bmp);
-        renderer_dc.SetBackground(*wxTheBrushList->FindOrCreateBrush(GetBackgroundColour(), wxBRUSHSTYLE_SOLID));
+        renderer_dc.SelectObject( checked_bmp );
+        renderer_dc.SetBackground( *wxTheBrushList->FindOrCreateBrush( GetBackgroundColour(), wxBRUSHSTYLE_SOLID ) );
         renderer_dc.Clear();
-        wxRendererNative::Get().DrawCheckBox(this, renderer_dc, wxRect(0, 0, 16, 16), wxCONTROL_CHECKED);
+        wxRendererNative::Get().DrawCheckBox( this, renderer_dc, wxRect( 0, 0, 16, 16 ), wxCONTROL_CHECKED );
     }
 
     wxImageList *imglist = new wxImageList( 16, 16, true, 1 );
@@ -2068,14 +2017,14 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
 
     m_lcSources->Refresh();
 
-    m_stcdialog_in = new SentenceListDlg(FILTER_INPUT, this);
-    m_stcdialog_out = new SentenceListDlg(FILTER_OUTPUT, this);
+    m_stcdialog_in = new SentenceListDlg( FILTER_INPUT, this );
+    m_stcdialog_out = new SentenceListDlg( FILTER_OUTPUT, this );
 
     FillSourceList();
 
-    if(m_pSerialArray){
-        for(size_t i = 0; i < m_pSerialArray->Count() ; i++){
-            m_comboPort->Append(m_pSerialArray->Item(i));
+    if ( m_pSerialArray ) {
+        for ( size_t i = 0; i < m_pSerialArray->Count() ; i++ ) {
+            m_comboPort->Append( m_pSerialArray->Item( i ) );
         }
     }
 
@@ -2085,20 +2034,6 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     connectionsaved = true;
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 void options::OnConnectionToggleEnable( wxMouseEvent &event )
 {
     wxPoint pos = event.GetPosition();
@@ -2106,11 +2041,11 @@ void options::OnConnectionToggleEnable( wxMouseEvent &event )
     long ptrSubItem = -1;
     long clicked_index = m_lcSources->HitTest( pos, flags, &ptrSubItem );
 
-    //    Clicking Enable Checkbox (full column)?
-    if( clicked_index > -1 && event.GetX() < m_lcSources->GetColumnWidth( 0 ) ) {
+    // Clicking Enable Checkbox (full column)?
+    if ( clicked_index > -1 && event.GetX() < m_lcSources->GetColumnWidth( 0 ) ) {
         // Process the clicked item
         ConnectionParams *conn = g_pConnectionParams->Item( m_lcSources->GetItemData( clicked_index ) );
-        if(conn){
+        if ( conn ) {
             conn->bEnabled = !conn->bEnabled;
             m_connection_enabled = conn->bEnabled;
             conn->b_IsSetup = false;            // Mark as changed
@@ -2119,8 +2054,7 @@ void options::OnConnectionToggleEnable( wxMouseEvent &event )
         }
 
         cc1->Refresh();
-    }
-    else if( clicked_index == -1 ) {
+    } else if ( clicked_index == -1 ) {
         ClearNMEAForm();
         m_buttonRemove->Enable( false );
     }
@@ -2129,17 +2063,15 @@ void options::OnConnectionToggleEnable( wxMouseEvent &event )
     event.Skip();
 }
 
-
-
 void options::CreatePanel_Ownship( size_t parent, int border_size, int group_item_spacing, wxSize small_button_size )
 {
-    itemPanelShip = AddPage( parent, _("Own Ship") );
+    itemPanelShip = AddPage( parent, _( "Own Ship" ) );
 
     ownShip = new wxBoxSizer( wxVERTICAL );
     itemPanelShip->SetSizer( ownShip );
 
-    //      OwnShip Display options
-    wxStaticBox* osdBox = new wxStaticBox( itemPanelShip, wxID_ANY, _("Display Options") );
+    // OwnShip Display options
+    wxStaticBox* osdBox = new wxStaticBox( itemPanelShip, wxID_ANY, _( "Display Options" ) );
     dispOptions = new wxStaticBoxSizer( osdBox, wxVERTICAL );
     ownShip->Add( dispOptions, 0, wxTOP | wxALL | wxEXPAND, border_size );
 
@@ -2147,60 +2079,62 @@ void options::CreatePanel_Ownship( size_t parent, int border_size, int group_ite
     dispOptionsGrid->AddGrowableCol( 1 );
     dispOptions->Add( dispOptionsGrid, 0, wxALL | wxEXPAND, border_size );
 
-    wxStaticText *pStatic_OSCOG_Predictor = new wxStaticText( itemPanelShip, wxID_ANY, _("COG Predictor Length (min)") );
+    wxStaticText *pStatic_OSCOG_Predictor = new wxStaticText( itemPanelShip, wxID_ANY, _( "COG Predictor Length (min)" ) );
     dispOptionsGrid->Add( pStatic_OSCOG_Predictor, 0 );
 
     m_pText_OSCOG_Predictor = new wxTextCtrl( itemPanelShip, wxID_ANY );
     dispOptionsGrid->Add( m_pText_OSCOG_Predictor, 0, wxALIGN_RIGHT );
 
-    wxStaticText *pStatic_OSHDT_Predictor = new wxStaticText( itemPanelShip, wxID_ANY, _("Heading Predictor Length (NMi)") );
+    wxStaticText *pStatic_OSHDT_Predictor = new wxStaticText( itemPanelShip, wxID_ANY, _( "Heading Predictor Length (NMi)" ) );
     dispOptionsGrid->Add( pStatic_OSHDT_Predictor, 0 );
 
     m_pText_OSHDT_Predictor = new wxTextCtrl( itemPanelShip, wxID_ANY );
     dispOptionsGrid->Add( m_pText_OSHDT_Predictor, 0, wxALIGN_RIGHT );
 
-    wxStaticText *iconTypeTxt = new wxStaticText( itemPanelShip, wxID_ANY, _("Ship Icon Type") );
+    wxStaticText *iconTypeTxt = new wxStaticText( itemPanelShip, wxID_ANY, _( "Ship Icon Type" ) );
     dispOptionsGrid->Add( iconTypeTxt, 0 );
 
-    wxString iconTypes[] = { _("Default"), _("Real Scale Bitmap"), _("Real Scale Vector") };
+    wxString iconTypes[] = { _( "Default" ), _( "Real Scale Bitmap" ), _( "Real Scale Vector" ) };
     m_pShipIconType = new wxChoice( itemPanelShip, ID_SHIPICONTYPE, wxDefaultPosition, wxDefaultSize, 3, iconTypes );
-    dispOptionsGrid->Add( m_pShipIconType, 0, wxALIGN_RIGHT | wxLEFT|wxRIGHT|wxTOP, group_item_spacing );
+    dispOptionsGrid->Add( m_pShipIconType, 0, wxALIGN_RIGHT | wxLEFT | wxRIGHT | wxTOP, group_item_spacing );
 
     realSizes = new wxFlexGridSizer( 5, 2, group_item_spacing, group_item_spacing );
-    realSizes->AddGrowableCol(1);
+    realSizes->AddGrowableCol( 1 );
 
     dispOptions->Add( realSizes, 0, wxEXPAND | wxLEFT, 30 );
 
-    realSizes->Add( new wxStaticText( itemPanelShip, wxID_ANY, _("Length Over All (m)") ), 1, wxALIGN_LEFT );
+    realSizes->Add( new wxStaticText( itemPanelShip, wxID_ANY, _( "Length Over All (m)" ) ), 1, wxALIGN_LEFT );
     m_pOSLength = new wxTextCtrl( itemPanelShip, 1 );
     realSizes->Add( m_pOSLength, 1, wxALIGN_RIGHT | wxALL, group_item_spacing );
 
-    realSizes->Add( new wxStaticText( itemPanelShip, wxID_ANY, _("Width Over All (m)") ), 1, wxALIGN_LEFT );
+    realSizes->Add( new wxStaticText( itemPanelShip, wxID_ANY, _( "Width Over All (m)" ) ), 1, wxALIGN_LEFT );
     m_pOSWidth = new wxTextCtrl( itemPanelShip, wxID_ANY );
     realSizes->Add( m_pOSWidth, 1, wxALIGN_RIGHT | wxALL, group_item_spacing );
 
-    realSizes->Add( new wxStaticText( itemPanelShip, wxID_ANY, _("GPS Offset from Bow (m)") ), 1, wxALIGN_LEFT );
+    realSizes->Add( new wxStaticText( itemPanelShip, wxID_ANY, _( "GPS Offset from Bow (m)" ) ), 1, wxALIGN_LEFT );
     m_pOSGPSOffsetY = new wxTextCtrl( itemPanelShip, wxID_ANY );
     realSizes->Add( m_pOSGPSOffsetY, 1, wxALIGN_RIGHT | wxALL, group_item_spacing );
 
-    realSizes->Add( new wxStaticText( itemPanelShip, wxID_ANY, _("GPS Offset from Midship (m)") ), 1, wxALIGN_LEFT );
+    realSizes->Add( new wxStaticText( itemPanelShip, wxID_ANY, _( "GPS Offset from Midship (m)" ) ), 1, wxALIGN_LEFT );
     m_pOSGPSOffsetX = new wxTextCtrl( itemPanelShip, wxID_ANY );
     realSizes->Add( m_pOSGPSOffsetX, 1, wxALIGN_RIGHT | wxALL, group_item_spacing );
 
-    realSizes->Add( new wxStaticText( itemPanelShip, wxID_ANY, _("Minimum Screen Size (mm)") ), 1, wxALIGN_LEFT );
+    realSizes->Add( new wxStaticText( itemPanelShip, wxID_ANY, _( "Minimum Screen Size (mm)" ) ), 1, wxALIGN_LEFT );
     m_pOSMinSize = new wxTextCtrl( itemPanelShip, wxID_ANY );
     realSizes->Add( m_pOSMinSize, 1, wxALIGN_RIGHT | wxALL, group_item_spacing );
 
     // Radar rings
-
     wxFlexGridSizer* rrSelect = new wxFlexGridSizer( 1, 2, group_item_spacing, group_item_spacing );
     rrSelect->AddGrowableCol( 1 );
-    dispOptions->Add( rrSelect, 0, wxLEFT|wxRIGHT | wxEXPAND, border_size );
+    dispOptions->Add( rrSelect, 0, wxLEFT | wxRIGHT | wxEXPAND, border_size );
 
-    wxStaticText *rrTxt = new wxStaticText( itemPanelShip, wxID_ANY, _("Show range rings") );
+    wxStaticText *rrTxt = new wxStaticText( itemPanelShip, wxID_ANY, _( "Show range rings" ) );
     rrSelect->Add( rrTxt, 1, wxEXPAND | wxALL, group_item_spacing );
 
-    wxString rrAlt[] = { _("None"), _T("1"), _T("2"), _T("3"), _T("4"), _T("5"), _T("6"), _T("7"), _T("8"), _T("9"), _T("10") };
+    wxString rrAlt[] = {
+        _( "None" ), _T( "1" ), _T( "2" ), _T( "3" ), _T( "4" ), _T( "5" ),
+        _T( "6" ), _T( "7" ), _T( "8" ), _T( "9" ), _T( "10" )
+    };
     pNavAidRadarRingsNumberVisible = new wxChoice( itemPanelShip, ID_RADARRINGS, wxDefaultPosition, m_pShipIconType->GetSize(), 11, rrAlt );
     rrSelect->Add( pNavAidRadarRingsNumberVisible, 0, wxALIGN_RIGHT | wxALL, group_item_spacing );
 
@@ -2208,43 +2142,43 @@ void options::CreatePanel_Ownship( size_t parent, int border_size, int group_ite
     radarGrid->AddGrowableCol( 1 );
     dispOptions->Add( radarGrid, 0, wxLEFT | wxEXPAND, 30 );
 
-    wxStaticText* distanceText = new wxStaticText( itemPanelShip, wxID_STATIC, _("Distance Between Rings") );
+    wxStaticText* distanceText = new wxStaticText( itemPanelShip, wxID_STATIC, _( "Distance Between Rings" ) );
     radarGrid->Add( distanceText, 1, wxEXPAND | wxALL, group_item_spacing );
 
     pNavAidRadarRingsStep = new wxTextCtrl( itemPanelShip, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize( 100, -1 ), 0 );
     radarGrid->Add( pNavAidRadarRingsStep, 0, wxALIGN_RIGHT | wxALL, group_item_spacing );
 
-    wxStaticText* unitText = new wxStaticText( itemPanelShip, wxID_STATIC, _("Distance Unit") );
+    wxStaticText* unitText = new wxStaticText( itemPanelShip, wxID_STATIC, _( "Distance Unit" ) );
     radarGrid->Add( unitText, 1, wxEXPAND | wxALL, group_item_spacing );
 
-    wxString pDistUnitsStrings[] = { _("Nautical Miles"), _("Kilometers") };
+    wxString pDistUnitsStrings[] = { _( "Nautical Miles" ), _( "Kilometers" ) };
     m_itemRadarRingsUnits = new wxChoice( itemPanelShip, ID_RADARDISTUNIT, wxDefaultPosition, m_pShipIconType->GetSize(), 2, pDistUnitsStrings );
     radarGrid->Add( m_itemRadarRingsUnits, 0, wxALIGN_RIGHT | wxALL, border_size );
 
      //  Tracks
-    wxStaticBox* trackText = new wxStaticBox( itemPanelShip, wxID_ANY, _("Tracks") );
+    wxStaticBox* trackText = new wxStaticBox( itemPanelShip, wxID_ANY, _( "Tracks" ) );
     wxStaticBoxSizer* trackSizer = new wxStaticBoxSizer( trackText, wxVERTICAL );
     ownShip->Add( trackSizer, 0, wxGROW | wxALL, border_size );
 
-    pTrackDaily = new wxCheckBox( itemPanelShip, ID_DAILYCHECKBOX, _("Automatic Daily Tracks") );
+    pTrackDaily = new wxCheckBox( itemPanelShip, ID_DAILYCHECKBOX, _( "Automatic Daily Tracks" ) );
     trackSizer->Add( pTrackDaily, 1, wxALL, border_size );
 
-    pTrackHighlite = new wxCheckBox( itemPanelShip, ID_TRACKHILITE, _("Highlight Tracks") );
+    pTrackHighlite = new wxCheckBox( itemPanelShip, ID_TRACKHILITE, _( "Highlight Tracks" ) );
     trackSizer->Add( pTrackHighlite, 1, wxALL, border_size );
 
     wxFlexGridSizer *pTrackGrid = new wxFlexGridSizer( 1, 2, group_item_spacing, group_item_spacing );
     pTrackGrid->AddGrowableCol( 1 );
     trackSizer->Add( pTrackGrid, 0, wxALL | wxEXPAND, border_size );
 
-    wxStaticText* tpText = new wxStaticText( itemPanelShip, wxID_STATIC, _("Tracking Precision") );
+    wxStaticText* tpText = new wxStaticText( itemPanelShip, wxID_STATIC, _( "Tracking Precision" ) );
     pTrackGrid->Add( tpText, 1, wxEXPAND | wxALL, group_item_spacing );
 
-    wxString trackAlt[] = { _("Low"), _("Medium"), _("High") };
+    wxString trackAlt[] = { _( "Low" ), _( "Medium" ), _( "High" ) };
     pTrackPrecision = new wxChoice( itemPanelShip, wxID_ANY, wxDefaultPosition, m_pShipIconType->GetSize(), 3, trackAlt );
     pTrackGrid->Add( pTrackPrecision, 0, wxALIGN_RIGHT | wxALL, group_item_spacing );
 
     //  Routes
-    wxStaticBox* routeText = new wxStaticBox( itemPanelShip, wxID_ANY, _("Routes") );
+    wxStaticBox* routeText = new wxStaticBox( itemPanelShip, wxID_ANY, _( "Routes" ) );
     wxStaticBoxSizer* routeSizer = new wxStaticBoxSizer( routeText, wxVERTICAL );
     ownShip->Add( routeSizer, 0, wxGROW | wxALL, border_size );
 
@@ -2252,17 +2186,17 @@ void options::CreatePanel_Ownship( size_t parent, int border_size, int group_ite
     pRouteGrid->AddGrowableCol( 1 );
     routeSizer->Add( pRouteGrid, 0, wxALL | wxEXPAND, border_size );
 
-    wxStaticText* raText = new wxStaticText( itemPanelShip, wxID_STATIC, _("Waypoint Arrival Circle Radius (NMi)") );
+    wxStaticText* raText = new wxStaticText( itemPanelShip, wxID_STATIC, _( "Waypoint Arrival Circle Radius (NMi)" ) );
     pRouteGrid->Add( raText, 1, wxEXPAND | wxALL, group_item_spacing );
 
     m_pText_ACRadius = new wxTextCtrl( itemPanelShip, -1 );
     pRouteGrid->Add( m_pText_ACRadius, 0, wxALL | wxALIGN_RIGHT, group_item_spacing );
 
-    pAdvanceRouteWaypointOnArrivalOnly = new wxCheckBox( itemPanelShip, ID_DAILYCHECKBOX, _("Advance route waypoint on arrival only") );
+    pAdvanceRouteWaypointOnArrivalOnly = new wxCheckBox( itemPanelShip, ID_DAILYCHECKBOX, _( "Advance route waypoint on arrival only" ) );
     routeSizer->Add( pAdvanceRouteWaypointOnArrivalOnly, 0 );
 
     //  Waypoints
-    wxStaticBox* waypointText = new wxStaticBox( itemPanelShip, wxID_ANY, _("Waypoints") );
+    wxStaticBox* waypointText = new wxStaticBox( itemPanelShip, wxID_ANY, _( "Waypoints" ) );
     wxStaticBoxSizer* waypointSizer = new wxStaticBoxSizer( waypointText, wxVERTICAL );
     ownShip->Add( waypointSizer, 0, wxTOP | wxALL | wxEXPAND, border_size );
 
@@ -2273,7 +2207,7 @@ void options::CreatePanel_Ownship( size_t parent, int border_size, int group_ite
     waypointrrSelect->AddGrowableCol( 1 );
     waypointSizer->Add( waypointrrSelect, 0, wxLEFT|wxRIGHT | wxEXPAND, border_size );
 
-    wxStaticText *waypointrrTxt = new wxStaticText( itemPanelShip, wxID_ANY, _("Waypoint range rings") );
+    wxStaticText *waypointrrTxt = new wxStaticText( itemPanelShip, wxID_ANY, _( "Waypoint range rings" ) );
     waypointrrSelect->Add( waypointrrTxt, 1, wxEXPAND | wxALL, group_item_spacing );
 
     pWaypointRangeRingsNumber = new wxChoice( itemPanelShip, ID_OPWAYPOINTRANGERINGS, wxDefaultPosition, m_pShipIconType->GetSize(), 11, rrAlt );
@@ -2283,7 +2217,7 @@ void options::CreatePanel_Ownship( size_t parent, int border_size, int group_ite
     waypointradarGrid->AddGrowableCol( 1 );
     waypointSizer->Add( waypointradarGrid, 0, wxLEFT | wxEXPAND, 30 );
 
-    wxStaticText* waypointdistanceText = new wxStaticText( itemPanelShip, wxID_STATIC, _("Distance Between Waypoint Rings") );
+    wxStaticText* waypointdistanceText = new wxStaticText( itemPanelShip, wxID_STATIC, _( "Distance Between Waypoint Rings" ) );
     waypointradarGrid->Add( waypointdistanceText, 1, wxEXPAND | wxALL, group_item_spacing );
 
     pWaypointRangeRingsStep = new wxTextCtrl( itemPanelShip, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize( 100, -1 ), 0 );
@@ -2295,26 +2229,24 @@ void options::CreatePanel_Ownship( size_t parent, int border_size, int group_ite
     m_itemWaypointRangeRingsUnits = new wxChoice( itemPanelShip, ID_RADARDISTUNIT, wxDefaultPosition, m_pShipIconType->GetSize(), 2, pDistUnitsStrings );
     waypointradarGrid->Add( m_itemWaypointRangeRingsUnits, 0, wxALIGN_RIGHT | wxALL, border_size );
 
-    wxStaticText* waypointrangeringsColour = new wxStaticText( itemPanelShip, wxID_STATIC, _("Waypoint Range Ring Colours") );
+    wxStaticText* waypointrangeringsColour = new wxStaticText( itemPanelShip, wxID_STATIC, _( "Waypoint Range Ring Colours" ) );
     waypointradarGrid->Add( waypointrangeringsColour, 1, wxEXPAND | wxALL, 1 );
 
-    m_colourWaypointRangeRingsColour = new wxColourPickerCtrl( itemPanelShip, wxID_ANY, *wxRED, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T("ID_COLOURWAYPOINTRANGERINGSCOLOUR") );
+    m_colourWaypointRangeRingsColour = new wxColourPickerCtrl( itemPanelShip, wxID_ANY, *wxRED, wxDefaultPosition, wxDefaultSize, 0, wxDefaultValidator, _T( "ID_COLOURWAYPOINTRANGERINGSCOLOUR" ) );
     waypointradarGrid->Add( m_colourWaypointRangeRingsColour, 0, wxALIGN_RIGHT | wxALL, 1);
-
-
 
     DimeControl( itemPanelShip );
 }
 
 void options::CreatePanel_ChartsLoad( size_t parent, int border_size, int group_item_spacing,
-        wxSize small_button_size )
+                                      wxSize small_button_size )
 {
-    wxScrolledWindow *chartPanelWin = AddPage( m_pageCharts, _("Chart Files") );
+    wxScrolledWindow *chartPanelWin = AddPage( m_pageCharts, _( "Chart Files" ) );
 
     chartPanel = new wxBoxSizer( wxVERTICAL );
     chartPanelWin->SetSizer( chartPanel );
 
-    wxStaticBox* loadedBox = new wxStaticBox( chartPanelWin, wxID_ANY, _("Directories") );
+    wxStaticBox* loadedBox = new wxStaticBox( chartPanelWin, wxID_ANY, _( "Directories" ) );
     activeSizer = new wxStaticBoxSizer( loadedBox, wxHORIZONTAL );
     chartPanel->Add( activeSizer, 1, wxALL | wxEXPAND, border_size );
 
@@ -2332,47 +2264,42 @@ void options::CreatePanel_ChartsLoad( size_t parent, int border_size, int group_
 
     // Currently loaded chart dirs
     wxString dirname;
-    if( pActiveChartsList ) {
+    if ( pActiveChartsList ) {
         pActiveChartsList->Clear();
         int nDir = m_CurrentDirList.GetCount();
-        for( int i = 0; i < nDir; i++ ) {
+        for ( int i = 0; i < nDir; i++ ) {
             dirname = m_CurrentDirList.Item( i ).fullpath;
             if( !dirname.IsEmpty() ) pActiveChartsList->Append( dirname );
         }
     }
 
-    wxButton* addBtn = new wxButton( chartPanelWin, ID_BUTTONADD, _("Add Directory...") );
+    wxButton* addBtn = new wxButton( chartPanelWin, ID_BUTTONADD, _( "Add Directory..." ) );
     cmdButtonSizer->Add( addBtn, 1, wxALL | wxEXPAND, group_item_spacing );
 
-    m_removeBtn = new wxButton( chartPanelWin, ID_BUTTONDELETE, _("Remove Selected") );
+    m_removeBtn = new wxButton( chartPanelWin, ID_BUTTONDELETE, _( "Remove Selected" ) );
     cmdButtonSizer->Add( m_removeBtn, 1, wxALL | wxEXPAND, group_item_spacing );
     m_removeBtn->Disable();
 
-
-    wxStaticBox* itemStaticBoxUpdateStatic = new wxStaticBox( chartPanelWin, wxID_ANY,
-            _("Update Control") );
-    wxStaticBoxSizer* itemStaticBoxSizerUpdate = new wxStaticBoxSizer( itemStaticBoxUpdateStatic,
-            wxVERTICAL );
+    wxStaticBox* itemStaticBoxUpdateStatic = new wxStaticBox( chartPanelWin, wxID_ANY, _( "Update Control" ) );
+    wxStaticBoxSizer* itemStaticBoxSizerUpdate = new wxStaticBoxSizer( itemStaticBoxUpdateStatic, wxVERTICAL );
     chartPanel->Add( itemStaticBoxSizerUpdate, 0, wxGROW | wxALL, 5 );
 
-    pScanCheckBox = new wxCheckBox( chartPanelWin, ID_SCANCHECKBOX,
-            _("Scan Charts and Update Database") );
+    pScanCheckBox = new wxCheckBox( chartPanelWin, ID_SCANCHECKBOX, _( "Scan Charts and Update Database" ) );
     itemStaticBoxSizerUpdate->Add( pScanCheckBox, 1, wxALL, 5 );
 
-    pUpdateCheckBox = new wxCheckBox( chartPanelWin, ID_UPDCHECKBOX,
-            _("Force Full Database Rebuild") );
+    pUpdateCheckBox = new wxCheckBox( chartPanelWin, ID_UPDCHECKBOX, _( "Force Full Database Rebuild" ) );
     itemStaticBoxSizerUpdate->Add( pUpdateCheckBox, 1, wxALL, 5 );
 
     chartPanel->Layout();
 }
 
 void options::CreatePanel_Advanced( size_t parent, int border_size, int group_item_spacing,
-                                        wxSize small_button_size )
+                                    wxSize small_button_size )
 {
     m_ChartDisplayPage = AddPage( parent, _("Advanced") );
 
     wxFlexGridSizer* itemBoxSizerUI = new wxFlexGridSizer( 2 );
-    itemBoxSizerUI->SetHGap(border_size);
+    itemBoxSizerUI->SetHGap( border_size );
 //    itemBoxSizerUI->AddGrowableCol( 0, 1 );
 //    itemBoxSizerUI->AddGrowableCol( 1, 1 );
 //    m_ChartDisplayPage->SetSizer( itemBoxSizerUI );
@@ -2382,113 +2309,104 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
     m_ChartDisplayPage->SetSizer( wrapperSizer );
     wrapperSizer->Add( itemBoxSizerUI, 1, wxALL | wxALIGN_CENTER, border_size );
 
-
     // spacer
     itemBoxSizerUI->Add( 0, border_size*3 );
     itemBoxSizerUI->Add( 0, border_size*3 );
 
-
     // Chart Display Options
-    itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Chart Display") ), groupLabelFlags );
+    itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _( "Chart Display" ) ), groupLabelFlags );
     wxBoxSizer* boxCharts = new wxBoxSizer( wxVERTICAL );
     itemBoxSizerUI->Add( boxCharts, groupInputFlags );
 
-    pSkewComp = new wxCheckBox( m_ChartDisplayPage, ID_SKEWCOMPBOX, _("Show Skewed Raster Charts as North-Up") );
+    pSkewComp = new wxCheckBox( m_ChartDisplayPage, ID_SKEWCOMPBOX, _( "Show Skewed Raster Charts as North-Up" ) );
     boxCharts->Add( pSkewComp, inputFlags );
 
-    pFullScreenQuilt = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _("Disable Full Screen Quilting") );
+    pFullScreenQuilt = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _( "Disable Full Screen Quilting" ) );
     boxCharts->Add( pFullScreenQuilt, inputFlags );
 
-    pOverzoomEmphasis = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _("Suppress blur/fog effects on overzoom") );
+    pOverzoomEmphasis = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _( "Suppress blur/fog effects on overzoom" ) );
     boxCharts->Add( pOverzoomEmphasis, inputFlags );
 
-    pOZScaleVector = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _("Suppress scaled vector charts on overzoom") );
+    pOZScaleVector = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _( "Suppress scaled vector charts on overzoom" ) );
     boxCharts->Add( pOZScaleVector, inputFlags );
 
     // spacer
     itemBoxSizerUI->Add( 0, border_size*3 );
     itemBoxSizerUI->Add( 0, border_size*3 );
 
-
     //  Course Up display update period
-    itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Course-Up Update Period") ), labelFlags );
+    itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _( "Course-Up Update Period" ) ), labelFlags );
     wxBoxSizer *pCOGUPFilterRow = new wxBoxSizer( wxHORIZONTAL );
     itemBoxSizerUI->Add( pCOGUPFilterRow, 0, wxALL | wxEXPAND, group_item_spacing );
 
     pCOGUPUpdateSecs = new wxTextCtrl( m_ChartDisplayPage, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize( 50, -1 ), wxTE_RIGHT  );
     pCOGUPFilterRow->Add( pCOGUPUpdateSecs, 0, wxALIGN_RIGHT | wxALL, group_item_spacing );
 
-    pCOGUPFilterRow->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("seconds") ), inputFlags );
-
+    pCOGUPFilterRow->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _( "seconds" ) ), inputFlags );
 
     // spacer
     itemBoxSizerUI->Add( 0, border_size*3 );
     itemBoxSizerUI->Add( 0, border_size*3 );
 
-
     // Chart Zoom Scale Weighting
-    itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Chart Zoom/Scale Weighting") ), labelFlags );
+    itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _( "Chart Zoom/Scale Weighting" ) ), labelFlags );
     m_pSlider_Zoom = new wxSlider( m_ChartDisplayPage, ID_CM93ZOOM, 0, -5,
                                   5, wxDefaultPosition, wxSize( 300, 50),
                                   wxSL_HORIZONTAL | wxSL_AUTOTICKS | wxSL_LABELS );
 
 #ifdef __OCPN__ANDROID__
-    m_pSlider_Zoom->GetHandle()->setStyleSheet( getQtStyleSheet());
+    m_pSlider_Zoom->GetHandle()->setStyleSheet( getQtStyleSheet() );
 #endif
 
     itemBoxSizerUI->Add( m_pSlider_Zoom, inputFlags );
 
     itemBoxSizerUI->Add( 0, border_size*3 );
     wxStaticText* zoomText = new wxStaticText( m_ChartDisplayPage, wxID_ANY,
-        _("With a lower value, the same zoom level shows a less detailed chart.\nWith a higher value, the same zoom level shows a more detailed chart.") );
+        _( "With a lower value, the same zoom level shows a less detailed chart.\nWith a higher value, the same zoom level shows a more detailed chart." ) );
 
-    wxFont *dialogFont = GetOCPNScaledFont(_("Dialog"));
+    wxFont *dialogFont = GetOCPNScaledFont(_( "Dialog" ));
     smallFont = new wxFont( * dialogFont ); // we can't use Smaller() because wx2.8 doesn't support it
-    smallFont->SetPointSize( (smallFont->GetPointSize() / 1.2) + 0.5 ); // + 0.5 to round instead of truncate
+    smallFont->SetPointSize( ( smallFont->GetPointSize() / 1.2 ) + 0.5 ); // + 0.5 to round instead of truncate
     zoomText->SetFont( * smallFont );
     itemBoxSizerUI->Add( zoomText, 0, wxALL | wxEXPAND, group_item_spacing );
 
-
     // spacer
-    itemBoxSizerUI->Add( 0, border_size*3 );
-    itemBoxSizerUI->Add( 0, border_size*3 );
-
+    itemBoxSizerUI->Add( 0, border_size * 3 );
+    itemBoxSizerUI->Add( 0, border_size * 3 );
 
     // Control Options
-    itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Controls") ), groupLabelFlags );
+    itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _( "Controls" ) ), groupLabelFlags );
     wxBoxSizer* boxCtrls = new wxBoxSizer( wxVERTICAL );
     itemBoxSizerUI->Add( boxCtrls, groupInputFlags );
 
-    pWayPointPreventDragging = new wxCheckBox( m_ChartDisplayPage, ID_DRAGGINGCHECKBOX, _("Lock Waypoints (Unless waypoint property dialog visible)") );
+    pWayPointPreventDragging = new wxCheckBox( m_ChartDisplayPage, ID_DRAGGINGCHECKBOX, _( "Lock Waypoints (Unless waypoint property dialog visible)" ) );
     pWayPointPreventDragging->SetValue( FALSE );
     boxCtrls->Add( pWayPointPreventDragging, inputFlags );
 
-    pConfirmObjectDeletion = new wxCheckBox( m_ChartDisplayPage, ID_DELETECHECKBOX, _("Confirm deletion of tracks and routes") );
+    pConfirmObjectDeletion = new wxCheckBox( m_ChartDisplayPage, ID_DELETECHECKBOX, _( "Confirm deletion of tracks and routes" ) );
     pConfirmObjectDeletion->SetValue( FALSE );
     boxCtrls->Add( pConfirmObjectDeletion, inputFlags );
 
     // spacer
-    itemBoxSizerUI->Add( 0, border_size*3 );
-    itemBoxSizerUI->Add( 0, border_size*3 );
-
-
+    itemBoxSizerUI->Add( 0, border_size * 3 );
+    itemBoxSizerUI->Add( 0, border_size * 3 );
 
     //  Display size/DPI
-    itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Physical Screen Width") ), labelFlags );
+    itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _( "Physical Screen Width" ) ), labelFlags );
     wxBoxSizer *pDPIRow = new wxBoxSizer( wxHORIZONTAL );
     itemBoxSizerUI->Add( pDPIRow, 0, wxEXPAND );
 
-    pRBSizeAuto = new wxRadioButton( m_ChartDisplayPage, wxID_ANY, _("Auto") );
+    pRBSizeAuto = new wxRadioButton( m_ChartDisplayPage, wxID_ANY, _( "Auto" ) );
     pDPIRow->Add( pRBSizeAuto, inputFlags );
     pDPIRow->AddSpacer( 10 );
-    pRBSizeManual = new wxRadioButton( m_ChartDisplayPage, ID_SIZEMANUALRADIOBUTTON, _("Manual:") );
+    pRBSizeManual = new wxRadioButton( m_ChartDisplayPage, ID_SIZEMANUALRADIOBUTTON, _( "Manual:" ) );
     pDPIRow->Add( pRBSizeManual, inputFlags );
 
-    pScreenMM = new wxTextCtrl( m_ChartDisplayPage, ID_OPTEXTCTRL, _T(""), wxDefaultPosition,
+    pScreenMM = new wxTextCtrl( m_ChartDisplayPage, ID_OPTEXTCTRL, _T( "" ), wxDefaultPosition,
                                 wxSize( 3 * m_fontHeight, -1 ), wxTE_RIGHT  );
     pDPIRow->Add( pScreenMM, 0, wxALIGN_RIGHT | wxALL, group_item_spacing );
 
-    pDPIRow->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("mm") ), inputFlags );
+    pDPIRow->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _( "mm" ) ), inputFlags );
 
     pRBSizeAuto->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED,
                            wxCommandEventHandler( options::OnSizeAutoButton ), NULL, this );
@@ -2500,11 +2418,11 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
     itemBoxSizerUI->Add( 0, border_size*3 );
 
     // OpenGL Options
-    itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Graphics") ), labelFlags );
+    itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _( "Graphics" ) ), labelFlags );
     wxBoxSizer* OpenGLSizer = new wxBoxSizer( wxHORIZONTAL );
     itemBoxSizerUI->Add( OpenGLSizer, 0, 0, 0 );
 
-    pOpenGL = new wxCheckBox( m_ChartDisplayPage, ID_OPENGLBOX, _("Use Accelerated Graphics (OpenGL)") );
+    pOpenGL = new wxCheckBox( m_ChartDisplayPage, ID_OPENGLBOX, _( "Use Accelerated Graphics (OpenGL)" ) );
     OpenGLSizer->Add( pOpenGL, inputFlags );
     pOpenGL->Enable(!g_bdisable_opengl);
 
@@ -2512,18 +2430,16 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
     pOpenGL->Disable();
 #endif
 
-    wxButton *bOpenGL = new wxButton( m_ChartDisplayPage, ID_OPENGLOPTIONS, _("Options...") );
+    wxButton *bOpenGL = new wxButton( m_ChartDisplayPage, ID_OPENGLOPTIONS, _( "Options..." ) );
     OpenGLSizer->Add( bOpenGL, inputFlags );
     bOpenGL->Enable(!g_bdisable_opengl);
 
-
     itemBoxSizerUI->Add( 0, border_size*3 );
     pTransparentToolbar = new wxCheckBox( m_ChartDisplayPage, ID_TRANSTOOLBARCHECKBOX,
-                                          _("Enable Transparent Toolbar") );
+                                          _( "Enable Transparent Toolbar" ) );
     itemBoxSizerUI->Add( pTransparentToolbar, 0, wxALL, border_size );
     if( g_bopengl && !g_bTransparentToolbarInOpenGLOK ) pTransparentToolbar->Disable();
 }
-
 
 void options::CreatePanel_VectorCharts( size_t parent, int border_size, int group_item_spacing,
         wxSize small_button_size )
@@ -2533,8 +2449,6 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
     vectorPanel = new wxBoxSizer( wxHORIZONTAL );
     ps57Ctl->SetSizer( vectorPanel );
 
-
-
     // 1st column, all options except Mariner's Standard
     wxFlexGridSizer* optionsColumn = new wxFlexGridSizer(2);
     optionsColumn->SetHGap(border_size);
@@ -2542,11 +2456,9 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
     optionsColumn->AddGrowableCol( 1, 3 );
     vectorPanel->Add( optionsColumn, 3, wxALL | wxEXPAND, border_size );
 
-
     // spacer
     optionsColumn->Add( new wxStaticText(ps57Ctl, wxID_ANY, _T("")) );
     optionsColumn->Add( new wxStaticText(ps57Ctl, wxID_ANY, _T("")) );
-
 
     // dislay category
     optionsColumn->Add( new wxStaticText(ps57Ctl, wxID_ANY, _("Display Category")), labelFlags );
@@ -2555,11 +2467,9 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
                             wxDefaultSize, 4, pDispCatStrings );
     optionsColumn->Add( pDispCat, 0, wxALL, 2 );
 
-
     // spacer
     optionsColumn->Add( new wxStaticText(ps57Ctl, wxID_ANY, _T("")) );
     optionsColumn->Add( new wxStaticText(ps57Ctl, wxID_ANY, _T("")) );
-
 
     // display options
     optionsColumn->Add( new wxStaticText(ps57Ctl, wxID_ANY, _("Display")), groupLabelFlags );
@@ -2614,11 +2524,9 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
     pCheck_SCAMIN->SetValue( FALSE );
     optionsColumn->Add( pCheck_SCAMIN, inputFlags );
 
-
     // spacer
     optionsColumn->Add( 0, border_size*4 );
     optionsColumn->Add( 0, border_size*4 );
-
 
     // graphics options
     optionsColumn->Add( new wxStaticText(ps57Ctl, wxID_ANY, _("Graphics Style")), labelFlags );
@@ -2639,11 +2547,9 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
             wxDefaultSize, 2, pColorNumStrings );
     optionsColumn->Add( p24Color, inputFlags );
 
-
     // spacer
     optionsColumn->Add( 0, border_size*4 );
     optionsColumn->Add( 0, border_size*4 );
-
 
     // depth options
     optionsColumn->Add( new wxStaticText( ps57Ctl, wxID_ANY, _("Shallow Depth") ), labelFlags );
@@ -2670,11 +2576,9 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
     m_depthUnitsDeep = new wxStaticText( ps57Ctl, wxID_ANY, _("metres") );
     depDeepRow->Add( m_depthUnitsDeep, inputFlags );
 
-
     // spacer
     optionsColumn->Add( 0, border_size*4 );
     optionsColumn->Add( 0, border_size*4 );
-
 
 #ifdef USE_S57
     int slider_width = wxMax(m_fontHeight * 4, 150);
@@ -2691,8 +2595,6 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
 
 //    cm93Sizer->SetSizeHints(cm93DetailBox);
 #endif
-
-
 
     // 2nd column, Display Category / Mariner's Standard options
     wxBoxSizer* dispSizer = new wxBoxSizer( wxVERTICAL );
@@ -2721,14 +2623,12 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
     bSizerScrollMariners->Add( ps57CtlListBox, 1, wxALL | wxEXPAND, group_item_spacing );
 #endif
 
-
      wxBoxSizer* btnRow = new wxBoxSizer( wxHORIZONTAL );
     itemButtonSelectList = new wxButton( ps57Ctl, ID_SELECTLIST, _("Select All") );
     btnRow->Add( itemButtonSelectList, 1, wxALL | wxEXPAND, group_item_spacing );
     itemButtonClearList = new wxButton( ps57Ctl, ID_CLEARLIST, _("Clear All") );
     btnRow->Add( itemButtonClearList, 1, wxALL | wxEXPAND, group_item_spacing );
     marinersSizer->Add( btnRow );
-
 
 //    m_choicePrecision->SetSelection( g_NMEAAPBPrecision );
 }
@@ -2892,11 +2792,9 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
     pDisplayPanel->SetSizer( wrapperSizer );
     wrapperSizer->Add( generalSizer, 1, wxALL | wxALIGN_CENTER, border_size );
 
-
     // spacer
     generalSizer->Add( 0, border_size*4 );
     generalSizer->Add( 0, border_size*4 );
-
 
     // Nav Mode
     generalSizer->Add( new wxStaticText( pDisplayPanel, wxID_ANY, _("Navigation Mode") ), groupLabelFlags );
@@ -2914,11 +2812,9 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
     pCBLookAhead = new wxCheckBox( pDisplayPanel, ID_CHECK_LOOKAHEAD, _("Look Ahead Mode") );
     boxNavMode->Add( pCBLookAhead, inputFlags );
 
-
     // spacer
     generalSizer->Add( 0, border_size*4 );
     generalSizer->Add( 0, border_size*4 );
-
 
     // Control Options
     generalSizer->Add( new wxStaticText( pDisplayPanel, wxID_ANY, _("Chart Display") ), groupLabelFlags );
@@ -2931,11 +2827,9 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
     pPreserveScale = new wxCheckBox( pDisplayPanel, ID_PRESERVECHECKBOX, _("Preserve Scale when Switching Charts") );
     boxCharts->Add( pPreserveScale, inputFlags );
 
-
     // spacer
     generalSizer->Add( 0, border_size*4 );
     generalSizer->Add( 0, border_size*4 );
-
 
     // Control Options
     generalSizer->Add( new wxStaticText( pDisplayPanel, wxID_ANY, _("Controls") ), groupLabelFlags );
@@ -2949,11 +2843,9 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
     pEnableZoomToCursor->SetValue( FALSE );
     boxCtrls->Add( pEnableZoomToCursor, inputFlags );
 
-
     // spacer
     generalSizer->Add( 0, border_size*4 );
     generalSizer->Add( 0, border_size*4 );
-
 
     // Display Options
     generalSizer->Add( new wxStaticText( pDisplayPanel, wxID_ANY, _("Display Features") ), groupLabelFlags );
@@ -2968,7 +2860,6 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
 
     pSDepthUnits = new wxCheckBox( pDisplayPanel, ID_SHOWDEPTHUNITSBOX1, _("Show Depth Units") );
     boxDisp->Add( pSDepthUnits, inputFlags );
-
 }
 
 void options::CreatePanel_Units( size_t parent, int border_size, int group_item_spacing,
@@ -2987,11 +2878,9 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
     panelUnits->SetSizer( wrapperSizer );
     wrapperSizer->Add( unitsSizer, 1, wxALL | wxALIGN_CENTER, border_size );
 
-
     // spacer
     unitsSizer->Add( 0, border_size*4 );
     unitsSizer->Add( 0, border_size*4 );
-
 
     // distance units
     unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Distance")), labelFlags );
@@ -3001,7 +2890,6 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
                                    wxDefaultSize, m_DistanceFormatsNChoices, pDistanceFormats );
     unitsSizer->Add( pDistanceFormat, inputFlags );
 
-
     // speed units
     unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Speed")), labelFlags );
     wxString pSpeedFormats[] = { _("Knots"), _("Mph"), _("km/h"), _("m/s") };
@@ -3010,7 +2898,6 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
                                 wxDefaultSize, m_SpeedFormatsNChoices, pSpeedFormats );
     unitsSizer->Add( pSpeedFormat, inputFlags );
 
-
     // depth units
     unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Depth")), labelFlags );
     wxString pDepthUnitStrings[] = { _("Feet"), _("Meters"), _("Fathoms"), };
@@ -3018,11 +2905,9 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
                                     wxDefaultSize, 3, pDepthUnitStrings );
     unitsSizer->Add( pDepthUnitSelect, inputFlags );
 
-
     // spacer
     unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
     unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
-
 
     // lat/long units
     unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Lat/Long")), labelFlags );
@@ -3032,11 +2917,9 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
                                wxDefaultSize, m_SDMMFormatsNChoices, pSDMMFormats );
     unitsSizer->Add( pSDMMFormat, inputFlags );
 
-
     // spacer
     unitsSizer->Add( 0, border_size*4 );
     unitsSizer->Add( 0, border_size*4 );
-
 
     // bearings (magnetic/true, variation)
     unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Bearings")), groupLabelFlags );
@@ -3116,7 +2999,6 @@ void options::CreatePanel_AIS( size_t parent, int border_size, int group_item_sp
 
     m_pCheck_CPA_Warn->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED,
                                 wxCommandEventHandler( options::OnCPAWarnClick ), NULL, this );
-
 
     m_pCheck_CPA_WarnT = new wxCheckBox( panelAIS, -1,
             _("...and TCPA is less than (min)") );
@@ -3261,12 +3143,10 @@ void options::CreatePanel_AIS( size_t parent, int border_size, int group_item_sp
     panelAIS->Layout();
 }
 
-
 void options::CreatePanel_UI( size_t parent, int border_size, int group_item_spacing,
         wxSize small_button_size )
 {
     wxScrolledWindow *itemPanelFont = AddPage( parent, _("General Options") );
-
 
     m_itemBoxSizerFontPanel = new wxBoxSizer( wxVERTICAL );
     itemPanelFont->SetSizer( m_itemBoxSizerFontPanel );
@@ -3406,8 +3286,6 @@ void options::CreatePanel_UI( size_t parent, int border_size, int group_item_spa
 #endif
 //#endif
 
-
-
     m_pSlider_Chart_Factor = new wxSlider( itemPanelFont, wxID_ANY, 0, -5, 5,
                                          wxDefaultPosition, wxSize( slider_width, 50),
                                          wxSL_HORIZONTAL | wxSL_AUTOTICKS | wxSL_LABELS );
@@ -3421,7 +3299,6 @@ void options::CreatePanel_UI( size_t parent, int border_size, int group_item_spa
     m_pSlider_Chart_Factor->GetHandle()->setStyleSheet( getQtStyleSheet());
 #endif
 //#endif
-
 }
 
 void options::CreateControls()
@@ -3529,7 +3406,6 @@ void options::CreateControls()
         lv->SetFont( *sFont );
     }
 #endif
-
 
     m_topImgList = new wxImageList( 40, 40, true, 1 );
     ocpnStyle::Style* style = g_StyleManager->GetCurrentStyle();
@@ -3642,7 +3518,6 @@ void options::CreateControls()
 
     //  The s57 chart panel is the one which controls the minimum width required to avoid horizontal scroll bars
     vectorPanel->SetSizeHints( ps57Ctl );
-
 }
 
 void options::SetInitialPage( int page_sel)
@@ -3660,7 +3535,6 @@ void options::SetInitialPage( int page_sel)
     }
 }
 
-
 void options::SetColorScheme( ColorScheme cs )
 {
     DimeControl( this );
@@ -3677,7 +3551,6 @@ void options::SetInitialSettings()
     wxString dirname;
 
     // ChartsLoad
-
     int nDir = m_CurrentDirList.GetCount();
 
     for( int i = 0; i < nDir; i++ ) {
@@ -3690,7 +3563,6 @@ void options::SetInitialSettings()
     }
 
     // ChartGroups
-
     if( pActiveChartsList ) {
         UpdateWorkArrayFromTextCtl();
         groupsPanel->SetDBDirs( *m_pWorkDirList );
@@ -3894,8 +3766,7 @@ void options::SetInitialSettings()
         pRBSizeAuto->SetValue( true );
         screenmm.Printf(_T("%d"), int(g_Platform->GetDisplaySizeMM()));
         pScreenMM->Disable();
-    }
-    else{
+    } else {
         screenmm.Printf(_T("%d"), int(g_config_display_size_mm));
         pRBSizeManual->SetValue( true );
     }
@@ -3993,7 +3864,6 @@ void options::SetInitialSettings()
 
     s.Printf( _T("%d"), g_nAutoHideToolbar );
     pToolbarHideSecs->SetValue( s );
-
 }
 
 void options::UpdateOptionsUnits()
@@ -4037,7 +3907,6 @@ void options::OnSizeAutoButton( wxCommandEvent& event )
     pScreenMM->SetValue(screenmm);
     pScreenMM->Disable();
     g_config_display_size_manual = false;
-
 }
 
 void options::OnSizeManualButton( wxCommandEvent& event )
@@ -4053,7 +3922,6 @@ void options::OnSizeManualButton( wxCommandEvent& event )
     pScreenMM->SetValue(screenmm);
     pScreenMM->Enable();
     g_config_display_size_manual = true;
-
 }
 
 void options::OnUnitsChoice( wxCommandEvent& event )
@@ -4156,7 +4024,6 @@ void options::OnOpenGLOptions( wxCommandEvent& event )
         g_bShowFPS = dlg.m_cbShowFPS->GetValue();
         if(dlg.m_cbSoftwareGL)
             g_bSoftwareGL = dlg.m_cbSoftwareGL->GetValue();
-
         if(g_bexpert){
             g_GLOptions.m_bTextureCompressionCaching = dlg.m_cbTextureCompressionCaching->GetValue();
             g_GLOptions.m_iTextureMemorySize = dlg.m_sTextureMemorySize->GetValue();
@@ -4164,7 +4031,6 @@ void options::OnOpenGLOptions( wxCommandEvent& event )
         else{
             g_GLOptions.m_bTextureCompressionCaching = g_GLOptions.m_bTextureCompression;
         }
-
         if(g_bopengl &&
            g_GLOptions.m_bTextureCompression != dlg.m_cbTextureCompression->GetValue()) {
             g_GLOptions.m_bTextureCompression = dlg.m_cbTextureCompression->GetValue();
@@ -4173,7 +4039,6 @@ void options::OnOpenGLOptions( wxCommandEvent& event )
             ::wxBeginBusyCursor();
             cc1->GetglCanvas()->ClearAllRasterTextures();
             ::wxEndBusyCursor();
-
         }
     }
 
@@ -4196,7 +4061,6 @@ void options::OnChartDirListSelect( wxCommandEvent& event )
         else
             m_removeBtn->Disable();
     }
-
 }
 
 void options::OnDisplayCategoryRadioButton( wxCommandEvent& event )
@@ -4279,11 +4143,9 @@ void options::OnButtonaddClick( wxCommandEvent& event )
     selDir = dirSelector->GetPath();
 #endif
 
-
     AddChartDir( selDir );
 
 done:
-
 //    delete dirSelector;
     event.Skip();
 }
@@ -4605,8 +4467,7 @@ void options::OnApplyClick( wxCommandEvent& event )
 
     g_config_display_size_manual = pRBSizeManual->GetValue();
 
-
-// Connections page.
+    // Connections page.
     g_bfilter_cogsog = m_cbFilterSogCog->GetValue();
 
     long filter_val = 1;
@@ -4618,8 +4479,7 @@ void options::OnApplyClick( wxCommandEvent& event )
     g_bMagneticAPB = m_cbAPBMagnetic->GetValue();
     g_NMEAAPBPrecision = m_choicePrecision->GetCurrentSelection();
 
-
-        // NMEA Source
+    // NMEA Source
     long itemIndex = m_lcSources->GetNextItem( -1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED );
 
     //  If the stream selected exists, capture some of its existing parameters
@@ -4666,7 +4526,6 @@ void options::OnApplyClick( wxCommandEvent& event )
                 event.SetInt (wxID_STOP );
         }
     }
-
 
     //Recreate datastreams that are new, or have been edited
     for ( size_t i = 0; i < g_pConnectionParams->Count(); i++ )
@@ -4718,8 +4577,7 @@ void options::OnApplyClick( wxCommandEvent& event )
     else
         g_GPS_Ident = _T("Generic");
 
-
-// End of Connections page
+    // End of Connections page
 
     g_bShowOutlines = pCDOOutlines->GetValue();
     g_bDisplayGrid = pSDisplayGrid->GetValue();
@@ -4827,7 +4685,6 @@ void options::OnApplyClick( wxCommandEvent& event )
             }
         }
     }
-
 
     g_bShowMoored = !m_pCheck_Show_Moored->GetValue();
     m_pText_Moored_Speed->GetValue().ToDouble( &g_ShowMoored_Kts );
@@ -5073,7 +4930,6 @@ void options::Finish()
 
 }
 
-
 void options::OnButtondeleteClick( wxCommandEvent& event )
 {
 
@@ -5194,7 +5050,6 @@ void options::OnChooseFont( wxCommandEvent& event )
     }
 #endif
 
-
     if(g_bresponsive){
         dg.SetSize(GetSize());
         dg.Centre();
@@ -5276,7 +5131,6 @@ void options::OnNBPageChange( wxNotebookEvent& event )
 {
     DoOnPageChange( event.GetSelection() );
 }
-
 
 void options::DoOnPageChange( size_t page )
 {
@@ -5394,11 +5248,7 @@ void options::DoOnPageChange( size_t page )
             ::wxEndBusyCursor();
         }
 #endif
-    }
-
-
-    else if( m_pagePlugins == i ) {                    // 7 is the index of "Plugins" page
-
+    } else if( m_pagePlugins == i ) {                    // 7 is the index of "Plugins" page
         // load the disabled plugins finally because the user might want to enable them
         if(g_pi_manager->LoadAllPlugIns( g_Platform->GetPluginDir(), false )) {
             delete m_pPlugInCtrl;
@@ -5491,7 +5341,6 @@ void options::OnButtonSelectSound( wxCommandEvent& event )
     sel_file = path;
 #endif
 
-
     if( response == wxID_OK ) {
         if( g_bportable ) {
             wxFileName f( sel_file );
@@ -5502,7 +5351,6 @@ void options::OnButtonSelectSound( wxCommandEvent& event )
 
         g_anchorwatch_sound.UnLoad();
     }
-
 }
 
 void options::OnButtonTestSound( wxCommandEvent& event )
@@ -5615,7 +5463,6 @@ wxString GetOCPNKnownLanguage( wxString lang_canonical, wxString *lang_dir )
     if( NULL != lang_dir ) *lang_dir = dir_suffix;
 #endif
     return return_string;
-
 }
 
 ChartGroupArray* ChartGroupsUI::CloneChartGroupArray( ChartGroupArray* s )
@@ -5652,7 +5499,6 @@ void ChartGroupsUI::EmptyChartGroupArray( ChartGroupArray* s )
             pe->m_missing_name_array.Clear();
             psg->m_element_array.RemoveAt( j );
             delete pe;
-
         }
         s->RemoveAt( i );
         delete psg;
@@ -5662,7 +5508,6 @@ void ChartGroupsUI::EmptyChartGroupArray( ChartGroupArray* s )
 }
 
 //    Chart Groups dialog implementation
-
 BEGIN_EVENT_TABLE( ChartGroupsUI, wxScrolledWindow )
     EVT_TREE_ITEM_EXPANDED( wxID_TREECTRL, ChartGroupsUI::OnNodeExpanded )
     EVT_BUTTON( ID_GROUPINSERTDIR, ChartGroupsUI::OnInsertChartItem )
@@ -5739,8 +5584,6 @@ void ChartGroupsUI::PopulateTrees()
                       iFont );
 }
 
-
-
 void ChartGroupsUI::CompleteInitialSettings()
 {
     PopulateTrees();
@@ -5752,8 +5595,6 @@ void ChartGroupsUI::CompleteInitialSettings()
     m_settingscomplete = true;
     m_treespopulated = true;
 }
-
-
 
 void ChartGroupsUI::PopulateTreeCtrl( wxTreeCtrl *ptc, const wxArrayString &dir_array,
         const wxColour &col, wxFont *pFont )
@@ -6106,10 +5947,7 @@ void options::OnInsertTideDataLocation( wxCommandEvent &event )
         else
             g_TCData_Dir = data_dir;
     }
-
-
 }
-
 
 void options::OnRemoveTideDataLocation( wxCommandEvent &event )
 {
@@ -6131,14 +5969,12 @@ void options::OnRemoveTideDataLocation( wxCommandEvent &event )
     int iSel = tcDataSelected->GetSelection();
     tcDataSelected->Delete( iSel );
 #endif
-
 }
 
 void options::OnValChange( wxCommandEvent& event )
 {
     event.Skip();
 }
-
 
 void options::OnScanBTClick( wxCommandEvent& event )
 {
@@ -6180,7 +6016,6 @@ void options::onBTScanTimer(wxTimerEvent &event)
             m_choiceBTDataSources->SetSelection( 1 );
         }
 
-
         //  Watch for changes.  When no changes occur after n seconds, stop the scan
         if(m_btNoChangeCounter > 5)
             StopBTScan();
@@ -6199,7 +6034,6 @@ void options::onBTScanTimer(wxTimerEvent &event)
     }
     else{
     }
-
     return;
 }
 
@@ -6215,9 +6049,7 @@ void options::StopBTScan()
         m_buttonScanBT->SetLabel(_("BT Scan"));
         m_buttonScanBT->Enable();
     }
-
 }
-
 
 void options::OnConnValChange( wxCommandEvent& event )
 {
@@ -6256,7 +6088,6 @@ void options::OnTypeBTSelected( wxCommandEvent& event )
     OnConnValChange(event);
     SetNMEAFormToBT();
 }
-
 
 void options::OnUploadFormatChange( wxCommandEvent& event )
 {
@@ -6607,12 +6438,7 @@ void options::SetConnectionParams(ConnectionParams *cp)
         m_choiceBTDataSources->Clear();
         m_choiceBTDataSources->Append(bts);
         m_choiceBTDataSources->SetSelection( 0 );
-
-
-
-    }
-
-    else
+    } else
         ClearNMEAForm();
 
     m_connection_enabled = cp->bEnabled;
@@ -6650,7 +6476,6 @@ void options::SetDefaultConnectionParams()
 
     m_connection_enabled = true;
 }
-
 
 void options::OnAddDatasourceClick( wxCommandEvent& event )
 {
@@ -6731,8 +6556,7 @@ void options::FillSourceList()
 void options::OnRemoveDatasourceClick( wxCommandEvent& event )
 {
     long itemIndex = -1;
-    for ( ;; )
-    {
+    for ( ;; ) {
         itemIndex = m_lcSources->GetNextItem( itemIndex, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED );
         if ( itemIndex == -1 )
             break;
@@ -6846,7 +6670,6 @@ void options::OnCbOutput( wxCommandEvent& event )
 }
 
 //SentenceListDlg
-
 SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
     m_dir = dir;
@@ -6879,7 +6702,6 @@ SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent, wxWindo
 
     m_clbSentences = new wxCheckListBox( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, standard_sentences );
 
-
     sbSizerclb->Add( m_clbSentences, 1, wxALL|wxEXPAND, 5 );
 
     wxBoxSizer* bSizer18;
@@ -6901,9 +6723,7 @@ SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent, wxWindo
 
     bSizer18->Add( m_btnDel, 0, wxALL, 5 );
 
-
     bSizer17->Add( bSizer18, 0, wxALL|wxEXPAND, 5 );
-
 
     bSizer16->Add( bSizer17, 1, wxEXPAND, 5 );
 
@@ -6915,7 +6735,6 @@ SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent, wxWindo
     m_sdbSizer4->Realize();
 
     bSizer16->Add( m_sdbSizer4, 0, wxALL|wxEXPAND, 5 );
-
 
     this->SetSizer( bSizer16 );
     this->Layout();
@@ -6995,7 +6814,6 @@ void SentenceListDlg::FillSentences()
             int item = m_clbSentences->FindString(m_sentences[i]);
             m_clbSentences->Check(item);
         }
-
     }
 
     m_btnDel->Enable(false);
@@ -7023,7 +6841,6 @@ void SentenceListDlg::OnCLBSelect( wxCommandEvent& event )
     else
         bdelete = false;
     m_btnDel->Enable( bdelete );
-
 }
 
 void SentenceListDlg::OnCLBToggle( wxCommandEvent& event )
@@ -7108,8 +6925,6 @@ void SentenceListDlg::SetType(int io, ListType type)
     Refresh();
 }
 
-
-
 void SentenceListDlg::OnCancelClick( wxCommandEvent& event ) { event.Skip(); }
 void SentenceListDlg::OnOkClick( wxCommandEvent& event ) { event.Skip(); }
 
@@ -7120,7 +6935,6 @@ BEGIN_EVENT_TABLE( OpenGLOptionsDlg, wxDialog )
     EVT_BUTTON( ID_BUTTON_REBUILD, OpenGLOptionsDlg::OnButtonRebuild )
     EVT_BUTTON( ID_BUTTON_CLEAR, OpenGLOptionsDlg::OnButtonClear )
 END_EVENT_TABLE()
-
 
 OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
 {
@@ -7173,7 +6987,6 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
         m_cbTextureCompression->SetValue(g_GLOptions.m_bTextureCompression);
         m_bSizer1->Add(m_cbTextureCompression, 0, wxALL | wxEXPAND, 5);
     }
-
 
         /* disable caching if unsupported */
     extern PFNGLCOMPRESSEDTEXIMAGE2DPROC s_glCompressedTexImage2D;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -5983,6 +5983,10 @@ void options::ShowNMEACommon( bool visible )
         m_choicePrecision->Enable( output );
         m_stTalkerIdText->Enable( output );
         m_TalkerIdText->Enable( output );
+    } else {
+        sbSizerOutFilter->SetDimension( 0, 0, 0, 0 );
+        sbSizerInFilter->SetDimension( 0, 0, 0, 0 );
+        sbSizerConnectionProps->SetDimension( 0, 0, 0, 0 );
     }
     m_bNMEAParams_shown = visible;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6554,19 +6554,10 @@ void SentenceListDlg::OnStcSelect( wxCommandEvent& event )
     m_btnDel->Enable();
 }
 
-void SentenceListDlg::OnCLBSelect( wxCommandEvent& event )
+void SentenceListDlg::OnCLBSelect( wxCommandEvent& e )
 {
-    // Only active the "Delete" button if the selection is not in the standard list
-    int isel = m_clbSentences->GetSelection();
-
-    bool bdelete = TRUE;
-    if ( isel >= 0 ) {
-        wxString s = m_clbSentences->GetString( isel );
-        if ( standard_sentences.Index( s ) != wxNOT_FOUND )
-            bdelete = FALSE;
-    } else
-        bdelete = FALSE;
-    m_btnDel->Enable( bdelete );
+    // Only activate the "Delete" button if the selection is not in the standard list
+    m_btnDel->Enable( standard_sentences.Index( e.GetString( ) ) == wxNOT_FOUND );
 }
 
 void SentenceListDlg::OnCLBToggle( wxCommandEvent& event )

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -5683,44 +5683,39 @@ void ChartGroupsUI::OnNodeExpanded( wxTreeEvent& event )
 {
     wxTreeItemId node = event.GetItem();
 
-    if( m_GroupSelectedPage > 0 ) {
-        wxGenericDirCtrl *pDirCtrl = ( m_DirCtrlArray.Item( m_GroupSelectedPage ) );
-        ChartGroup *pGroup = m_pGroupArray->Item( m_GroupSelectedPage - 1 );
-        if( pDirCtrl ) {
-            wxTreeCtrl *ptree = pDirCtrl->GetTreeCtrl();
+    if ( m_GroupSelectedPage <= 0 ) return;
+    wxGenericDirCtrl *pDirCtrl = ( m_DirCtrlArray.Item( m_GroupSelectedPage ) );
+    ChartGroup *pGroup = m_pGroupArray->Item( m_GroupSelectedPage - 1 );
+    if ( !pDirCtrl ) return;
 
-            wxString branch_adder;
-            int target_item_index = FindGroupBranch( pGroup, ptree, node, &branch_adder );
-            if( target_item_index >= 0 ) {
-                ChartGroupElement *target_element = pGroup->m_element_array.Item(
-                        target_item_index );
-                wxString branch_name = target_element->m_element_name;
+    wxTreeCtrl *ptree = pDirCtrl->GetTreeCtrl();
+    wxString branch_adder;
+    int target_item_index = FindGroupBranch( pGroup, ptree, node, &branch_adder );
+    if ( target_item_index < 0 ) return;
+    ChartGroupElement *target_element = pGroup->m_element_array.Item( target_item_index );
+    wxString branch_name = target_element->m_element_name;
 
-                //    Walk the children of the expanded node, marking any items which appear in
-                //    the "missing" list
-                if( ( target_element->m_missing_name_array.GetCount() ) ) {
-                    wxString full_root = branch_name;
-                    full_root += branch_adder;
-                    full_root += wxString( wxFILE_SEP_PATH );
+    // Walk the children of the expanded node, marking any items which appear in
+    // the "missing" list
+    if ( !target_element->m_missing_name_array.GetCount() ) return;
+    wxString full_root = branch_name;
+    full_root += branch_adder;
+    full_root += wxString( wxFILE_SEP_PATH );
 
-                    wxTreeItemIdValue cookie;
-                    wxTreeItemId child = ptree->GetFirstChild( node, cookie );
-                    while( child.IsOk() ) {
-                        wxString target_string = full_root;
-                        target_string += ptree->GetItemText( child );
+    wxTreeItemIdValue cookie;
+    wxTreeItemId child = ptree->GetFirstChild( node, cookie );
+    while ( child.IsOk() ) {
+        wxString target_string = full_root;
+        target_string += ptree->GetItemText( child );
 
-                        for( unsigned int k = 0;
-                                k < target_element->m_missing_name_array.GetCount(); k++ ) {
-                            if( target_element->m_missing_name_array.Item( k ) == target_string ) {
-                                ptree->SetItemTextColour( child, wxColour( 128, 128, 128 ) );
-                                break;
-                            }
-                        }
-                        child = ptree->GetNextChild( node, cookie );
-                    }
-                }
+        for( unsigned int k = 0;
+                k < target_element->m_missing_name_array.GetCount(); k++ ) {
+            if( target_element->m_missing_name_array.Item( k ) == target_string ) {
+                ptree->SetItemTextColour( child, wxColour( 128, 128, 128 ) );
+                break;
             }
         }
+        child = ptree->GetNextChild( node, cookie );
     }
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6156,41 +6156,28 @@ void options::ShowNMEASerial(bool visible)
     }
 }
 
-void options::ShowNMEAGPS(bool visible)
-{
-    if ( visible )
-    {
-    }
-    else
-    {
-    }
-}
+void options::ShowNMEAGPS( bool visible ) {}
 
-void options::ShowNMEABT(bool visible)
+void options::ShowNMEABT( bool visible )
 {
-    if ( visible )
-    {
-        if(m_buttonScanBT) m_buttonScanBT->Show();
-        if(m_stBTPairs) m_stBTPairs->Show();
-        if(m_choiceBTDataSources){
-            if(m_choiceBTDataSources->GetCount() > 1)
-                m_choiceBTDataSources->SetSelection(1);
+    if ( visible ) {
+        if ( m_buttonScanBT ) m_buttonScanBT->Show();
+        if ( m_stBTPairs ) m_stBTPairs->Show();
+        if ( m_choiceBTDataSources ) {
+            if ( m_choiceBTDataSources->GetCount() > 1 )
+                m_choiceBTDataSources->SetSelection( 1 );
             m_choiceBTDataSources->Show();
         }
-
-    }
-    else
-    {
-        if(m_buttonScanBT) m_buttonScanBT->Hide();
-        if(m_stBTPairs) m_stBTPairs->Hide();
-        if(m_choiceBTDataSources) m_choiceBTDataSources->Hide();
+    } else {
+        if ( m_buttonScanBT ) m_buttonScanBT->Hide();
+        if ( m_stBTPairs ) m_stBTPairs->Hide();
+        if ( m_choiceBTDataSources ) m_choiceBTDataSources->Hide();
     }
 }
 
 void options::SetNMEAFormToSerial()
 {
     ShowNMEACommon( TRUE );
-
     ShowNMEANet( FALSE );
     ShowNMEAGPS( FALSE );
     ShowNMEABT( FALSE );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6444,10 +6444,8 @@ SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent,
                                   long style )
     : wxDialog( parent, id, title, pos, size, style ), m_dir( dir )
 {
-    SetSizeHints( wxDefaultSize, wxDefaultSize );
 
-    wxBoxSizer* bSizer16 = new wxBoxSizer( wxVERTICAL );
-    wxBoxSizer* bSizer17 = new wxBoxSizer( wxHORIZONTAL );
+    wxBoxSizer* mainSizer = new wxBoxSizer( wxVERTICAL );
 
     NMEA0183 nmea;
     standard_sentences = nmea.GetRecognizedArray();
@@ -6461,57 +6459,46 @@ SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent,
     standard_sentences.Add( _T("FRPOS") );
     standard_sentences.Add( _T("CD") );
 
+    wxBoxSizer* secondSizer = new wxBoxSizer( wxHORIZONTAL );
     m_pclbBox = new wxStaticBox( this, wxID_ANY, wxEmptyString ) ;
-    wxStaticBoxSizer* sbSizerclb = new wxStaticBoxSizer( m_pclbBox,
-                                                         wxVERTICAL );
-    bSizer17->Add( sbSizerclb, 1, wxALL | wxEXPAND, 5 );
-
+    wxStaticBoxSizer* stcSizer = new wxStaticBoxSizer( m_pclbBox, wxVERTICAL );
     m_clbSentences = new wxCheckListBox( this, wxID_ANY, wxDefaultPosition,
                                          wxDefaultSize, standard_sentences );
-    sbSizerclb->Add( m_clbSentences, 1, wxALL|wxEXPAND, 5 );
-
-    wxBoxSizer* bSizer18 = new wxBoxSizer( wxVERTICAL );
-
-    m_btnCheckAll = new wxButton( this, wxID_ANY, _("Select All") );
-    bSizer18->Add( m_btnCheckAll, 0, wxALL, 5 );
-
-    m_btnClearAll = new wxButton( this, wxID_ANY, _("Clear All") );
-    bSizer18->Add( m_btnClearAll, 0, wxALL, 5 );
-
-    bSizer18->AddSpacer( 1 );
-
-    m_btnAdd = new wxButton( this, wxID_ANY, _("Add"));
-    bSizer18->Add( m_btnAdd, 0, wxALL, 5 );
-
+    wxBoxSizer* btnEntrySizer = new wxBoxSizer( wxVERTICAL );
+    wxButton *btnCheckAll = new wxButton( this, wxID_ANY, _("Select All") );
+    wxButton *btnClearAll = new wxButton( this, wxID_ANY, _("Clear All") );
+    wxButton *btnAdd = new wxButton( this, wxID_ANY, _("Add"));
     m_btnDel = new wxButton( this, wxID_ANY, _("Delete"));
+    wxStdDialogButtonSizer *btnSizer = new wxStdDialogButtonSizer();
+    wxButton *btnOK = new wxButton( this, wxID_OK );
+    wxButton *btnCancel = new wxButton( this, wxID_CANCEL );
+
+    secondSizer->Add( stcSizer, 1, wxALL | wxEXPAND, 5 );
+    stcSizer->Add( m_clbSentences, 1, wxALL | wxEXPAND, 5 );
+    btnEntrySizer->Add( btnCheckAll, 0, wxALL, 5 );
+    btnEntrySizer->Add( btnClearAll, 0, wxALL, 5 );
+    btnEntrySizer->AddSpacer( 1 );
+    btnEntrySizer->Add( btnAdd, 0, wxALL, 5 );
     m_btnDel->Disable();
+    btnEntrySizer->Add( m_btnDel, 0, wxALL, 5 );
+    secondSizer->Add( btnEntrySizer, 0, wxALL | wxEXPAND, 5 );
+    mainSizer->Add( secondSizer, 1, wxEXPAND, 5 );
+    btnSizer->AddButton( btnOK );
+    btnSizer->AddButton( btnCancel );
+    btnSizer->Realize();
+    mainSizer->Add( btnSizer, 0, wxALL | wxEXPAND, 5 );
 
-    bSizer18->Add( m_btnDel, 0, wxALL, 5 );
-    bSizer17->Add( bSizer18, 0, wxALL | wxEXPAND, 5 );
-    bSizer16->Add( bSizer17, 1, wxEXPAND, 5 );
-
-    m_sdbSizer4 = new wxStdDialogButtonSizer();
-    m_sdbSizer4OK = new wxButton( this, wxID_OK );
-    m_sdbSizer4->AddButton( m_sdbSizer4OK );
-    m_sdbSizer4Cancel = new wxButton( this, wxID_CANCEL );
-    m_sdbSizer4->AddButton( m_sdbSizer4Cancel );
-    m_sdbSizer4->Realize();
-
-    bSizer16->Add( m_sdbSizer4, 0, wxALL | wxEXPAND, 5 );
-
-    SetSizer( bSizer16 );
-    Layout();
+    SetSizer( mainSizer );
+    mainSizer->SetSizeHints( this );
     Centre();
 
     // Connect Events
-    m_btnAdd->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnAddClick ), NULL, this );
+    btnAdd->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnAddClick ), NULL, this );
     m_btnDel->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnDeleteClick ), NULL, this );
-    m_sdbSizer4Cancel->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnCancelClick ), NULL, this );
-    m_sdbSizer4OK->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnOkClick ), NULL, this );
     m_clbSentences->Connect( wxEVT_COMMAND_CHECKLISTBOX_TOGGLED, wxCommandEventHandler( SentenceListDlg::OnCLBToggle ), NULL, this );
     m_clbSentences->Connect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( SentenceListDlg::OnCLBSelect ), NULL, this );
-    m_btnCheckAll->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnCheckAllClick ), NULL, this );
-    m_btnClearAll->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnClearAllClick ), NULL, this );
+    btnCheckAll->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnCheckAllClick ), NULL, this );
+    btnClearAll->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnClearAllClick ), NULL, this );
 }
 
 void SentenceListDlg::SetSentenceList(wxArrayString sentences)
@@ -6668,9 +6655,6 @@ void SentenceListDlg::SetType( int io, ListType type )
     Refresh();
 }
 
-void SentenceListDlg::OnCancelClick( wxCommandEvent& event ) { event.Skip(); }
-void SentenceListDlg::OnOkClick( wxCommandEvent& event ) { event.Skip(); }
-
 // OpenGLOptionsDlg
 enum { ID_BUTTON_REBUILD, ID_BUTTON_CLEAR };
 
@@ -6785,12 +6769,12 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
 
     m_bSizer1->AddSpacer(0);
 
-    wxStdDialogButtonSizer * m_sdbSizer4 = new wxStdDialogButtonSizer();
-    m_sdbSizer4->AddButton( new wxButton( this, wxID_OK ) );
-    m_sdbSizer4->AddButton( new wxButton( this, wxID_CANCEL ) );
-    m_sdbSizer4->Realize();
+    wxStdDialogButtonSizer * btnSizer = new wxStdDialogButtonSizer();
+    btnSizer->AddButton( new wxButton( this, wxID_OK ) );
+    btnSizer->AddButton( new wxButton( this, wxID_CANCEL ) );
+    btnSizer->Realize();
 
-    m_bSizer1->Add( m_sdbSizer4, 0, wxALL | wxEXPAND, 5 );
+    m_bSizer1->Add( btnSizer, 0, wxALL | wxEXPAND, 5 );
 
     SetSizer( m_bSizer1 );
     Layout();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2991,13 +2991,13 @@ void options::CreatePanel_AIS( size_t parent, int border_size, int group_item_sp
     pDisplayGrid->Add( m_pCheck_Show_Area_Notices, 1, wxALL, group_item_spacing );
 
     wxStaticText *pStatic_Dummy5 = new wxStaticText( panelAIS, -1, _T("") );
-    pDisplayGrid->Add( pStatic_Dummy5, 1, wxALL | wxALL, group_item_spacing );
+    pDisplayGrid->Add( pStatic_Dummy5, 1, wxALL, group_item_spacing );
 
     m_pCheck_Draw_Target_Size = new wxCheckBox( panelAIS, -1, _("Show AIS targets real size") );
     pDisplayGrid->Add( m_pCheck_Draw_Target_Size, 1, wxALL, group_item_spacing );
 
     wxStaticText *pStatic_Dummy6 = new wxStaticText( panelAIS, -1, _T("") );
-    pDisplayGrid->Add( pStatic_Dummy6, 1, wxALL | wxALL, group_item_spacing );
+    pDisplayGrid->Add( pStatic_Dummy6, 1, wxALL, group_item_spacing );
 
     m_pCheck_Show_Target_Name = new wxCheckBox( panelAIS, -1, _("Show names with AIS targets at scale greater than 1:") );
     pDisplayGrid->Add( m_pCheck_Show_Target_Name, 1, wxALL, group_item_spacing );
@@ -3009,10 +3009,10 @@ void options::CreatePanel_AIS( size_t parent, int border_size, int group_item_sp
     pDisplayGrid->Add( m_pCheck_Wpl_Aprs, 1, wxALL, group_item_spacing );
 
     wxStaticText *pStatic_Dummy7 = new wxStaticText( panelAIS, -1, _T("") );
-    pDisplayGrid->Add( pStatic_Dummy7, 1, wxALL | wxALL, group_item_spacing );
+    pDisplayGrid->Add( pStatic_Dummy7, 1, wxALL, group_item_spacing );
 
     wxStaticText *pStatic_Dummy5a = new wxStaticText( panelAIS, -1, _T("") );
-    pDisplayGrid->Add( pStatic_Dummy5a, 1, wxALL | wxALL, group_item_spacing );
+    pDisplayGrid->Add( pStatic_Dummy5a, 1, wxALL, group_item_spacing );
 
     // Rollover
     wxStaticBox* rolloverBox = new wxStaticBox( panelAIS, wxID_ANY, _("Rollover") );
@@ -3061,7 +3061,7 @@ void options::CreatePanel_AIS( size_t parent, int border_size, int group_item_sp
     pAlertGrid->Add( m_pCheck_Alert_Moored, 1, wxALL, group_item_spacing );
 
     wxStaticText *pStatic_Dummy2 = new wxStaticText( panelAIS, -1, _T("") );
-    pAlertGrid->Add( pStatic_Dummy2, 1, wxALL | wxALL, group_item_spacing );
+    pAlertGrid->Add( pStatic_Dummy2, 1, wxALL, group_item_spacing );
 
     m_pCheck_Ack_Timout = new wxCheckBox( panelAIS, -1,
             _("Enable Target Alert Acknowledge timeout (min)") );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -313,9 +313,9 @@ END_EVENT_TABLE()
 MMSIEditDialog::MMSIEditDialog() {}
 
 MMSIEditDialog::MMSIEditDialog( MMSIProperties *props, wxWindow* parent, wxWindowID id, const wxString& caption,
-                                const wxPoint& pos, const wxSize& size, long style )
+                                const wxPoint& pos, const wxSize& size, long style ) :
+    m_props( props )
 {
-    m_props = props;
     long wstyle = wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER;
     wxDialog::Create( parent, id, caption, pos, size, wstyle );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6511,62 +6511,56 @@ void options::OnCbOutput( wxCommandEvent& event )
     }
 }
 
-//SentenceListDlg
-SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
+SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent,
+                                  wxWindowID id, const wxString& title,
+                                  const wxPoint& pos, const wxSize& size,
+                                  long style )
+    : wxDialog( parent, id, title, pos, size, style ), m_dir( dir )
 {
-    m_dir = dir;
-    this->SetSizeHints( wxDefaultSize, wxDefaultSize );
+    SetSizeHints( wxDefaultSize, wxDefaultSize );
 
-    wxBoxSizer* bSizer16;
-    bSizer16 = new wxBoxSizer( wxVERTICAL );
-
-    wxBoxSizer* bSizer17;
-    bSizer17 = new wxBoxSizer( wxHORIZONTAL );
+    wxBoxSizer* bSizer16 = new wxBoxSizer( wxVERTICAL );
+    wxBoxSizer* bSizer17 = new wxBoxSizer( wxHORIZONTAL );
 
     NMEA0183 nmea;
     standard_sentences = nmea.GetRecognizedArray();
-    if(m_dir == FILTER_OUTPUT) {
-        standard_sentences.Add(_T("ECRMB"));
-        standard_sentences.Add(_T("ECRMC"));
-        standard_sentences.Add(_T("ECAPB"));
+    if ( m_dir == FILTER_OUTPUT ) {
+        standard_sentences.Add( _T("ECRMB") );
+        standard_sentences.Add( _T("ECRMC") );
+        standard_sentences.Add( _T("ECAPB") );
     }
+    standard_sentences.Add( _T("AIVDM") );
+    standard_sentences.Add( _T("AIVDO") );
+    standard_sentences.Add( _T("FRPOS") );
+    standard_sentences.Add( _T("CD") );
 
-    standard_sentences.Add(_T("AIVDM"));
-    standard_sentences.Add(_T("AIVDO"));
-    standard_sentences.Add(_T("FRPOS"));
-    standard_sentences.Add(_T("CD"));
+    m_pclbBox = new wxStaticBox( this, wxID_ANY, wxEmptyString ) ;
+    wxStaticBoxSizer* sbSizerclb = new wxStaticBoxSizer( m_pclbBox,
+                                                         wxVERTICAL );
+    bSizer17->Add( sbSizerclb, 1, wxALL | wxEXPAND, 5 );
 
-    m_pclbBox = new wxStaticBox( this,  wxID_ANY, _T("")) ;
-
-    wxStaticBoxSizer* sbSizerclb;
-    sbSizerclb = new wxStaticBoxSizer( m_pclbBox , wxVERTICAL );
-    bSizer17->Add( sbSizerclb, 1, wxALL|wxEXPAND, 5 );
-
-    m_clbSentences = new wxCheckListBox( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, standard_sentences );
-
+    m_clbSentences = new wxCheckListBox( this, wxID_ANY, wxDefaultPosition,
+                                         wxDefaultSize, standard_sentences );
     sbSizerclb->Add( m_clbSentences, 1, wxALL|wxEXPAND, 5 );
 
-    wxBoxSizer* bSizer18;
-    bSizer18 = new wxBoxSizer( wxVERTICAL );
+    wxBoxSizer* bSizer18 = new wxBoxSizer( wxVERTICAL );
 
-    m_btnCheckAll = new wxButton( this, wxID_ANY, _("Select All"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_btnCheckAll = new wxButton( this, wxID_ANY, _("Select All") );
     bSizer18->Add( m_btnCheckAll, 0, wxALL, 5 );
 
-    m_btnClearAll = new wxButton( this, wxID_ANY, _("Clear All"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_btnClearAll = new wxButton( this, wxID_ANY, _("Clear All") );
     bSizer18->Add( m_btnClearAll, 0, wxALL, 5 );
 
-    bSizer18->AddSpacer(1);
+    bSizer18->AddSpacer( 1 );
 
-    m_btnAdd = new wxButton( this, wxID_ANY, _("Add"), wxDefaultPosition, wxDefaultSize, 0 );
+    m_btnAdd = new wxButton( this, wxID_ANY, _("Add"));
     bSizer18->Add( m_btnAdd, 0, wxALL, 5 );
 
-    m_btnDel = new wxButton( this, wxID_ANY, _("Delete"), wxDefaultPosition, wxDefaultSize, 0 );
-    m_btnDel->Enable( FALSE );
+    m_btnDel = new wxButton( this, wxID_ANY, _("Delete"));
+    m_btnDel->Disable();
 
     bSizer18->Add( m_btnDel, 0, wxALL, 5 );
-
-    bSizer17->Add( bSizer18, 0, wxALL|wxEXPAND, 5 );
-
+    bSizer17->Add( bSizer18, 0, wxALL | wxEXPAND, 5 );
     bSizer16->Add( bSizer17, 1, wxEXPAND, 5 );
 
     m_sdbSizer4 = new wxStdDialogButtonSizer();
@@ -6576,12 +6570,11 @@ SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent, wxWindo
     m_sdbSizer4->AddButton( m_sdbSizer4Cancel );
     m_sdbSizer4->Realize();
 
-    bSizer16->Add( m_sdbSizer4, 0, wxALL|wxEXPAND, 5 );
+    bSizer16->Add( m_sdbSizer4, 0, wxALL | wxEXPAND, 5 );
 
-    this->SetSizer( bSizer16 );
-    this->Layout();
-
-    this->Centre( wxBOTH );
+    SetSizer( bSizer16 );
+    Layout();
+    Centre();
 
     // Connect Events
     m_btnAdd->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnAddClick ), NULL, this );
@@ -6596,7 +6589,7 @@ SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent, wxWindo
 
 SentenceListDlg::~SentenceListDlg( void )
 {
-    // Disconnect Events
+    // Disconnect Events... Why?
     m_btnAdd->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnAddClick ), NULL, this );
     m_btnDel->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnDeleteClick ), NULL, this );
     m_sdbSizer4Cancel->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnCancelClick ), NULL, this );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6592,7 +6592,6 @@ SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent, wxWindo
     m_clbSentences->Connect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( SentenceListDlg::OnCLBSelect ), NULL, this );
     m_btnCheckAll->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnCheckAllClick ), NULL, this );
     m_btnClearAll->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnClearAllClick ), NULL, this );
-
 }
 
 SentenceListDlg::~SentenceListDlg( void )
@@ -6612,13 +6611,13 @@ void SentenceListDlg::SetSentenceList(wxArrayString sentences)
 {
     m_sentences = sentences;
 
-    if( (m_sentences.Count() == 0) && (m_type == WHITELIST) ){
-        for (size_t i = 0; i < m_clbSentences->GetCount(); i++)
-            m_clbSentences->Check(i, TRUE);
+    if ( m_sentences.Count() == 0 && m_type == WHITELIST ) {
+        for ( size_t i = 0; i < m_clbSentences->GetCount(); i++ )
+            m_clbSentences->Check( i, TRUE );
     }
-    if( (m_sentences.Count() == 0) && (m_type == BLACKLIST) ){
-        for (size_t i = 0; i < m_clbSentences->GetCount(); i++)
-            m_clbSentences->Check(i, FALSE);
+    if ( m_sentences.Count() == 0 && m_type == BLACKLIST ) {
+        for ( size_t i = 0; i < m_clbSentences->GetCount(); i++ )
+            m_clbSentences->Check( i, FALSE );
     }
 
     FillSentences();
@@ -6626,35 +6625,33 @@ void SentenceListDlg::SetSentenceList(wxArrayString sentences)
 
 wxString SentenceListDlg::GetSentencesAsText( void )
 {
-    return StringArrayToString(m_sentences);
+    return StringArrayToString( m_sentences );
 }
 
 void SentenceListDlg::BuildSentenceArray( void )
 {
     m_sentences.Clear();
     wxString s;
-    for (size_t i = 0; i < m_clbSentences->GetCount(); i++) {
-        if( m_clbSentences->IsChecked(i))
-            m_sentences.Add( m_clbSentences->GetString(i) );
+    for ( size_t i = 0; i < m_clbSentences->GetCount(); i++ ) {
+        if ( m_clbSentences->IsChecked( i ) )
+            m_sentences.Add( m_clbSentences->GetString( i ) );
     }
 }
 
 void SentenceListDlg::FillSentences( void )
 {
-    if(m_sentences.Count() == 0)
-        return;
+    if ( m_sentences.Count() == 0 ) return;
 
-    for (size_t i = 0; i < m_clbSentences->GetCount(); i++)
-        m_clbSentences->Check(i, FALSE);
+    for ( size_t i = 0; i < m_clbSentences->GetCount(); i++ )
+        m_clbSentences->Check( i, FALSE );
 
-    for (size_t i = 0; i < m_sentences.Count(); i++) {
-        int item = m_clbSentences->FindString(m_sentences[i]);
-        if( wxNOT_FOUND != item )
-            m_clbSentences->Check(item);
+    for ( size_t i = 0; i < m_sentences.Count(); i++ ) {
+        int item = m_clbSentences->FindString( m_sentences[i] );
+        if ( item != wxNOT_FOUND )
+            m_clbSentences->Check( item );
         else {
-            m_clbSentences->Append(m_sentences[i]);
-            int item = m_clbSentences->FindString(m_sentences[i]);
-            m_clbSentences->Check(item);
+            m_clbSentences->Append( m_sentences[i] );
+            m_clbSentences->Check( m_clbSentences->FindString( m_sentences[i] ) );
         }
     }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1461,40 +1461,13 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     m_cbAPBMagnetic->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnValChange ), NULL, this );
     m_lcSources->Connect( wxEVT_LEFT_DOWN, wxMouseEventHandler(options::OnConnectionToggleEnable), NULL, this );
 
-    wxListItem col0;
-    col0.SetId( 0 );
-    col0.SetText( _( "On" ) );
-    m_lcSources->InsertColumn( 0, col0 );
-
-    wxListItem col1;
-    col1.SetId( 1 );
-    col1.SetText( _( "Type" ) );
-    m_lcSources->InsertColumn( 1, col1 );
-
-    wxListItem col2;
-    col2.SetId( 2 );
-    col2.SetText( _( "Port" ) );
-    m_lcSources->InsertColumn( 2, col2 );
-
-    wxListItem col3;
-    col3.SetId( 3 );
-    col3.SetText( _("Prio") );
-    m_lcSources->InsertColumn( 3, col3 );
-
-    wxListItem col4;
-    col4.SetId( 4 );
-    col4.SetText( _( "Parm" ) );
-    m_lcSources->InsertColumn( 4, col4 );
-
-    wxListItem col5;
-    col5.SetId( 5 );
-    col5.SetText( _( "I/O" ) );
-    m_lcSources->InsertColumn( 5, col5 );
-
-    wxListItem col6;
-    col6.SetId( 6 );
-    col6.SetText( _( "Filters" ) );
-    m_lcSources->InsertColumn( 6, col6 );
+    wxString columns[] = { _( "On" ), _( "Type" ), _( "Port" ), _("Prio"), _( "Parm" ), _( "I/O" ), _( "Filters" ) };
+    for ( int i = 0; i < 7; ++i ) {
+        wxListItem col;
+        col.SetId( i );
+        col.SetText( columns[ i ] );
+        m_lcSources->InsertColumn( i, col );
+    }
 
     //  Build the image list
     wxBitmap unchecked_bmp(16, 16), checked_bmp(16, 16);
@@ -1939,40 +1912,14 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     m_cbAPBMagnetic->Connect( wxEVT_COMMAND_CHECKBOX_CLICKED, wxCommandEventHandler( options::OnValChange ), NULL, this );
     m_lcSources->Connect( wxEVT_LEFT_DOWN, wxMouseEventHandler(options::OnConnectionToggleEnable), NULL, this );
 
-    wxListItem col0;
-    col0.SetId( 0 );
-    col0.SetText( _( "Enable" ) );
-    m_lcSources->InsertColumn( 0, col0 );
 
-    wxListItem col1;
-    col1.SetId( 1 );
-    col1.SetText( _( "Type" ) );
-    m_lcSources->InsertColumn( 1, col1 );
-
-    wxListItem col2;
-    col2.SetId( 2 );
-    col2.SetText( _( "DataPort" ) );
-    m_lcSources->InsertColumn( 2, col2 );
-
-    wxListItem col3;
-    col3.SetId( 3 );
-    col3.SetText( _( "Priority" ) );
-    m_lcSources->InsertColumn( 3, col3 );
-
-    wxListItem col4;
-    col4.SetId( 4 );
-    col4.SetText( _( "Parameters" ) );
-    m_lcSources->InsertColumn( 4, col4 );
-
-    wxListItem col5;
-    col5.SetId( 5 );
-    col5.SetText( _( "Connection" ) );
-    m_lcSources->InsertColumn( 5, col5 );
-
-    wxListItem col6;
-    col6.SetId( 6 );
-    col6.SetText( _( "Filters" ) );
-    m_lcSources->InsertColumn( 6, col6 );
+    wxString columns[] = { _( "Enable" ), _( "Type" ), _( "DataPort" ), _("Priority"), _( "Parameters" ), _( "Connection" ), _( "Filters" ) };
+    for ( int i = 0; i < 7; ++i ) {
+        wxListItem col;
+        col.SetId( i );
+        col.SetText( columns[ i ] );
+        m_lcSources->InsertColumn( i, col );
+    }
 
     //  Build the image list
     wxBitmap unchecked_bmp( 16, 16 ), checked_bmp( 16, 16 );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6522,19 +6522,6 @@ SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent,
     m_btnClearAll->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnClearAllClick ), NULL, this );
 }
 
-SentenceListDlg::~SentenceListDlg( void )
-{
-    // Disconnect Events... Why?
-    m_btnAdd->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnAddClick ), NULL, this );
-    m_btnDel->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnDeleteClick ), NULL, this );
-    m_sdbSizer4Cancel->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnCancelClick ), NULL, this );
-    m_sdbSizer4OK->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnOkClick ), NULL, this );
-    m_clbSentences->Disconnect( wxEVT_COMMAND_CHECKLISTBOX_TOGGLED, wxCommandEventHandler( SentenceListDlg::OnCLBToggle ), NULL, this );
-    m_clbSentences->Disconnect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( SentenceListDlg::OnCLBSelect ), NULL, this );
-    m_btnCheckAll->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnCheckAllClick ), NULL, this );
-    m_btnClearAll->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnClearAllClick ), NULL, this );
-}
-
 void SentenceListDlg::SetSentenceList(wxArrayString sentences)
 {
     m_sentences = sentences;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -219,8 +219,6 @@ extern double           g_overzoom_emphasis_base;
 extern bool             g_oz_vector_scale;
 extern bool             g_bShowStatusBar;
 
-
-
 #ifdef USE_S57
 extern s52plib          *ps52plib;
 #endif
@@ -311,15 +309,12 @@ EVT_BUTTON( ID_MMSIEDIT_CANCEL, MMSIEditDialog::OnMMSIEditCancelClick )
 EVT_BUTTON( ID_MMSIEDIT_OK, MMSIEditDialog::OnMMSIEditOKClick )
 END_EVENT_TABLE()
 
-MMSIEditDialog::MMSIEditDialog()
-{
-}
+MMSIEditDialog::MMSIEditDialog() {}
 
 MMSIEditDialog::MMSIEditDialog( MMSIProperties *props, wxWindow* parent, wxWindowID id, const wxString& caption,
                                 const wxPoint& pos, const wxSize& size, long style )
 {
     m_props = props;
-
     long wstyle = wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER;
     wxDialog::Create( parent, id, caption, pos, size, wstyle );
 
@@ -350,81 +345,72 @@ bool MMSIEditDialog::Create( MMSIProperties *props, wxWindow* parent, wxWindowID
 
 void MMSIEditDialog::CreateControls()
 {
-    MMSIEditDialog* itemDialog1 = this;
-    wxBoxSizer* itemBoxSizer2 = new wxBoxSizer( wxVERTICAL );
-    itemDialog1->SetSizer( itemBoxSizer2 );
+    wxBoxSizer* mainSizer = new wxBoxSizer( wxVERTICAL );
+    SetSizer( mainSizer );
 
-    wxStaticBox* itemStaticBoxSizer4Static = new wxStaticBox( itemDialog1, wxID_ANY,
-                                                              _("MMSI Extended Properties") );
+    wxStaticBox* mmsiBox = new wxStaticBox( this, wxID_ANY,
+                                            _( "MMSI Extended Properties" ) );
 
-    wxStaticBoxSizer* itemStaticBoxSizer4 = new wxStaticBoxSizer( itemStaticBoxSizer4Static,
-                                                                  wxVERTICAL );
-    itemBoxSizer2->Add( itemStaticBoxSizer4, 0, wxEXPAND | wxALL, 5 );
+    wxStaticBoxSizer* mmsiSizer = new wxStaticBoxSizer( mmsiBox, wxVERTICAL );
+    mainSizer->Add( mmsiSizer, 0, wxEXPAND | wxALL, 5 );
 
-    wxStaticText* itemStaticText5 = new wxStaticText( itemDialog1, wxID_STATIC, _("MMSI") );
-    itemStaticBoxSizer4->Add( itemStaticText5, 0,
-                              wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
+    mmsiSizer->Add( new wxStaticText( this, wxID_STATIC, _( "MMSI" ) ), 0,
+                    wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
 
-    m_MMSICtl = new wxTextCtrl( itemDialog1, ID_MMSI_CTL, _T(""), wxDefaultPosition, wxSize( 180, -1 ), 0 );
-    itemStaticBoxSizer4->Add( m_MMSICtl, 0,
-                              wxALIGN_LEFT | wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 5 );
+    m_MMSICtl = new wxTextCtrl( this, ID_MMSI_CTL, wxEmptyString,
+                                wxDefaultPosition, wxSize( 180, -1 ), 0 );
+    mmsiSizer->Add( m_MMSICtl, 0,
+                    wxALIGN_LEFT | wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 5 );
 
+    wxStaticBoxSizer *trackSizer = new wxStaticBoxSizer(
+        new wxStaticBox( this, wxID_ANY, _( "Tracking" ) ), wxVERTICAL
+    );
 
-    wxStaticBoxSizer *sbSizerPropsTrack = new wxStaticBoxSizer( new wxStaticBox( itemDialog1, wxID_ANY, _("Tracking") ), wxVERTICAL );
+    wxGridSizer* gridSizer = new wxGridSizer( 0, 3, 0, 0 );
 
-    wxGridSizer* bSizer15;
-    bSizer15 = new wxGridSizer( 0, 3, 0, 0 );
+    m_rbTypeTrackDefault = new wxRadioButton(
+        this, wxID_ANY, _("Default tracking"), wxDefaultPosition,
+        wxDefaultSize, wxRB_GROUP
+    );
+    m_rbTypeTrackDefault->SetValue( TRUE );
+    gridSizer->Add( m_rbTypeTrackDefault, 0, wxALL, 5 );
 
-    m_rbTypeTrackDefault = new wxRadioButton( itemDialog1, wxID_ANY, _("Default tracking"), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
-    m_rbTypeTrackDefault->SetValue( true );
-    bSizer15->Add( m_rbTypeTrackDefault, 0, wxALL, 5 );
+    m_rbTypeTrackAlways = new wxRadioButton( this, wxID_ANY, _( "Always track" ) );
+    gridSizer->Add( m_rbTypeTrackAlways, 0, wxALL, 5 );
 
-    m_rbTypeTrackAlways = new wxRadioButton( itemDialog1, wxID_ANY, _("Always track"), wxDefaultPosition, wxDefaultSize, 0 );
-    bSizer15->Add( m_rbTypeTrackAlways, 0, wxALL, 5 );
+    m_rbTypeTrackNever = new wxRadioButton( this, wxID_ANY, _(" Never track" ) );
+    gridSizer->Add( m_rbTypeTrackNever, 0, wxALL, 5 );
 
-    m_rbTypeTrackNever = new wxRadioButton( itemDialog1, wxID_ANY, _("Never track"), wxDefaultPosition, wxDefaultSize, 0 );
-    bSizer15->Add( m_rbTypeTrackNever, 0, wxALL, 5 );
+    m_cbTrackPersist = new wxCheckBox( this, wxID_ANY, _( "Persistent" ) );
+    gridSizer->Add( m_cbTrackPersist, 0, wxALL, 5 );
 
-    m_cbTrackPersist = new wxCheckBox( itemDialog1, wxID_ANY, _("Persistent") );
-    bSizer15->Add( m_cbTrackPersist, 0, wxALL, 5 );
+    trackSizer->Add( gridSizer, 0, wxEXPAND, 0 );
+    mmsiSizer->Add(trackSizer, 0, wxEXPAND, 0);
 
-    sbSizerPropsTrack->Add( bSizer15, 0, wxEXPAND, 0 );
-    itemStaticBoxSizer4->Add(sbSizerPropsTrack, 0, wxEXPAND, 0);
+    m_IgnoreButton = new wxCheckBox( this, wxID_ANY, _( "Ignore this MMSI" ) );
+    mmsiSizer->Add( m_IgnoreButton, 0, wxEXPAND, 5 );
 
+    m_MOBButton = new wxCheckBox( this, wxID_ANY, _( "Handle this MMSI as SART/PLB(AIS) MOB." ) );
+    mmsiSizer->Add( m_MOBButton, 0, wxEXPAND, 5 );
 
-    m_IgnoreButton = new wxCheckBox( itemDialog1, wxID_ANY, _("Ignore this MMSI") );
-    itemStaticBoxSizer4->Add( m_IgnoreButton, 0, wxEXPAND, 5 );
+    m_VDMButton = new wxCheckBox( this, wxID_ANY, _( "Convert AIVDM to AIVDO for this MMSI" ) );
+    mmsiSizer->Add( m_VDMButton, 0, wxEXPAND, 5 );
 
-    m_MOBButton = new wxCheckBox( itemDialog1, wxID_ANY, _("Handle this MMSI as SART/PLB(AIS) MOB.") );
-    itemStaticBoxSizer4->Add( m_MOBButton, 0, wxEXPAND, 5 );
+    wxBoxSizer* btnSizer = new wxBoxSizer( wxHORIZONTAL );
+    mainSizer->Add( btnSizer, 0, wxALIGN_RIGHT | wxALL, 5 );
 
-    m_VDMButton = new wxCheckBox( itemDialog1, wxID_ANY, _("Convert AIVDM to AIVDO for this MMSI") );
-    itemStaticBoxSizer4->Add( m_VDMButton, 0, wxEXPAND, 5 );
+    m_CancelButton = new wxButton( this, ID_MMSIEDIT_CANCEL, _( "Cancel" ) );
+    btnSizer->Add( m_CancelButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5 );
 
-
-    wxBoxSizer* itemBoxSizer16 = new wxBoxSizer( wxHORIZONTAL );
-    itemBoxSizer2->Add( itemBoxSizer16, 0, wxALIGN_RIGHT | wxALL, 5 );
-
-    m_CancelButton = new wxButton( itemDialog1, ID_MMSIEDIT_CANCEL, _("Cancel"), wxDefaultPosition,
-    wxDefaultSize, 0 );
-    itemBoxSizer16->Add( m_CancelButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5 );
-
-    m_OKButton = new wxButton( itemDialog1, ID_MMSIEDIT_OK, _("OK"), wxDefaultPosition,
-    wxDefaultSize, 0 );
-    itemBoxSizer16->Add( m_OKButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5 );
+    m_OKButton = new wxButton( this, ID_MMSIEDIT_OK, _( "OK" ) );
+    btnSizer->Add( m_OKButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5 );
     m_OKButton->SetDefault();
 
     //  Set initial values...
-    wxString sMMSI;
-    if ( m_props->MMSI > 0 )
-       sMMSI.Printf( _T( "%d" ), m_props->MMSI );
-    else
-        sMMSI = _T( "" );
-    m_MMSICtl->AppendText(sMMSI);
+    if (m_props->MMSI > 0)
+        m_MMSICtl->AppendText( wxString::Format( "%d", m_props->MMSI ) );
 
     switch ( m_props->TrackType ){
-        case TRACKTYPE_DEFAULT:
-            break;
         case TRACKTYPE_ALWAYS:
             m_rbTypeTrackAlways->SetValue(true);
             break;
@@ -440,7 +426,7 @@ void MMSIEditDialog::CreateControls()
     m_MOBButton->SetValue( m_props->m_bMOB );
     m_VDMButton->SetValue( m_props->m_bVDM );
 
-    SetColorScheme( (ColorScheme) 0 );
+    SetColorScheme( GLOBAL_COLOR_SCHEME_RGB );
 }
 
 void MMSIEditDialog::SetColorScheme( ColorScheme cs )

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -5978,17 +5978,11 @@ void options::ShowNMEACommon( bool visible )
     m_TalkerIdText->Show( visible );
     m_cbCheckCRC->Show( visible );
     if ( visible ) {
-        if ( m_cbOutput->IsChecked() ) {
-            m_stPrecision->Enable( TRUE );
-            m_choicePrecision->Enable( TRUE );
-            m_stTalkerIdText->Enable( TRUE );
-            m_TalkerIdText->Enable( TRUE );
-        } else {
-            m_stPrecision->Enable( FALSE );
-            m_choicePrecision->Enable( FALSE );
-            m_stTalkerIdText->Enable( FALSE );
-            m_TalkerIdText->Enable( FALSE );
-        }
+        const bool output = m_cbOutput->IsChecked();
+        m_stPrecision->Enable( output );
+        m_choicePrecision->Enable( output );
+        m_stTalkerIdText->Enable( output );
+        m_TalkerIdText->Enable( output );
     }
     m_bNMEAParams_shown = visible;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3923,7 +3923,7 @@ void options::OnGLClicked( wxCommandEvent& event )
 
 void options::OnOpenGLOptions( wxCommandEvent& event )
 {
-    OpenGLOptionsDlg dlg(this, pOpenGL->GetValue());
+    OpenGLOptionsDlg dlg( this );
 
     if(dlg.ShowModal() == wxID_OK) {
         if(g_bexpert)
@@ -6586,7 +6586,7 @@ BEGIN_EVENT_TABLE( OpenGLOptionsDlg, wxDialog )
     EVT_BUTTON( ID_BUTTON_CLEAR, OpenGLOptionsDlg::OnButtonClear )
 END_EVENT_TABLE()
 
-OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked ) :
+OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent ) :
     wxDialog( parent, wxID_ANY, _T( "OpenGL Options" ),
               wxDefaultPosition, wxDefaultSize,
               wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1968,23 +1968,20 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
 
 void options::OnConnectionToggleEnable( wxMouseEvent &event )
 {
-    wxPoint pos = event.GetPosition();
-    int flags = 0;
-    long ptrSubItem = -1;
-    long clicked_index = m_lcSources->HitTest( pos, flags, &ptrSubItem );
+    int flags;
+    long clicked_index = m_lcSources->HitTest( event.GetPosition(), flags );
 
-    // Clicking Enable Checkbox (full column)?
+    // Clicking Enable Checkbox (full column)
     if ( clicked_index > -1 && event.GetX() < m_lcSources->GetColumnWidth( 0 ) ) {
         // Process the clicked item
         ConnectionParams *conn = g_pConnectionParams->Item( m_lcSources->GetItemData( clicked_index ) );
         if ( conn ) {
             conn->bEnabled = !conn->bEnabled;
             m_connection_enabled = conn->bEnabled;
-            conn->b_IsSetup = FALSE;            // Mark as changed
-
+            // Mark as changed
+            conn->b_IsSetup = FALSE;
             m_lcSources->SetItemImage( clicked_index, conn->bEnabled ? 1 : 0 );
         }
-
         cc1->Refresh();
     } else if ( clicked_index == -1 ) {
         ClearNMEAForm();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6607,7 +6607,7 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent ) :
     m_memorySize = new wxStaticText( this, wxID_ANY, _("Texture Memory Size (MB)") );
     m_sTextureMemorySize = new wxSpinCtrl( this );
     m_sTextureMemorySize->SetRange( 1, 16384 );
-    m_cacheSize = new wxStaticText(this, wxID_ANY, _("Size: ") + TextureCacheSize());
+    m_cacheSize = new wxStaticText(this, wxID_ANY, _("Size: ") + GetTextureCacheSize());
     wxButton *btnRebuild = new wxButton( this, ID_BUTTON_REBUILD, _( "Rebuild Texture Cache" ) );
     wxButton *btnClear = new wxButton(this, ID_BUTTON_CLEAR, _( "Clear Texture Cache" ) );
     btnRebuild->Enable( g_GLOptions.m_bTextureCompressionCaching );
@@ -6721,11 +6721,11 @@ void OpenGLOptionsDlg::OnButtonClear( wxCommandEvent& event )
             ::wxRemoveFile(files[i]);
     }
 
-    m_cacheSize->SetLabel( TextureCacheSize() );
+    m_cacheSize->SetLabel( GetTextureCacheSize() );
     ::wxEndBusyCursor();
 }
 
-wxString OpenGLOptionsDlg::TextureCacheSize( void )
+wxString OpenGLOptionsDlg::GetTextureCacheSize( void )
 {
     wxString path =  g_Platform->GetPrivateDataDir() +
         wxFileName::GetPathSeparator() + _T( "raster_texture_cache" );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6744,33 +6744,24 @@ void SentenceListDlg::OnCheckAllClick( wxCommandEvent& event )
     BuildSentenceArray();
 }
 
-void SentenceListDlg::SetType(int io, ListType type)
+void SentenceListDlg::SetType( int io, ListType type )
 {
     m_type = type;
 
-    switch (io)
-    {
-        case 0:                 // input
-        default:
-            if(type == WHITELIST)
-                m_pclbBox->SetLabel(_("Accept Sentences"));
-            else
-                m_pclbBox->SetLabel(_("Ignore Sentences"));
-            break;
-        case 1:                 // output
-            if(type == WHITELIST)
-                m_pclbBox->SetLabel(_("Transmit Sentences"));
-            else
-                m_pclbBox->SetLabel(_("Drop Sentences"));
-            break;
-    }
+    if ( io == 1 )
+        m_pclbBox->SetLabel( type == WHITELIST ? _( "Transmit Sentences" ) :
+                                                 _( "Drop Sentences" ) );
+    else
+        m_pclbBox->SetLabel( type == WHITELIST ? _( "Accept Sentences" ) :
+                                                 _( "Ignore Sentences" ) );
+
     Refresh();
 }
 
 void SentenceListDlg::OnCancelClick( wxCommandEvent& event ) { event.Skip(); }
 void SentenceListDlg::OnOkClick( wxCommandEvent& event ) { event.Skip(); }
 
-//OpenGLOptionsDlg
+// OpenGLOptionsDlg
 enum { ID_BUTTON_REBUILD, ID_BUTTON_CLEAR };
 
 BEGIN_EVENT_TABLE( OpenGLOptionsDlg, wxDialog )
@@ -6785,10 +6776,10 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
     style |= wxSTAY_ON_TOP;
 #endif
 
-    wxDialog::Create( parent, wxID_ANY, _T("OpenGL Options"), wxDefaultPosition, wxDefaultSize,
-                      style );
+    wxDialog::Create( parent, wxID_ANY, _T( "OpenGL Options" ),
+                      wxDefaultPosition, wxDefaultSize, style );
 
-    wxFont *qFont = GetOCPNScaledFont(_("Dialog"));
+    wxFont *qFont = GetOCPNScaledFont( _( "Dialog" ) );
     SetFont( *qFont );
 
     m_brebuild_cache = FALSE;
@@ -6797,90 +6788,85 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
     m_bSizer1 = new wxFlexGridSizer( 3 );
     this->SetSizeHints( wxDefaultSize, wxDefaultSize );
 
-    if(g_bexpert) {
-        m_cbUseAcceleratedPanning = new wxCheckBox(this, wxID_ANY, _("Use Accelerated Panning") );
-        m_bSizer1->Add(m_cbUseAcceleratedPanning, 0, wxALL | wxEXPAND, 5);
-        if( cc1->GetglCanvas()->CanAcceleratePanning() ) {
+    if ( g_bexpert ) {
+        m_cbUseAcceleratedPanning = new wxCheckBox( this, wxID_ANY, _( "Use Accelerated Panning" ) );
+        m_bSizer1->Add( m_cbUseAcceleratedPanning, 0, wxALL | wxEXPAND, 5 );
+        if ( cc1->GetglCanvas()->CanAcceleratePanning() ) {
             m_cbUseAcceleratedPanning->Enable();
-            m_cbUseAcceleratedPanning->SetValue(g_GLOptions.m_bUseAcceleratedPanning);
+            m_cbUseAcceleratedPanning->SetValue( g_GLOptions.m_bUseAcceleratedPanning );
         } else {
-            m_cbUseAcceleratedPanning->SetValue(FALSE);
+            m_cbUseAcceleratedPanning->SetValue( FALSE );
             m_cbUseAcceleratedPanning->Disable();
         }
 
         m_cbTextureCompression = new wxCheckBox(this, wxID_ANY, _("Texture Compression") );
-        m_cbTextureCompression->SetValue(g_GLOptions.m_bTextureCompression);
-        m_bSizer1->Add(m_cbTextureCompression, 0, wxALL | wxEXPAND, 5);
+        m_cbTextureCompression->SetValue( g_GLOptions.m_bTextureCompression );
+        m_bSizer1->Add( m_cbTextureCompression, 0, wxALL | wxEXPAND, 5 );
 
-        m_cbTextureCompressionCaching = new wxCheckBox(this, wxID_ANY, _("Texture Compression Caching") );
-        m_cbTextureCompressionCaching->SetValue(g_GLOptions.m_bTextureCompressionCaching);
+        m_cbTextureCompressionCaching = new wxCheckBox( this, wxID_ANY, _("Texture Compression Caching") );
+        m_cbTextureCompressionCaching->SetValue( g_GLOptions.m_bTextureCompressionCaching );
 
         /* disable caching if unsupported */
         extern PFNGLCOMPRESSEDTEXIMAGE2DPROC s_glCompressedTexImage2D;
-        if(!s_glCompressedTexImage2D) {
+        if ( !s_glCompressedTexImage2D ) {
             g_GLOptions.m_bTextureCompression = FALSE;
             m_cbTextureCompressionCaching->Disable();
         }
 
-        m_bSizer1->Add(m_cbTextureCompressionCaching, 0, wxALL | wxEXPAND, 5);
-    }
-    else {
-        m_cbTextureCompression = new wxCheckBox(this, wxID_ANY, _("Texture Compression with Caching") );
-        m_cbTextureCompression->SetValue(g_GLOptions.m_bTextureCompression);
-        m_bSizer1->Add(m_cbTextureCompression, 0, wxALL | wxEXPAND, 5);
+        m_bSizer1->Add( m_cbTextureCompressionCaching, 0, wxALL | wxEXPAND, 5 );
+    } else {
+        m_cbTextureCompression = new wxCheckBox( this, wxID_ANY, _( "Texture Compression with Caching" ) );
+        m_cbTextureCompression->SetValue( g_GLOptions.m_bTextureCompression );
+        m_bSizer1->Add( m_cbTextureCompression, 0, wxALL | wxEXPAND, 5 );
     }
 
-        /* disable caching if unsupported */
+    /* disable caching if unsupported */
     extern PFNGLCOMPRESSEDTEXIMAGE2DPROC s_glCompressedTexImage2D;
     extern bool  b_glEntryPointsSet;
 
-    if(b_glEntryPointsSet){
-        if(!s_glCompressedTexImage2D) {
-            g_GLOptions.m_bTextureCompressionCaching = FALSE;
-            m_cbTextureCompression->Disable();
-            m_cbTextureCompression->SetValue(FALSE);
-        }
+    if ( b_glEntryPointsSet && !s_glCompressedTexImage2D ) {
+        g_GLOptions.m_bTextureCompressionCaching = FALSE;
+        m_cbTextureCompression->Disable();
+        m_cbTextureCompression->SetValue(FALSE);
     }
 
-    if(g_bexpert){
+    if ( g_bexpert ) {
         wxStaticText* stTextureMemorySize =
             new wxStaticText( this, wxID_STATIC, _("Texture Memory Size (MB)") );
-        m_bSizer1->Add( stTextureMemorySize, 0,
-                wxLEFT | wxRIGHT | wxTOP, 5 );
+        m_bSizer1->Add( stTextureMemorySize, 0, wxLEFT | wxRIGHT | wxTOP, 5 );
 
         m_sTextureMemorySize = new wxSpinCtrl( this );
-        m_sTextureMemorySize->SetRange(1, 16384 );
-        m_sTextureMemorySize->SetValue(g_GLOptions.m_iTextureMemorySize);
-        m_bSizer1->Add(m_sTextureMemorySize, 0, wxALL | wxEXPAND, 5);
-
+        m_sTextureMemorySize->SetRange( 1, 16384 );
+        m_sTextureMemorySize->SetValue( g_GLOptions.m_iTextureMemorySize );
+        m_bSizer1->Add( m_sTextureMemorySize, 0, wxALL | wxEXPAND, 5) ;
     } else
         m_bSizer1->AddSpacer(0);
 
     m_bSizer1->AddSpacer(0);
 
-    m_bRebuildTextureCache = new wxButton(this, ID_BUTTON_REBUILD, _("Rebuild Texture Cache") );
-    m_bSizer1->Add(m_bRebuildTextureCache, 0, wxALL | wxEXPAND, 5);
-    m_bRebuildTextureCache->Enable(g_GLOptions.m_bTextureCompressionCaching);
+    m_bRebuildTextureCache = new wxButton( this, ID_BUTTON_REBUILD, _( "Rebuild Texture Cache" ) );
+    m_bSizer1->Add( m_bRebuildTextureCache, 0, wxALL | wxEXPAND, 5 );
+    m_bRebuildTextureCache->Enable( g_GLOptions.m_bTextureCompressionCaching );
 
-    if(!g_bopengl || g_raster_format == GL_RGB)
+    if ( !g_bopengl || g_raster_format == GL_RGB )
         m_bRebuildTextureCache->Disable();
 
-    m_bClearTextureCache = new wxButton(this, ID_BUTTON_CLEAR, _("Clear Texture Cache") );
-    m_bSizer1->Add(m_bClearTextureCache, 0, wxALL | wxEXPAND, 5);
-    m_bClearTextureCache->Enable(g_GLOptions.m_bTextureCompressionCaching);
+    m_bClearTextureCache = new wxButton(this, ID_BUTTON_CLEAR, _( "Clear Texture Cache" ) );
+    m_bSizer1->Add( m_bClearTextureCache, 0, wxALL | wxEXPAND, 5 );
+    m_bClearTextureCache->Enable( g_GLOptions.m_bTextureCompressionCaching );
 
     m_stTextureCacheSize = new wxStaticText(this, wxID_STATIC, TextureCacheSize());
     m_bSizer1->Add( m_stTextureCacheSize, 0,
                     wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
 
-    m_cbShowFPS = new wxCheckBox( this, wxID_ANY, _("Show FPS") );
+    m_cbShowFPS = new wxCheckBox( this, wxID_ANY, _( "Show FPS" ) );
     m_bSizer1->Add( m_cbShowFPS, 0,  wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
-    m_cbShowFPS->SetValue(g_bShowFPS);
+    m_cbShowFPS->SetValue( g_bShowFPS );
 
     m_cbSoftwareGL = NULL;
 #if defined(__UNIX__) && !defined(__OCPN__ANDROID__) && !defined(__WXOSX__)
-    if(cc1->GetglCanvas()->GetVersionString().Upper().Find( _T("MESA") ) != wxNOT_FOUND) {
-        m_cbSoftwareGL = new wxCheckBox( this, wxID_ANY, _("Software OpenGL (restart OpenCPN)") );
+    if ( cc1->GetglCanvas()->GetVersionString().Upper().Find( _T( "MESA" ) ) != wxNOT_FOUND ) {
+        m_cbSoftwareGL = new wxCheckBox( this, wxID_ANY, _( "Software OpenGL (restart OpenCPN)" ) );
         m_bSizer1->Add( m_cbSoftwareGL, 0,  wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
         m_cbSoftwareGL->SetValue(g_bSoftwareGL);
     } else
@@ -6890,19 +6876,15 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
     m_bSizer1->AddSpacer(0);
 
     wxStdDialogButtonSizer * m_sdbSizer4 = new wxStdDialogButtonSizer();
-    wxButton *bOK = new wxButton( this, wxID_OK );
-    m_sdbSizer4->AddButton( bOK );
-    wxButton *bCancel = new wxButton( this, wxID_CANCEL );
-    m_sdbSizer4->AddButton( bCancel );
+    m_sdbSizer4->AddButton( new wxButton( this, wxID_OK ) );
+    m_sdbSizer4->AddButton( new wxButton( this, wxID_CANCEL ) );
     m_sdbSizer4->Realize();
 
-    m_bSizer1->Add( m_sdbSizer4, 0, wxALL|wxEXPAND, 5 );
+    m_bSizer1->Add( m_sdbSizer4, 0, wxALL | wxEXPAND, 5 );
 
-    this->SetSizer( m_bSizer1 );
-    this->Layout();
-
-    this->Centre( wxBOTH );
-
+    SetSizer( m_bSizer1 );
+    Layout();
+    Centre( wxBOTH );
     Fit();
 #endif
 }
@@ -6910,7 +6892,7 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
 void OpenGLOptionsDlg::OnButtonRebuild( wxCommandEvent& event )
 {
 #ifdef ocpnUSE_GL
-    if(g_GLOptions.m_bTextureCompressionCaching) {
+    if ( g_GLOptions.m_bTextureCompressionCaching ) {
         m_brebuild_cache = TRUE;
         EndModal(wxID_CANCEL);
     }
@@ -6921,38 +6903,37 @@ void OpenGLOptionsDlg::OnButtonClear( wxCommandEvent& event )
 {
 #ifdef ocpnUSE_GL
     ::wxBeginBusyCursor();
-    if(g_bopengl)
+    if ( g_bopengl )
         cc1->GetglCanvas()->ClearAllRasterTextures();
 
-    wxString path =  g_Platform->GetPrivateDataDir() + wxFileName::GetPathSeparator() + _T("raster_texture_cache");
-    if(::wxDirExists( path )){
+    wxString path =  g_Platform->GetPrivateDataDir() +
+        wxFileName::GetPathSeparator() + _T( "raster_texture_cache" );
+    if ( ::wxDirExists( path ) ) {
         wxArrayString files;
-        size_t nfiles = wxDir::GetAllFiles(path, &files);
-        for(unsigned int i=0 ; i < files.GetCount() ; i++){
+        size_t nfiles = wxDir::GetAllFiles( path, &files );
+        for ( unsigned int i = 0 ; i < files.GetCount() ; i++ )
             ::wxRemoveFile(files[i]);
-        }
     }
 
-    m_stTextureCacheSize->SetLabel(TextureCacheSize());
+    m_stTextureCacheSize->SetLabel( TextureCacheSize() );
     ::wxEndBusyCursor();
 #endif
 }
 
 wxString OpenGLOptionsDlg::TextureCacheSize( void )
 {
-    wxString path =  g_Platform->GetPrivateDataDir() + wxFileName::GetPathSeparator() + _T("raster_texture_cache");
+    wxString path =  g_Platform->GetPrivateDataDir() +
+        wxFileName::GetPathSeparator() + _T( "raster_texture_cache" );
     long long total = 0;
-    if(::wxDirExists( path )) {
+    if ( ::wxDirExists( path ) ) {
         wxArrayString files;
-        size_t nfiles = wxDir::GetAllFiles(path, &files);
-        for(unsigned int i=0 ; i < files.GetCount() ; i++){
-            total += wxFile(files[i]).Length();
-        }
+        size_t nfiles = wxDir::GetAllFiles( path, &files );
+        for ( unsigned int i = 0 ; i < files.GetCount() ; i++ )
+            total += wxFile( files[i] ).Length();
     }
-    double mb = total/1024.0/1024.0;
-    if (mb < 10000.0)
+    double mb = total / ( 1024.0 * 2 );
+    if ( mb < 10000.0 )
         return wxString::Format(_T("%.1f MB"), mb);
     mb = mb / 1024.0;
     return wxString::Format(_T("%.1f GB"), mb);
-
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6748,7 +6748,7 @@ void OpenGLOptionsDlg::OnButtonClear( wxCommandEvent& event )
             ::wxRemoveFile( files[i] );
     }
 
-    m_cacheSize->SetLabel( GetTextureCacheSize() );
+    m_cacheSize->SetLabel( _( "Size: " ) + GetTextureCacheSize() );
     ::wxEndBusyCursor();
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6524,7 +6524,7 @@ wxString SentenceListDlg::GetSentences( void )
 void SentenceListDlg::OnCLBSelect( wxCommandEvent& e )
 {
     // Only activate the "Delete" button if the selection is not in the standard list
-    m_btnDel->Enable( m_sentences.Index( e.GetString( ) ) == wxNOT_FOUND );
+    m_btnDel->Enable( m_sentences.Index( e.GetString() ) == wxNOT_FOUND );
 }
 
 void SentenceListDlg::OnAddClick( wxCommandEvent& event )
@@ -6627,9 +6627,9 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent ) :
     flexSizer->Add( btnClear, 0, wxALL | wxEXPAND, 5 );
     flexSizer->Add( new wxStaticText(this, wxID_ANY, _( "Miscellaneous" )), 0,
                     wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL, 5 );
-    flexSizer->Add( m_cbShowFPS, 0,  wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
+    flexSizer->Add( m_cbShowFPS, 0, wxALL | wxEXPAND, 5 );
     flexSizer->AddSpacer( 0 );
-    flexSizer->Add( m_cbSoftwareGL, 0,  wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5 );
+    flexSizer->Add( m_cbSoftwareGL, 0, wxALL | wxEXPAND, 5 );
     flexSizer->AddSpacer( 0 );
     flexSizer->Add( m_cbUseAcceleratedPanning, 0, wxALL | wxEXPAND, 5 );
     flexSizer->AddGrowableCol( 1 );
@@ -6688,7 +6688,7 @@ const int OpenGLOptionsDlg::GetTextureMemorySize( void ) const
 void OpenGLOptionsDlg::Populate( void )
 {
     extern PFNGLCOMPRESSEDTEXIMAGE2DPROC s_glCompressedTexImage2D;
-    extern bool  b_glEntryPointsSet;
+    extern bool b_glEntryPointsSet;
 
     m_cbTextureCompression->SetValue( g_GLOptions.m_bTextureCompression );
     /* disable caching if unsupported */

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -412,10 +412,10 @@ void MMSIEditDialog::CreateControls()
 
     switch ( m_props->TrackType ){
         case TRACKTYPE_ALWAYS:
-            m_rbTypeTrackAlways->SetValue(true);
+            m_rbTypeTrackAlways->SetValue(TRUE);
             break;
         case TRACKTYPE_NEVER:
-            m_rbTypeTrackNever->SetValue(true);
+            m_rbTypeTrackNever->SetValue(TRUE);
             break;
         default:
             break;
@@ -627,8 +627,8 @@ MMSI_Props_Panel::MMSI_Props_Panel( wxWindow *parent ):
     long lwidth;
 
     m_pListCtrlMMSI = new MMSIListCtrl( this, ID_MMSI_PROPS_LIST, wxDefaultPosition,  wxSize( -1, 400 ),
-            wxLC_REPORT | wxLC_SINGLE_SEL | wxLC_HRULES | wxLC_VRULES | wxBORDER_SUNKEN  | wxLC_VIRTUAL );
-    wxImageList *imglist = new wxImageList( 16, 16, true, 2 );
+            wxLC_REPORT | wxLC_SINGLE_SEL | wxLC_HRULES | wxLC_VRULES | wxBORDER_SUNKEN | wxLC_VIRTUAL );
+    wxImageList *imglist = new wxImageList( 16, 16, TRUE, 2 );
 
     ocpnStyle::Style* style = g_StyleManager->GetCurrentStyle();
     imglist->Add( style->GetIcon( _T( "sort_asc" ) ) );
@@ -690,7 +690,7 @@ MMSI_Props_Panel::MMSI_Props_Panel( wxWindow *parent ):
     //  If not done, the SECOND invocation of the panel fails to expand the list to the full wxSizer size....
     SetSize( GetSize().x, GetSize().y - 1 );
 
-    SetColorScheme( (ColorScheme) 0 );
+    SetColorScheme( GLOBAL_COLOR_SCHEME_RGB );
 }
 
 MMSI_Props_Panel::~MMSI_Props_Panel() {}
@@ -712,20 +712,20 @@ void MMSI_Props_Panel::OnNewButton( wxCommandEvent &event )
 void MMSI_Props_Panel::UpdateMMSIList( void )
 {
     // Capture the MMSI of the curently selected list item
-    long selItemID = -1;
-    selItemID = m_pListCtrlMMSI->GetNextItem( selItemID, wxLIST_NEXT_ALL,
-                                              wxLIST_STATE_SELECTED );
+    long selItemID = wxNOT_FOUND;
+        m_pListCtrlMMSI->GetNextItem( selItemID, wxLIST_NEXT_ALL,
+                                      wxLIST_STATE_SELECTED );
 
-    int selMMSI = -1;
-    if( selItemID != -1 )
+    int selMMSI = wxNOT_FOUND;
+    if ( selItemID != wxNOT_FOUND )
         selMMSI = g_MMSI_Props_Array.Item( selItemID )->MMSI;
 
     m_pListCtrlMMSI->SetItemCount( g_MMSI_Props_Array.GetCount() );
 
     // Restore selected item
-    long item_sel = 0;
-    if( ( selItemID != -1 ) && ( selMMSI != -1 ) ) {
-        for( unsigned int i = 0; i < g_MMSI_Props_Array.GetCount(); i++ ) {
+    long item_sel = wxNOT_FOUND;
+    if ( selItemID != wxNOT_FOUND && selMMSI != wxNOT_FOUND ) {
+        for ( unsigned int i = 0; i < g_MMSI_Props_Array.GetCount(); i++ ) {
             if( g_MMSI_Props_Array.Item( i )->MMSI == selMMSI ) {
                 item_sel = i;
                 break;
@@ -733,13 +733,14 @@ void MMSI_Props_Panel::UpdateMMSIList( void )
         }
     }
 
-    if( g_MMSI_Props_Array.GetCount() != 0 )
-        m_pListCtrlMMSI->SetItemState( item_sel,
-                                       wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED,
-                                       wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED );
+    if( g_MMSI_Props_Array.GetCount() > 0 )
+        m_pListCtrlMMSI->SetItemState(
+            item_sel, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED,
+            wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED
+        );
 
 #ifdef __WXMSW__
-    m_pListCtrlMMSI->Refresh( false );
+    m_pListCtrlMMSI->Refresh( FALSE );
 #endif
 }
 
@@ -784,8 +785,8 @@ options::options()
     Init();
 }
 
-options::options( MyFrame* parent, wxWindowID id, const wxString& caption, const wxPoint& pos,
-                  const wxSize& size, long style )
+options::options( MyFrame* parent, wxWindowID id, const wxString& caption,
+                  const wxPoint& pos, const wxSize& size, long style )
 {
     Init();
     // Need to load S52 Options
@@ -909,7 +910,7 @@ void options::Init()
     activeSizer = NULL;
     itemActiveChartStaticBox = NULL;
 
-    m_bVisitLang = false;
+    m_bVisitLang = FALSE;
     m_itemFontElementListBox = NULL;
     m_topImgList = NULL;
     m_pSerialArray = EnumerateSerialPorts();
@@ -977,16 +978,16 @@ size_t options::CreatePanel(const wxString & title)
     /* This is the default empty content for any top tab.
        It'll be replaced when we call AddPage */
     wxPanel *panel = new wxPanel( m_pListbook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, title );
-    m_pListbook->AddPage( panel, title, false, id );
+    m_pListbook->AddPage( panel, title, FALSE, id );
     return id;
 }
 
 wxScrolledWindow *options::AddPage( size_t parent, const wxString & title)
 {
     if ( parent > m_pListbook->GetPageCount() - 1 ) {
-        wxLogMessage(
-                wxString::Format( _T("Warning: invalid parent in options::AddPage( %d, "),
-                        parent ) + title + _T(" )") );
+        wxLogMessage( wxString::Format(
+            _T("Warning: invalid parent in options::AddPage( %d, %s )"),
+                        parent, title));
         return NULL;
     }
     wxNotebookPage* page = m_pListbook->GetPage( parent );
@@ -999,9 +1000,9 @@ wxScrolledWindow *options::AddPage( size_t parent, const wxString & title)
         ( ( wxNotebook * ) page )->AddPage( window, title );
     } else if ( page->IsKindOf( CLASSINFO( wxScrolledWindow ) ) ) {
         wxString toptitle = m_pListbook->GetPageText( parent );
-        wxNotebook *nb = new wxNotebook( m_pListbook, wxID_ANY, wxDefaultPosition, wxDefaultSize,wxNB_TOP );
+        wxNotebook *nb = new wxNotebook( m_pListbook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP );
         /* Only remove the tab from listbook, we still have original content in {page} */
-        m_pListbook->InsertPage( parent, nb, toptitle, false, parent );
+        m_pListbook->InsertPage( parent, nb, toptitle, FALSE, parent );
         m_pListbook->RemovePage( parent + 1 );
         wxString previoustitle = page->GetName();
         page->Reparent( nb );
@@ -1017,9 +1018,8 @@ wxScrolledWindow *options::AddPage( size_t parent, const wxString & title)
         window = new wxScrolledWindow( m_pListbook, wxID_ANY, wxDefaultPosition, wxDefaultSize, style, title );
         window->SetScrollRate( m_scrollRate, m_scrollRate );
         wxString toptitle = m_pListbook->GetPageText( parent );
-        m_pListbook->InsertPage( parent, window, toptitle, false, parent );
+        m_pListbook->InsertPage( parent, window, toptitle, FALSE, parent );
         m_pListbook->DeletePage( parent + 1 );
-
     }
 
 #ifdef __OCPN__ANDROID__
@@ -1047,9 +1047,9 @@ bool options::DeletePage( wxScrolledWindow *page  )
                         nb->RemovePage( 0 );
                         wxString toptitle = m_pListbook->GetPageText( i );
                         m_pListbook->DeletePage( i );
-                        m_pListbook->InsertPage( i, spg, toptitle, false, i );
+                        m_pListbook->InsertPage( i, spg, toptitle, FALSE, i );
                     }
-                    return true;
+                    return TRUE;
                 }
             }
         } else if ( pg->IsKindOf( CLASSINFO( wxScrolledWindow ) ) && pg == page ) {
@@ -1057,11 +1057,11 @@ bool options::DeletePage( wxScrolledWindow *page  )
             m_pListbook->DeletePage( i );
             wxPanel *panel = new wxPanel( m_pListbook, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxTAB_TRAVERSAL, _T( "" ) );
             wxString toptitle = m_pListbook->GetPageText( i );
-            m_pListbook->InsertPage( i, panel, toptitle, false, i );
-            return true;
+            m_pListbook->InsertPage( i, panel, toptitle, FALSE, i );
+            return TRUE;
         }
     }
-    return false;
+    return FALSE;
 }
 
 void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int group_item_spacing, wxSize small_button_size )
@@ -1146,7 +1146,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     bSizer18->Add( m_buttonAdd, 0, wxALL, 5 );
 
     m_buttonRemove = new wxButton( m_pNMEAForm, wxID_ANY, _( "Remove" ), wxDefaultPosition, wxDefaultSize, 0 );
-    m_buttonRemove->Enable( false );
+    m_buttonRemove->Enable( FALSE );
     bSizer18->Add( m_buttonRemove, 0, wxALL, 5 );
 
     sbSizerLB->Add( bSizer17, 1, wxEXPAND, 5 );
@@ -1162,7 +1162,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     sbSizerConnectionProps->Add( bSizer15, 0, wxEXPAND, 0 );
 
     m_rbTypeSerial = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Serial" ), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
-    m_rbTypeSerial->SetValue( true );
+    m_rbTypeSerial->SetValue( TRUE );
     bSizer15->Add( m_rbTypeSerial, 0, wxALL, 5 );
 
     m_rbTypeNet = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Network" ), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1235,17 +1235,17 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     gSizerNetPropsV->Add( bSizer16, 1, wxEXPAND, 5 );
 
     m_rbNetProtoTCP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "TCP" ), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
-    m_rbNetProtoTCP->Enable( true );
+    m_rbNetProtoTCP->Enable( TRUE );
 
     bSizer16->Add( m_rbNetProtoTCP, 0, wxALL, 5 );
 
     m_rbNetProtoUDP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "UDP" ), wxDefaultPosition, wxDefaultSize, 0 );
-    m_rbNetProtoUDP->Enable( true );
+    m_rbNetProtoUDP->Enable( TRUE );
 
     bSizer16->Add( m_rbNetProtoUDP, 0, wxALL, 5 );
 
     m_rbNetProtoGPSD = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "GPSD" ), wxDefaultPosition, wxDefaultSize, 0 );
-    m_rbNetProtoGPSD->SetValue( true );
+    m_rbNetProtoGPSD->SetValue( TRUE );
     bSizer16->Add( m_rbNetProtoGPSD, 0, wxALL, 5 );
 
     wxFlexGridSizer* fgSizer1a = new wxFlexGridSizer( 0, 2, 0, 0 );
@@ -1301,7 +1301,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     int m_choiceSerialProtocolNChoices = sizeof( m_choiceSerialProtocolChoices ) / sizeof( wxString );
     m_choiceSerialProtocol = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choiceSerialProtocolNChoices, m_choiceSerialProtocolChoices, 0 );
     m_choiceSerialProtocol->SetSelection( 0 );
-    m_choiceSerialProtocol->Enable( false );
+    m_choiceSerialProtocol->Enable( FALSE );
 
     fgSizer1->Add( m_choiceSerialProtocol, 1, wxEXPAND|wxTOP, 5 );
     m_stPriority = new wxStaticText( m_pNMEAForm, wxID_ANY, _( "Priority" ), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1320,12 +1320,12 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     wxBoxSizer* fgSizer5 = new wxBoxSizer( wxVERTICAL );
 
     m_cbCheckCRC = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Control checksum" ), wxDefaultPosition, wxDefaultSize, 0 );
-    m_cbCheckCRC->SetValue(true);
+    m_cbCheckCRC->SetValue(TRUE);
     m_cbCheckCRC->SetToolTip( _( "If checked, only the sentences with a valid checksum are passed through" ) );
     fgSizer5->Add( m_cbCheckCRC, 0, wxALL, 5 );
 
     m_cbGarminHost = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Use GRMN mode for input" ), wxDefaultPosition, wxDefaultSize, 0 );
-    m_cbGarminHost->SetValue(false);
+    m_cbGarminHost->SetValue(FALSE);
     fgSizer5->Add( m_cbGarminHost, 0, wxALL, 5 );
     #ifndef USE_GARMINHOST
     //m_cbGarminHost->Hide();
@@ -1518,7 +1518,7 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
         wxRendererNative::Get().DrawCheckBox( this, renderer_dc, wxRect( 0, 0, 16, 16 ), wxCONTROL_CHECKED );
     }
 
-    wxImageList *imglist = new wxImageList( 16, 16, true, 1 );
+    wxImageList *imglist = new wxImageList( 16, 16, TRUE, 1 );
     imglist->Add( unchecked_bmp );
     imglist->Add( checked_bmp );
     m_lcSources->AssignImageList( imglist, wxIMAGE_LIST_SMALL );
@@ -1536,10 +1536,10 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
         }
     }
 
-    ShowNMEACommon( false );
-    ShowNMEASerial( false );
-    ShowNMEANet( false );
-    connectionsaved = true;
+    ShowNMEACommon( FALSE );
+    ShowNMEASerial( FALSE );
+    ShowNMEANet( FALSE );
+    connectionsaved = TRUE;
 }
 
 
@@ -1622,7 +1622,7 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     bSizer18->Add( m_buttonAdd, 0, wxALL, 5 );
 
     m_buttonRemove = new wxButton( m_pNMEAForm, wxID_ANY, _( "Remove Connection" ), wxDefaultPosition, wxDefaultSize, 0 );
-    m_buttonRemove->Enable( false );
+    m_buttonRemove->Enable( FALSE );
     bSizer18->Add( m_buttonRemove, 0, wxALL, 5 );
 
     bSizer17->Add( bSizer18, 0, wxEXPAND, 5 );
@@ -1638,7 +1638,7 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     sbSizerConnectionProps->Add( bSizer15, 0, wxEXPAND, 0 );
 
     m_rbTypeSerial = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Serial" ), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
-    m_rbTypeSerial->SetValue( true );
+    m_rbTypeSerial->SetValue( TRUE );
     bSizer15->Add( m_rbTypeSerial, 0, wxALL, 5 );
 
     m_rbTypeNet = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "Network" ), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1711,17 +1711,17 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     bSizer16 = new wxBoxSizer( wxHORIZONTAL );
 
     m_rbNetProtoTCP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "TCP" ), wxDefaultPosition, wxDefaultSize, wxRB_GROUP );
-    m_rbNetProtoTCP->Enable( true );
+    m_rbNetProtoTCP->Enable( TRUE );
 
     bSizer16->Add( m_rbNetProtoTCP, 0, wxALL, 5 );
 
     m_rbNetProtoUDP = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "UDP" ), wxDefaultPosition, wxDefaultSize, 0 );
-    m_rbNetProtoUDP->Enable( true );
+    m_rbNetProtoUDP->Enable( TRUE );
 
     bSizer16->Add( m_rbNetProtoUDP, 0, wxALL, 5 );
 
     m_rbNetProtoGPSD = new wxRadioButton( m_pNMEAForm, wxID_ANY, _( "GPSD" ), wxDefaultPosition, wxDefaultSize, 0 );
-    m_rbNetProtoGPSD->SetValue( true );
+    m_rbNetProtoGPSD->SetValue( TRUE );
     bSizer16->Add( m_rbNetProtoGPSD, 0, wxALL, 5 );
 
     gSizerNetProps->Add( bSizer16, 1, wxEXPAND, 5 );
@@ -1778,7 +1778,7 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     int m_choiceSerialProtocolNChoices = sizeof( m_choiceSerialProtocolChoices ) / sizeof( wxString );
     m_choiceSerialProtocol = new wxChoice( m_pNMEAForm, wxID_ANY, wxDefaultPosition, wxDefaultSize, m_choiceSerialProtocolNChoices, m_choiceSerialProtocolChoices, 0 );
     m_choiceSerialProtocol->SetSelection( 0 );
-    m_choiceSerialProtocol->Enable( false );
+    m_choiceSerialProtocol->Enable( FALSE );
 
     fgSizer1->Add( m_choiceSerialProtocol, 1, wxEXPAND | wxTOP, 5 );
     m_stPriority = new wxStaticText( m_pNMEAForm, wxID_ANY, _("Priority"), wxDefaultPosition, wxDefaultSize, 0 );
@@ -1802,12 +1802,12 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
     fgSizer5->SetNonFlexibleGrowMode( wxFLEX_GROWMODE_SPECIFIED );
 
     m_cbCheckCRC = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Control checksum" ), wxDefaultPosition, wxDefaultSize, 0 );
-    m_cbCheckCRC->SetValue( true );
+    m_cbCheckCRC->SetValue( TRUE );
     m_cbCheckCRC->SetToolTip( _( "If checked, only the sentences with a valid checksum are passed through" ) );
     fgSizer5->Add( m_cbCheckCRC, 0, wxALL, 5 );
 
     m_cbGarminHost = new wxCheckBox( m_pNMEAForm, wxID_ANY, _( "Use Garmin (GRMN) mode for input" ), wxDefaultPosition, wxDefaultSize, 0 );
-    m_cbGarminHost->SetValue( false );
+    m_cbGarminHost->SetValue( FALSE );
     fgSizer5->Add( m_cbGarminHost, 0, wxALL, 5 );
     #ifndef USE_GARMINHOST
     m_cbGarminHost->Hide();
@@ -1996,7 +1996,7 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
         wxRendererNative::Get().DrawCheckBox( this, renderer_dc, wxRect( 0, 0, 16, 16 ), wxCONTROL_CHECKED );
     }
 
-    wxImageList *imglist = new wxImageList( 16, 16, true, 1 );
+    wxImageList *imglist = new wxImageList( 16, 16, TRUE, 1 );
     imglist->Add( unchecked_bmp );
     imglist->Add( checked_bmp );
     m_lcSources->AssignImageList( imglist, wxIMAGE_LIST_SMALL );
@@ -2014,10 +2014,10 @@ void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_s
         }
     }
 
-    ShowNMEACommon( false );
-    ShowNMEASerial( false );
-    ShowNMEANet( false );
-    connectionsaved = true;
+    ShowNMEACommon( FALSE );
+    ShowNMEASerial( FALSE );
+    ShowNMEANet( FALSE );
+    connectionsaved = TRUE;
 }
 
 void options::OnConnectionToggleEnable( wxMouseEvent &event )
@@ -2034,7 +2034,7 @@ void options::OnConnectionToggleEnable( wxMouseEvent &event )
         if ( conn ) {
             conn->bEnabled = !conn->bEnabled;
             m_connection_enabled = conn->bEnabled;
-            conn->b_IsSetup = false;            // Mark as changed
+            conn->b_IsSetup = FALSE;            // Mark as changed
 
             m_lcSources->SetItemImage( clicked_index, conn->bEnabled ? 1 : 0 );
         }
@@ -2042,7 +2042,7 @@ void options::OnConnectionToggleEnable( wxMouseEvent &event )
         cc1->Refresh();
     } else if ( clicked_index == -1 ) {
         ClearNMEAForm();
-        m_buttonRemove->Enable( false );
+        m_buttonRemove->Enable( FALSE );
     }
 
     // Allow wx to process...
@@ -2672,7 +2672,7 @@ void options::CreatePanel_ChartGroups( size_t parent, int border_size, int group
 void ChartGroupsUI::CreatePanel( size_t parent, int border_size, int group_item_spacing,
         wxSize small_button_size )
 {
-    modified = false;
+    modified = FALSE;
     m_border_size = border_size;
     m_group_item_spacing = group_item_spacing;
 
@@ -2683,7 +2683,7 @@ void ChartGroupsUI::CreatePanel( size_t parent, int border_size, int group_item_
 
     SetSizer( groupsSizer );
 
-    m_UIcomplete = false;
+    m_UIcomplete = FALSE;
 }
 
 void ChartGroupsUI::CompletePanel( void )
@@ -2758,7 +2758,7 @@ void ChartGroupsUI::CompletePanel( void )
     this->Connect( wxEVT_COMMAND_TREE_SEL_CHANGED,
     wxTreeEventHandler(ChartGroupsUI::OnAvailableSelection), NULL, this );
 
-    m_UIcomplete = true;
+    m_UIcomplete = TRUE;
 
 }
 
@@ -2907,7 +2907,7 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
     unitsSizer->Add( 0, border_size*4 );
     unitsSizer->Add( 0, border_size*4 );
 
-    // bearings (magnetic/true, variation)
+    // bearings (magnetic/TRUE, variation)
     unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Bearings")), groupLabelFlags );
 
     wxBoxSizer* bearingsSizer = new wxBoxSizer( wxVERTICAL );
@@ -3393,11 +3393,11 @@ void options::CreateControls()
     }
 #endif
 
-    m_topImgList = new wxImageList( 40, 40, true, 1 );
+    m_topImgList = new wxImageList( 40, 40, TRUE, 1 );
     ocpnStyle::Style* style = g_StyleManager->GetCurrentStyle();
 
 #ifndef __OCPN__ANDROID__
-    m_topImgList = new wxImageList( 40, 40, true, 1 );
+    m_topImgList = new wxImageList( 40, 40, TRUE, 1 );
 
 #if wxCHECK_VERSION(2, 8, 12)
     m_topImgList->Add( style->GetIcon( _T("Display") ) );
@@ -3424,7 +3424,7 @@ void options::CreateControls()
 #endif
 
 #else
-    m_topImgList = new wxImageList( 80, 80, true, 1 );
+    m_topImgList = new wxImageList( 80, 80, TRUE, 1 );
 
     wxBitmap bmp;
     wxImage img, simg;
@@ -3586,7 +3586,7 @@ void options::SetInitialSettings()
     pSmoothPanZoom->SetValue( g_bsmoothpanzoom );
 #if 0
     if( g_bEnableZoomToCursor || pEnableZoomToCursor->GetValue() ) {
-        pSmoothPanZoom->SetValue( false );
+        pSmoothPanZoom->SetValue( FALSE );
         pSmoothPanZoom->Disable();
     }
 #endif
@@ -3749,12 +3749,12 @@ void options::SetInitialSettings()
     wxString screenmm;
 
     if( !g_config_display_size_manual ){
-        pRBSizeAuto->SetValue( true );
+        pRBSizeAuto->SetValue( TRUE );
         screenmm.Printf(_T("%d"), int(g_Platform->GetDisplaySizeMM()));
         pScreenMM->Disable();
     } else {
         screenmm.Printf(_T("%d"), int(g_config_display_size_mm));
-        pRBSizeManual->SetValue( true );
+        pRBSizeManual->SetValue( TRUE );
     }
 
     pScreenMM->SetValue(screenmm);
@@ -3873,15 +3873,15 @@ void options::UpdateOptionsUnits()
     // set depth input values
     wxString s;
     s.Printf( _T("%6.2f"), S52_getMarinerParam( S52_MAR_SHALLOW_CONTOUR ) / conv );
-    s.Trim(false);
+    s.Trim(FALSE);
     m_ShallowCtl->SetValue( s );
 
     s.Printf( _T("%6.2f"), S52_getMarinerParam( S52_MAR_SAFETY_CONTOUR ) / conv );
-    s.Trim(false);
+    s.Trim(FALSE);
     m_SafetyCtl->SetValue( s );
 
     s.Printf( _T("%6.2f"), S52_getMarinerParam( S52_MAR_DEEP_CONTOUR ) / conv );
-    s.Trim(false);
+    s.Trim(FALSE);
     m_DeepCtl->SetValue( s );
 }
 
@@ -3892,7 +3892,7 @@ void options::OnSizeAutoButton( wxCommandEvent& event )
     screenmm.Printf(_T("%d"), int(g_Platform->GetDisplaySizeMM()));
     pScreenMM->SetValue(screenmm);
     pScreenMM->Disable();
-    g_config_display_size_manual = false;
+    g_config_display_size_manual = FALSE;
 }
 
 void options::OnSizeManualButton( wxCommandEvent& event )
@@ -3907,7 +3907,7 @@ void options::OnSizeManualButton( wxCommandEvent& event )
 
     pScreenMM->SetValue(screenmm);
     pScreenMM->Enable();
-    g_config_display_size_manual = true;
+    g_config_display_size_manual = TRUE;
 }
 
 void options::OnUnitsChoice( wxCommandEvent& event )
@@ -3920,7 +3920,7 @@ void options::OnCPAWarnClick( wxCommandEvent& event )
     if( m_pCheck_CPA_Warn->GetValue() ) {
         m_pCheck_CPA_WarnT->Enable();
     } else {
-        m_pCheck_CPA_WarnT->SetValue( false );
+        m_pCheck_CPA_WarnT->SetValue( FALSE );
         m_pCheck_CPA_WarnT->Disable();
     }
 }
@@ -3949,9 +3949,9 @@ void options::OnZTCCheckboxClick( wxCommandEvent& event )
 void options::OnShipTypeSelect( wxCommandEvent& event )
 {
     if( m_pShipIconType->GetSelection() == 0 ) {
-        realSizes->ShowItems( false );
+        realSizes->ShowItems( FALSE );
     } else {
-        realSizes->ShowItems( true );
+        realSizes->ShowItems( TRUE );
     }
     dispOptions->Layout();
     ownShip->Layout();
@@ -3963,9 +3963,9 @@ void options::OnShipTypeSelect( wxCommandEvent& event )
 void options::OnRadarringSelect( wxCommandEvent& event )
 {
     if( pNavAidRadarRingsNumberVisible->GetSelection() == 0 ) {
-        radarGrid->ShowItems( false );
+        radarGrid->ShowItems( FALSE );
     } else {
-        radarGrid->ShowItems( true );
+        radarGrid->ShowItems( TRUE );
     }
     dispOptions->Layout();
     ownShip->Layout();
@@ -3977,9 +3977,9 @@ void options::OnRadarringSelect( wxCommandEvent& event )
 void options::OnWaypointRangeRingSelect( wxCommandEvent& event )
 {
     if( pWaypointRangeRingsNumber->GetSelection() == 0 ) {
-        waypointradarGrid->ShowItems( false );
+        waypointradarGrid->ShowItems( FALSE );
     } else {
-        waypointradarGrid->ShowItems( true );
+        waypointradarGrid->ShowItems( TRUE );
     }
     dispOptions->Layout();
     ownShip->Layout();
@@ -4072,7 +4072,7 @@ void options::OnButtonClearClick( wxCommandEvent& event )
 {
     int nOBJL = ps57CtlListBox->GetCount();
     for( int iPtr = 0; iPtr < nOBJL; iPtr++ )
-        ps57CtlListBox->Check( iPtr, false );
+        ps57CtlListBox->Check( iPtr, FALSE );
 
     event.Skip();
 }
@@ -4081,7 +4081,7 @@ void options::OnButtonSelectClick( wxCommandEvent& event )
 {
     int nOBJL = ps57CtlListBox->GetCount();
     for( int iPtr = 0; iPtr < nOBJL; iPtr++ )
-        ps57CtlListBox->Check( iPtr, true );
+        ps57CtlListBox->Check( iPtr, TRUE );
 
     event.Skip();
 }
@@ -4188,7 +4188,7 @@ void options::UpdateWorkArrayFromTextCtl()
                 //    scan the current array to find a match
                 //    if found, add the info to the work list, preserving the magic number
                 //    If not found, make a new ChartDirInfo, and add it
-                bool b_added = false;
+                bool b_added = FALSE;
 //                        if(m_pCurrentDirList)
                 {
                     int nDir = m_CurrentDirList.GetCount();
@@ -4197,7 +4197,7 @@ void options::UpdateWorkArrayFromTextCtl()
                         if( m_CurrentDirList.Item( i ).fullpath == dirname ) {
                             ChartDirInfo cdi = m_CurrentDirList.Item( i );
                             m_pWorkDirList->Add( cdi );
-                            b_added = true;
+                            b_added = TRUE;
                             break;
                         }
                     }
@@ -4255,7 +4255,7 @@ ConnectionParams *options::CreateConnectionParamsFromSelectedItem()
 
     ConnectionParams * pConnectionParams = new ConnectionParams();
 
-    pConnectionParams->Valid = true;
+    pConnectionParams->Valid = TRUE;
     if ( m_rbTypeSerial->GetValue() )
         pConnectionParams->Type = SERIAL;
     else if ( m_rbTypeNet->GetValue() )
@@ -4305,7 +4305,7 @@ ConnectionParams *options::CreateConnectionParamsFromSelectedItem()
     pConnectionParams->Protocol = PROTO_NMEA0183;
 
     pConnectionParams->bEnabled = m_connection_enabled;
-    pConnectionParams->b_IsSetup = false;
+    pConnectionParams->b_IsSetup = FALSE;
 
     if(pConnectionParams->Type == INTERNAL_GPS){
         pConnectionParams->NetworkAddress = _T("");
@@ -4395,13 +4395,13 @@ void options::OnApplyClick( wxCommandEvent& event )
         }
     }
     groupsPanel->SetDBDirs( *m_pWorkDirList );          // update the Groups tab
-    groupsPanel->m_treespopulated = false;
+    groupsPanel->m_treespopulated = FALSE;
 
     int k_force = FORCE_UPDATE;
     if( pUpdateCheckBox ) {
         if( !pUpdateCheckBox->GetValue() ) k_force = 0;
         pUpdateCheckBox->Enable();
-        pUpdateCheckBox->SetValue( false );
+        pUpdateCheckBox->SetValue( FALSE );
     } else {
         k_force = 0;
     }
@@ -4412,7 +4412,7 @@ void options::OnApplyClick( wxCommandEvent& event )
     if( pScanCheckBox ) {
         if( !pScanCheckBox->GetValue() ) k_scan = 0;
         pScanCheckBox->Enable();
-        pScanCheckBox->SetValue( false );
+        pScanCheckBox->SetValue( FALSE );
     } else {
         k_scan = 0;
     }
@@ -4505,7 +4505,7 @@ void options::OnApplyClick( wxCommandEvent& event )
             FillSourceList();
             m_lcSources->SetItemState(itemIndex, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
             m_lcSources->Refresh();
-            connectionsaved = true;
+            connectionsaved = TRUE;
         } else {
             ::wxEndBusyCursor();
             if( m_bNMEAParams_shown )
@@ -4552,7 +4552,7 @@ void options::OnApplyClick( wxCommandEvent& event )
 
                 g_pMUX->AddStream(dstr);
 
-                cp->b_IsSetup = true;
+                cp->b_IsSetup = TRUE;
             }
         }
     }
@@ -5101,7 +5101,7 @@ void options::OnChartsPageChange( wxListbookEvent& event )
         }
         else if( !groupsPanel->m_treespopulated ) {
             groupsPanel->PopulateTrees();
-            groupsPanel->m_treespopulated = true;
+            groupsPanel->m_treespopulated = TRUE;
         }
     }
 
@@ -5179,12 +5179,12 @@ void options::DoOnPageChange( size_t page )
             for( int it = 0; it < nLang; it++)
             {
                 {
-                    wxLog::EnableLogging(false);  // avoid "Cannot set locale to..." log message
+                    wxLog::EnableLogging(FALSE);  // avoid "Cannot set locale to..." log message
 
                     wxLocale ltest(lang_list[it], 0);
                     ltest.AddCatalog(_T("opencpn"));
 
-                    wxLog::EnableLogging(true);
+                    wxLog::EnableLogging(TRUE);
 
                     if(ltest.IsLoaded(_T("opencpn")))
                     {
@@ -5229,14 +5229,14 @@ void options::DoOnPageChange( size_t page )
 //                        m_itemLangListBox->SetValue(clang);
             }
 
-            m_bVisitLang = true;
+            m_bVisitLang = TRUE;
 
             ::wxEndBusyCursor();
         }
 #endif
     } else if( m_pagePlugins == i ) {                    // 7 is the index of "Plugins" page
         // load the disabled plugins finally because the user might want to enable them
-        if(g_pi_manager->LoadAllPlugIns( g_Platform->GetPluginDir(), false )) {
+        if(g_pi_manager->LoadAllPlugIns( g_Platform->GetPluginDir(), FALSE )) {
             delete m_pPlugInCtrl;
             m_pPlugInCtrl = NULL;
         }
@@ -5527,9 +5527,9 @@ ChartGroupsUI::ChartGroupsUI( wxWindow* parent )
     m_pNewGroupButton = NULL;
     m_pGroupArray= NULL;
     m_GroupNB = NULL;
-    modified = false;
-    m_UIcomplete = false;
-    m_treespopulated = false;
+    modified = FALSE;
+    m_UIcomplete = FALSE;
+    m_treespopulated = FALSE;
 }
 
 ChartGroupsUI::~ChartGroupsUI()
@@ -5540,8 +5540,8 @@ ChartGroupsUI::~ChartGroupsUI()
 
 void ChartGroupsUI::SetInitialSettings()
 {
-    m_settingscomplete = false;
-    m_treespopulated = false;
+    m_settingscomplete = FALSE;
+    m_treespopulated = FALSE;
 }
 
 void ChartGroupsUI::PopulateTrees()
@@ -5578,8 +5578,8 @@ void ChartGroupsUI::CompleteInitialSettings()
 
     groupsSizer->Layout();
 
-    m_settingscomplete = true;
-    m_treespopulated = true;
+    m_settingscomplete = TRUE;
+    m_treespopulated = TRUE;
 }
 
 void ChartGroupsUI::PopulateTreeCtrl( wxTreeCtrl *ptc, const wxArrayString &dir_array,
@@ -5587,7 +5587,7 @@ void ChartGroupsUI::PopulateTreeCtrl( wxTreeCtrl *ptc, const wxArrayString &dir_
 {
     ptc->DeleteAllItems();
 
-    wxDirItemData* rootData = new wxDirItemData( _T("Dummy"), _T("Dummy"), true );
+    wxDirItemData* rootData = new wxDirItemData( _T("Dummy"), _T("Dummy"), TRUE );
     wxString rootName;
     rootName = _T("Dummy");
     wxTreeItemId m_rootId = ptc->AddRoot( rootName, 3, -1, rootData );
@@ -5598,7 +5598,7 @@ void ChartGroupsUI::PopulateTreeCtrl( wxTreeCtrl *ptc, const wxArrayString &dir_
     for( int i = 0; i < nDir; i++ ) {
         wxString dirname = dir_array.Item( i );
         if( !dirname.IsEmpty() ) {
-            wxDirItemData *dir_item = new wxDirItemData( dirname, dirname, true );
+            wxDirItemData *dir_item = new wxDirItemData( dirname, dirname, TRUE );
             wxTreeItemId id = ptc->AppendItem( m_rootId, dirname, 0, -1, dir_item );
 
             //wxWidgets bug workaraound (Ticket #10085)
@@ -5622,7 +5622,7 @@ void ChartGroupsUI::OnInsertChartItem( wxCommandEvent &event )
                 if( ptree ) {
                     if( ptree->IsEmpty() ) {
                         wxDirItemData* rootData = new wxDirItemData( wxEmptyString, wxEmptyString,
-                                true );
+                                TRUE );
                         wxString rootName = _T("Dummy");
                         wxTreeItemId rootId = ptree->AddRoot( rootName, 3, -1, rootData );
 
@@ -5631,7 +5631,7 @@ void ChartGroupsUI::OnInsertChartItem( wxCommandEvent &event )
 
                     wxTreeItemId root_Id = ptree->GetRootItem();
                     wxDirItemData *dir_item = new wxDirItemData( insert_candidate, insert_candidate,
-                            true );
+                            TRUE );
                     wxTreeItemId id = ptree->AppendItem( root_Id, insert_candidate, 0, -1,
                             dir_item );
                     if( wxDir::Exists( insert_candidate ) ) ptree->SetItemHasChildren( id );
@@ -5643,7 +5643,7 @@ void ChartGroupsUI::OnInsertChartItem( wxCommandEvent &event )
             }
         }
     }
-    modified = true;
+    modified = TRUE;
     allAvailableCtl->GetTreeCtrl()->UnselectAll();
     m_pAddButton->Disable();
 }
@@ -5667,11 +5667,11 @@ void ChartGroupsUI::OnRemoveChartItem( wxCommandEvent &event )
                     if( group_item_index >= 0 ) {
                         ChartGroupElement *pelement = pGroup->m_element_array.Item(
                                 group_item_index );
-                        bool b_duplicate = false;
+                        bool b_duplicate = FALSE;
                         for( unsigned int k = 0; k < pelement->m_missing_name_array.GetCount();
                                 k++ ) {
                             if( pelement->m_missing_name_array.Item( k ) == sel_item ) {
-                                b_duplicate = true;
+                                b_duplicate = TRUE;
                                 break;
                             }
                         }
@@ -5691,7 +5691,7 @@ void ChartGroupsUI::OnRemoveChartItem( wxCommandEvent &event )
                         }
                     }
                 }
-                modified = true;
+                modified = TRUE;
                 lastSelectedCtl->Unselect();
                 m_pRemoveButton->Disable();
                 wxLogMessage( _T("Disable"));
@@ -5747,7 +5747,7 @@ void ChartGroupsUI::OnNewGroup( wxCommandEvent &event )
 
             m_GroupSelectedPage = m_GroupNB->GetPageCount() - 1;      // select the new page
             m_GroupNB->ChangeSelection( m_GroupSelectedPage );
-            modified = true;
+            modified = TRUE;
         }
     }
     delete pd;
@@ -5759,7 +5759,7 @@ void ChartGroupsUI::OnDeleteGroup( wxCommandEvent &event )
         m_DirCtrlArray.RemoveAt( m_GroupSelectedPage );
         if( m_pGroupArray ) m_pGroupArray->RemoveAt( m_GroupSelectedPage - 1 );
         m_GroupNB->DeletePage( m_GroupSelectedPage );
-        modified = true;
+        modified = TRUE;
     }
 }
 
@@ -5863,7 +5863,7 @@ void ChartGroupsUI::BuildNotebookPages( ChartGroupArray *pGroupArray )
         for( int i = 0; i < nItems; i++ ) {
             wxString itemname = pGroup->m_element_array.Item( i )->m_element_name;
             if( !itemname.IsEmpty() ) {
-                wxDirItemData *dir_item = new wxDirItemData( itemname, itemname, true );
+                wxDirItemData *dir_item = new wxDirItemData( itemname, itemname, TRUE );
                 wxTreeItemId id = ptc->AppendItem( ptc->GetRootItem(), itemname, 0, -1, dir_item );
 
                 if( wxDir::Exists( itemname ) ) ptc->SetItemHasChildren( id );
@@ -5880,7 +5880,7 @@ wxTreeCtrl *ChartGroupsUI::AddEmptyGroupPage( const wxString& label )
     wxTreeCtrl *ptree = GroupDirCtl->GetTreeCtrl();
     ptree->DeleteAllItems();
 
-    wxDirItemData* rootData = new wxDirItemData( wxEmptyString, wxEmptyString, true );
+    wxDirItemData* rootData = new wxDirItemData( wxEmptyString, wxEmptyString, TRUE );
     wxString rootName = _T("Dummy");
     wxTreeItemId rootId = ptree->AddRoot( rootName, 3, -1, rootData );
     ptree->SetItemHasChildren( rootId );
@@ -6039,7 +6039,7 @@ void options::StopBTScan()
 
 void options::OnConnValChange( wxCommandEvent& event )
 {
-    connectionsaved = false;
+    connectionsaved = FALSE;
     event.Skip();
 }
 
@@ -6049,7 +6049,7 @@ void options::OnTypeSerialSelected( wxCommandEvent& event )
     if( ! g_bserial_access_checked ){
         if( !CheckSerialAccess() ){
         }
-        g_bserial_access_checked = true;
+        g_bserial_access_checked = TRUE;
     }
 #endif
 
@@ -6078,9 +6078,9 @@ void options::OnTypeBTSelected( wxCommandEvent& event )
 void options::OnUploadFormatChange( wxCommandEvent& event )
 {
     if ( event.GetEventObject() == m_cbGarminUploadHost && event.IsChecked() )
-        m_cbFurunoGP3X->SetValue(false);
+        m_cbFurunoGP3X->SetValue(FALSE);
     else if ( event.GetEventObject() == m_cbFurunoGP3X && event.IsChecked() )
-        m_cbGarminUploadHost->SetValue(false);
+        m_cbGarminUploadHost->SetValue(FALSE);
     event.Skip();
 }
 
@@ -6106,15 +6106,15 @@ void options::ShowNMEACommon(bool visible)
         m_stPrecision->Show();
         m_choicePrecision->Show();
         if (m_cbOutput->IsChecked()) {
-            m_stPrecision->Enable(true);
-            m_choicePrecision->Enable(true);
-            m_stTalkerIdText->Enable(true);
-            m_TalkerIdText->Enable( true );
+            m_stPrecision->Enable(TRUE);
+            m_choicePrecision->Enable(TRUE);
+            m_stTalkerIdText->Enable(TRUE);
+            m_TalkerIdText->Enable( TRUE );
         } else {
-            m_stPrecision->Enable( false );
-            m_choicePrecision->Enable( false );
-            m_stTalkerIdText->Enable( false );
-            m_TalkerIdText->Enable( false );
+            m_stPrecision->Enable( FALSE );
+            m_choicePrecision->Enable( FALSE );
+            m_stTalkerIdText->Enable( FALSE );
+            m_TalkerIdText->Enable( FALSE );
         }
         m_choicePriority->Show();
         m_stPriority->Show();
@@ -6240,12 +6240,12 @@ void options::ShowNMEABT(bool visible)
 
 void options::SetNMEAFormToSerial()
 {
-    ShowNMEACommon( true );
+    ShowNMEACommon( TRUE );
 
-    ShowNMEANet( false );
-    ShowNMEAGPS( false );
-    ShowNMEABT( false );
-    ShowNMEASerial( true );
+    ShowNMEANet( FALSE );
+    ShowNMEAGPS( FALSE );
+    ShowNMEABT( FALSE );
+    ShowNMEASerial( TRUE );
 
     m_pNMEAForm->FitInside();
     m_pNMEAForm->Layout();
@@ -6257,11 +6257,11 @@ void options::SetNMEAFormToSerial()
 
 void options::SetNMEAFormToNet()
 {
-    ShowNMEACommon( true );
-    ShowNMEANet( true );
-    ShowNMEAGPS( false );
-    ShowNMEABT( false );
-    ShowNMEASerial( false );
+    ShowNMEACommon( TRUE );
+    ShowNMEANet( TRUE );
+    ShowNMEAGPS( FALSE );
+    ShowNMEABT( FALSE );
+    ShowNMEASerial( FALSE );
     m_pNMEAForm->FitInside();
     m_pNMEAForm->Layout();
     Fit();
@@ -6272,11 +6272,11 @@ void options::SetNMEAFormToNet()
 
 void options::SetNMEAFormToGPS()
 {
-    ShowNMEACommon( true );
-    ShowNMEANet( false );
-    ShowNMEAGPS( true );
-    ShowNMEABT( false );
-    ShowNMEASerial( false );
+    ShowNMEACommon( TRUE );
+    ShowNMEANet( FALSE );
+    ShowNMEAGPS( TRUE );
+    ShowNMEABT( FALSE );
+    ShowNMEASerial( FALSE );
     m_pNMEAForm->FitInside();
     m_pNMEAForm->Layout();
     Fit();
@@ -6287,11 +6287,11 @@ void options::SetNMEAFormToGPS()
 
 void options::SetNMEAFormToBT()
 {
-    ShowNMEACommon( true );
-    ShowNMEANet( false );
-    ShowNMEAGPS( false );
-    ShowNMEABT( true );
-    ShowNMEASerial( false );
+    ShowNMEACommon( TRUE );
+    ShowNMEANet( FALSE );
+    ShowNMEAGPS( FALSE );
+    ShowNMEABT( TRUE );
+    ShowNMEASerial( FALSE );
     m_pNMEAForm->FitInside();
     m_pNMEAForm->Layout();
     Fit();
@@ -6302,11 +6302,11 @@ void options::SetNMEAFormToBT()
 
 void options::ClearNMEAForm()
 {
-    ShowNMEACommon( false );
-    ShowNMEANet( false );
-    ShowNMEAGPS( false );
-    ShowNMEABT( false );
-    ShowNMEASerial( false );
+    ShowNMEACommon( FALSE );
+    ShowNMEANet( FALSE );
+    ShowNMEAGPS( FALSE );
+    ShowNMEABT( FALSE );
+    ShowNMEASerial( FALSE );
     m_pNMEAForm->FitInside();
     m_pNMEAForm->Layout();
     Fit();
@@ -6331,33 +6331,33 @@ void options::SetDSFormRWStates()
 {
     if (m_rbTypeSerial->GetValue())
     {
-        m_cbInput->Enable(false);
-        m_cbOutput->Enable(true);
-        m_rbOAccept->Enable(true);
-        m_rbOIgnore->Enable(true);
-        m_btnOutputStcList->Enable(true);
+        m_cbInput->Enable(FALSE);
+        m_cbOutput->Enable(TRUE);
+        m_rbOAccept->Enable(TRUE);
+        m_rbOIgnore->Enable(TRUE);
+        m_btnOutputStcList->Enable(TRUE);
     }
     else if (m_rbNetProtoGPSD->GetValue())
     {
         if (m_tNetPort->GetValue() == wxEmptyString)
             m_tNetPort->SetValue(_T("2947"));
-        m_cbInput->SetValue(true);
-        m_cbInput->Enable(false);
-        m_cbOutput->SetValue(false);
-        m_cbOutput->Enable(false);
-        m_rbOAccept->Enable(false);
-        m_rbOIgnore->Enable(false);
-        m_btnOutputStcList->Enable(false);
+        m_cbInput->SetValue(TRUE);
+        m_cbInput->Enable(FALSE);
+        m_cbOutput->SetValue(FALSE);
+        m_cbOutput->Enable(FALSE);
+        m_rbOAccept->Enable(FALSE);
+        m_rbOIgnore->Enable(FALSE);
+        m_btnOutputStcList->Enable(FALSE);
     }
     else
     {
         if (m_tNetPort->GetValue() == wxEmptyString)
             m_tNetPort->SetValue(_T("10110"));
-        m_cbInput->Enable(true);
-        m_cbOutput->Enable(true);
-        m_rbOAccept->Enable(true);
-        m_rbOIgnore->Enable(true);
-        m_btnOutputStcList->Enable(true);
+        m_cbInput->Enable(TRUE);
+        m_cbOutput->Enable(TRUE);
+        m_rbOAccept->Enable(TRUE);
+        m_rbOIgnore->Enable(TRUE);
+        m_btnOutputStcList->Enable(TRUE);
     }
 }
 
@@ -6370,13 +6370,13 @@ void options::SetConnectionParams(ConnectionParams *cp)
     m_cbInput->SetValue(!(cp->IOSelect == DS_TYPE_OUTPUT));
     m_cbOutput->SetValue(!(cp->IOSelect == DS_TYPE_INPUT));
     if(cp->InputSentenceListType == WHITELIST)
-        m_rbIAccept->SetValue(true);
+        m_rbIAccept->SetValue(TRUE);
     else
-        m_rbIIgnore->SetValue(true);
+        m_rbIIgnore->SetValue(TRUE);
     if(cp->OutputSentenceListType == WHITELIST)
-        m_rbOAccept->SetValue(true);
+        m_rbOAccept->SetValue(TRUE);
     else
-        m_rbOIgnore->SetValue(true);
+        m_rbOIgnore->SetValue(TRUE);
     m_tcInputStc->SetValue(StringArrayToString(cp->InputSentenceList));
     m_tcOutputStc->SetValue(StringArrayToString(cp->OutputSentenceList));
     m_choiceBaudRate->Select(m_choiceBaudRate->FindString(wxString::Format(_T("%d"),cp->Baudrate)));
@@ -6391,32 +6391,32 @@ void options::SetConnectionParams(ConnectionParams *cp)
         m_tNetPort->SetValue(wxString::Format(wxT("%i"), cp->NetworkPort));
 
     if(cp->NetProtocol == TCP)
-        m_rbNetProtoTCP->SetValue(true);
+        m_rbNetProtoTCP->SetValue(TRUE);
     else if (cp->NetProtocol == UDP)
-        m_rbNetProtoUDP->SetValue(true);
+        m_rbNetProtoUDP->SetValue(TRUE);
     else
-        m_rbNetProtoGPSD->SetValue(true);
+        m_rbNetProtoGPSD->SetValue(TRUE);
 
     if ( cp->Type == SERIAL )
     {
-        m_rbTypeSerial->SetValue( true );
+        m_rbTypeSerial->SetValue( TRUE );
         SetNMEAFormToSerial();
     }
     else if ( cp->Type == NETWORK )
     {
-        m_rbTypeNet->SetValue( true );
+        m_rbTypeNet->SetValue( TRUE );
         SetNMEAFormToNet();
     }
     else if ( cp->Type == INTERNAL_GPS )
     {
         if(m_rbTypeInternalGPS)
-            m_rbTypeInternalGPS->SetValue( true );
+            m_rbTypeInternalGPS->SetValue( TRUE );
         SetNMEAFormToGPS();
     }
     else if ( cp->Type == INTERNAL_BT )
     {
         if(m_rbTypeInternalBT)
-            m_rbTypeInternalBT->SetValue( true );
+            m_rbTypeInternalBT->SetValue( TRUE );
         SetNMEAFormToBT();
 
         // Preset the source selector
@@ -6434,22 +6434,22 @@ void options::SetDefaultConnectionParams()
 {
     m_comboPort->Select(0);
     m_comboPort->SetValue(_T(""));
-    m_cbCheckCRC->SetValue(true);
-    m_cbGarminHost->SetValue(false);
-    m_cbInput->SetValue(true);
-    m_cbOutput->SetValue(false);
-    m_rbIAccept->SetValue(true);
-    m_rbOAccept->SetValue(true);
+    m_cbCheckCRC->SetValue(TRUE);
+    m_cbGarminHost->SetValue(FALSE);
+    m_cbInput->SetValue(TRUE);
+    m_cbOutput->SetValue(FALSE);
+    m_rbIAccept->SetValue(TRUE);
+    m_rbOAccept->SetValue(TRUE);
     m_tcInputStc->SetValue(_T(""));
     m_tcOutputStc->SetValue(_T(""));
     m_choiceBaudRate->Select(m_choiceBaudRate->FindString(_T("4800")));
 //    m_choiceSerialProtocol->Select(cp->Protocol); //TODO
     m_choicePriority->Select(m_choicePriority->FindString(_T("1")));
 
-    bool bserial = true;
+    bool bserial = TRUE;
 #ifdef __WXGTK__
     if(!g_bserial_access_checked)
-        bserial = false;
+        bserial = FALSE;
 #endif
 
     m_rbTypeSerial->SetValue( bserial );
@@ -6460,12 +6460,12 @@ void options::SetDefaultConnectionParams()
     else
         SetNMEAFormToNet();
 
-    m_connection_enabled = true;
+    m_connection_enabled = TRUE;
 }
 
 void options::OnAddDatasourceClick( wxCommandEvent& event )
 {
-    connectionsaved = false;
+    connectionsaved = FALSE;
     SetDefaultConnectionParams();
 
     long itemIndex = -1;
@@ -6476,14 +6476,14 @@ void options::OnAddDatasourceClick( wxCommandEvent& event )
             break;
         m_lcSources->SetItemState( itemIndex, 0, wxLIST_STATE_SELECTED|wxLIST_STATE_FOCUSED );
     }
-    m_buttonRemove->Enable( false );
+    m_buttonRemove->Enable( FALSE );
 
     RecalculateSize();
 }
 
 void options::FillSourceList()
 {
-    m_buttonRemove->Enable(false);
+    m_buttonRemove->Enable(FALSE);
     m_lcSources->DeleteAllItems();
     for (size_t i = 0; i < g_pConnectionParams->Count(); i++)
     {
@@ -6558,18 +6558,18 @@ void options::OnRemoveDatasourceClick( wxCommandEvent& event )
         }
 
         //  Mark connection deleted
-        m_rbTypeSerial->SetValue(true);
+        m_rbTypeSerial->SetValue(TRUE);
         m_comboPort->SetValue( _T("Deleted") );
     }
     FillSourceList();
-    ShowNMEACommon( false );
-    ShowNMEANet( false );
-    ShowNMEASerial( false );
+    ShowNMEACommon( FALSE );
+    ShowNMEANet( FALSE );
+    ShowNMEASerial( FALSE );
 }
 
 void options::OnSelectDatasource( wxListEvent& event )
 {
-    connectionsaved = false;
+    connectionsaved = FALSE;
     int params_index = event.GetData();
     SetConnectionParams(g_pConnectionParams->Item(params_index));
     m_buttonRemove->Enable();
@@ -6579,7 +6579,7 @@ void options::OnSelectDatasource( wxListEvent& event )
 void options::OnBtnIStcs( wxCommandEvent& event )
 {
     m_stcdialog_in->SetSentenceList(wxStringTokenize(m_tcInputStc->GetValue(), _T(",")));
-    m_stcdialog_in->SetType(0, (m_rbIAccept->GetValue() == true) ? WHITELIST:BLACKLIST);
+    m_stcdialog_in->SetType(0, (m_rbIAccept->GetValue() == TRUE) ? WHITELIST:BLACKLIST);
 
     if (m_stcdialog_in->ShowModal() == wxID_OK)
         m_tcInputStc->SetValue(m_stcdialog_in->GetSentencesAsText());
@@ -6588,7 +6588,7 @@ void options::OnBtnIStcs( wxCommandEvent& event )
 void options::OnBtnOStcs( wxCommandEvent& event )
 {
     m_stcdialog_out->SetSentenceList(wxStringTokenize(m_tcOutputStc->GetValue(), _T(",")));
-    m_stcdialog_out->SetType(1, (m_rbOAccept->GetValue() == true) ? WHITELIST:BLACKLIST);
+    m_stcdialog_out->SetType(1, (m_rbOAccept->GetValue() == TRUE) ? WHITELIST:BLACKLIST);
 
     if (m_stcdialog_out->ShowModal() == wxID_OK)
         m_tcOutputStc->SetValue(m_stcdialog_out->GetSentencesAsText());
@@ -6643,15 +6643,15 @@ void options::OnCbOutput( wxCommandEvent& event )
 {
     OnConnValChange(event);
     if (m_cbOutput->IsChecked()) {
-        m_stPrecision->Enable(true);
-        m_choicePrecision->Enable(true);
-        m_stTalkerIdText->Enable(true);
-        m_TalkerIdText->Enable( true );
+        m_stPrecision->Enable(TRUE);
+        m_choicePrecision->Enable(TRUE);
+        m_stTalkerIdText->Enable(TRUE);
+        m_TalkerIdText->Enable( TRUE );
     } else {
-        m_stPrecision->Enable(false);
-        m_choicePrecision->Enable(false);
-        m_stTalkerIdText->Enable( false );
-        m_TalkerIdText->Enable( false );
+        m_stPrecision->Enable(FALSE);
+        m_choicePrecision->Enable(FALSE);
+        m_stTalkerIdText->Enable( FALSE );
+        m_TalkerIdText->Enable( FALSE );
     }
 }
 
@@ -6705,7 +6705,7 @@ SentenceListDlg::SentenceListDlg( FilterDirection dir, wxWindow* parent, wxWindo
     bSizer18->Add( m_btnAdd, 0, wxALL, 5 );
 
     m_btnDel = new wxButton( this, wxID_ANY, _("Delete"), wxDefaultPosition, wxDefaultSize, 0 );
-    m_btnDel->Enable( false );
+    m_btnDel->Enable( FALSE );
 
     bSizer18->Add( m_btnDel, 0, wxALL, 5 );
 
@@ -6758,11 +6758,11 @@ void SentenceListDlg::SetSentenceList(wxArrayString sentences)
 
     if( (m_sentences.Count() == 0) && (m_type == WHITELIST) ){
         for (size_t i = 0; i < m_clbSentences->GetCount(); i++)
-            m_clbSentences->Check(i, true);
+            m_clbSentences->Check(i, TRUE);
     }
     if( (m_sentences.Count() == 0) && (m_type == BLACKLIST) ){
         for (size_t i = 0; i < m_clbSentences->GetCount(); i++)
-            m_clbSentences->Check(i, false);
+            m_clbSentences->Check(i, FALSE);
     }
 
     FillSentences();
@@ -6789,7 +6789,7 @@ void SentenceListDlg::FillSentences()
         return;
 
     for (size_t i = 0; i < m_clbSentences->GetCount(); i++)
-        m_clbSentences->Check(i, false);
+        m_clbSentences->Check(i, FALSE);
 
     for (size_t i = 0; i < m_sentences.Count(); i++) {
         int item = m_clbSentences->FindString(m_sentences[i]);
@@ -6802,7 +6802,7 @@ void SentenceListDlg::FillSentences()
         }
     }
 
-    m_btnDel->Enable(false);
+    m_btnDel->Enable(FALSE);
 }
 
 void SentenceListDlg::OnStcSelect( wxCommandEvent& event )
@@ -6814,18 +6814,18 @@ void SentenceListDlg::OnCLBSelect( wxCommandEvent& event )
 {
     // Only active the "Delete" button if the selection is not in the standard list
     int isel = m_clbSentences->GetSelection();
-    bool bdelete = true;
+    bool bdelete = TRUE;
     if(isel >= 0) {
         wxString s = m_clbSentences->GetString(isel);
         for (size_t i = 0; i < standard_sentences.Count(); i++) {
             if(standard_sentences[i] == s){
-                bdelete = false;
+                bdelete = FALSE;
                 break;
             }
         }
     }
     else
-        bdelete = false;
+        bdelete = FALSE;
     m_btnDel->Enable( bdelete );
 }
 
@@ -6856,10 +6856,10 @@ void SentenceListDlg::OnDeleteClick( wxCommandEvent& event )
     // One can only delete items that do not appear in the standard sentence list
     int isel = m_clbSentences->GetSelection();
     wxString s = m_clbSentences->GetString(isel);
-    bool bdelete = true;
+    bool bdelete = TRUE;
     for (size_t i = 0; i < standard_sentences.Count(); i++) {
         if(standard_sentences[i] == s){
-            bdelete = false;
+            bdelete = FALSE;
             break;
         }
     }
@@ -6875,7 +6875,7 @@ void SentenceListDlg::OnDeleteClick( wxCommandEvent& event )
 void SentenceListDlg::OnClearAllClick( wxCommandEvent& event )
 {
     for (size_t i = 0; i < m_clbSentences->GetCount(); i++)
-        m_clbSentences->Check(i, false);
+        m_clbSentences->Check(i, FALSE);
 
     BuildSentenceArray();
 }
@@ -6883,7 +6883,7 @@ void SentenceListDlg::OnClearAllClick( wxCommandEvent& event )
 void SentenceListDlg::OnCheckAllClick( wxCommandEvent& event )
 {
     for (size_t i = 0; i < m_clbSentences->GetCount(); i++)
-        m_clbSentences->Check(i, true);
+        m_clbSentences->Check(i, TRUE);
 
     BuildSentenceArray();
 }
@@ -6935,7 +6935,7 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
     wxFont *qFont = GetOCPNScaledFont(_("Dialog"));
     SetFont( *qFont );
 
-    m_brebuild_cache = false;
+    m_brebuild_cache = FALSE;
 
 #ifdef ocpnUSE_GL
     m_bSizer1 = new wxFlexGridSizer( 3 );
@@ -6948,7 +6948,7 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
             m_cbUseAcceleratedPanning->Enable();
             m_cbUseAcceleratedPanning->SetValue(g_GLOptions.m_bUseAcceleratedPanning);
         } else {
-            m_cbUseAcceleratedPanning->SetValue(false);
+            m_cbUseAcceleratedPanning->SetValue(FALSE);
             m_cbUseAcceleratedPanning->Disable();
         }
 
@@ -6962,7 +6962,7 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
         /* disable caching if unsupported */
         extern PFNGLCOMPRESSEDTEXIMAGE2DPROC s_glCompressedTexImage2D;
         if(!s_glCompressedTexImage2D) {
-            g_GLOptions.m_bTextureCompression = false;
+            g_GLOptions.m_bTextureCompression = FALSE;
             m_cbTextureCompressionCaching->Disable();
         }
 
@@ -6980,9 +6980,9 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked )
 
     if(b_glEntryPointsSet){
         if(!s_glCompressedTexImage2D) {
-            g_GLOptions.m_bTextureCompressionCaching = false;
+            g_GLOptions.m_bTextureCompressionCaching = FALSE;
             m_cbTextureCompression->Disable();
-            m_cbTextureCompression->SetValue(false);
+            m_cbTextureCompression->SetValue(FALSE);
         }
     }
 
@@ -7055,7 +7055,7 @@ void OpenGLOptionsDlg::OnButtonRebuild( wxCommandEvent& event )
 {
 #ifdef ocpnUSE_GL
     if(g_GLOptions.m_bTextureCompressionCaching) {
-        m_brebuild_cache = true;
+        m_brebuild_cache = TRUE;
         EndModal(wxID_CANCEL);
     }
 #endif

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6494,7 +6494,6 @@ SentenceListDlg::SentenceListDlg( wxWindow* parent, FilterDirection dir,
     // Connect Events
     btnAdd->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnAddClick ), NULL, this );
     m_btnDel->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnDeleteClick ), NULL, this );
-    m_clbSentences->Connect( wxEVT_COMMAND_CHECKLISTBOX_TOGGLED, wxCommandEventHandler( SentenceListDlg::OnCLBToggle ), NULL, this );
     m_clbSentences->Connect( wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler( SentenceListDlg::OnCLBSelect ), NULL, this );
     btnCheckAll->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnCheckAllClick ), NULL, this );
     btnClearAll->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( SentenceListDlg::OnClearAllClick ), NULL, this );
@@ -6515,6 +6514,7 @@ void SentenceListDlg::SetSentenceList( void )
 
 wxString SentenceListDlg::GetSentencesAsText( void )
 {
+    BuildSentenceArray();
     return StringArrayToString( m_sentences );
 }
 
@@ -6545,20 +6545,10 @@ void SentenceListDlg::FillSentences( void )
     }
 }
 
-void SentenceListDlg::OnStcSelect( wxCommandEvent& event )
-{
-    m_btnDel->Enable();
-}
-
 void SentenceListDlg::OnCLBSelect( wxCommandEvent& e )
 {
     // Only activate the "Delete" button if the selection is not in the standard list
     m_btnDel->Enable( standard_sentences.Index( e.GetString( ) ) == wxNOT_FOUND );
-}
-
-void SentenceListDlg::OnCLBToggle( wxCommandEvent& event )
-{
-    BuildSentenceArray();
 }
 
 void SentenceListDlg::OnAddClick( wxCommandEvent& event )
@@ -6591,8 +6581,6 @@ void SentenceListDlg::OnAddClick( wxCommandEvent& event )
 
 void SentenceListDlg::OnDeleteClick( wxCommandEvent& event )
 {
-    BuildSentenceArray();
-
     // Only delete items that do not appear in the standard sentence list
     int isel = m_clbSentences->GetSelection();
     wxString s = m_clbSentences->GetString( isel );
@@ -6616,16 +6604,12 @@ void SentenceListDlg::OnClearAllClick( wxCommandEvent& event )
 {
     for ( size_t i = 0; i < m_clbSentences->GetCount(); i++ )
         m_clbSentences->Check( i, FALSE );
-
-    BuildSentenceArray();
 }
 
 void SentenceListDlg::OnCheckAllClick( wxCommandEvent& event )
 {
     for ( size_t i = 0; i < m_clbSentences->GetCount(); i++ )
         m_clbSentences->Check( i, TRUE );
-
-    BuildSentenceArray();
 }
 
 const wxString SentenceListDlg::GetType( void )

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6544,7 +6544,6 @@ wxString SentenceListDlg::GetSentencesAsText( void )
 void SentenceListDlg::BuildSentenceArray( void )
 {
     m_sentences.Clear();
-    wxString s;
     for ( size_t i = 0; i < m_clbSentences->GetCount(); i++ ) {
         if ( m_clbSentences->IsChecked( i ) )
             m_sentences.Add( m_clbSentences->GetString( i ) );
@@ -6560,15 +6559,15 @@ void SentenceListDlg::FillSentences( void )
 
     for ( size_t i = 0; i < m_sentences.Count(); i++ ) {
         int item = m_clbSentences->FindString( m_sentences[i] );
-        if ( item != wxNOT_FOUND )
+        if ( item != wxNOT_FOUND ) {
             m_clbSentences->Check( item );
-        else {
+        } else {
             m_clbSentences->Append( m_sentences[i] );
             m_clbSentences->Check( m_clbSentences->FindString( m_sentences[i] ) );
         }
     }
 
-    m_btnDel->Enable(FALSE);
+    m_btnDel->Disable();
 }
 
 void SentenceListDlg::OnStcSelect( wxCommandEvent& event )

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6763,7 +6763,7 @@ const wxString OpenGLOptionsDlg::GetTextureCacheSize( void )
         for ( unsigned int i = 0 ; i < files.GetCount() ; i++ )
             total += wxFile( files[i] ).Length();
     }
-    double mb = total / ( 1024.0 * 2 );
+    double mb = total / ( 1024.0 * 1024.0 );
     if ( mb < 10000.0 )
         return wxString::Format( _T( "%.1f MB" ), mb );
     mb = mb / 1024.0;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4934,15 +4934,13 @@ void options::OnClose( wxCloseEvent& event )
 void options::OnChooseFont( wxCommandEvent& event )
 {
     wxString sel_text_element = m_itemFontElementListBox->GetStringSelection();
-
-    wxFont *psfont;
     wxFontData font_data;
 
     wxFont *pif = FontMgr::Get().GetFont( sel_text_element );
     wxColour init_color = FontMgr::Get().GetFontColor( sel_text_element );
 
     wxFontData init_font_data;
-    if( pif ) init_font_data.SetInitialFont( *pif );
+    if ( pif ) init_font_data.SetInitialFont( *pif );
     init_font_data.SetColour( init_color );
 
 #ifdef __WXGTK__
@@ -4963,27 +4961,26 @@ void options::OnChooseFont( wxCommandEvent& event )
     wxFont *dialogFont = GetOCPNScaledFont(_("Dialog"));
     float font_size = dialogFont->GetPointSize();
 
-    if( (proposed_size.y / font_size) < n_lines){
+    if ( ( proposed_size.y / font_size ) < n_lines ) {
         float new_font_size = proposed_size.y / n_lines;
-        wxFont *smallFont = new wxFont( * dialogFont );
+        wxFont *smallFont = new wxFont( *dialogFont );
         smallFont->SetPointSize( new_font_size );
         dg.SetFont( *smallFont );
     }
 #endif
 
-    if(g_bresponsive){
+    if ( g_bresponsive ) {
         dg.SetSize(GetSize());
         dg.Centre();
     }
 
     int retval = dg.ShowModal();
-    if( wxID_CANCEL != retval ) {
+    if ( wxID_CANCEL != retval ) {
         font_data = dg.GetFontData();
         wxFont font = font_data.GetChosenFont();
-        psfont = new wxFont( font );
+        wxFont *psfont = new wxFont( font );
         wxColor color = font_data.GetColour();
         FontMgr::Get().SetFont( sel_text_element, psfont, color );
-
         pParent->UpdateAllFonts();
     }
 
@@ -5714,19 +5711,18 @@ void ChartGroupsUI::OnDeleteGroup( wxCommandEvent &event )
 WX_DEFINE_OBJARRAY( ChartGroupElementArray );
 WX_DEFINE_OBJARRAY( ChartGroupArray );
 
-int ChartGroupsUI::FindGroupBranch( ChartGroup *pGroup, wxTreeCtrl *ptree, wxTreeItemId item,
-        wxString *pbranch_adder )
+int ChartGroupsUI::FindGroupBranch( ChartGroup *pGroup, wxTreeCtrl *ptree,
+                                    wxTreeItemId item, wxString *pbranch_adder )
 {
     wxString branch_name;
     wxString branch_adder;
 
     wxTreeItemId current_node = item;
-    while( current_node.IsOk() ) {
-
+    while ( current_node.IsOk() ) {
         wxTreeItemId parent_node = ptree->GetItemParent( current_node );
-        if( !parent_node ) break;
+        if ( !parent_node ) break;
 
-        if( parent_node == ptree->GetRootItem() ) {
+        if ( parent_node == ptree->GetRootItem() ) {
             branch_name = ptree->GetItemText( current_node );
             break;
         }
@@ -5737,20 +5733,19 @@ int ChartGroupsUI::FindGroupBranch( ChartGroup *pGroup, wxTreeCtrl *ptree, wxTre
         current_node = ptree->GetItemParent( current_node );
     }
 
-    //    Find the index and element pointer of the target branch in the Group
-    ChartGroupElement *target_element = NULL;
+    // Find the index and element pointer of the target branch in the Group
     unsigned int target_item_index = -1;
 
-    for( unsigned int i = 0; i < pGroup->m_element_array.GetCount(); i++ ) {
+    for ( unsigned int i = 0; i < pGroup->m_element_array.GetCount(); i++ ) {
         wxString target = pGroup->m_element_array.Item( i )->m_element_name;
-        if( branch_name == target ) {
-            target_element = pGroup->m_element_array.Item( i );
+        if ( branch_name == target ) {
+            ChartGroupElement *target_element = pGroup->m_element_array.Item( i );
             target_item_index = i;
             break;
         }
     }
 
-    if( pbranch_adder ) *pbranch_adder = branch_adder;
+    if ( pbranch_adder ) *pbranch_adder = branch_adder;
 
     return target_item_index;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6219,39 +6219,38 @@ void options::SetDSFormRWStates( void )
 
 void options::SetConnectionParams( ConnectionParams *cp )
 {
-    m_comboPort->Select(m_comboPort->FindString(cp->Port));
-    m_comboPort->SetValue(cp->Port);
-    m_cbCheckCRC->SetValue(cp->ChecksumCheck);
-    m_cbGarminHost->SetValue(cp->Garmin);
-    m_cbInput->SetValue(!(cp->IOSelect == DS_TYPE_OUTPUT));
-    m_cbOutput->SetValue(!(cp->IOSelect == DS_TYPE_INPUT));
-    if(cp->InputSentenceListType == WHITELIST)
-        m_rbIAccept->SetValue(TRUE);
+    m_comboPort->Select( m_comboPort->FindString( cp->Port ) );
+    m_comboPort->SetValue( cp->Port );
+    m_cbCheckCRC->SetValue( cp->ChecksumCheck );
+    m_cbGarminHost->SetValue( cp->Garmin );
+    m_cbInput->SetValue( cp->IOSelect != DS_TYPE_OUTPUT );
+    m_cbOutput->SetValue( cp->IOSelect != DS_TYPE_INPUT );
+    if ( cp->InputSentenceListType == WHITELIST )
+        m_rbIAccept->SetValue( TRUE );
     else
-        m_rbIIgnore->SetValue(TRUE);
-    if(cp->OutputSentenceListType == WHITELIST)
-        m_rbOAccept->SetValue(TRUE);
+        m_rbIIgnore->SetValue( TRUE );
+    if ( cp->OutputSentenceListType == WHITELIST )
+        m_rbOAccept->SetValue( TRUE );
     else
-        m_rbOIgnore->SetValue(TRUE);
-    m_tcInputStc->SetValue(StringArrayToString(cp->InputSentenceList));
-    m_tcOutputStc->SetValue(StringArrayToString(cp->OutputSentenceList));
-    m_choiceBaudRate->Select(m_choiceBaudRate->FindString(wxString::Format(_T("%d"),cp->Baudrate)));
-    m_choiceSerialProtocol->Select(cp->Protocol); //TODO
-    m_choicePriority->Select(m_choicePriority->FindString(wxString::Format(_T("%d"),cp->Priority)));
+        m_rbOIgnore->SetValue( TRUE );
+    m_tcInputStc->SetValue( StringArrayToString( cp->InputSentenceList ) );
+    m_tcOutputStc->SetValue( StringArrayToString( cp->OutputSentenceList ) );
+    m_choiceBaudRate->Select( m_choiceBaudRate->FindString( wxString::Format( _T( "%d" ), cp->Baudrate ) ) );
+    m_choiceSerialProtocol->Select( cp->Protocol ); //TODO
+    m_choicePriority->Select( m_choicePriority->FindString( wxString::Format( _T( "%d" ), cp->Priority ) ) );
+    m_tNetAddress->SetValue( cp->NetworkAddress );
 
-    m_tNetAddress->SetValue(cp->NetworkAddress);
-
-    if( cp->NetworkPort == 0)
-        m_tNetPort->SetValue(_T(""));
+    if ( cp->NetworkPort == 0  )
+        m_tNetPort->SetValue( wxEmptyString );
     else
-        m_tNetPort->SetValue(wxString::Format(wxT("%i"), cp->NetworkPort));
+        m_tNetPort->SetValue( wxString::Format( wxT( "%i" ), cp->NetworkPort ) );
 
-    if(cp->NetProtocol == TCP)
-        m_rbNetProtoTCP->SetValue(TRUE);
-    else if (cp->NetProtocol == UDP)
-        m_rbNetProtoUDP->SetValue(TRUE);
+    if ( cp->NetProtocol == TCP )
+        m_rbNetProtoTCP->SetValue( TRUE );
+    else if ( cp->NetProtocol == UDP )
+        m_rbNetProtoUDP->SetValue( TRUE );
     else
-        m_rbNetProtoGPSD->SetValue(TRUE);
+        m_rbNetProtoGPSD->SetValue( TRUE );
 
     if ( cp->Type == SERIAL )
     {
@@ -6288,34 +6287,30 @@ void options::SetConnectionParams( ConnectionParams *cp )
 
 void options::SetDefaultConnectionParams( void )
 {
-    m_comboPort->Select(0);
-    m_comboPort->SetValue(_T(""));
-    m_cbCheckCRC->SetValue(TRUE);
-    m_cbGarminHost->SetValue(FALSE);
-    m_cbInput->SetValue(TRUE);
-    m_cbOutput->SetValue(FALSE);
-    m_rbIAccept->SetValue(TRUE);
-    m_rbOAccept->SetValue(TRUE);
-    m_tcInputStc->SetValue(_T(""));
-    m_tcOutputStc->SetValue(_T(""));
-    m_choiceBaudRate->Select(m_choiceBaudRate->FindString(_T("4800")));
-//    m_choiceSerialProtocol->Select(cp->Protocol); //TODO
-    m_choicePriority->Select(m_choicePriority->FindString(_T("1")));
+    m_comboPort->Select( 0 );
+    m_comboPort->SetValue( wxEmptyString );
+    m_cbCheckCRC->SetValue( TRUE );
+    m_cbGarminHost->SetValue( FALSE );
+    m_cbInput->SetValue( TRUE );
+    m_cbOutput->SetValue( FALSE );
+    m_rbIAccept->SetValue( TRUE );
+    m_rbOAccept->SetValue( TRUE );
+    m_tcInputStc->SetValue( wxEmptyString );
+    m_tcOutputStc->SetValue( wxEmptyString );
+    m_choiceBaudRate->Select( m_choiceBaudRate->FindString( _T( "4800" ) ) );
+//    m_choiceSerialProtocol->Select( cp->Protocol ); // TODO
+    m_choicePriority->Select( m_choicePriority->FindString( _T( "1" ) ) );
 
     bool bserial = TRUE;
 #ifdef __WXGTK__
-    if(!g_bserial_access_checked)
+    if ( !g_bserial_access_checked )
         bserial = FALSE;
 #endif
 
     m_rbTypeSerial->SetValue( bserial );
     m_rbTypeNet->SetValue( !bserial );
 
-    if(bserial)
-        SetNMEAFormToSerial();
-    else
-        SetNMEAFormToNet();
-
+    bserial ? SetNMEAFormToSerial() : SetNMEAFormToNet();
     m_connection_enabled = TRUE;
 }
 
@@ -6330,7 +6325,7 @@ void options::OnAddDatasourceClick( wxCommandEvent& event )
         itemIndex = m_lcSources->GetNextItem( itemIndex, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED );
         if ( itemIndex == -1 )
             break;
-        m_lcSources->SetItemState( itemIndex, 0, wxLIST_STATE_SELECTED|wxLIST_STATE_FOCUSED );
+        m_lcSources->SetItemState( itemIndex, 0, wxLIST_STATE_SELECTED | wxLIST_STATE_FOCUSED );
     }
     m_buttonRemove->Enable( FALSE );
 
@@ -6339,29 +6334,27 @@ void options::OnAddDatasourceClick( wxCommandEvent& event )
 
 void options::FillSourceList( void )
 {
-    m_buttonRemove->Enable(FALSE);
+    m_buttonRemove->Enable( FALSE );
     m_lcSources->DeleteAllItems();
-    for (size_t i = 0; i < g_pConnectionParams->Count(); i++)
-    {
+    for ( size_t i = 0; i < g_pConnectionParams->Count(); i++ ) {
         wxListItem li;
         li.SetId( i );
-        li.SetImage( g_pConnectionParams->Item(i)->bEnabled ? 1 : 0  );
+        li.SetImage( g_pConnectionParams->Item(i)->bEnabled );
         li.SetData( i );
-        li.SetText( _T("") );
+        li.SetText( wxEmptyString );
 
         long itemIndex = m_lcSources->InsertItem( li );
 
-        m_lcSources->SetItem(itemIndex, 1, g_pConnectionParams->Item(i)->GetSourceTypeStr());
-        m_lcSources->SetItem(itemIndex, 2, g_pConnectionParams->Item(i)->GetAddressStr());
-        wxString prio_str;
-        prio_str.Printf(_T("%d"), g_pConnectionParams->Item(i)->Priority );
-        m_lcSources->SetItem(itemIndex, 3, prio_str);
-        wxString parms = g_pConnectionParams->Item(i)->GetParametersStr();
-        if(parms.IsEmpty())
-            parms = g_pConnectionParams->Item(i)->GetPortStr();
-        m_lcSources->SetItem(itemIndex, 4, parms);
-        m_lcSources->SetItem(itemIndex, 5, g_pConnectionParams->Item(i)->GetIOTypeValueStr());
-        m_lcSources->SetItem(itemIndex, 6, g_pConnectionParams->Item(i)->GetFiltersStr());
+        m_lcSources->SetItem( itemIndex, 1, g_pConnectionParams->Item( i )->GetSourceTypeStr() );
+        m_lcSources->SetItem( itemIndex, 2, g_pConnectionParams->Item( i )->GetAddressStr() );
+        wxString prio_str = wxString::Format( _T( "%d" ), g_pConnectionParams->Item( i )->Priority );
+        m_lcSources->SetItem( itemIndex, 3, prio_str );
+        wxString parms = g_pConnectionParams->Item( i )->GetParametersStr();
+        if ( parms.IsEmpty() )
+            parms = g_pConnectionParams->Item( i )->GetPortStr();
+        m_lcSources->SetItem( itemIndex, 4, parms );
+        m_lcSources->SetItem( itemIndex, 5, g_pConnectionParams->Item( i )->GetIOTypeValueStr() );
+        m_lcSources->SetItem( itemIndex, 6, g_pConnectionParams->Item( i )->GetFiltersStr() );
     }
 
 #ifndef __OCPN__ANDROID__
@@ -6405,7 +6398,7 @@ void options::OnRemoveDatasourceClick( wxCommandEvent& event )
 
         int params_index = m_lcSources->GetItemData(itemIndex);
         if( params_index != -1 ){
-            ConnectionParams *cp = g_pConnectionParams->Item(params_index);
+            ConnectionParams *cp = g_pConnectionParams->Item( params_index );
             g_pConnectionParams->RemoveAt( params_index );
 
             DataStream *pds_existing = g_pMUX->FindStream( cp->GetDSPort() );
@@ -6414,8 +6407,8 @@ void options::OnRemoveDatasourceClick( wxCommandEvent& event )
         }
 
         //  Mark connection deleted
-        m_rbTypeSerial->SetValue(TRUE);
-        m_comboPort->SetValue( _T("Deleted") );
+        m_rbTypeSerial->SetValue( TRUE );
+        m_comboPort->SetValue( _T( "Deleted" ) );
     }
     FillSourceList();
     ShowNMEACommon( FALSE );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -751,7 +751,9 @@ BEGIN_EVENT_TABLE( options, wxDialog )
 #ifdef __WXGTK__
     EVT_BUTTON( ID_BUTTONFONTCOLOR, options::OnChooseFontColor )
 #endif
+#ifdef ocpnUSE_GL
     EVT_BUTTON( ID_OPENGLOPTIONS, options::OnOpenGLOptions )
+#endif
     EVT_CHOICE( ID_RADARDISTUNIT, options::OnDisplayCategoryRadioButton )
     EVT_CHOICE( ID_DEPTHUNITSCHOICE, options::OnUnitsChoice )
     EVT_BUTTON( ID_CLEARLIST, options::OnButtonClearClick )
@@ -3921,7 +3923,6 @@ void options::OnGLClicked( wxCommandEvent& event )
 
 void options::OnOpenGLOptions( wxCommandEvent& event )
 {
-#ifdef ocpnUSE_GL
     OpenGLOptionsDlg dlg(this, pOpenGL->GetValue());
 
     if(dlg.ShowModal() == wxID_OK) {
@@ -3957,7 +3958,6 @@ void options::OnOpenGLOptions( wxCommandEvent& event )
         m_returnChanges = REBUILD_RASTER_CACHE;
         Finish();
     }
-#endif
 }
 
 void options::OnChartDirListSelect( wxCommandEvent& event )
@@ -6599,8 +6599,6 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked ) :
     wxFont *qFont = GetOCPNScaledFont( _( "Dialog" ) );
     SetFont( *qFont );
 
-
-#ifdef ocpnUSE_GL
     m_bSizer1 = new wxFlexGridSizer( 3 );
     this->SetSizeHints( wxDefaultSize, wxDefaultSize );
 
@@ -6702,7 +6700,6 @@ OpenGLOptionsDlg::OpenGLOptionsDlg( wxWindow* parent, bool glTicked ) :
     Layout();
     Centre( wxBOTH );
     Fit();
-#endif
 }
 
 void OpenGLOptionsDlg::OnButtonRebuild( wxCommandEvent& event )

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6509,12 +6509,12 @@ void SentenceListDlg::Populate( const wxArrayString &list )
     m_sentences.Add( _T("CD") );
     m_clbSentences->Clear();
     m_clbSentences->InsertItems( m_sentences, 0 );
-    m_clbSentences->InsertItems( list, m_sentences.GetCount() );
 
     if ( list.Count() == 0 ) {
         for ( size_t i = 0; i < m_clbSentences->GetCount(); ++i )
             m_clbSentences->Check( i, m_type == WHITELIST );
     } else {
+        m_clbSentences->InsertItems( list, m_sentences.GetCount() );
         for ( size_t i = 0; i < list.Count(); ++i ) {
             int item = m_clbSentences->FindString( list[i] );
             if ( item != wxNOT_FOUND )


### PR DESCRIPTION
Another pull request that attempts to clean up the code a bit.

There is nothing fancy here just some whitespace/newline removals etc..
The most interesting changes are the switch from C-Style casting to C++-Style casting (see b47e8e3 and 347bfff), clearing wxMemoryDC, used for native checkboxes in a listctrl, properly (see 961f418) and a pointer fix (see 195e101).

