### PR TITLE
Charts cache replace time with a counter for LRU aging.

### DIFF
--- a/include/chartdb.h
+++ b/include/chartdb.h
@@ -170,6 +170,7 @@ private:
       
       
       wxArrayPtrVoid    *pChartCache;
+      int              m_ticks;
 
       bool              m_b_locked;
       bool              m_b_busy;

--- a/include/glChartCanvas.h
+++ b/include/glChartCanvas.h
@@ -218,6 +218,8 @@ protected:
     OCPNRegion  m_canvasregion;
     TexFont     m_gridfont;
 
+    int		m_LRUtime;
+
     GLuint       m_tideTex;
     GLuint       m_currentTex;
     int          m_tideTexWidth;

--- a/include/glTexCache.h
+++ b/include/glTexCache.h
@@ -123,8 +123,8 @@ public:
     bool BackgroundCompressionAsJob() const;
     void PurgeBackgroundCompressionPool();
     void OnTimer(wxTimerEvent &event);
-    void SetLRUTime(wxDateTime time) { m_LRUtime = time; }
-    wxDateTime &GetLRUTime() { return m_LRUtime; }
+    void SetLRUTime(int lru) { m_LRUtime = lru; }
+    int	 GetLRUTime() { return m_LRUtime; }
     void FreeSome( long target );
     
     glTextureDescriptor *GetpTD( wxRect & rect );
@@ -179,7 +179,7 @@ private:
     ColorScheme m_colorscheme;
     wxTimer     m_timer;
     size_t      m_ticks;
-    wxDateTime  m_LRUtime;
+    int		m_LRUtime;
     
     glTextureDescriptor  **m_td_array;
 

--- a/src/chartdb.cpp
+++ b/src/chartdb.cpp
@@ -1033,7 +1033,7 @@ CacheEntry *ChartDB::FindOldestDeleteCandidate( bool blog)
                 
             if( (!pce->n_lock) && (Current_Ch != pDeleteCandidate) ){
                 if(blog)
-                    wxLogMessage(_T("Oldest unlocked cache index is %d, delta t is %d"), iOldest, LRUTime);
+                    wxLogMessage(_T("Oldest unlocked cache index is %d, delta t is %d"), iOldest, dt);
                 
                 pret = pce;
             }

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -845,6 +845,8 @@ glChartCanvas::glChartCanvas( wxWindow *parent ) :
     m_last_render_time = -1;
 
     m_prevMemUsed = 0;    
+
+    m_LRUtime = 0;
     
     m_tideTex = 0;
     m_currentTex = 0;
@@ -3056,8 +3058,8 @@ void glChartCanvas::RenderRasterChartRegionGL( ChartBase *chart, ViewPort &vp, L
         m_chart_texfactory_hash[key] = new glTexFactory(chart, g_raster_format);
     
     pTexFact = m_chart_texfactory_hash[key];
-    pTexFact->SetLRUTime(wxDateTime::Now());
-
+    pTexFact->SetLRUTime(++m_LRUtime);
+    
     // for small scales, don't use normalized coordinates for accuracy (difference is up to 3 meters error)
     bool use_norm_vp = glChartCanvas::HasNormalizedViewPort(vp) && pBSBChart->GetPPM() < 1;
     pTexFact->PrepareTiles(vp, use_norm_vp, pBSBChart);
@@ -3920,7 +3922,7 @@ bool glChartCanvas::FactoryCrunch(double factor)
     if(bGLMemCrunch){
         
         //      Find the oldest unused factory
-        wxDateTime lru_oldest = wxDateTime::Now();
+        int lru_oldest = 2147483647;
         glTexFactory *ptf_oldest = NULL;
         
         for( it0 = m_chart_texfactory_hash.begin(); it0 != m_chart_texfactory_hash.end(); ++it0 ) {
@@ -3936,8 +3938,8 @@ bool glChartCanvas::FactoryCrunch(double factor)
                 if( cc1->m_pQuilt && cc1->m_pQuilt->IsComposed() &&
                     !cc1->m_pQuilt->IsChartInQuilt( chart_full_path ) ) {
                     
-                    wxDateTime lru = ptf->GetLRUTime();
-                    if(lru.IsEarlierThan(lru_oldest) && !ptf->BackgroundCompressionAsJob()){
+                    int lru = ptf->GetLRUTime();
+                    if(lru < lru_oldest && !ptf->BackgroundCompressionAsJob()){
                         lru_oldest = lru;
                         ptf_oldest = ptf;
                     }
@@ -3945,8 +3947,8 @@ bool glChartCanvas::FactoryCrunch(double factor)
             }
             else {
                 if( !Current_Ch->GetFullPath().IsSameAs(chart_full_path)) {
-                    wxDateTime lru = ptf->GetLRUTime();
-                    if(lru.IsEarlierThan(lru_oldest) && !ptf->BackgroundCompressionAsJob()){
+                    int lru = ptf->GetLRUTime();
+                    if(lru < lru_oldest && !ptf->BackgroundCompressionAsJob()){
                         lru_oldest = lru;
                         ptf_oldest = ptf;
                     }

--- a/src/glTexCache.cpp
+++ b/src/glTexCache.cpp
@@ -930,7 +930,7 @@ glTexFactory::glTexFactory(ChartBase *chart, int raster_format)
     m_catalogCorrupted = false;
 
     m_fs = 0;
-
+    m_LRUtime = 0;
 
     for (int i = 0; i < N_COLOR_SCHEMES; i++) {
         for (int j = 0; j < MAX_TEX_LEVEL; j++) {


### PR DESCRIPTION
Hi,
Replace usage of time with a counter.

it's called rather often for charts textures and on some systems it's a slow syscall, well more than one, it's also stats /etc/localtime.

Regards
Didier