### PR TITLE
Add a default path for portable charts.

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -1855,6 +1855,16 @@ bool MyApp::OnInit()
 
         }
 
+		if (g_bportable)
+		{
+			ChartDirInfo cdi;
+			cdi.fullpath =_T("charts");
+			cdi.fullpath.Prepend(g_Platform->GetSharedDataDir());
+			cdi.magic_number = _T("");
+			ChartDirArray.Add(cdi);
+			ndirs++;
+		}
+
         if( ndirs ) pConfig->UpdateChartDirs( ChartDirArray );
 
         //    As a favor to new users, poll the database and


### PR DESCRIPTION
You can distribute a portable version of OCPN with including maps in a subdir "charts". This is very useful if you use OCPN from a USB pen drive on various computers.