### PR TITLE
Add UI language detection for Windows on first start.

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -1407,7 +1407,20 @@ bool MyApp::OnInit()
 
     //  Get the default language info
     wxString def_lang_canonical;
+#ifdef __WXMSW__
+	LANGID lang_id = GetUserDefaultUILanguage();
+	wxChar lngcp[100];
+	const wxLanguageInfo* languageInfo = 0;
+	if (0 != GetLocaleInfo(MAKELCID(lang_id, SORT_DEFAULT), LOCALE_SENGLANGUAGE, lngcp, 100))
+	{
+		languageInfo = wxLocale::FindLanguageInfo(lngcp);
+		g_locale = wxString(lngcp);
+	}
+	else
+		languageInfo = wxLocale::GetLanguageInfo(wxLANGUAGE_DEFAULT);
+#else
     const wxLanguageInfo* languageInfo = wxLocale::GetLanguageInfo(wxLANGUAGE_DEFAULT);
+#endif
     if( languageInfo ) {
         def_lang_canonical = languageInfo->CanonicalName;
         imsg = _T("System default Language:  ");


### PR DESCRIPTION
Detects the language of Windows UI.

From MSDN:
`GetUserDefaultUILanguage`: Minimum supported client is Windows 2000 Professional
`GetLocaleInfo`: Minimum supported client is Windows 2000 Professional