### PR TITLE
Fixes build by explicitly converting to c string

### DIFF
--- a/plugins/dashboard_pi/src/wind_history.cpp
+++ b/plugins/dashboard_pi/src/wind_history.cpp
@@ -53,7 +53,7 @@ DashboardInstrument_WindDirHistory::DashboardInstrument_WindDirHistory( wxWindow
       m_WindDir = -1;
       m_WindDirRange=90;
       m_MaxWindSpd = 0;
-	  m_WindSpeedUnit = _("--");
+      m_WindSpeedUnit = _("--");
       m_TotalMaxWindSpd = 0;
       m_WindSpd = 0;
       m_TopLineHeight=30;
@@ -328,7 +328,7 @@ void  DashboardInstrument_WindDirHistory::DrawWindSpeedScale(wxGCDC* dc)
   //round maxWindSpd up to the next full knot; nicer view ...
   m_MaxWindSpdScale=(int)m_MaxWindSpd + 1;
   if(!m_IsRunning) {
- 	label1.Printf(_("--- %s"), m_WindSpeedUnit);
+ 	label1.Printf(_("--- %s"), m_WindSpeedUnit.c_str());
 	label2 = label1;
 	label3 = label1;
 	label4 = label1;
@@ -341,38 +341,38 @@ void  DashboardInstrument_WindDirHistory::DrawWindSpeedScale(wxGCDC* dc)
  The goal is to draw the legend with decimals only, if we really have them !
 */
     // top legend for max wind
-	label1.Printf(_T("%.0f %s"), m_MaxWindSpdScale,m_WindSpeedUnit);
+	label1.Printf(_T("%.0f %s"), m_MaxWindSpdScale,m_WindSpeedUnit.c_str());
     // 3/4 legend
     WindSpdScale=m_MaxWindSpdScale*3./4.;
     // do we need a decimal ?
     val1=(int)((WindSpdScale-(int)WindSpdScale)*100);
     if(val1==25 || val1==75)  // it's a .25 or a .75
-	  label2.Printf(_T("%.2f %s"), WindSpdScale, m_WindSpeedUnit);
+	  label2.Printf(_T("%.2f %s"), WindSpdScale, m_WindSpeedUnit.c_str());
 	else if (val1 == 50)
-	  label2.Printf(_T("%.1f %s"), WindSpdScale, m_WindSpeedUnit);
+	  label2.Printf(_T("%.1f %s"), WindSpdScale, m_WindSpeedUnit.c_str());
     else
-	  label2.Printf(_T("%.0f %s"), WindSpdScale, m_WindSpeedUnit);
+	  label2.Printf(_T("%.0f %s"), WindSpdScale, m_WindSpeedUnit.c_str());
     // center legend
     WindSpdScale=m_MaxWindSpdScale/2.;
     // center line can either have a .0 or .5 value !
     if((int)(WindSpdScale*10) % 10 == 5)
-	  label3.Printf(_T("%.1f %s"), WindSpdScale, m_WindSpeedUnit);
+	  label3.Printf(_T("%.1f %s"), WindSpdScale, m_WindSpeedUnit.c_str());
     else
-	  label3.Printf(_T("%.0f %s"), WindSpdScale, m_WindSpeedUnit);
+	  label3.Printf(_T("%.0f %s"), WindSpdScale, m_WindSpeedUnit.c_str());
 
     // 1/4 legend
     WindSpdScale=m_MaxWindSpdScale/4.;
     // do we need a decimal ?
     val1=(int)((WindSpdScale-(int)WindSpdScale)*100);
     if(val1==25 || val1==75)
- 	  label4.Printf(_T("%.2f %s"), WindSpdScale, m_WindSpeedUnit);
+ 	  label4.Printf(_T("%.2f %s"), WindSpdScale, m_WindSpeedUnit.c_str());
 	else if (val1 == 50)
-	  label4.Printf(_T("%.1f %s"), WindSpdScale, m_WindSpeedUnit);
+	  label4.Printf(_T("%.1f %s"), WindSpdScale, m_WindSpeedUnit.c_str());
 	else
-	  label4.Printf(_T("%.0f %s"), WindSpdScale, m_WindSpeedUnit);
+	  label4.Printf(_T("%.0f %s"), WindSpdScale, m_WindSpeedUnit.c_str());
 
     //bottom legend for min wind, always 0
-	label5.Printf(_T("%.0f %s"), 0.0, m_WindSpeedUnit);
+	label5.Printf(_T("%.0f %s"), 0.0, m_WindSpeedUnit.c_str());
   }
   dc->GetTextExtent(label1, &m_LeftLegend, &height, 0, 0, g_pFontSmall);
   dc->DrawText(label1, 4, (int)(m_TopLineHeight-height/2));
@@ -417,10 +417,10 @@ void DashboardInstrument_WindDirHistory::DrawBackground(wxGCDC* dc)
   dc->SetPen(pen);
   dc->DrawLine(m_LeftLegend+3, (int)(m_TopLineHeight+m_DrawAreaRect.height*0.25), m_WindowRect.width-3-m_RightLegend, (int)(m_TopLineHeight+m_DrawAreaRect.height*0.25));
   dc->DrawLine(m_LeftLegend+3, (int)(m_TopLineHeight+m_DrawAreaRect.height*0.75), m_WindowRect.width-3-m_RightLegend, (int)(m_TopLineHeight+m_DrawAreaRect.height*0.75));
-#ifdef __WXMSW__  
+#ifdef __WXMSW__
   pen.SetStyle(wxSHORT_DASH);
   dc->SetPen(pen);
-#endif  
+#endif
   dc->DrawLine(m_LeftLegend+3, (int)(m_TopLineHeight+m_DrawAreaRect.height*0.5), m_WindowRect.width-3-m_RightLegend, (int)(m_TopLineHeight+m_DrawAreaRect.height*0.5));
 }
 
@@ -557,7 +557,7 @@ void DashboardInstrument_WindDirHistory::DrawForeground(wxGCDC* dc)
   col=wxColour(61,61,204,255); //blue, opaque
   dc->SetFont(*g_pFontData);
   dc->SetTextForeground(col);
-  WindSpeed=wxString::Format(_T("TWS %3.1f %s "), m_WindSpd, m_WindSpeedUnit);
+  WindSpeed=wxString::Format(_T("TWS %3.1f %s "), m_WindSpd, m_WindSpeedUnit.c_str());
   dc->GetTextExtent(WindSpeed, &degw, &degh, 0, 0, g_pFontData);
   dc->DrawText(WindSpeed, m_LeftLegend+3, m_TopLineHeight-degh);
   dc->SetFont(*g_pFontLabel);
@@ -572,7 +572,7 @@ void DashboardInstrument_WindDirHistory::DrawForeground(wxGCDC* dc)
     min=m_ArrayRecTime[i].GetMinute();
     hour=m_ArrayRecTime[i].GetHour();
   }
-  dc->DrawText(wxString::Format(_("Max %.1f %s since %02d:%02d  Overall %.1f %s"), m_MaxWindSpd, m_WindSpeedUnit, hour, min, m_TotalMaxWindSpd, m_WindSpeedUnit), m_LeftLegend + 3 + 2 + degw, m_TopLineHeight - degh + 5);
+  dc->DrawText(wxString::Format(_("Max %.1f %s since %02d:%02d  Overall %.1f %s"), m_MaxWindSpd, m_WindSpeedUnit.c_str(), hour, min, m_TotalMaxWindSpd, m_WindSpeedUnit.c_str()), m_LeftLegend + 3 + 2 + degw, m_TopLineHeight - degh + 5);
   pen.SetStyle(wxPENSTYLE_SOLID);
   pen.SetColour(wxColour(61,61,204,96)); //blue, transparent
   pen.SetWidth(1);


### PR DESCRIPTION
When I tried to build a fresh clone of this repo, I got a couple of errors like this: 

```
//OpenCPN/plugins/dashboard_pi/src/wind_history.cpp:331:45: error: cannot pass objects of non-trivially-copyable type ‘class wxString’ through ‘...’
   label1.Printf(_("--- %s"), m_WindSpeedUnit);
```
Fixed by explicitly converting with `c_str()`.

This file has a lot of inconsistent white space (mixing tabs/spaces, 2/4/6 spaces).  Are you interested in a PR fixing that?
Are you interested in a PR enabling CI (appveyor for windows builds, travis/circleCI for linux builds)?