### PR TITLE
CI: travis (linux builds), Appveyor (windows build)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,9 @@ script:
     - mkdir build && cd build
     - cmake ../
     - make
+
+notifications:
+    email: false
+    
+git:
+    depth: 10

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: cpp
+install:
+    - sudo apt-get install libwxgtk3.0-dev libwxgtk3.0-0
+
+script:
+    - mkdir build && cd build
+    - cmake ../
+    - make

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,6 @@ test: OFF
 
 install:
   - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86'
-  - cmd: SET WINDOWS_SDK_VERSION="v7.1"
 
   # sent environment variables for wxWidgets
   - set WXWIN=C:\wxWidgets-3.0.2
@@ -42,5 +41,5 @@ before_build:
 
 build_script:
   - cmake --build . --config debug
-  # commented out because of nsis not correctly installed
-  # - cmake --build . --config Release
+  - cmake --build . --config release
+  # --target package doesn't work because of nsis not correctly installed

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,48 @@
+clone_folder: c:\project\opencpn
+shallow_clone: true
+
+platform: x64
+configuration: Release
+deploy: OFF
+test: OFF
+
+install:
+  - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86'
+  - cmd: SET WINDOWS_SDK_VERSION="v7.1"
+
+  # sent environment variables for wxWidgets
+  - set WXWIN=C:\wxWidgets-3.0.2
+  - set wxWidgets_ROOT_DIR=%WXWIN%
+  - set wxWidgets_LIB_DIR=%WXWIN%\lib\vc_dll
+  - cmd: SET PATH=%PATH%;%WXWIN%;%wxWidgets_LIB_DIR%;C:\Program Files (x86)\Poedit\Gettexttools\bin;
+
+  # install dependencies:
+  - choco install poedit nsis -x86
+
+  # Download and unzip wxwidgets
+  - ps: Start-FileDownload http://downloads.sourceforge.net/project/wxwindows/3.0.2/wxWidgets-3.0.2.zip
+  - cmd: 7z x wxwidgets-3.0.2.zip -o%WXWIN% > null
+
+  # some debugging information
+  - ls "c:\program files"
+  - ls "c:\program files (x86)"
+  - set
+  # - cmake --help
+
+  # build wxWidgets
+  - cmd: cd %WXWIN%\build\msw\
+  - cmd: nmake -f makefile.vc BUILD=release SHARED=1 CFLAGS=/D_USING_V120_SDK71_ CXXFLAGS=/D_USING_V120_SDK71_
+  - cmd: nmake -f makefile.vc BUILD=debug SHARED=1 CFLAGS=/D_USING_V120_SDK71_ CXXFLAGS=/D_USING_V120_SDK71_
+
+before_build:
+  - cd c:\project\opencpn
+  - mkdir build
+  - cd build
+  - cmake -T v120_xp ..
+  - ps: Start-FileDownload http://downloads.sourceforge.net/project/opencpnplugins/opencpn_packaging_data/OpenCPN_buildwin.7z
+  - cmd: 7z x OpenCPN_buildwin.7z -oc:\project\opencpn
+
+build_script:
+  - cmake --build . --config debug
+  # commented out because of nsis not correctly installed
+  # - cmake --build . --config Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,8 +24,6 @@ install:
   - cmd: 7z x wxwidgets-3.0.2.zip -o%WXWIN% > null
 
   # some debugging information
-  - ls "c:\program files"
-  - ls "c:\program files (x86)"
   - set
   # - cmake --help
 


### PR DESCRIPTION
Linux build just took about 13 mins.

You'll have to enable a hook in github/travis to make this work for the OpenCPN/OpenCPN repo.