### PR TITLE
chart dld plugin: protect against null chartSource

### DIFF
--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -459,6 +459,8 @@ void ChartDldrPanelImpl::OnContextMenu( wxMouseEvent& event )
 
 void ChartDldrPanelImpl::OnShowLocalDir( wxCommandEvent& event )
 {
+    if (pPlugIn->m_pChartSource == 0)
+        return;
 #ifdef __WXGTK__
     wxExecute(wxString::Format(_T("xdg-open %s"), pPlugIn->m_pChartSource->GetDir().c_str()));
 #endif


### PR DESCRIPTION
hi,

If there's no charts directory you can kill OCPN by clicking on 'Show local files' button.
 
Regards
Didier