### PR TITLE
on linux c21dbcc94ef78f0ad31c6a5df932920a2ab0a4aa breaks groups with cm93

### DIFF
--- a/src/chartdbs.cpp
+++ b/src/chartdbs.cpp
@@ -1874,9 +1874,7 @@ int ChartDatabase::SearchDirAndAddCharts(wxString& dir_name_base,
       }
       else {                            // This is a cm93 dataset, specified as yada/yada/cm93
             wxString dir_plus = dir_name;
-#ifdef __WXMSW__
             dir_plus += wxFileName::GetPathSeparator();
-#endif            
             FileList .Add(dir_plus);
       }
 


### PR DESCRIPTION
Hi,
For example if you create a group with only the cm93 directory, when selected this group only display the world chart.

it may have side effect.

Regards
Didier