### PR TITLE
Duplication in opencpn_plugin.h

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -989,8 +989,6 @@ extern DECL_EXP wxBitmap GetIcon_PlugIn(const wxString & name);
 extern DECL_EXP void SetCursor_PlugIn( wxCursor *pPlugin_Cursor = NULL );
 
 /* API 1.13 */
-extern DECL_EXP void SetCanvasRotation(double rotation);
-extern DECL_EXP bool GetSingleWaypoint( wxString &GUID, PlugIn_Waypoint *pwaypoint );
 extern DECL_EXP bool PlugInPlaySoundEx( wxString &sound_file, int deviceIndex=-1 );
 extern DECL_EXP void AddChartDirectory( wxString &path );
 extern DECL_EXP void ForceChartDBUpdate();


### PR DESCRIPTION
Only showed up when the & was removed from GetSingleWaypoint.
I should have got it earlier.