### PR TITLE
Polish options.cpp and options.h

### DIFF
--- a/include/options.h
+++ b/include/options.h
@@ -239,7 +239,7 @@ class options: private Uncopyable, public wxScrollingDialog
     void SetWorkDirListPtr( ArrayOfCDI *p ) { m_pWorkDirList = p; }
     ArrayOfCDI *GetWorkDirListPtr( void ) { return m_pWorkDirList; }
 
-    void AddChartDir( wxString &dir );
+    void AddChartDir( const wxString &dir );
 
     void UpdateDisplayedChartDirList(ArrayOfCDI p);
     void UpdateOptionsUnits( void );

--- a/include/options.h
+++ b/include/options.h
@@ -213,22 +213,22 @@ class options: private Uncopyable, public wxScrollingDialog
 #endif
 {
   public:
-    explicit options( MyFrame* parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME,
-                      const wxString& caption = SYMBOL_OPTIONS_TITLE,
-                      const wxPoint& pos = SYMBOL_OPTIONS_POSITION,
-                      const wxSize& size = SYMBOL_OPTIONS_SIZE,
+    explicit options( MyFrame *parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME,
+                      const wxString &caption = SYMBOL_OPTIONS_TITLE,
+                      const wxPoint &pos = SYMBOL_OPTIONS_POSITION,
+                      const wxSize &size = SYMBOL_OPTIONS_SIZE,
                       long style = SYMBOL_OPTIONS_STYLE );
 
     ~options( void );
 
-    void SetInitialPage( int page_sel);
+    void SetInitialPage( int page_sel );
     void Finish( void);
 
-    void OnClose( wxCloseEvent& event );
+    void OnClose( wxCloseEvent &event );
 
     void CreateControls( void );
-    size_t CreatePanel( const wxString & title );
-    wxScrolledWindow *AddPage( size_t parent, const wxString & title );
+    size_t CreatePanel( const wxString &title );
+    wxScrolledWindow *AddPage( size_t parent, const wxString &title );
     bool DeletePage( wxScrolledWindow *page );
     void SetColorScheme( ColorScheme cs );
     void RecalculateSize( void );

--- a/include/options.h
+++ b/include/options.h
@@ -481,39 +481,31 @@ class options: private Uncopyable, public wxScrollingDialog
   private:
     void Init( void );
     void CreatePanel_MMSI( size_t parent, int border_size,
-                           int group_item_spacing, wxSize small_button_size );
+                           int group_item_spacing );
     void CreatePanel_AIS( size_t parent, int border_size,
-                          int group_item_spacing, wxSize small_button_size );
+                          int group_item_spacing );
     void CreatePanel_Ownship( size_t parent, int border_size,
-                              int group_item_spacing,
-                              wxSize small_button_size );
+                              int group_item_spacing );
     void CreatePanel_NMEA( size_t parent, int border_size,
-                           int group_item_spacing, wxSize small_button_size );
+                           int group_item_spacing );
     void CreatePanel_NMEA_Compact( size_t parent, int border_size,
-                                   int group_item_spacing,
-                                   wxSize small_button_size );
+                                   int group_item_spacing );
     void CreatePanel_ChartsLoad( size_t parent, int border_size,
-                                 int group_item_spacing,
-                                 wxSize small_button_size );
+                                 int group_item_spacing );
     void CreatePanel_VectorCharts( size_t parent, int border_size,
-                                   int group_item_spacing,
-                                   wxSize small_button_size );
+                                   int group_item_spacing );
     void CreatePanel_TidesCurrents( size_t parent, int border_size,
-                                    int group_item_spacing,
-                                    wxSize small_button_size );
+                                    int group_item_spacing );
     void CreatePanel_ChartGroups( size_t parent, int border_size,
-                                  int group_item_spacing,
-                                  wxSize small_button_size );
+                                  int group_item_spacing );
     void CreatePanel_Display( size_t parent, int border_size,
-                              int group_item_spacing,
-                              wxSize small_button_size );
-    void CreatePanel_UI( size_t parent, int border_size, int group_item_spacing,
-                         wxSize small_button_size );
+                              int group_item_spacing );
+    void CreatePanel_UI( size_t parent, int border_size,
+                         int group_item_spacing );
     void CreatePanel_Units( size_t parent, int border_size,
-                            int group_item_spacing, wxSize small_button_size );
+                            int group_item_spacing );
     void CreatePanel_Advanced( size_t parent, int border_size,
-                               int group_item_spacing,
-                               wxSize small_button_size );
+                               int group_item_spacing );
 
     int m_returnChanges;
     wxListBox *tcDataSelected;
@@ -561,8 +553,7 @@ class ChartGroupsUI: private Uncopyable, public wxScrolledWindow {
     explicit ChartGroupsUI( wxWindow *parent );
     ~ChartGroupsUI( void );
 
-    void CreatePanel( size_t parent, int border_size, int group_item_spacing,
-                      wxSize small_button_size );
+    void CreatePanel( size_t parent, int border_size, int group_item_spacing );
     void CompletePanel( void );
     void SetDBDirs( ArrayOfCDI &array ) { m_db_dirs = array; }
     void SetGroupArray( ChartGroupArray *pGroupArray ) {

--- a/include/options.h
+++ b/include/options.h
@@ -937,7 +937,6 @@ class MMSIListCtrl: public wxListCtrl
 class MMSIEditDialog: public wxDialog
 {
   public:
-    explicit MMSIEditDialog( );
     explicit MMSIEditDialog( MMSIProperties *props, wxWindow *parent,
                              wxWindowID id = wxID_ANY,
                              const wxString& caption = wxEmptyString,
@@ -946,11 +945,6 @@ class MMSIEditDialog: public wxDialog
                              long style = 0 );
     ~MMSIEditDialog( void );
 
-    bool Create( MMSIProperties *props, wxWindow *parent,
-                 wxWindowID id = wxID_ANY,
-                 const wxString& caption = wxEmptyString,
-                 const wxPoint& pos = wxDefaultPosition,
-                 const wxSize& size = wxDefaultSize, long style = 0 );
     void SetColorScheme(ColorScheme cs);
     void CreateControls( void );
     void OnMMSIEditCancelClick( wxCommandEvent& event );
@@ -964,7 +958,6 @@ class MMSIEditDialog: public wxDialog
     wxCheckBox *m_cbTrackPersist, *m_IgnoreButton, *m_MOBButton, *m_VDMButton;
     wxButton *m_CancelButton, *m_OKButton;
 
-    DECLARE_DYNAMIC_CLASS( MMSIEditDialog )
     DECLARE_EVENT_TABLE()
 };
 

--- a/include/options.h
+++ b/include/options.h
@@ -540,18 +540,14 @@ class options: public wxScrollingDialog
     void SetDSFormRWStates();
     void FillSourceList();
     ConnectionParams *CreateConnectionParamsFromSelectedItem();
-    
-    wxNotebookPage*             m_groupsPage;
-    wxFont*     smallFont;
-    wxFont*     dialogFont;
-    
-    wxSize      m_small_button_size;
-    
-    wxTimer     m_BTScanTimer;
-    wxArrayString m_BTscan_results;
-    
-    bool        m_bcompact;
 
+    wxNotebookPage *m_groupsPage;
+    wxFont *smallFont, *dialogFont;
+    wxSize m_small_button_size;
+    wxTimer m_BTScanTimer;
+    wxArrayString m_BTscan_results;
+
+    bool m_bcompact;
     int m_fontHeight, m_scrollRate, m_BTscanning, m_btNoChangeCounter;
     int m_btlastResultCount;
 

--- a/include/options.h
+++ b/include/options.h
@@ -203,7 +203,6 @@ class options: public wxScrollingDialog
 #endif
 {
   public:
-    explicit options( void );
     explicit options( MyFrame* parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME,
                       const wxString& caption = SYMBOL_OPTIONS_TITLE,
                       const wxPoint& pos = SYMBOL_OPTIONS_POSITION,
@@ -212,16 +211,9 @@ class options: public wxScrollingDialog
 
     ~options( void );
 
-    bool Create( MyFrame* parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME,
-                 const wxString& caption = SYMBOL_OPTIONS_TITLE,
-                 const wxPoint& pos = SYMBOL_OPTIONS_POSITION,
-                 const wxSize& size = SYMBOL_OPTIONS_SIZE,
-                 long style = SYMBOL_OPTIONS_STYLE );
-
     void SetInitialPage( int page_sel);
     void Finish( void);
 
-    wxWindow *GetContentWindow( void ) const;
     void OnClose( wxCloseEvent& event );
 
     void CreateControls( void );
@@ -551,7 +543,6 @@ class options: public wxScrollingDialog
     int m_fontHeight, m_scrollRate, m_BTscanning, m_btNoChangeCounter;
     int m_btlastResultCount;
 
-    DECLARE_DYNAMIC_CLASS( options )
     DECLARE_EVENT_TABLE()
 };
 

--- a/include/options.h
+++ b/include/options.h
@@ -946,7 +946,7 @@ class MMSIEditDialog: private Uncopyable, public wxDialog
                              long style = 0 );
     ~MMSIEditDialog( void );
 
-    void SetColorScheme(ColorScheme cs);
+    void SetColorScheme( ColorScheme cs );
     void CreateControls( void );
     void OnMMSIEditCancelClick( wxCommandEvent& event );
     void OnMMSIEditOKClick( wxCommandEvent& event );

--- a/include/options.h
+++ b/include/options.h
@@ -196,10 +196,20 @@ enum {
 
 WX_DECLARE_OBJARRAY(wxGenericDirCtrl *, ArrayOfDirCtrls);
 
+class Uncopyable {
+  protected:
+    Uncopyable( void ) {}
+    ~Uncopyable( void ) {}
+
+  private:
+    Uncopyable( const Uncopyable& );
+    Uncopyable& operator=( const Uncopyable& );
+};
+
 #ifndef bert // wxCHECK_VERSION(2, 9, 0)
-class options: public wxDialog
+class options: private Uncopyable, public wxDialog
 #else
-class options: public wxScrollingDialog
+class options: private Uncopyable, public wxScrollingDialog
 #endif
 {
   public:
@@ -546,7 +556,7 @@ class options: public wxScrollingDialog
     DECLARE_EVENT_TABLE()
 };
 
-class ChartGroupsUI: public wxScrolledWindow {
+class ChartGroupsUI: private Uncopyable, public wxScrolledWindow {
   public:
     explicit ChartGroupsUI( wxWindow *parent );
     ~ChartGroupsUI( void );
@@ -837,7 +847,7 @@ static int lang_list[] = {
 };
 #endif
 
-class SentenceListDlg : public wxDialog
+class SentenceListDlg : private Uncopyable, public wxDialog
 {
   public:
     explicit SentenceListDlg( wxWindow *parent, FilterDirection dir,
@@ -862,7 +872,7 @@ class SentenceListDlg : public wxDialog
     wxArrayString m_sentences;
 };
 
-class OpenGLOptionsDlg : public wxDialog
+class OpenGLOptionsDlg : private Uncopyable, public wxDialog
 {
   public:
     explicit OpenGLOptionsDlg( wxWindow *parent );
@@ -900,7 +910,7 @@ enum {
     mlVDM
 }; // MMSIListCtrl Columns;
 
-class MMSIListCtrl: public wxListCtrl
+class MMSIListCtrl: private Uncopyable, public wxListCtrl
 {
   public:
      explicit MMSIListCtrl( wxWindow *parent, wxWindowID id, const wxPoint& pos,
@@ -925,7 +935,7 @@ class MMSIListCtrl: public wxListCtrl
 #define ID_DEF_MENU_MMSI_EDIT   8194
 #define ID_DEF_MENU_MMSI_DELETE 8195
 
-class MMSIEditDialog: public wxDialog
+class MMSIEditDialog: private Uncopyable, public wxDialog
 {
   public:
     explicit MMSIEditDialog( MMSIProperties *props, wxWindow *parent,
@@ -952,7 +962,7 @@ class MMSIEditDialog: public wxDialog
     DECLARE_EVENT_TABLE()
 };
 
-class MMSI_Props_Panel: public wxPanel
+class MMSI_Props_Panel: private Uncopyable, public wxPanel
 {
   public:
     explicit MMSI_Props_Panel( wxWindow *parent );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4268,19 +4268,17 @@ void options::OnCharHook( wxKeyEvent& event ) {
     event.Skip();
 }
 
-void options::OnButtonaddClick( wxCommandEvent& event )
+void options::OnButtonaddClick( wxCommandEvent &event )
 {
     wxString selDir;
+    int dresult =g_Platform->DoDirSelectorDialog(
+        this, &selDir, _("Add a directory containing chart files"),
+        *pInit_Chart_Dir
+    );
 
-    int dresult = g_Platform->DoDirSelectorDialog( this, &selDir, _("Add a directory containing chart files"),
-                                                   *pInit_Chart_Dir);
+    if ( dresult != wxID_CANCEL )
+        AddChartDir( selDir );
 
-    if(wxID_CANCEL == dresult)
-        goto done;
-    AddChartDir( selDir );
-
-done:
-//    delete dirSelector;
     event.Skip();
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4216,19 +4216,10 @@ void options::OnChartDirListSelect( wxCommandEvent& event )
 
 void options::OnDisplayCategoryRadioButton( wxCommandEvent& event )
 {
-    int select = pDispCat->GetSelection();
-
-    if( 3 == select ) {
-        ps57CtlListBox->Enable();
-        itemButtonClearList->Enable();
-        itemButtonSelectList->Enable();
-    }
-
-    else {
-        ps57CtlListBox->Disable();
-        itemButtonClearList->Disable();
-        itemButtonSelectList->Disable();
-    }
+    const bool select = pDispCat->GetSelection() == 3;
+    ps57CtlListBox->Enable( select );
+    itemButtonClearList->Enable( select );
+    itemButtonSelectList->Enable( select );
 
     event.Skip();
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2936,179 +2936,124 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
     }
 }
 
-void options::CreatePanel_Units( size_t parent, int border_size, int group_item_spacing,
+void options::CreatePanel_Units( size_t parent, int border_size,
+                                 int group_item_spacing,
                                  wxSize small_button_size )
 {
     wxScrolledWindow *panelUnits = AddPage( parent, _("Units") );
+    wxSize size = m_bcompact ? wxSize( 250, -1 ) : wxDefaultSize;
 
-    if(m_bcompact){
-        wxFlexGridSizer *unitsSizer = new wxFlexGridSizer( 2 );
-        unitsSizer->SetHGap(border_size);
+    wxFlexGridSizer *unitsSizer = new wxFlexGridSizer( 2 );
+    unitsSizer->SetHGap( border_size );
 
-        // wxFlexGridSizer grows wrongly in wx2.8, so we need to centre it in another sizer instead of letting it grow.
-        wxBoxSizer* wrapperSizer = new wxBoxSizer( wxVERTICAL );
-        panelUnits->SetSizer( wrapperSizer );
-        wrapperSizer->Add( unitsSizer, 1, wxALL | wxALIGN_CENTER, border_size );
+    // wxFlexGridSizer grows wrongly in wx2.8, so we need to centre it
+    // in another sizer instead of letting it grow.
+    wxBoxSizer *wrapperSizer = new wxBoxSizer( wxVERTICAL );
+    panelUnits->SetSizer( wrapperSizer );
+    wrapperSizer->Add( unitsSizer, 1, wxALL | wxALIGN_CENTER, border_size );
 
+    // spacer
+    unitsSizer->Add( 0, border_size * 4 );
+    unitsSizer->Add( 0, border_size * 4 );
 
-        // spacer
-        unitsSizer->Add( 0, border_size*4 );
-        unitsSizer->Add( 0, border_size*4 );
+    // distance units
+    unitsSizer->Add( new wxStaticText( panelUnits, wxID_ANY, _( "Distance" ) ),
+                     labelFlags );
+    wxArrayString pDistanceFormats;
+    pDistanceFormats.Add( _( "Nautical miles" ) );
+    pDistanceFormats.Add( _( "Statute miles" ) );
+    pDistanceFormats.Add( _( "Kilometers" ) );
+    pDistanceFormats.Add( _( "Meters" ) );
+    pDistanceFormat = new wxChoice( panelUnits, ID_DISTANCEUNITSCHOICE,
+                                    wxDefaultPosition, size, pDistanceFormats );
+    unitsSizer->Add( pDistanceFormat, inputFlags );
 
+    // speed units
+    unitsSizer->Add( new wxStaticText( panelUnits, wxID_ANY, _( "Speed" ) ),
+                     labelFlags );
+    wxArrayString pSpeedFormats;
+    pSpeedFormats.Add( _( "Knots" ) );
+    pSpeedFormats.Add( _( "Mph" ) );
+    pSpeedFormats.Add( _( "km/h" ) );
+    pSpeedFormats.Add( _( "m/s" ) );
+    pSpeedFormat = new wxChoice( panelUnits, ID_SPEEDUNITSCHOICE,
+                                 wxDefaultPosition, size, pSpeedFormats );
+    unitsSizer->Add( pSpeedFormat, inputFlags );
 
-        // distance units
-        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Distance")), labelFlags );
-        wxString pDistanceFormats[] = { _("Nautical miles"), _("Statute miles"), _("Kilometers"), _("Meters") };
-        int m_DistanceFormatsNChoices = sizeof(pDistanceFormats) / sizeof(wxString);
-        pDistanceFormat = new wxChoice( panelUnits, ID_DISTANCEUNITSCHOICE, wxDefaultPosition,
-                                        wxSize(250, -1), m_DistanceFormatsNChoices, pDistanceFormats );
-        unitsSizer->Add( pDistanceFormat, inputFlags );
+    // depth units
+    unitsSizer->Add( new wxStaticText( panelUnits, wxID_ANY, _( "Depth" ) ),
+                    labelFlags );
+    wxArrayString pDepthUnitStrings;
+    pDepthUnitStrings.Add( _( "Feet" ) );
+    pDepthUnitStrings.Add( _( "Meters" ) );
+    pDepthUnitStrings.Add( _( "Fathoms" ) );
+    pDepthUnitSelect = new wxChoice( panelUnits, ID_DEPTHUNITSCHOICE,
+                                     wxDefaultPosition, size,
+                                     pDepthUnitStrings );
+    unitsSizer->Add( pDepthUnitSelect, inputFlags );
 
+    // spacer
+    unitsSizer->Add( 0, border_size * 4 );
+    unitsSizer->Add( 0, border_size * 4 );
 
-        // speed units
-        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Speed")), labelFlags );
-        wxString pSpeedFormats[] = { _("Knots"), _("Mph"), _("km/h"), _("m/s") };
-        int m_SpeedFormatsNChoices = sizeof( pSpeedFormats ) / sizeof(wxString);
-        pSpeedFormat = new wxChoice( panelUnits, ID_SPEEDUNITSCHOICE, wxDefaultPosition,
-                                     wxSize(250, -1), m_SpeedFormatsNChoices, pSpeedFormats );
-        unitsSizer->Add( pSpeedFormat, inputFlags );
+    // lat/long units
+    unitsSizer->Add( new wxStaticText( panelUnits, wxID_ANY, _( "Lat/Long" ) ),
+                     labelFlags );
+    wxArrayString pSDMMFormats;
+    pSDMMFormats.Add( _( "Degrees, Decimal Minutes" ) );
+    pSDMMFormats.Add( _( "Decimal Degrees" ) );
+    pSDMMFormats.Add( _( "Degrees, Minutes, Seconds" ) );
+    pSDMMFormat = new wxChoice( panelUnits, ID_SDMMFORMATCHOICE,
+                                wxDefaultPosition, size, pSDMMFormats );
+    unitsSizer->Add( pSDMMFormat, inputFlags );
 
+    // spacer
+    unitsSizer->Add( 0, border_size * 4 );
+    unitsSizer->Add( 0, border_size * 4 );
 
-        // depth units
-        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Depth")), labelFlags );
-        wxString pDepthUnitStrings[] = { _("Feet"), _("Meters"), _("Fathoms"), };
-        pDepthUnitSelect = new wxChoice( panelUnits, ID_DEPTHUNITSCHOICE, wxDefaultPosition,
-                                         wxSize(250, -1), 3, pDepthUnitStrings );
-        unitsSizer->Add( pDepthUnitSelect, inputFlags );
+    // bearings (magnetic/true, variation)
+    unitsSizer->Add( new wxStaticText( panelUnits, wxID_ANY, _( "Bearings" ) ),
+                     groupLabelFlags );
 
-
-        // spacer
-        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
-        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
-
-
-        // lat/long units
-        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Lat/Long")), labelFlags );
-        wxString pSDMMFormats[] = { _("Degrees, Decimal Minutes"), _("Decimal Degrees"), _("Degrees, Minutes, Seconds") };
-        int m_SDMMFormatsNChoices = sizeof( pSDMMFormats ) / sizeof(wxString);
-        pSDMMFormat = new wxChoice( panelUnits, ID_SDMMFORMATCHOICE, wxDefaultPosition,
-                                    wxDefaultSize, m_SDMMFormatsNChoices, pSDMMFormats );
-        unitsSizer->Add( pSDMMFormat, inputFlags );
-
-
-        // spacer
-        unitsSizer->Add( 0, border_size*4 );
-        unitsSizer->Add( 0, border_size*4 );
-
-
-        // bearings (magnetic/true, variation)
-        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Bearings")), groupLabelFlags );
-
-
-        //  "Mag Heading" checkbox
-        pCBMagShow = new wxCheckBox( panelUnits, ID_MAGSHOWCHECKBOX, _("Show magnetic") );
-        unitsSizer->Add( pCBMagShow, 0, wxALL, group_item_spacing );
-
-
-        //  Mag Heading user variation
-        wxStaticText* itemStaticTextUserVar = new wxStaticText( panelUnits, wxID_ANY, _("Assumed magnetic variation") );
-        wrapperSizer->Add( itemStaticTextUserVar, 0, wxEXPAND | wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
-
-        wxBoxSizer* magVarSizer = new wxBoxSizer( wxHORIZONTAL );
-        wrapperSizer->Add( magVarSizer, 0, wxALL | wxEXPAND, group_item_spacing );
-
-        magVarSizer->Add( 0, border_size*4 );
-
-        pMagVar = new wxTextCtrl( panelUnits, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize(150, -1), wxTE_RIGHT );
-        magVarSizer->Add( pMagVar, 0, wxALIGN_CENTRE_VERTICAL, group_item_spacing );
-
-        magVarSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("deg (-W, +E)")),
-                          0, wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
-
-    }
-    else{
-        wxFlexGridSizer *unitsSizer = new wxFlexGridSizer( 2 );
-        unitsSizer->SetHGap(border_size);
-
-        // wxFlexGridSizer grows wrongly in wx2.8, so we need to centre it in another sizer instead of letting it grow.
-        wxBoxSizer* wrapperSizer = new wxBoxSizer( wxVERTICAL );
-        panelUnits->SetSizer( wrapperSizer );
-        wrapperSizer->Add( unitsSizer, 1, wxALL | wxALIGN_CENTER, border_size );
-
-
-        // spacer
-        unitsSizer->Add( 0, border_size*4 );
-        unitsSizer->Add( 0, border_size*4 );
-
-
-        // distance units
-        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Distance")), labelFlags );
-        wxString pDistanceFormats[] = { _("Nautical miles"), _("Statute miles"), _("Kilometers"), _("Meters") };
-        int m_DistanceFormatsNChoices = sizeof(pDistanceFormats) / sizeof(wxString);
-        pDistanceFormat = new wxChoice( panelUnits, ID_DISTANCEUNITSCHOICE, wxDefaultPosition,
-                                        wxDefaultSize, m_DistanceFormatsNChoices, pDistanceFormats );
-        unitsSizer->Add( pDistanceFormat, inputFlags );
-
-
-        // speed units
-        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Speed")), labelFlags );
-        wxString pSpeedFormats[] = { _("Knots"), _("Mph"), _("km/h"), _("m/s") };
-        int m_SpeedFormatsNChoices = sizeof( pSpeedFormats ) / sizeof(wxString);
-        pSpeedFormat = new wxChoice( panelUnits, ID_SPEEDUNITSCHOICE, wxDefaultPosition,
-                                     wxDefaultSize, m_SpeedFormatsNChoices, pSpeedFormats );
-        unitsSizer->Add( pSpeedFormat, inputFlags );
-
-
-        // depth units
-        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Depth")), labelFlags );
-        wxString pDepthUnitStrings[] = { _("Feet"), _("Meters"), _("Fathoms"), };
-        pDepthUnitSelect = new wxChoice( panelUnits, ID_DEPTHUNITSCHOICE, wxDefaultPosition,
-                                         wxDefaultSize, 3, pDepthUnitStrings );
-        unitsSizer->Add( pDepthUnitSelect, inputFlags );
-
-
-        // spacer
-        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
-        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
-
-
-        // lat/long units
-        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Lat/Long")), labelFlags );
-        wxString pSDMMFormats[] = { _("Degrees, Decimal Minutes"), _("Decimal Degrees"), _("Degrees, Minutes, Seconds") };
-        int m_SDMMFormatsNChoices = sizeof( pSDMMFormats ) / sizeof(wxString);
-        pSDMMFormat = new wxChoice( panelUnits, ID_SDMMFORMATCHOICE, wxDefaultPosition,
-                                    wxDefaultSize, m_SDMMFormatsNChoices, pSDMMFormats );
-        unitsSizer->Add( pSDMMFormat, inputFlags );
-
-
-        // spacer
-        unitsSizer->Add( 0, border_size*4 );
-        unitsSizer->Add( 0, border_size*4 );
-
-
-        // bearings (magnetic/true, variation)
-        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Bearings")), groupLabelFlags );
-
-        wxBoxSizer* bearingsSizer = new wxBoxSizer( wxVERTICAL );
+    wxBoxSizer* bearingsSizer = new wxBoxSizer( wxVERTICAL );
+    if ( !m_bcompact )
         unitsSizer->Add( bearingsSizer, 0, 0, 0 );
 
-        //  "Mag Heading" checkbox
-        pCBMagShow = new wxCheckBox( panelUnits, ID_MAGSHOWCHECKBOX, _("Show magnetic bearings and headings") );
+    //  "Mag Heading" checkbox
+    pCBMagShow = new wxCheckBox( panelUnits, ID_MAGSHOWCHECKBOX, m_bcompact ?
+        _( "Show magnetic" ) : _( "Show magnetic bearings and headings" ));
+    if ( m_bcompact )
+        unitsSizer->Add( pCBMagShow, 0, wxALL, group_item_spacing );
+    else
         bearingsSizer->Add( pCBMagShow, 0, wxALL, group_item_spacing );
 
-        //  Mag Heading user variation
-        wxBoxSizer* magVarSizer = new wxBoxSizer( wxHORIZONTAL );
+    //  Mag Heading user variation
+    wxStaticText *itemStaticTextUserVar =
+        new wxStaticText( panelUnits, wxID_ANY,
+                          _( "Assumed magnetic variation" ) );
+    wxBoxSizer* magVarSizer = new wxBoxSizer( wxHORIZONTAL );
+
+    if ( m_bcompact ) {
+        wrapperSizer->Add( itemStaticTextUserVar, 0,
+                           wxEXPAND | wxALL | wxALIGN_CENTRE_VERTICAL,
+                           group_item_spacing );
+        wrapperSizer->Add( magVarSizer, 0, wxALL | wxEXPAND,
+                           group_item_spacing );
+        magVarSizer->Add( 0, border_size * 4 );
+    } else {
         bearingsSizer->Add( magVarSizer, 0, wxALL, group_item_spacing );
-
-        wxStaticText* itemStaticTextUserVar = new wxStaticText( panelUnits, wxID_ANY, _("Assumed magnetic variation") );
-        magVarSizer->Add( itemStaticTextUserVar, 0, wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
-
-        pMagVar = new wxTextCtrl( panelUnits, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize(50, -1), wxTE_RIGHT );
-        magVarSizer->Add( pMagVar, 0, wxALIGN_CENTRE_VERTICAL, group_item_spacing );
-
-        magVarSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("deg (-W, +E)")),
-                          0, wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
+        magVarSizer->Add( itemStaticTextUserVar, 0,
+                          wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
     }
+
+    pMagVar = new wxTextCtrl( panelUnits, ID_OPTEXTCTRL, wxEmptyString,
+                              wxDefaultPosition,
+                              wxSize( m_bcompact ? 150 : 50, -1 ), wxTE_RIGHT );
+    magVarSizer->Add( pMagVar, 0, wxALIGN_CENTRE_VERTICAL, group_item_spacing );
+
+    magVarSizer->Add( new wxStaticText( panelUnits, wxID_ANY,
+                                        _( "deg (-W, +E)" ) ),
+                      0, wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
 }
 
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3708,17 +3708,14 @@ void options::SetColorScheme( ColorScheme cs )
 void options::SetInitialSettings( void )
 {
     wxString s;
-    wxString dirname;
 
     // ChartsLoad
     int nDir = m_CurrentDirList.GetCount();
 
-    for( int i = 0; i < nDir; i++ ) {
-        dirname = m_CurrentDirList.Item( i ).fullpath;
-        if( !dirname.IsEmpty() ) {
-            if( pActiveChartsList ) {
-                pActiveChartsList->Append( dirname );
-            }
+    for ( int i = 0; i < nDir; ++i ) {
+        wxString dirname = m_CurrentDirList.Item( i ).fullpath;
+        if ( !dirname.IsEmpty() && pActiveChartsList ) {
+            pActiveChartsList->Append( dirname );
         }
     }
 
@@ -3901,7 +3898,7 @@ void options::SetInitialSettings( void )
 
     m_pCheck_Wpl_Aprs->SetValue( g_bWplIsAprsPosition );
 
-    //      Alerts
+    // Alerts
     m_pCheck_AlertDialog->SetValue( g_bAIS_CPA_Alert );
     m_pCheck_AlertAudio->SetValue( g_bAIS_CPA_Alert_Audio );
     m_pCheck_Alert_Moored->SetValue( g_bAIS_CPA_Alert_Suppress_Moored );
@@ -4046,16 +4043,16 @@ void options::UpdateOptionsUnits( void )
 
     // set depth input values
     wxString s;
-    s.Printf( _T("%6.2f"), S52_getMarinerParam( S52_MAR_SHALLOW_CONTOUR ) / conv );
-    s.Trim(FALSE);
+    s.Printf( _T( "%6.2f" ), S52_getMarinerParam( S52_MAR_SHALLOW_CONTOUR ) / conv );
+    s.Trim( FALSE );
     m_ShallowCtl->SetValue( s );
 
-    s.Printf( _T("%6.2f"), S52_getMarinerParam( S52_MAR_SAFETY_CONTOUR ) / conv );
-    s.Trim(FALSE);
+    s.Printf( _T( "%6.2f" ), S52_getMarinerParam( S52_MAR_SAFETY_CONTOUR ) / conv );
+    s.Trim( FALSE );
     m_SafetyCtl->SetValue( s );
 
-    s.Printf( _T("%6.2f"), S52_getMarinerParam( S52_MAR_DEEP_CONTOUR ) / conv );
-    s.Trim(FALSE);
+    s.Printf( _T( "%6.2f" ), S52_getMarinerParam( S52_MAR_DEEP_CONTOUR ) / conv );
+    s.Trim( FALSE );
     m_DeepCtl->SetValue( s );
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -974,7 +974,8 @@ bool options::DeletePage( wxScrolledWindow *page  )
     return FALSE;
 }
 
-void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int group_item_spacing, wxSize small_button_size )
+void options::CreatePanel_NMEA_Compact( size_t parent, int border_size,
+                                        int group_item_spacing )
 {
     m_pNMEAForm = AddPage( parent, _( "NMEA" ) );
 
@@ -1423,7 +1424,8 @@ void options::CreatePanel_NMEA_Compact( size_t parent, int border_size, int grou
     connectionsaved = TRUE;
 }
 
-void options::CreatePanel_NMEA( size_t parent, int border_size, int group_item_spacing, wxSize small_button_size )
+void options::CreatePanel_NMEA( size_t parent, int border_size,
+                                int group_item_spacing )
 {
     m_pNMEAForm = AddPage( parent, _( "NMEA" ) );
 
@@ -1906,7 +1908,8 @@ void options::OnConnectionToggleEnable( wxMouseEvent &event )
     event.Skip();
 }
 
-void options::CreatePanel_Ownship( size_t parent, int border_size, int group_item_spacing, wxSize small_button_size )
+void options::CreatePanel_Ownship( size_t parent, int border_size,
+                                   int group_item_spacing )
 {
     itemPanelShip = AddPage( parent, _( "Own Ship" ) );
 
@@ -2081,8 +2084,8 @@ void options::CreatePanel_Ownship( size_t parent, int border_size, int group_ite
     DimeControl( itemPanelShip );
 }
 
-void options::CreatePanel_ChartsLoad( size_t parent, int border_size, int group_item_spacing,
-                                      wxSize small_button_size )
+void options::CreatePanel_ChartsLoad( size_t parent, int border_size,
+                                      int group_item_spacing )
 {
     wxScrolledWindow *chartPanelWin = AddPage( m_pageCharts, _( "Chart Files" ) );
 
@@ -2137,8 +2140,8 @@ void options::CreatePanel_ChartsLoad( size_t parent, int border_size, int group_
 }
 
 
-void options::CreatePanel_Advanced( size_t parent, int border_size, int group_item_spacing,
-                                        wxSize small_button_size )
+void options::CreatePanel_Advanced( size_t parent, int border_size,
+                                    int group_item_spacing )
 {
     m_ChartDisplayPage = AddPage( parent, _("Advanced") );
 
@@ -2422,8 +2425,8 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
 
 }
 
-void options::CreatePanel_VectorCharts( size_t parent, int border_size, int group_item_spacing,
-        wxSize small_button_size )
+void options::CreatePanel_VectorCharts( size_t parent, int border_size,
+                                        int group_item_spacing )
 {
     ps57Ctl = AddPage( parent, _("Vector Chart Display") );
 
@@ -2614,8 +2617,8 @@ void options::CreatePanel_VectorCharts( size_t parent, int border_size, int grou
 //    m_choicePrecision->SetSelection( g_NMEAAPBPrecision );
 }
 
-void options::CreatePanel_TidesCurrents( size_t parent, int border_size, int group_item_spacing,
-        wxSize small_button_size )
+void options::CreatePanel_TidesCurrents( size_t parent, int border_size,
+                                         int group_item_spacing )
 {
     wxScrolledWindow *tcPanel = AddPage( parent, _("Tides && Currents") );
 
@@ -2647,8 +2650,8 @@ void options::CreatePanel_TidesCurrents( size_t parent, int border_size, int gro
     btnSizer->Add( removeButton, 1, wxALL | wxEXPAND, group_item_spacing );
 }
 
-void options::CreatePanel_ChartGroups( size_t parent, int border_size, int group_item_spacing,
-        wxSize small_button_size )
+void options::CreatePanel_ChartGroups( size_t parent, int border_size,
+                                       int group_item_spacing )
 {
     // Special case for adding the tab here. We know this page has multiple tabs,
     // and we have the actual widgets in a separate class (because of its complexity)
@@ -2656,7 +2659,7 @@ void options::CreatePanel_ChartGroups( size_t parent, int border_size, int group
     m_groupsPage = m_pListbook->GetPage( parent );
     groupsPanel = new ChartGroupsUI( m_groupsPage );
 
-    groupsPanel->CreatePanel( parent, border_size, group_item_spacing, small_button_size );
+    groupsPanel->CreatePanel( parent, border_size, group_item_spacing );
     wxNotebook *nb = dynamic_cast<wxNotebook *>( m_groupsPage );
     if ( nb ) nb->AddPage( groupsPanel, _("Chart Groups") );
 
@@ -2665,8 +2668,8 @@ void options::CreatePanel_ChartGroups( size_t parent, int border_size, int group
 //    groupsPanel->CompletePanel();     // Deferred until panel is selected....
 }
 
-void ChartGroupsUI::CreatePanel( size_t parent, int border_size, int group_item_spacing,
-        wxSize small_button_size )
+void ChartGroupsUI::CreatePanel( size_t parent, int border_size,
+                                 int group_item_spacing )
 {
     modified = FALSE;
     m_border_size = border_size;
@@ -2757,8 +2760,8 @@ void ChartGroupsUI::CompletePanel( void )
 
 }
 
-void options::CreatePanel_Display( size_t parent, int border_size, int group_item_spacing,
-        wxSize small_button_size )
+void options::CreatePanel_Display( size_t parent, int border_size,
+                                   int group_item_spacing )
 {
     pDisplayPanel = AddPage( parent, _("General") );
 
@@ -2937,8 +2940,7 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
 }
 
 void options::CreatePanel_Units( size_t parent, int border_size,
-                                 int group_item_spacing,
-                                 wxSize small_button_size )
+                                 int group_item_spacing )
 {
     wxScrolledWindow *panelUnits = AddPage( parent, _("Units") );
     wxSize size = m_bcompact ? wxSize( 250, -1 ) : wxDefaultSize;
@@ -3057,7 +3059,8 @@ void options::CreatePanel_Units( size_t parent, int border_size,
 }
 
 
-void options::CreatePanel_MMSI( size_t parent, int border_size, int group_item_spacing, wxSize small_button_size )
+void options::CreatePanel_MMSI( size_t parent, int border_size,
+                                int group_item_spacing )
 {
     wxScrolledWindow *panelMMSI = AddPage( parent, _("MMSI Properties") );
 
@@ -3078,7 +3081,8 @@ void options::CreatePanel_MMSI( size_t parent, int border_size, int group_item_s
     panelMMSI->Layout();
 }
 
-void options::CreatePanel_AIS( size_t parent, int border_size, int group_item_spacing, wxSize small_button_size )
+void options::CreatePanel_AIS( size_t parent, int border_size,
+                               int group_item_spacing )
 {
     wxScrolledWindow *panelAIS = AddPage( parent, _("AIS Targets") );
 
@@ -3226,7 +3230,7 @@ void options::CreatePanel_AIS( size_t parent, int border_size, int group_item_sp
     pAlertGrid->Add( m_pCheck_AlertDialog, 0, wxALL, group_item_spacing );
 
     wxButton *m_SelSound = new wxButton( panelAIS, ID_AISALERTSELECTSOUND,
-            _("Select Alert Sound"), wxDefaultPosition, small_button_size, 0 );
+            _("Select Alert Sound"), wxDefaultPosition, m_small_button_size, 0 );
     pAlertGrid->Add( m_SelSound, 0, wxALL | wxALIGN_RIGHT, group_item_spacing );
 
     m_pCheck_AlertAudio = new wxCheckBox( panelAIS, ID_AISALERTAUDIO,
@@ -3234,7 +3238,7 @@ void options::CreatePanel_AIS( size_t parent, int border_size, int group_item_sp
     pAlertGrid->Add( m_pCheck_AlertAudio, 0, wxALL, group_item_spacing );
 
     wxButton *m_pPlay_Sound = new wxButton( panelAIS, ID_AISALERTTESTSOUND,
-            _("Test Alert Sound"), wxDefaultPosition, small_button_size, 0 );
+            _("Test Alert Sound"), wxDefaultPosition, m_small_button_size, 0 );
     pAlertGrid->Add( m_pPlay_Sound, 0, wxALL | wxALIGN_RIGHT, group_item_spacing );
 
     m_pCheck_Alert_Moored = new wxCheckBox( panelAIS, -1,
@@ -3254,8 +3258,8 @@ void options::CreatePanel_AIS( size_t parent, int border_size, int group_item_sp
     panelAIS->Layout();
 }
 
-void options::CreatePanel_UI( size_t parent, int border_size, int group_item_spacing,
-        wxSize small_button_size )
+void options::CreatePanel_UI( size_t parent, int border_size,
+                              int group_item_spacing )
 {
     wxScrolledWindow *itemPanelFont = AddPage( parent, _("General Options") );
 
@@ -3582,33 +3586,33 @@ void options::CreateControls( void )
     buttons->Add( m_ApplyButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, border_size );
 
     m_pageDisplay = CreatePanel( _("Display") );
-    CreatePanel_Display( m_pageDisplay, border_size, group_item_spacing, m_small_button_size );
-    CreatePanel_Units( m_pageDisplay, border_size, group_item_spacing, m_small_button_size );
-    CreatePanel_Advanced( m_pageDisplay, border_size, group_item_spacing, m_small_button_size );
+    CreatePanel_Display( m_pageDisplay, border_size, group_item_spacing );
+    CreatePanel_Units( m_pageDisplay, border_size, group_item_spacing );
+    CreatePanel_Advanced( m_pageDisplay, border_size, group_item_spacing );
 
     m_pageCharts = CreatePanel( _("Charts") );
-    CreatePanel_ChartsLoad( m_pageCharts, border_size, group_item_spacing, m_small_button_size );
-    CreatePanel_VectorCharts( m_pageCharts, border_size, group_item_spacing, m_small_button_size );
+    CreatePanel_ChartsLoad( m_pageCharts, border_size, group_item_spacing );
+    CreatePanel_VectorCharts( m_pageCharts, border_size, group_item_spacing );
     // ChartGroups must be created after ChartsLoad and must be at least third
-    CreatePanel_ChartGroups( m_pageCharts, border_size, group_item_spacing, m_small_button_size );
-    CreatePanel_TidesCurrents( m_pageCharts, border_size, group_item_spacing, m_small_button_size );
+    CreatePanel_ChartGroups( m_pageCharts, border_size, group_item_spacing );
+    CreatePanel_TidesCurrents( m_pageCharts, border_size, group_item_spacing );
 
     m_pageConnections = CreatePanel( _("Connections") );
 #ifndef __OCPN__ANDROID__
-    CreatePanel_NMEA( m_pageConnections, border_size, group_item_spacing, m_small_button_size );
+    CreatePanel_NMEA( m_pageConnections, border_size, group_item_spacing );
 #else
-    CreatePanel_NMEA_Compact( m_pageConnections, border_size, group_item_spacing, m_small_button_size );
+    CreatePanel_NMEA_Compact( m_pageConnections, border_size, group_item_spacing );
 #endif
 
 //    SetDefaultConnectionParams();
 
     m_pageShips = CreatePanel( _("Ships") );
-    CreatePanel_Ownship( m_pageShips, border_size, group_item_spacing, m_small_button_size );
-    CreatePanel_AIS( m_pageShips, border_size, group_item_spacing, m_small_button_size );
-    CreatePanel_MMSI( m_pageShips, border_size, group_item_spacing, m_small_button_size );
+    CreatePanel_Ownship( m_pageShips, border_size, group_item_spacing );
+    CreatePanel_AIS( m_pageShips, border_size, group_item_spacing );
+    CreatePanel_MMSI( m_pageShips, border_size, group_item_spacing );
 
     m_pageUI = CreatePanel( _("User Interface") );
-    CreatePanel_UI( m_pageUI, border_size, group_item_spacing, m_small_button_size );
+    CreatePanel_UI( m_pageUI, border_size, group_item_spacing );
 
     m_pagePlugins = CreatePanel( _("Plugins") );
     itemPanelPlugins = AddPage( m_pagePlugins, _("Plugins") );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -3674,10 +3674,10 @@ void options::CreateControls( void )
     //      PlugIns can add panels, too
     if( g_pi_manager ) g_pi_manager->NotifySetupOptions();
 
-    SetColorScheme( (ColorScheme) 0 );
+    SetColorScheme( static_cast<ColorScheme>( 0 ) );
 
     //Set the maximum size of the entire settings dialog
-    SetSizeHints( -1, -1, width-100, height-100 );
+    SetSizeHints( -1, -1, width - 100, height - 100 );
 
     //  The s57 chart panel is the one which controls the minimum width required to avoid horizontal scroll bars
     vectorPanel->SetSizeHints( ps57Ctl );
@@ -3687,11 +3687,11 @@ void options::SetInitialPage( int page_sel )
 {
     m_pListbook->SetSelection( page_sel );
 
-    for (size_t i = 0; i < m_pListbook->GetPageCount(); i++)
+    for ( size_t i = 0; i < m_pListbook->GetPageCount(); i++ )
     {
         wxNotebookPage* pg = m_pListbook->GetPage( i );
         wxNotebook *nb = dynamic_cast<wxNotebook *>( pg );
-        if ( nb ) nb->ChangeSelection(0);
+        if ( nb ) nb->ChangeSelection( 0 );
     }
 }
 
@@ -3700,8 +3700,8 @@ void options::SetColorScheme( ColorScheme cs )
     DimeControl( this );
 
 #ifdef __OCPN__OPTIONS_USE_LISTBOOK__
-    wxListView* lv = m_pListbook->GetListView();
-    lv->SetBackgroundColour(this->GetBackgroundColour());
+    wxListView *lv = m_pListbook->GetListView();
+    lv->SetBackgroundColour( GetBackgroundColour() );
 #endif
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4284,20 +4284,19 @@ done:
     event.Skip();
 }
 
-void options::AddChartDir( wxString &dir )
+void options::AddChartDir( const wxString &dir )
 {
     wxFileName dirname = wxFileName( dir );
-
     pInit_Chart_Dir->Empty();
-    if( !g_bportable )
-        pInit_Chart_Dir->Append( dirname.GetPath() );
 
-    if( g_bportable ) {
+    if ( g_bportable ) {
         wxFileName f( dir );
         f.MakeRelativeTo( g_Platform->GetHomeDir() );
         pActiveChartsList->Append( f.GetFullPath() );
-    } else
+    } else {
+        pInit_Chart_Dir->Append( dirname.GetPath() );
         pActiveChartsList->Append( dir );
+    }
 
     k_charts |= CHANGE_CHARTS;
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4061,25 +4061,21 @@ void options::UpdateOptionsUnits( void )
 
 void options::OnSizeAutoButton( wxCommandEvent& event )
 {
-//    pScreenMM->SetValue(_("Auto"));
-    wxString screenmm;
-    screenmm.Printf(_T("%d"), int(g_Platform->GetDisplaySizeMM()));
-    pScreenMM->SetValue(screenmm);
+    wxString screenmm = wxString::Format(
+        _T( "%d" ), static_cast<int>( g_Platform->GetDisplaySizeMM() )
+    );
+    pScreenMM->SetValue( screenmm );
     pScreenMM->Disable();
     g_config_display_size_manual = FALSE;
 }
 
 void options::OnSizeManualButton( wxCommandEvent& event )
 {
-    wxString screenmm;
-    if(g_config_display_size_mm > 0){
-        screenmm.Printf(_T("%d"), int(g_config_display_size_mm));
-    }
-    else {
-        screenmm.Printf(_T("%d"), int(g_Platform->GetDisplaySizeMM()));
-    }
-
-    pScreenMM->SetValue(screenmm);
+    wxString screenmm = wxString::Format(
+        _T( "%d" ), static_cast<int>( g_config_display_size_mm > 0 ?
+            g_config_display_size_mm : g_Platform->GetDisplaySizeMM() )
+    );
+    pScreenMM->SetValue( screenmm );
     pScreenMM->Enable();
     g_config_display_size_manual = TRUE;
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -471,18 +471,21 @@ wxString MMSIListCtrl::OnGetItemText( long item, long column ) const
                 ret = wxString::Format( _T( "%d" ), props->MMSI );
             break;
         case mlTrackMode:
-            if ( TRACKTYPE_DEFAULT == props->TrackType )
-                ret = _( "Default" );
-            else if ( TRACKTYPE_ALWAYS == props->TrackType )
-                ret = _( "Always" );
-            else if ( TRACKTYPE_NEVER == props->TrackType )
-                ret = _( "Never" );
-            else
-                ret = _T( "???" );
-            if ( props->m_bPersistentTrack ){
-                ret.Append( _T( ", " ));
-                ret.Append( _( "Persistent" ) );
+            switch ( props->TrackType ) {
+                case TRACKTYPE_DEFAULT:
+                    ret = _( "Default" );
+                    break;
+                case TRACKTYPE_ALWAYS:
+                    ret = _( "Always" );
+                    break;
+                case TRACKTYPE_NEVER:
+                    ret = _( "Never" );
+                    break;
+                default:
+                    ret = _T( "???" );
             }
+            if ( props->m_bPersistentTrack )
+                ret.Append( _T( ", " ) ).Append( _( "Persistent" ) );
             break;
         case mlIgnore:
             if ( props->m_bignore )

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -791,7 +791,7 @@ options::options( MyFrame* parent, wxWindowID id, const wxString& caption,
     wxDialog::Create( parent, id, caption, pos, size, wstyle );
 
     SetFont( *dialogFont );
-    
+
     CreateControls();
     RecalculateSize();
 
@@ -900,16 +900,16 @@ void options::Init( void )
     m_BTscanning = 0;
 
     dialogFont = GetOCPNScaledFont(_("Dialog"));
-    
+
     // This variable is used by plugin callback function AddOptionsPage
     g_pOptions = this;
-    
+
     m_bcompact = false;
-    
+
 #ifdef __OCPN__ANDROID__
     m_bcompact = true;
 #endif
-    
+
 }
 
 bool options::Create( MyFrame* parent, wxWindowID id, const wxString& caption, const wxPoint& pos,
@@ -2195,28 +2195,28 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
         m_ChartDisplayPage->SetSizer( wrapperSizer );
 
         wxBoxSizer* itemBoxSizerUI = wrapperSizer;
-        
+
         // spacer
         itemBoxSizerUI->Add( 0, border_size*3 );
         itemBoxSizerUI->Add( 0, border_size*3 );
-        
-        
+
+
         // Chart Display Options
         wxBoxSizer* boxCharts = new wxBoxSizer( wxVERTICAL );
         itemBoxSizerUI->Add( boxCharts, groupInputFlags );
 
         pSkewComp = new wxCheckBox( m_ChartDisplayPage, ID_SKEWCOMPBOX, _("De-skew Raster Charts") );
         boxCharts->Add( pSkewComp, inputFlags );
-        
+
         pFullScreenQuilt = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _("Disable Full Screen Quilting") );
         boxCharts->Add( pFullScreenQuilt, inputFlags );
 
         pOverzoomEmphasis = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _("Suppress blur/fog effects") );
         boxCharts->Add( pOverzoomEmphasis, inputFlags );
-        
+
         pOZScaleVector = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _("Suppress scaled vector charts") );
         boxCharts->Add( pOZScaleVector, inputFlags );
-        
+
 
 
         // Control Options
@@ -2237,7 +2237,7 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
 
         itemBoxSizerUI->Add( 0, border_size*3 );
         itemBoxSizerUI->Add( 0, border_size*3 );
-        
+
         // OpenGL Options
         wxBoxSizer* OpenGLSizer = new wxBoxSizer( wxVERTICAL );
         itemBoxSizerUI->Add( OpenGLSizer, 0, 0, 0 );
@@ -2248,49 +2248,49 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
 
     #ifdef __OCPN__ANDROID__
         pOpenGL->Disable();
-    #endif    
-        
+    #endif
+
         wxButton *bOpenGL = new wxButton( m_ChartDisplayPage, ID_OPENGLOPTIONS, _("Options...") );
         OpenGLSizer->Add( bOpenGL, inputFlags );
         bOpenGL->Enable(!g_bdisable_opengl);
-        
+
         itemBoxSizerUI->Add( 0, border_size*3 );
         itemBoxSizerUI->Add( 0, border_size*3 );
-        
+
         //  Course Up display update period
         wrapperSizer->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Course-Up Update Period") ), inputFlags );
-        
+
         wxBoxSizer *pCOGUPFilterRow = new wxBoxSizer( wxHORIZONTAL );
         wrapperSizer->Add( pCOGUPFilterRow, 0, wxALL | wxEXPAND, group_item_spacing );
-        
+
         pCOGUPUpdateSecs = new wxTextCtrl( m_ChartDisplayPage, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize( 50, -1 ), wxTE_RIGHT  );
         pCOGUPFilterRow->Add( pCOGUPUpdateSecs, 0, wxALIGN_RIGHT | wxALL, group_item_spacing );
-        
+
         pCOGUPFilterRow->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("seconds") ), inputFlags );
-        
+
         itemBoxSizerUI->Add( 0, border_size*3 );
         itemBoxSizerUI->Add( 0, border_size*3 );
-        
+
         // Chart Zoom Scale Weighting
         itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Chart Zoom/Scale Weighting") ),  0, wxEXPAND );
         m_pSlider_Zoom = new wxSlider( m_ChartDisplayPage, ID_CM93ZOOM, 0, -5,
                                        5, wxDefaultPosition, wxSize( 300, 50),
                                        wxSL_HORIZONTAL | wxSL_AUTOTICKS | wxSL_LABELS );
-        
+
         #ifdef __OCPN__ANDROID__
         m_pSlider_Zoom->GetHandle()->setStyleSheet( getQtStyleSheet());
-        #endif    
-        
+        #endif
+
         itemBoxSizerUI->Add( m_pSlider_Zoom, inputFlags );
-  
+
         itemBoxSizerUI->Add( 0, border_size*3 );
         itemBoxSizerUI->Add( 0, border_size*3 );
-        
+
         //  Display size/DPI
         itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Physical Screen Width") ), inputFlags );
         wxBoxSizer *pDPIRow = new wxBoxSizer( wxHORIZONTAL );
         itemBoxSizerUI->Add( pDPIRow, 0, wxEXPAND );
-        
+
         pRBSizeAuto = new wxRadioButton( m_ChartDisplayPage, wxID_ANY, _("Auto") );
         pDPIRow->Add( pRBSizeAuto, inputFlags );
         pDPIRow->AddSpacer( 10 );
@@ -2299,7 +2299,7 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
 
         wxBoxSizer *pmmRow = new wxBoxSizer( wxHORIZONTAL );
         itemBoxSizerUI->Add( pmmRow, 0, wxEXPAND );
-        
+
         pScreenMM = new wxTextCtrl( m_ChartDisplayPage, ID_OPTEXTCTRL, _T(""), wxDefaultPosition,
                                     wxSize( 100, -1 ), wxTE_RIGHT  );
         pmmRow->Add( pScreenMM, 0, wxALIGN_RIGHT | wxALL, group_item_spacing );
@@ -2310,10 +2310,10 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
                             wxCommandEventHandler( options::OnSizeAutoButton ), NULL, this );
         pRBSizeManual->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED,
                             wxCommandEventHandler( options::OnSizeManualButton ), NULL, this );
-        
-                                                  
+
+
     }
-    
+
     else{
         wxFlexGridSizer* itemBoxSizerUI = new wxFlexGridSizer( 2 );
         itemBoxSizerUI->SetHGap(border_size);
@@ -2331,7 +2331,7 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
         itemBoxSizerUI->Add( 0, border_size*3 );
         itemBoxSizerUI->Add( 0, border_size*3 );
 
-        
+
         // Chart Display Options
         itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Chart Display") ), groupLabelFlags );
         wxBoxSizer* boxCharts = new wxBoxSizer( wxVERTICAL );
@@ -2339,21 +2339,21 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
 
         pSkewComp = new wxCheckBox( m_ChartDisplayPage, ID_SKEWCOMPBOX, _("Show Skewed Raster Charts as North-Up") );
         boxCharts->Add( pSkewComp, inputFlags );
-        
+
         pFullScreenQuilt = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _("Disable Full Screen Quilting") );
         boxCharts->Add( pFullScreenQuilt, inputFlags );
 
         pOverzoomEmphasis = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _("Suppress blur/fog effects on overzoom") );
         boxCharts->Add( pOverzoomEmphasis, inputFlags );
-        
+
         pOZScaleVector = new wxCheckBox( m_ChartDisplayPage, ID_FULLSCREENQUILT, _("Suppress scaled vector charts on overzoom") );
         boxCharts->Add( pOZScaleVector, inputFlags );
-        
+
         // spacer
         itemBoxSizerUI->Add( 0, border_size*3 );
         itemBoxSizerUI->Add( 0, border_size*3 );
 
-        
+
         //  Course Up display update period
         itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Course-Up Update Period") ), labelFlags );
         wxBoxSizer *pCOGUPFilterRow = new wxBoxSizer( wxHORIZONTAL );
@@ -2361,7 +2361,7 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
 
         pCOGUPUpdateSecs = new wxTextCtrl( m_ChartDisplayPage, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize( 50, -1 ), wxTE_RIGHT  );
         pCOGUPFilterRow->Add( pCOGUPUpdateSecs, 0, wxALIGN_RIGHT | wxALL, group_item_spacing );
-        
+
         pCOGUPFilterRow->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("seconds") ), inputFlags );
 
 
@@ -2375,23 +2375,23 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
         m_pSlider_Zoom = new wxSlider( m_ChartDisplayPage, ID_CM93ZOOM, 0, -5,
                                     5, wxDefaultPosition, wxSize( 300, 50),
                                     wxSL_HORIZONTAL | wxSL_AUTOTICKS | wxSL_LABELS );
-        
+
     #ifdef __OCPN__ANDROID__
         m_pSlider_Zoom->GetHandle()->setStyleSheet( getQtStyleSheet());
-    #endif    
-        
+    #endif
+
         itemBoxSizerUI->Add( m_pSlider_Zoom, inputFlags );
 
         itemBoxSizerUI->Add( 0, border_size*3 );
         wxStaticText* zoomText = new wxStaticText( m_ChartDisplayPage, wxID_ANY,
             _("With a lower value, the same zoom level shows a less detailed chart.\nWith a higher value, the same zoom level shows a more detailed chart.") );
-        
+
         smallFont = new wxFont( * dialogFont ); // we can't use Smaller() because wx2.8 doesn't support it
         smallFont->SetPointSize( (smallFont->GetPointSize() / 1.2) + 0.5 ); // + 0.5 to round instead of truncate
         zoomText->SetFont( * smallFont );
         itemBoxSizerUI->Add( zoomText, 0, wxALL | wxEXPAND, group_item_spacing );
-        
-        
+
+
         // spacer
         itemBoxSizerUI->Add( 0, border_size*3 );
         itemBoxSizerUI->Add( 0, border_size*3 );
@@ -2420,7 +2420,7 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
         itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Physical Screen Width") ), labelFlags );
         wxBoxSizer *pDPIRow = new wxBoxSizer( wxHORIZONTAL );
         itemBoxSizerUI->Add( pDPIRow, 0, wxEXPAND );
-        
+
         pRBSizeAuto = new wxRadioButton( m_ChartDisplayPage, wxID_ANY, _("Auto") );
         pDPIRow->Add( pRBSizeAuto, inputFlags );
         pDPIRow->AddSpacer( 10 );
@@ -2437,11 +2437,11 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
                             wxCommandEventHandler( options::OnSizeAutoButton ), NULL, this );
         pRBSizeManual->Connect( wxEVT_COMMAND_RADIOBUTTON_SELECTED,
                             wxCommandEventHandler( options::OnSizeManualButton ), NULL, this );
-        
+
         // spacer
         itemBoxSizerUI->Add( 0, border_size*3 );
         itemBoxSizerUI->Add( 0, border_size*3 );
-        
+
         // OpenGL Options
         itemBoxSizerUI->Add( new wxStaticText( m_ChartDisplayPage, wxID_ANY, _("Graphics") ), labelFlags );
         wxBoxSizer* OpenGLSizer = new wxBoxSizer( wxHORIZONTAL );
@@ -2453,20 +2453,20 @@ void options::CreatePanel_Advanced( size_t parent, int border_size, int group_it
 
     #ifdef __OCPN__ANDROID__
         pOpenGL->Disable();
-    #endif    
-        
+    #endif
+
         wxButton *bOpenGL = new wxButton( m_ChartDisplayPage, ID_OPENGLOPTIONS, _("Options...") );
         OpenGLSizer->Add( bOpenGL, inputFlags );
         bOpenGL->Enable(!g_bdisable_opengl);
-        
-    
+
+
         itemBoxSizerUI->Add( 0, border_size*3 );
         pTransparentToolbar = new wxCheckBox( m_ChartDisplayPage, ID_TRANSTOOLBARCHECKBOX,
                                             _("Enable Transparent Toolbar") );
         itemBoxSizerUI->Add( pTransparentToolbar, 0, wxALL, border_size );
         if( g_bopengl && !g_bTransparentToolbarInOpenGLOK ) pTransparentToolbar->Disable();
     }
-    
+
 }
 
 void options::CreatePanel_VectorCharts( size_t parent, int border_size, int group_item_spacing,
@@ -2842,13 +2842,13 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
 
         pCBLookAhead = new wxCheckBox( pDisplayPanel, ID_CHECK_LOOKAHEAD, _("Look Ahead Mode") );
         boxNavMode->Add( pCBLookAhead, inputFlags );
-        
-        
+
+
         // spacer
         generalSizer->Add( 0, border_size*4 );
         generalSizer->Add( 0, border_size*4 );
 
-        
+
         // Control Options
         generalSizer->Add( new wxStaticText( pDisplayPanel, wxID_ANY, _("Chart Display") ), groupLabelFlags );
         wxBoxSizer* boxCharts = new wxBoxSizer( wxVERTICAL );
@@ -2865,25 +2865,25 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
         generalSizer->Add( 0, border_size*4 );
         generalSizer->Add( 0, border_size*4 );
 
-        
+
         // Control Options
         generalSizer->Add( new wxStaticText( pDisplayPanel, wxID_ANY, _("Controls") ), groupLabelFlags );
         wxBoxSizer* boxCtrls = new wxBoxSizer( wxVERTICAL );
         generalSizer->Add( boxCtrls, groupInputFlags );
-        
+
         pSmoothPanZoom = new wxCheckBox( pDisplayPanel, ID_SMOOTHPANZOOMBOX, _("Smooth Panning / Zooming") );
         boxCtrls->Add( pSmoothPanZoom, inputFlags );
-        
+
         pEnableZoomToCursor = new wxCheckBox( pDisplayPanel, ID_ZTCCHECKBOX, _("Zoom to Cursor") );
         pEnableZoomToCursor->SetValue( FALSE );
         boxCtrls->Add( pEnableZoomToCursor, inputFlags );
-        
+
 
         // spacer
         generalSizer->Add( 0, border_size*4 );
         generalSizer->Add( 0, border_size*4 );
 
-        
+
         // Display Options
         generalSizer->Add( new wxStaticText( pDisplayPanel, wxID_ANY, _("Display Features") ), groupLabelFlags );
         wxBoxSizer* boxDisp = new wxBoxSizer( wxVERTICAL );
@@ -2901,85 +2901,85 @@ void options::CreatePanel_Display( size_t parent, int border_size, int group_ite
     else{
         wxBoxSizer* wrapperSizer = new wxBoxSizer( wxVERTICAL );
         pDisplayPanel->SetSizer( wrapperSizer );
-        
+
         wxBoxSizer* generalSizer = wrapperSizer;
-        
+
         // spacer
         generalSizer->Add( 0, border_size*4 );
         generalSizer->Add( 0, border_size*4 );
-        
-        
+
+
         // Nav Mode
         //generalSizer->Add( new wxStaticText( pDisplayPanel, wxID_ANY, _("Navigation Mode") ), groupLabelFlags );
         wxBoxSizer* boxNavMode = new wxBoxSizer( wxVERTICAL );
         generalSizer->Add( boxNavMode, groupInputFlags );
-        
+
         wxBoxSizer* rowOrientation = new wxBoxSizer( wxHORIZONTAL );
         boxNavMode->Add( rowOrientation );
-        
+
         pCBNorthUp = new wxRadioButton( pDisplayPanel, wxID_ANY, _("North Up") );
         rowOrientation->Add( pCBNorthUp, inputFlags );
         pCBCourseUp = new wxRadioButton( pDisplayPanel, ID_COURSEUPCHECKBOX, _("Course Up") );
         rowOrientation->Add( pCBCourseUp, wxSizerFlags(0).Align(wxALIGN_CENTRE_VERTICAL).Border(wxLEFT, group_item_spacing*2) );
-        
+
         pCBLookAhead = new wxCheckBox( pDisplayPanel, ID_CHECK_LOOKAHEAD, _("Look Ahead Mode") );
         boxNavMode->Add( pCBLookAhead, inputFlags );
-        
-        
+
+
         // spacer
         generalSizer->Add( 0, border_size*4 );
         generalSizer->Add( 0, border_size*4 );
-        
-        
+
+
         // Control Options
         //generalSizer->Add( new wxStaticText( pDisplayPanel, wxID_ANY, _("Chart Display") ), groupLabelFlags );
         wxBoxSizer* boxCharts = new wxBoxSizer( wxVERTICAL );
         generalSizer->Add( boxCharts, groupInputFlags );
-        
+
         pCDOQuilting = new wxCheckBox( pDisplayPanel, ID_QUILTCHECKBOX1, _("Enable Chart Quilting") );
         boxCharts->Add( pCDOQuilting, inputFlags );
-        
+
         pPreserveScale = new wxCheckBox( pDisplayPanel, ID_PRESERVECHECKBOX, _("Preserve Scale on Chart Switch") );
         boxCharts->Add( pPreserveScale, inputFlags );
-        
-        
+
+
         // spacer
         generalSizer->Add( 0, border_size*4 );
         generalSizer->Add( 0, border_size*4 );
-        
-        
+
+
         // Control Options
         //generalSizer->Add( new wxStaticText( pDisplayPanel, wxID_ANY, _("Controls") ), groupLabelFlags );
         wxBoxSizer* boxCtrls = new wxBoxSizer( wxVERTICAL );
         generalSizer->Add( boxCtrls, groupInputFlags );
-        
+
         pSmoothPanZoom = new wxCheckBox( pDisplayPanel, ID_SMOOTHPANZOOMBOX, _("Smooth Panning / Zooming") );
         boxCtrls->Add( pSmoothPanZoom, inputFlags );
-        
+
         pEnableZoomToCursor = new wxCheckBox( pDisplayPanel, ID_ZTCCHECKBOX, _("Zoom to Cursor") );
         pEnableZoomToCursor->SetValue( FALSE );
         boxCtrls->Add( pEnableZoomToCursor, inputFlags );
-        
-        
+
+
         // spacer
         generalSizer->Add( 0, border_size*4 );
         generalSizer->Add( 0, border_size*4 );
-        
-        
+
+
         // Display Options
         //generalSizer->Add( new wxStaticText( pDisplayPanel, wxID_ANY, _("Display Features") ), groupLabelFlags );
         wxBoxSizer* boxDisp = new wxBoxSizer( wxVERTICAL );
         generalSizer->Add( boxDisp, groupInputFlags );
-        
+
         pSDisplayGrid = new wxCheckBox( pDisplayPanel, ID_CHECK_DISPLAYGRID, _("Show Grid") );
         boxDisp->Add( pSDisplayGrid, inputFlags );
-        
+
         pCDOOutlines = new wxCheckBox( pDisplayPanel, ID_OUTLINECHECKBOX1, _("Show Chart Outlines") );
         boxDisp->Add( pCDOOutlines, inputFlags );
-        
+
         pSDepthUnits = new wxCheckBox( pDisplayPanel, ID_SHOWDEPTHUNITSBOX1, _("Show Depth Units") );
         boxDisp->Add( pSDepthUnits, inputFlags );
-        
+
     }
 }
 
@@ -2987,22 +2987,22 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
                                  wxSize small_button_size )
 {
     wxScrolledWindow *panelUnits = AddPage( parent, _("Units") );
-    
+
     if(m_bcompact){
         wxFlexGridSizer *unitsSizer = new wxFlexGridSizer( 2 );
         unitsSizer->SetHGap(border_size);
-        
+
         // wxFlexGridSizer grows wrongly in wx2.8, so we need to centre it in another sizer instead of letting it grow.
         wxBoxSizer* wrapperSizer = new wxBoxSizer( wxVERTICAL );
         panelUnits->SetSizer( wrapperSizer );
         wrapperSizer->Add( unitsSizer, 1, wxALL | wxALIGN_CENTER, border_size );
-        
-        
+
+
         // spacer
         unitsSizer->Add( 0, border_size*4 );
         unitsSizer->Add( 0, border_size*4 );
-        
-        
+
+
         // distance units
         unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Distance")), labelFlags );
         wxString pDistanceFormats[] = { _("Nautical miles"), _("Statute miles"), _("Kilometers"), _("Meters") };
@@ -3010,8 +3010,8 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
         pDistanceFormat = new wxChoice( panelUnits, ID_DISTANCEUNITSCHOICE, wxDefaultPosition,
                                         wxSize(250, -1), m_DistanceFormatsNChoices, pDistanceFormats );
         unitsSizer->Add( pDistanceFormat, inputFlags );
-        
-        
+
+
         // speed units
         unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Speed")), labelFlags );
         wxString pSpeedFormats[] = { _("Knots"), _("Mph"), _("km/h"), _("m/s") };
@@ -3019,21 +3019,21 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
         pSpeedFormat = new wxChoice( panelUnits, ID_SPEEDUNITSCHOICE, wxDefaultPosition,
                                      wxSize(250, -1), m_SpeedFormatsNChoices, pSpeedFormats );
         unitsSizer->Add( pSpeedFormat, inputFlags );
-        
-        
+
+
         // depth units
         unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Depth")), labelFlags );
         wxString pDepthUnitStrings[] = { _("Feet"), _("Meters"), _("Fathoms"), };
         pDepthUnitSelect = new wxChoice( panelUnits, ID_DEPTHUNITSCHOICE, wxDefaultPosition,
                                          wxSize(250, -1), 3, pDepthUnitStrings );
         unitsSizer->Add( pDepthUnitSelect, inputFlags );
-        
-        
+
+
         // spacer
         unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
         unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
-        
-        
+
+
         // lat/long units
         unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Lat/Long")), labelFlags );
         wxString pSDMMFormats[] = { _("Degrees, Decimal Minutes"), _("Decimal Degrees"), _("Degrees, Minutes, Seconds") };
@@ -3041,53 +3041,53 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
         pSDMMFormat = new wxChoice( panelUnits, ID_SDMMFORMATCHOICE, wxDefaultPosition,
                                     wxDefaultSize, m_SDMMFormatsNChoices, pSDMMFormats );
         unitsSizer->Add( pSDMMFormat, inputFlags );
-        
-        
+
+
         // spacer
         unitsSizer->Add( 0, border_size*4 );
         unitsSizer->Add( 0, border_size*4 );
-        
-        
+
+
         // bearings (magnetic/true, variation)
         unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Bearings")), groupLabelFlags );
-        
-        
+
+
         //  "Mag Heading" checkbox
         pCBMagShow = new wxCheckBox( panelUnits, ID_MAGSHOWCHECKBOX, _("Show magnetic") );
         unitsSizer->Add( pCBMagShow, 0, wxALL, group_item_spacing );
-        
-        
+
+
         //  Mag Heading user variation
         wxStaticText* itemStaticTextUserVar = new wxStaticText( panelUnits, wxID_ANY, _("Assumed magnetic variation") );
         wrapperSizer->Add( itemStaticTextUserVar, 0, wxEXPAND | wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
-        
+
         wxBoxSizer* magVarSizer = new wxBoxSizer( wxHORIZONTAL );
         wrapperSizer->Add( magVarSizer, 0, wxALL | wxEXPAND, group_item_spacing );
-        
+
         magVarSizer->Add( 0, border_size*4 );
-        
+
         pMagVar = new wxTextCtrl( panelUnits, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize(150, -1), wxTE_RIGHT );
         magVarSizer->Add( pMagVar, 0, wxALIGN_CENTRE_VERTICAL, group_item_spacing );
-        
+
         magVarSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("deg (-W, +E)")),
                           0, wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
-        
+
     }
     else{
         wxFlexGridSizer *unitsSizer = new wxFlexGridSizer( 2 );
         unitsSizer->SetHGap(border_size);
-        
+
         // wxFlexGridSizer grows wrongly in wx2.8, so we need to centre it in another sizer instead of letting it grow.
         wxBoxSizer* wrapperSizer = new wxBoxSizer( wxVERTICAL );
         panelUnits->SetSizer( wrapperSizer );
         wrapperSizer->Add( unitsSizer, 1, wxALL | wxALIGN_CENTER, border_size );
-        
-        
+
+
         // spacer
         unitsSizer->Add( 0, border_size*4 );
         unitsSizer->Add( 0, border_size*4 );
-        
-        
+
+
         // distance units
         unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Distance")), labelFlags );
         wxString pDistanceFormats[] = { _("Nautical miles"), _("Statute miles"), _("Kilometers"), _("Meters") };
@@ -3095,8 +3095,8 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
         pDistanceFormat = new wxChoice( panelUnits, ID_DISTANCEUNITSCHOICE, wxDefaultPosition,
                                         wxDefaultSize, m_DistanceFormatsNChoices, pDistanceFormats );
         unitsSizer->Add( pDistanceFormat, inputFlags );
-        
-        
+
+
         // speed units
         unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Speed")), labelFlags );
         wxString pSpeedFormats[] = { _("Knots"), _("Mph"), _("km/h"), _("m/s") };
@@ -3104,21 +3104,21 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
         pSpeedFormat = new wxChoice( panelUnits, ID_SPEEDUNITSCHOICE, wxDefaultPosition,
                                      wxDefaultSize, m_SpeedFormatsNChoices, pSpeedFormats );
         unitsSizer->Add( pSpeedFormat, inputFlags );
-        
-        
+
+
         // depth units
         unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Depth")), labelFlags );
         wxString pDepthUnitStrings[] = { _("Feet"), _("Meters"), _("Fathoms"), };
         pDepthUnitSelect = new wxChoice( panelUnits, ID_DEPTHUNITSCHOICE, wxDefaultPosition,
                                          wxDefaultSize, 3, pDepthUnitStrings );
         unitsSizer->Add( pDepthUnitSelect, inputFlags );
-        
-        
+
+
         // spacer
         unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
         unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
-        
-        
+
+
         // lat/long units
         unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Lat/Long")), labelFlags );
         wxString pSDMMFormats[] = { _("Degrees, Decimal Minutes"), _("Decimal Degrees"), _("Degrees, Minutes, Seconds") };
@@ -3126,33 +3126,33 @@ void options::CreatePanel_Units( size_t parent, int border_size, int group_item_
         pSDMMFormat = new wxChoice( panelUnits, ID_SDMMFORMATCHOICE, wxDefaultPosition,
                                     wxDefaultSize, m_SDMMFormatsNChoices, pSDMMFormats );
         unitsSizer->Add( pSDMMFormat, inputFlags );
-        
-        
+
+
         // spacer
         unitsSizer->Add( 0, border_size*4 );
         unitsSizer->Add( 0, border_size*4 );
-        
-        
+
+
         // bearings (magnetic/true, variation)
         unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Bearings")), groupLabelFlags );
-        
+
         wxBoxSizer* bearingsSizer = new wxBoxSizer( wxVERTICAL );
         unitsSizer->Add( bearingsSizer, 0, 0, 0 );
-        
+
         //  "Mag Heading" checkbox
         pCBMagShow = new wxCheckBox( panelUnits, ID_MAGSHOWCHECKBOX, _("Show magnetic bearings and headings") );
         bearingsSizer->Add( pCBMagShow, 0, wxALL, group_item_spacing );
-        
+
         //  Mag Heading user variation
         wxBoxSizer* magVarSizer = new wxBoxSizer( wxHORIZONTAL );
         bearingsSizer->Add( magVarSizer, 0, wxALL, group_item_spacing );
-        
+
         wxStaticText* itemStaticTextUserVar = new wxStaticText( panelUnits, wxID_ANY, _("Assumed magnetic variation") );
         magVarSizer->Add( itemStaticTextUserVar, 0, wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
-        
+
         pMagVar = new wxTextCtrl( panelUnits, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize(50, -1), wxTE_RIGHT );
         magVarSizer->Add( pMagVar, 0, wxALIGN_CENTRE_VERTICAL, group_item_spacing );
-        
+
         magVarSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("deg (-W, +E)")),
                           0, wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
     }
@@ -3611,7 +3611,7 @@ void options::CreateControls( void )
     if(text_width > tbmp.GetWidth() * 2 ){
         wxListView* lv = m_pListbook->GetListView();
         wxFont *qFont = dialogFont;         // to get type, weight, etc...
-        
+
         wxFont *sFont = wxTheFontList->FindOrCreateFont( 10, qFont->GetFamily(), qFont->GetStyle(), qFont->GetWeight());
         lv->SetFont( *sFont );
     }
@@ -6990,8 +6990,8 @@ void OpenGLOptionsDlg::Populate( void )
 #else
     m_cbSoftwareGL->Hide();
 #endif
-    
-    
+
+
     wxFont *dialogFont = GetOCPNScaledFont(_("Dialog"));
     SetFont( *dialogFont );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2946,119 +2946,175 @@ void options::CreatePanel_Units( size_t parent, int border_size,
                                  int group_item_spacing )
 {
     wxScrolledWindow *panelUnits = AddPage( parent, _("Units") );
-    wxSize size = m_bcompact ? wxSize( 250, -1 ) : wxDefaultSize;
 
-    wxFlexGridSizer *unitsSizer = new wxFlexGridSizer( 2 );
-    unitsSizer->SetHGap( border_size );
+    if(m_bcompact){
+        wxFlexGridSizer *unitsSizer = new wxFlexGridSizer( 2 );
+        unitsSizer->SetHGap(border_size);
 
-    // wxFlexGridSizer grows wrongly in wx2.8, so we need to centre it
-    // in another sizer instead of letting it grow.
-    wxBoxSizer *wrapperSizer = new wxBoxSizer( wxVERTICAL );
-    panelUnits->SetSizer( wrapperSizer );
-    wrapperSizer->Add( unitsSizer, 1, wxALL | wxALIGN_CENTER, border_size );
+        // wxFlexGridSizer grows wrongly in wx2.8, so we need to centre it in another sizer instead of letting it grow.
+        wxBoxSizer* wrapperSizer = new wxBoxSizer( wxVERTICAL );
+        panelUnits->SetSizer( wrapperSizer );
+        wrapperSizer->Add( unitsSizer, 1, wxALL | wxALIGN_CENTER, border_size );
 
-    // spacer
-    unitsSizer->Add( 0, border_size * 4 );
-    unitsSizer->Add( 0, border_size * 4 );
 
-    // distance units
-    unitsSizer->Add( new wxStaticText( panelUnits, wxID_ANY, _( "Distance" ) ),
-                     labelFlags );
-    wxArrayString pDistanceFormats;
-    pDistanceFormats.Add( _( "Nautical miles" ) );
-    pDistanceFormats.Add( _( "Statute miles" ) );
-    pDistanceFormats.Add( _( "Kilometers" ) );
-    pDistanceFormats.Add( _( "Meters" ) );
-    pDistanceFormat = new wxChoice( panelUnits, ID_DISTANCEUNITSCHOICE,
-                                    wxDefaultPosition, size, pDistanceFormats );
-    unitsSizer->Add( pDistanceFormat, inputFlags );
+        // spacer
+        unitsSizer->Add( 0, border_size*4 );
+        unitsSizer->Add( 0, border_size*4 );
 
-    // speed units
-    unitsSizer->Add( new wxStaticText( panelUnits, wxID_ANY, _( "Speed" ) ),
-                     labelFlags );
-    wxArrayString pSpeedFormats;
-    pSpeedFormats.Add( _( "Knots" ) );
-    pSpeedFormats.Add( _( "Mph" ) );
-    pSpeedFormats.Add( _( "km/h" ) );
-    pSpeedFormats.Add( _( "m/s" ) );
-    pSpeedFormat = new wxChoice( panelUnits, ID_SPEEDUNITSCHOICE,
-                                 wxDefaultPosition, size, pSpeedFormats );
-    unitsSizer->Add( pSpeedFormat, inputFlags );
 
-    // depth units
-    unitsSizer->Add( new wxStaticText( panelUnits, wxID_ANY, _( "Depth" ) ),
-                    labelFlags );
-    wxArrayString pDepthUnitStrings;
-    pDepthUnitStrings.Add( _( "Feet" ) );
-    pDepthUnitStrings.Add( _( "Meters" ) );
-    pDepthUnitStrings.Add( _( "Fathoms" ) );
-    pDepthUnitSelect = new wxChoice( panelUnits, ID_DEPTHUNITSCHOICE,
-                                     wxDefaultPosition, size,
-                                     pDepthUnitStrings );
-    unitsSizer->Add( pDepthUnitSelect, inputFlags );
+        // distance units
+        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Distance")), labelFlags );
+        wxString pDistanceFormats[] = { _("Nautical miles"), _("Statute miles"), _("Kilometers"), _("Meters") };
+        int m_DistanceFormatsNChoices = sizeof(pDistanceFormats) / sizeof(wxString);
+        pDistanceFormat = new wxChoice( panelUnits, ID_DISTANCEUNITSCHOICE, wxDefaultPosition,
+                                        wxSize(250, -1), m_DistanceFormatsNChoices, pDistanceFormats );
+        unitsSizer->Add( pDistanceFormat, inputFlags );
 
-    // spacer
-    unitsSizer->Add( 0, border_size * 4 );
-    unitsSizer->Add( 0, border_size * 4 );
 
-    // lat/long units
-    unitsSizer->Add( new wxStaticText( panelUnits, wxID_ANY, _( "Lat/Long" ) ),
-                     labelFlags );
-    wxArrayString pSDMMFormats;
-    pSDMMFormats.Add( _( "Degrees, Decimal Minutes" ) );
-    pSDMMFormats.Add( _( "Decimal Degrees" ) );
-    pSDMMFormats.Add( _( "Degrees, Minutes, Seconds" ) );
-    pSDMMFormat = new wxChoice( panelUnits, ID_SDMMFORMATCHOICE,
-                                wxDefaultPosition, size, pSDMMFormats );
-    unitsSizer->Add( pSDMMFormat, inputFlags );
+        // speed units
+        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Speed")), labelFlags );
+        wxString pSpeedFormats[] = { _("Knots"), _("Mph"), _("km/h"), _("m/s") };
+        int m_SpeedFormatsNChoices = sizeof( pSpeedFormats ) / sizeof(wxString);
+        pSpeedFormat = new wxChoice( panelUnits, ID_SPEEDUNITSCHOICE, wxDefaultPosition,
+                                     wxSize(250, -1), m_SpeedFormatsNChoices, pSpeedFormats );
+        unitsSizer->Add( pSpeedFormat, inputFlags );
 
-    // spacer
-    unitsSizer->Add( 0, border_size * 4 );
-    unitsSizer->Add( 0, border_size * 4 );
 
-    // bearings (magnetic/true, variation)
-    unitsSizer->Add( new wxStaticText( panelUnits, wxID_ANY, _( "Bearings" ) ),
-                     groupLabelFlags );
+        // depth units
+        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Depth")), labelFlags );
+        wxString pDepthUnitStrings[] = { _("Feet"), _("Meters"), _("Fathoms"), };
+        pDepthUnitSelect = new wxChoice( panelUnits, ID_DEPTHUNITSCHOICE, wxDefaultPosition,
+                                         wxSize(250, -1), 3, pDepthUnitStrings );
+        unitsSizer->Add( pDepthUnitSelect, inputFlags );
 
-    wxBoxSizer* bearingsSizer = new wxBoxSizer( wxVERTICAL );
-    if ( !m_bcompact )
+
+        // spacer
+        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
+        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
+
+
+        // lat/long units
+        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Lat/Long")), labelFlags );
+        wxString pSDMMFormats[] = { _("Degrees, Decimal Minutes"), _("Decimal Degrees"), _("Degrees, Minutes, Seconds") };
+        int m_SDMMFormatsNChoices = sizeof( pSDMMFormats ) / sizeof(wxString);
+        pSDMMFormat = new wxChoice( panelUnits, ID_SDMMFORMATCHOICE, wxDefaultPosition,
+                                    wxDefaultSize, m_SDMMFormatsNChoices, pSDMMFormats );
+        unitsSizer->Add( pSDMMFormat, inputFlags );
+
+
+        // spacer
+        unitsSizer->Add( 0, border_size*4 );
+        unitsSizer->Add( 0, border_size*4 );
+
+
+        // bearings (magnetic/true, variation)
+        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Bearings")), groupLabelFlags );
+
+
+        //  "Mag Heading" checkbox
+        pCBMagShow = new wxCheckBox( panelUnits, ID_MAGSHOWCHECKBOX, _("Show magnetic") );
+        unitsSizer->Add( pCBMagShow, 0, wxALL, group_item_spacing );
+
+
+        //  Mag Heading user variation
+        wxStaticText* itemStaticTextUserVar = new wxStaticText( panelUnits, wxID_ANY, _("Assumed magnetic variation") );
+        wrapperSizer->Add( itemStaticTextUserVar, 0, wxEXPAND | wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
+
+        wxBoxSizer* magVarSizer = new wxBoxSizer( wxHORIZONTAL );
+        wrapperSizer->Add( magVarSizer, 0, wxALL | wxEXPAND, group_item_spacing );
+
+        magVarSizer->Add( 0, border_size*4 );
+
+        pMagVar = new wxTextCtrl( panelUnits, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize(150, -1), wxTE_RIGHT );
+        magVarSizer->Add( pMagVar, 0, wxALIGN_CENTRE_VERTICAL, group_item_spacing );
+
+        magVarSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("deg (-W, +E)")),
+                          0, wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
+
+    }
+    else{
+        wxFlexGridSizer *unitsSizer = new wxFlexGridSizer( 2 );
+        unitsSizer->SetHGap(border_size);
+
+        // wxFlexGridSizer grows wrongly in wx2.8, so we need to centre it in another sizer instead of letting it grow.
+        wxBoxSizer* wrapperSizer = new wxBoxSizer( wxVERTICAL );
+        panelUnits->SetSizer( wrapperSizer );
+        wrapperSizer->Add( unitsSizer, 1, wxALL | wxALIGN_CENTER, border_size );
+
+
+        // spacer
+        unitsSizer->Add( 0, border_size*4 );
+        unitsSizer->Add( 0, border_size*4 );
+
+
+        // distance units
+        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Distance")), labelFlags );
+        wxString pDistanceFormats[] = { _("Nautical miles"), _("Statute miles"), _("Kilometers"), _("Meters") };
+        int m_DistanceFormatsNChoices = sizeof(pDistanceFormats) / sizeof(wxString);
+        pDistanceFormat = new wxChoice( panelUnits, ID_DISTANCEUNITSCHOICE, wxDefaultPosition,
+                                        wxDefaultSize, m_DistanceFormatsNChoices, pDistanceFormats );
+        unitsSizer->Add( pDistanceFormat, inputFlags );
+
+
+        // speed units
+        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Speed")), labelFlags );
+        wxString pSpeedFormats[] = { _("Knots"), _("Mph"), _("km/h"), _("m/s") };
+        int m_SpeedFormatsNChoices = sizeof( pSpeedFormats ) / sizeof(wxString);
+        pSpeedFormat = new wxChoice( panelUnits, ID_SPEEDUNITSCHOICE, wxDefaultPosition,
+                                     wxDefaultSize, m_SpeedFormatsNChoices, pSpeedFormats );
+        unitsSizer->Add( pSpeedFormat, inputFlags );
+
+
+        // depth units
+        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Depth")), labelFlags );
+        wxString pDepthUnitStrings[] = { _("Feet"), _("Meters"), _("Fathoms"), };
+        pDepthUnitSelect = new wxChoice( panelUnits, ID_DEPTHUNITSCHOICE, wxDefaultPosition,
+                                         wxDefaultSize, 3, pDepthUnitStrings );
+        unitsSizer->Add( pDepthUnitSelect, inputFlags );
+
+
+        // spacer
+        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
+        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _T("")) );
+
+
+        // lat/long units
+        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Lat/Long")), labelFlags );
+        wxString pSDMMFormats[] = { _("Degrees, Decimal Minutes"), _("Decimal Degrees"), _("Degrees, Minutes, Seconds") };
+        int m_SDMMFormatsNChoices = sizeof( pSDMMFormats ) / sizeof(wxString);
+        pSDMMFormat = new wxChoice( panelUnits, ID_SDMMFORMATCHOICE, wxDefaultPosition,
+                                    wxDefaultSize, m_SDMMFormatsNChoices, pSDMMFormats );
+        unitsSizer->Add( pSDMMFormat, inputFlags );
+
+
+        // spacer
+        unitsSizer->Add( 0, border_size*4 );
+        unitsSizer->Add( 0, border_size*4 );
+
+
+        // bearings (magnetic/true, variation)
+        unitsSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("Bearings")), groupLabelFlags );
+
+        wxBoxSizer* bearingsSizer = new wxBoxSizer( wxVERTICAL );
         unitsSizer->Add( bearingsSizer, 0, 0, 0 );
 
-    //  "Mag Heading" checkbox
-    pCBMagShow = new wxCheckBox( panelUnits, ID_MAGSHOWCHECKBOX, m_bcompact ?
-        _( "Show magnetic" ) : _( "Show magnetic bearings and headings" ));
-    if ( m_bcompact )
-        unitsSizer->Add( pCBMagShow, 0, wxALL, group_item_spacing );
-    else
+        //  "Mag Heading" checkbox
+        pCBMagShow = new wxCheckBox( panelUnits, ID_MAGSHOWCHECKBOX, _("Show magnetic bearings and headings") );
         bearingsSizer->Add( pCBMagShow, 0, wxALL, group_item_spacing );
 
-    //  Mag Heading user variation
-    wxStaticText *itemStaticTextUserVar =
-        new wxStaticText( panelUnits, wxID_ANY,
-                          _( "Assumed magnetic variation" ) );
-    wxBoxSizer* magVarSizer = new wxBoxSizer( wxHORIZONTAL );
-
-    if ( m_bcompact ) {
-        wrapperSizer->Add( itemStaticTextUserVar, 0,
-                           wxEXPAND | wxALL | wxALIGN_CENTRE_VERTICAL,
-                           group_item_spacing );
-        wrapperSizer->Add( magVarSizer, 0, wxALL | wxEXPAND,
-                           group_item_spacing );
-        magVarSizer->Add( 0, border_size * 4 );
-    } else {
+        //  Mag Heading user variation
+        wxBoxSizer* magVarSizer = new wxBoxSizer( wxHORIZONTAL );
         bearingsSizer->Add( magVarSizer, 0, wxALL, group_item_spacing );
-        magVarSizer->Add( itemStaticTextUserVar, 0,
-                          wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
+
+        wxStaticText* itemStaticTextUserVar = new wxStaticText( panelUnits, wxID_ANY, _("Assumed magnetic variation") );
+        magVarSizer->Add( itemStaticTextUserVar, 0, wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
+
+        pMagVar = new wxTextCtrl( panelUnits, ID_OPTEXTCTRL, _T(""), wxDefaultPosition, wxSize(50, -1), wxTE_RIGHT );
+        magVarSizer->Add( pMagVar, 0, wxALIGN_CENTRE_VERTICAL, group_item_spacing );
+
+        magVarSizer->Add( new wxStaticText(panelUnits, wxID_ANY, _("deg (-W, +E)")),
+                          0, wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
     }
-
-    pMagVar = new wxTextCtrl( panelUnits, ID_OPTEXTCTRL, wxEmptyString,
-                              wxDefaultPosition,
-                              wxSize( m_bcompact ? 150 : 50, -1 ), wxTE_RIGHT );
-    magVarSizer->Add( pMagVar, 0, wxALIGN_CENTRE_VERTICAL, group_item_spacing );
-
-    magVarSizer->Add( new wxStaticText( panelUnits, wxID_ANY,
-                                        _( "deg (-W, +E)" ) ),
-                      0, wxALL | wxALIGN_CENTRE_VERTICAL, group_item_spacing );
 }
 
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4257,13 +4257,12 @@ bool options::ShowToolTips( void )
 }
 
 void options::OnCharHook( wxKeyEvent& event ) {
-    if( event.GetKeyCode() == WXK_RETURN ) {
-        if( event.GetModifiers() == wxMOD_CONTROL ) {
-            wxCommandEvent okEvent;
-            okEvent.SetId( xID_OK );
-            okEvent.SetEventType( wxEVT_COMMAND_BUTTON_CLICKED );
-            GetEventHandler()->AddPendingEvent( okEvent );
-        }
+    if ( event.GetKeyCode() == WXK_RETURN &&
+         event.GetModifiers() == wxMOD_CONTROL ) {
+        wxCommandEvent okEvent;
+        okEvent.SetId( xID_OK );
+        okEvent.SetEventType( wxEVT_COMMAND_BUTTON_CLICKED );
+        GetEventHandler()->AddPendingEvent( okEvent );
     }
     event.Skip();
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -274,21 +274,20 @@ int wxCALLBACK SortConnectionOnPriority(long item1, long item2, wxIntPtr list)
 #else
 int wxCALLBACK SortConnectionOnPriority(long item1, long item2, long list)
 #endif
-
 {
-    wxListCtrl *lc = (wxListCtrl*)list;
+    wxListCtrl *lc = reinterpret_cast<wxListCtrl*>( list );
 
     wxListItem it1, it2;
-    it1.SetId(lc->FindItem(-1, item1));
-    it1.SetColumn(3);
-    it1.SetMask(it1.GetMask() | wxLIST_MASK_TEXT);
+    it1.SetId( lc->FindItem( -1, item1 ) );
+    it1.SetColumn( 3 );
+    it1.SetMask( it1.GetMask() | wxLIST_MASK_TEXT );
 
-    it2.SetId(lc->FindItem(-1, item2));
-    it2.SetColumn(3);
-    it2.SetMask(it2.GetMask() | wxLIST_MASK_TEXT);
+    it2.SetId( lc->FindItem( -1, item2 ) );
+    it2.SetColumn( 3 );
+    it2.SetMask( it2.GetMask() | wxLIST_MASK_TEXT );
 
-    lc->GetItem(it1);
-    lc->GetItem(it2);
+    lc->GetItem( it1 );
+    lc->GetItem( it2 );
 
 #ifdef __WXOSX__
     return it1.GetText().CmpNoCase( it2.GetText() );
@@ -303,22 +302,16 @@ extern ArrayOfMMSIProperties   g_MMSI_Props_Array;
 /// Class MMSIEditDialog
 ///////////////////////////////////////////////////////////////////////////////
 
-IMPLEMENT_DYNAMIC_CLASS( MMSIEditDialog, wxDialog )
-
 BEGIN_EVENT_TABLE( MMSIEditDialog, wxDialog )
 EVT_BUTTON( ID_MMSIEDIT_CANCEL, MMSIEditDialog::OnMMSIEditCancelClick )
 EVT_BUTTON( ID_MMSIEDIT_OK, MMSIEditDialog::OnMMSIEditOKClick )
 END_EVENT_TABLE()
 
-MMSIEditDialog::MMSIEditDialog( void ) {}
-
 MMSIEditDialog::MMSIEditDialog( MMSIProperties *props, wxWindow* parent, wxWindowID id, const wxString& caption,
                                 const wxPoint& pos, const wxSize& size, long style ) :
+    wxDialog( parent, id, caption, pos, size, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER ),
     m_props( props )
 {
-    long wstyle = wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER;
-    wxDialog::Create( parent, id, caption, pos, size, wstyle );
-
     CreateControls();
     GetSizer()->SetSizeHints( this );
     Centre();
@@ -327,21 +320,6 @@ MMSIEditDialog::MMSIEditDialog( MMSIProperties *props, wxWindow* parent, wxWindo
 MMSIEditDialog::~MMSIEditDialog( void )
 {
     delete m_MMSICtl;
-}
-
-bool MMSIEditDialog::Create( MMSIProperties *props, wxWindow* parent, wxWindowID id, const wxString& caption,
-                             const wxPoint& pos, const wxSize& size, long style )
-{
-    m_props = props;
-
-    SetExtraStyle( GetExtraStyle() | wxWS_EX_BLOCK_EVENTS );
-    wxDialog::Create( parent, id, caption, pos, size, style );
-
-    CreateControls();
-    GetSizer()->SetSizeHints( this );
-    Centre();
-
-    return TRUE;
 }
 
 void MMSIEditDialog::CreateControls( void )

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4202,15 +4202,11 @@ void options::OnOpenGLOptions( wxCommandEvent& event )
 
 void options::OnChartDirListSelect( wxCommandEvent& event )
 {
-    if(event.IsSelection()){
+    if ( event.IsSelection() ) {
         m_removeBtn->Enable();
-    }
-    else{
+    } else {
         wxArrayInt sel;
-        if(pActiveChartsList->GetSelections( sel ) )
-            m_removeBtn->Enable();
-        else
-            m_removeBtn->Disable();
+        m_removeBtn->Enable( pActiveChartsList->GetSelections( sel ) );
     }
 }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -266,8 +266,6 @@ extern "C" bool CheckSerialAccess( void );
 #include <wx/arrimpl.cpp>
 WX_DEFINE_OBJARRAY(ArrayOfDirCtrls);
 
-IMPLEMENT_DYNAMIC_CLASS( options, wxDialog )
-
 // sort callback for Connections list  Sort by priority.
 #if wxCHECK_VERSION(2, 9, 0)
 int wxCALLBACK SortConnectionOnPriority(long item1, long item2, wxIntPtr list)
@@ -749,11 +747,6 @@ BEGIN_EVENT_TABLE( options, wxDialog )
     EVT_TIMER ( ID_BT_SCANTIMER, options::onBTScanTimer )
 END_EVENT_TABLE()
 
-options::options( void )
-{
-    Init();
-}
-
 options::options( MyFrame* parent, wxWindowID id, const wxString& caption,
                   const wxPoint& pos, const wxSize& size, long style )
 {
@@ -888,24 +881,6 @@ void options::Init( void )
     m_bcompact = true;
 #endif
 
-}
-
-bool options::Create( MyFrame* parent, wxWindowID id, const wxString& caption, const wxPoint& pos,
-                      const wxSize& size, long style )
-{
-    SetExtraStyle( GetExtraStyle() | wxWS_EX_BLOCK_EVENTS );
-    wxDialog::Create( parent, id, caption, pos, size, style );
-
-    CreateControls();
-    Fit();
-    lastWindowPos == wxPoint( 0, 0 ) ? Centre() : Move( lastWindowPos );
-    lastWindowPos = GetPosition();
-    return TRUE;
-}
-
-wxWindow* options::GetContentWindow( void ) const
-{
-    return NULL;
 }
 
 size_t options::CreatePanel(const wxString & title)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4101,10 +4101,10 @@ void options::OnCPAWarnClick( wxCommandEvent& event )
 
 void options::OnShowGpsWindowCheckboxClick( wxCommandEvent& event )
 {
-    if( !m_cbNMEADebug->GetValue() ) {
+    if ( !m_cbNMEADebug->GetValue() ) {
         NMEALogWindow::Get().DestroyWindow();
     } else {
-        NMEALogWindow::Get().Create(pParent, 35);
+        NMEALogWindow::Get().Create( pParent, 35 );
         Raise();
     }
 }
@@ -4122,11 +4122,7 @@ void options::OnZTCCheckboxClick( wxCommandEvent& event )
 
 void options::OnShipTypeSelect( wxCommandEvent& event )
 {
-    if( m_pShipIconType->GetSelection() == 0 ) {
-        realSizes->ShowItems( FALSE );
-    } else {
-        realSizes->ShowItems( TRUE );
-    }
+    realSizes->ShowItems( m_pShipIconType->GetSelection() != 0 );
     dispOptions->Layout();
     ownShip->Layout();
     itemPanelShip->Layout();
@@ -4136,11 +4132,7 @@ void options::OnShipTypeSelect( wxCommandEvent& event )
 
 void options::OnRadarringSelect( wxCommandEvent& event )
 {
-    if( pNavAidRadarRingsNumberVisible->GetSelection() == 0 ) {
-        radarGrid->ShowItems( FALSE );
-    } else {
-        radarGrid->ShowItems( TRUE );
-    }
+    radarGrid->ShowItems( pNavAidRadarRingsNumberVisible->GetSelection() != 0 );
     dispOptions->Layout();
     ownShip->Layout();
     itemPanelShip->Layout();
@@ -4150,11 +4142,7 @@ void options::OnRadarringSelect( wxCommandEvent& event )
 
 void options::OnWaypointRangeRingSelect( wxCommandEvent& event )
 {
-    if( pWaypointRangeRingsNumber->GetSelection() == 0 ) {
-        waypointradarGrid->ShowItems( FALSE );
-    } else {
-        waypointradarGrid->ShowItems( TRUE );
-    }
+    waypointradarGrid->ShowItems( pWaypointRangeRingsNumber->GetSelection() != 0 );
     dispOptions->Layout();
     ownShip->Layout();
     itemPanelShip->Layout();
@@ -4164,8 +4152,8 @@ void options::OnWaypointRangeRingSelect( wxCommandEvent& event )
 
 void options::OnGLClicked( wxCommandEvent& event )
 {
-    if(!g_bTransparentToolbarInOpenGLOK)
-        pTransparentToolbar->Enable(!pOpenGL->GetValue());
+    if ( !g_bTransparentToolbarInOpenGLOK )
+        pTransparentToolbar->Enable( !pOpenGL->GetValue() );
 }
 
 void options::OnOpenGLOptions( wxCommandEvent& event )


### PR DESCRIPTION
The code in options.cpp/options.h still needs a lot of work, I'll do what I can in my free time.
So far I have...
  ... applied the style guide
  ... applied C++ style casting (see 2c2c49b and 88169ba)
  ... removed dynamic class macros and the bulk that came with it (see 0a124f4)
  ... added a base class to mark classes uncopyable (see df6a6d7)
  ... removed a bit of bulk for differentiating between compact device (see 683a6ba)
  ... removed global object being passed by value in class methods (see efb220e)