### PR TITLE
reset cursor with wxNullCursor

### DIFF
--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -497,7 +497,7 @@ void ChartDldrPanelImpl::SetSource( int id )
     {
         pPlugIn->m_pChartSource = NULL;
     }
-    wxSetCursor(wxCURSOR_DEFAULT);
+    wxSetCursor(wxNullCursor);
 }
 
 void ChartDldrPanelImpl::SelectSource( wxListEvent& event )


### PR DESCRIPTION
Hi,

On linux wxSetCursor(wxCURSOR_DEFAULT) set the global cursor and
following changes are ignored, at least with wx 3.0.

ie after opening the option dialog box, cursor isn't modified for
measure tool, near the main window edges and so on.

from wx manual replace wxCURSOR_DEFAULT with wxNullCursor.

On the other hand using wxSetCursor here may be wrong.

Regards
Didier
