### PR TITLE
A few bug fixes, and adding Peruvian charts to chart downloader

### DIFF
--- a/plugins/chartdldr_pi/data/chart_sources.xml
+++ b/plugins/chartdldr_pi/data/chart_sources.xml
@@ -925,6 +925,12 @@
           <dir>{USERDATA}/RNC/NZ</dir>
         </catalog>
         <catalog>
+          <name>Peru RNC Nautical Charts</name>
+          <type>RNC</type>
+          <location>https://raw.githubusercontent.com/chartcatalogs/catalogs/master/PE_RNC_Catalog.xml</location>
+          <dir>{USERDATA}/RNC/PERU</dir>
+        </catalog>
+        <catalog>
           <name>Poland Inland ENC Charts</name>
           <type>ENC</type>
           <location>https://raw.githubusercontent.com/chartcatalogs/catalogs/master/PL_IENC_Catalog.xml</location>

--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -1755,8 +1755,11 @@ void ChartDldrGuiAddSourceDlg::OnOkClick( wxCommandEvent& event )
 
     if( msg != wxEmptyString )
         wxMessageBox( msg, _("Chart source definition problem"), wxOK | wxCENTRE | wxICON_ERROR );
-    else
+    else {
         event.Skip();
+        SetReturnCode(wxID_OK);
+        EndModal( wxID_OK );
+    }
 }
 
 void ChartDldrGuiAddSourceDlg::OnCancelClick( wxCommandEvent& event )

--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -1044,7 +1044,8 @@ bool OCPNPlatform::InitializeLogFile( void )
     
 #ifdef  __WXOSX__
     
-    wxFileName LibPref(mlog_file);          // starts like "~/Library/Preferences"
+    wxFileName LibPref(mlog_file);          // starts like "~/Library/Preferences/opencpn"
+    LibPref.RemoveLastDir();// takes off "opencpn"
     LibPref.RemoveLastDir();// takes off "Preferences"
     
     mlog_file = LibPref.GetFullPath();


### PR DESCRIPTION
This addresses three separate issues:
On OS X log files for OpenCPN were appearing in the wrong directory. This should now be fixed.
I've added Peruvian RNCs to the chart catalog; this patch also adds them to the list of chart sources.
And finally, I've added a patch for a bug when trying to add chart sources manually (the modal dialog box won't close!).