### PR TITLE
Remove gtk direct dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,6 @@
 
 # define minimum cmake version
 CMAKE_MINIMUM_REQUIRED(VERSION 2.6.2)
-# This should be 2.8.0 to have FindGTK2 module
 IF (COMMAND cmake_policy)
   CMAKE_POLICY(SET CMP0002 OLD)
   CMAKE_POLICY(SET CMP0003 OLD)
@@ -270,13 +269,6 @@ ENDIF(_wx_selected_config MATCHES "androideabi-qt")
 
 ENDIF(DEFINED _wx_selected_config)
 
-IF(UNIX)
-  if(NOT QT)
-   MESSAGE (STATUS "Building for wxGTK2")
-   SET(GTK2 "ON")
-  ENDIF(NOT QT)
-ENDIF(UNIX)
-
 IF((_wx_selected_config MATCHES "qt-armv7"))
 #SET(CMAKE_BUILD_TYPE Debug)
 ENDIF()
@@ -459,25 +451,6 @@ SET(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/build)
 SET(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/")
 
 IF (NOT WIN32 AND NOT APPLE)
-
-IF(GTK2)
-FIND_PACKAGE(GTK2 2.6)
-IF (GTK2_FOUND)
-    MESSAGE (STATUS "Found GTK2")
-    ADD_DEFINITIONS(-DocpnUSE_GTK_OPTIMIZE)
-    ADD_DEFINITIONS(-DocpnHAS_GTK)
-    INCLUDE_DIRECTORIES(${GTK2_INCLUDE_DIRS})
-    SET(EXTRA_LIBS ${EXTRA_LIBS} ${GTK2_LIBRARIES})
-
-    # Add a definition to satisfy some linux system builds, avoiding Apple builds
-    IF (NOT WIN32 AND NOT APPLE)
-       ADD_DEFINITIONS("`pkg-config --cflags --libs gtk+-2.0`")
-    ENDIF (NOT WIN32 AND NOT APPLE)
-
-ELSE(GTK2_FOUND)
-    MESSAGE (STATUS "GTK2 Not found...")
-ENDIF (GTK2_FOUND)
-ENDIF(GTK2)
 
 IF(QT_ANDROID)
   SET(CMAKE_BUILD_TYPE Debug)
@@ -1485,10 +1458,6 @@ ENDIF(UNIX)
 IF(UNIX)
 TARGET_LINK_LIBRARIES( ${PACKAGE_NAME} dl )
 ENDIF(UNIX)
-
-IF(GTK2_FOUND)
-TARGET_LINK_LIBRARIES( ${PACKAGE_NAME} gobject-2.0 )
-ENDIF(GTK2_FOUND)
 
 IF(QT_LINUX)
   TARGET_LINK_LIBRARIES( ${PACKAGE_NAME} Qt5Widgets Qt5OpenGL Qt5Gui Qt5Test Qt5Core )

--- a/include/dychart.h
+++ b/include/dychart.h
@@ -197,20 +197,6 @@
 #endif
 
 
-/***********************************************************************
- * Enable GTK Display Optimization
- * Note this requires libgtk+2-devel
- * which is not often available on basic systems.
- * On standard linux platforms, configure will set
- * ocpnUSE_GTK_OPTIMIZE if possible, i.e. if libgtk+2-devel is installed
- */
-
-#ifdef __WXGTK__
-#ifdef ocpnUSE_GTK_OPTIMIZE
-    #include <gtk/gtk.h>
-#endif
-#endif
-
 #ifndef OCPN_GL_INCLUDES
 #define OCPN_GL_INCLUDES 1
 

--- a/src/canvasMenu.cpp
+++ b/src/canvasMenu.cpp
@@ -297,20 +297,6 @@ void CanvasMenuHandler::CanvasPopupMenu( int x, int y, int seltype )
     popx = x;
     popy = y;
 
-#ifdef __WXGTK__
-#ifdef ocpnUSE_GTK_OPTIMIZE
-    //  This code changes the background color on the popup context menu
-    wxColour back_color = GetGlobalColor(_T("UIBCK"));
-    GdkColor color;
-
-    color.red = back_color.Red() << 8;
-    color.green = back_color.Green() << 8;
-    color.blue = back_color.Blue() << 8;
-
-//    gtk_widget_modify_bg (GTK_WIDGET(contextMenu->m_menu), GTK_STATE_NORMAL, &color);
-#endif
-#endif
-
     if( seltype == SELTYPE_ROUTECREATE ) {
         MenuAppend1( contextMenu, ID_RC_MENU_FINISH, _menuText( _( "End Route" ), _T("Esc") ) );
     }


### PR DESCRIPTION
wxGTK3 is built with GTK2 on Debian while it's built with GTK3 on Fedora.

wxGTK3 should pull the required dependencies without needing to add GTK2 or GTK3 in our packaging. Let's try to remove it:

The only place we're including some gtk dependencies is:
```
include/dychart.h: #include <gtk/gtk.h>
```
and the only gtk_* call is commented out:
```
src/canvasMenu.cpp:// gtk_widget_modify_bg (GTK_WIDGET(contextMenu->m_menu), GTK_STATE_NORMAL, &color);
```
*GdkColor color* is unused sot the whole block can be removed.

Then I guess we can remove the include from dychart.h and we don't need gtk include (thus dependency)

The other definition ocpnHAS_GTK is unused

The only remaining gtk is this block of code:
```
# Add a definition to satisfy some linux system builds, avoiding Apple builds
IF (NOT WIN32 AND NOT APPLE)
ADD_DEFINITIONS("pkg-config --cflags --libs gtk+-2.0")
ENDIF (NOT WIN32 AND NOT APPLE)
```
that're added "to satisfy some linux system builds" but I don't know if they're still valid with current code base on any platform.

I've created a new patch to remove GTK, can you check and report? Works for me on Fedora with either wx2 or wx3

Tested successfully with Fedora, CentOS and Debian