### PR TITLE
Extend the plugin API with online check and HTTP POST

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -1057,6 +1057,7 @@ enum OCPN_DLDialogStyle
     OCPN_DLDS_DEFAULT_STYLE = OCPN_DLDS_CAN_START|OCPN_DLDS_CAN_PAUSE|OCPN_DLDS_CAN_ABORT|OCPN_DLDS_SHOW_ALL|OCPN_DLDS_AUTO_CLOSE
 };
 
+#define ONLINE_CHECK_RETRY 30 // Recheck the Internet connection availability every ONLINE_CHECK_RETRY s
 
 /*   Synchronous (Blocking) download of a single file  */
 
@@ -1065,6 +1066,7 @@ extern DECL_EXP _OCPN_DLStatus OCPN_downloadFile( const wxString& url, const wxS
                                        const wxBitmap& bitmap,
                                        wxWindow *parent, long style, int timeout_secs);
 
+
 /*   Asynchronous (Background) download of a single file  */
 
 extern DECL_EXP _OCPN_DLStatus OCPN_downloadFileBackground( const wxString& url, const wxString &outputFile,
@@ -1072,6 +1074,13 @@ extern DECL_EXP _OCPN_DLStatus OCPN_downloadFileBackground( const wxString& url,
 
 extern DECL_EXP void OCPN_cancelDownloadFileBackground( long handle );
 
+/*   Synchronous (Blocking) HTTP POST operation for small amounts of data */
+
+extern DECL_EXP _OCPN_DLStatus OCPN_postDataHttp( const wxString& url, const wxString& parameters, wxString& result, int timeout_secs );
+
+/*   Check whether connection to the Internet is working */
+
+extern DECL_EXP bool OCPN_isOnline();
 
 /*  Supporting  Event for Background downloading          */
 /*  OCPN_downloadEvent Definition  */

--- a/include/pluginmanager.h
+++ b/include/pluginmanager.h
@@ -50,6 +50,7 @@
 #include <wx/bmpcbox.h>
 
 #ifndef __OCPN__ANDROID__
+#include "wx/curl/http.h"
 #include "wx/curl/dialog.h"
 #endif
 
@@ -319,7 +320,7 @@ private:
       wxArrayString     m_plugin_order;
       void SetPluginOrder( wxString serialized_names );
       wxString GetPluginOrder();
-      
+    
 #ifndef __OCPN__ANDROID__
 public:
       wxCurlDownloadThread *m_pCurlThread;
@@ -331,6 +332,8 @@ public:
       
       wxEvtHandler   *m_download_evHandler;
       long           *m_downloadHandle;
+      bool m_last_online;
+      long m_last_online_chk;
 #endif
 
 DECLARE_EVENT_TABLE()

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -248,6 +248,8 @@ PlugInManager::PlugInManager(MyFrame *parent)
     #ifndef __OCPN__ANDROID__
     wxCurlBase::Init();
     #endif
+    m_last_online = false;
+    m_last_online_chk = -1;
 }
 
 PlugInManager::~PlugInManager()
@@ -5316,6 +5318,43 @@ void OCPN_cancelDownloadFileBackground( long handle )
         g_pi_manager->m_download_evHandler = NULL;
         g_pi_manager->m_downloadHandle = NULL;
     }
+#endif
+}
+
+_OCPN_DLStatus OCPN_postDataHttp( const wxString& url, const wxString& parameters, wxString& result, int timeout_secs )
+{
+#ifdef __OCPN__ANDROID__
+    //TODO
+#else
+    wxCurlHTTP post;
+    post.SetOpt(CURLOPT_TIMEOUT, timeout_secs);
+    size_t res = post.Post( parameters.ToAscii(), parameters.Len(), url );
+    
+    if( res )
+    {
+        result = post.GetResponseBody();
+        return OCPN_DL_NO_ERROR;
+    } else
+        result = wxEmptyString;
+    
+    return OCPN_DL_FAILED;
+#endif
+}
+
+bool OCPN_isOnline()
+{
+#ifdef __OCPN__ANDROID__
+    //TODO
+#else
+    if (wxDateTime::GetTimeNow() > g_pi_manager->m_last_online_chk + ONLINE_CHECK_RETRY)
+    {
+        wxCurlHTTP get;
+        get.Head( _T("http://yahoo.com/") );
+        g_pi_manager->m_last_online = get.GetResponseCode() > 0;
+        
+        g_pi_manager->m_last_online_chk = wxDateTime::GetTimeNow();
+    }
+    return g_pi_manager->m_last_online;
 #endif
 }
 


### PR DESCRIPTION
Extensions to the networking API to support functionality needed by Squiddio plugin.
Not commiting directly to the master as the Android counterparts of the wxCurl implementation are missing.