### PR TITLE
New MMSI MID code added. 374-PA

### DIFF
--- a/src/AIS_Target_Data.cpp
+++ b/src/AIS_Target_Data.cpp
@@ -1017,8 +1017,9 @@ wxString AIS_Target_Data::GetCountryCode( bool b_CntryLongStr )  //false = Short
     case 369: return b_CntryLongStr ? _("United States of America") : _T("US") ;
     case 370: 
     case 371: 
-    case 372: 
-    case 373: return b_CntryLongStr ? _("Panama") : _T("PA") ;
+    case 372:
+    case 373:
+    case 374: return b_CntryLongStr ? _("Panama") : _T("PA") ;
     case 375: 
     case 376: 
     case 377: return b_CntryLongStr ? _("Saint Vincent and the Grenadines") : _T("VC") ;


### PR DESCRIPTION
One new MID code added this year.
From www.itu.int:
Maritime Identification Digits
Series 	Allocated to	Date 	Operational Bulletin 	
-------
374 	       PNR 	               13/05/2015 	1078