### PR TITLE
optimize route distance calculation when adding new points

### DIFF
--- a/include/Route.h
+++ b/include/Route.h
@@ -49,8 +49,7 @@ public:
 
       void AddPoint(RoutePoint *pNewPoint,
                     bool b_rename_in_sequence = true,
-                    bool b_deferBoxCalc = false,
-                    bool b_isLoading = false);
+                    bool b_deferBoxCalc = false);
 
       void AddTentativePoint(const wxString& GUID);
       RoutePoint *GetPoint(int nPoint);
@@ -68,6 +67,7 @@ public:
       void RemovePoint(RoutePoint *rp, bool bRenamePoints = false);
       void DeSelectRoute();
       void FinalizeForRendering();
+      void UpdateSegmentDistance( RoutePoint *prp0, RoutePoint *prp, double planspeed = -1.0 );
       void UpdateSegmentDistances(double planspeed = -1.0);
       void CalculateDCRect(wxDC& dc_route, wxRect *prect, ViewPort &VP);
       int GetnPoints(void){ return m_nPoints; }

--- a/src/NavObjectCollection.cpp
+++ b/src/NavObjectCollection.cpp
@@ -286,7 +286,7 @@ Track *GPXLoadTrack1( pugi::xml_node &trk_node, bool b_fullviz,
                     if( tpChildName == _T("trkpt") ) {
                         pWp = ::GPXLoadWaypoint1(tpchild, _T("empty"), _T("noGUID"), false, b_layer, b_layerviz, layer_id);
                         pWp->m_bIsolatedMark = false;
-                        pTentTrack->AddPoint( pWp, false, true, true );          // defer BBox calculation
+                        pTentTrack->AddPoint( pWp, false, true );          // defer BBox calculation
                         pWp->m_bIsInRoute = false;                      // Hack
                         pWp->m_bIsInTrack = true;
                         pWp->m_GPXTrkSegNo = GPXSeg;
@@ -409,8 +409,7 @@ Track *GPXLoadTrack1( pugi::xml_node &trk_node, bool b_fullviz,
         delete pTentTrack->m_HyperlinkList;                    // created in RoutePoint ctor
         pTentTrack->m_HyperlinkList = linklist;
     }
-    if( pTentTrack )
-        pTentTrack->UpdateSegmentDistances();
+
     return pTentTrack;
 }
 
@@ -530,7 +529,7 @@ Route *GPXLoadRoute1( pugi::xml_node &wpt_node, bool b_fullviz,
 					}
 				}
 
-                pTentRoute->AddPoint( pWp, false, true, true );          // defer BBox calculation
+                pTentRoute->AddPoint( pWp, false, true );          // defer BBox calculation
                 pWp->m_bIsInRoute = true;                      // Hack
                 pWp->m_bIsInTrack = false;
 
@@ -607,8 +606,7 @@ Route *GPXLoadRoute1( pugi::xml_node &wpt_node, bool b_fullviz,
         delete pTentRoute->m_HyperlinkList;                    // created in RoutePoint ctor
         pTentRoute->m_HyperlinkList = linklist;
     }
-    if( pTentRoute )
-        pTentRoute->UpdateSegmentDistances();
+
     return pTentRoute;
 }
 


### PR DESCRIPTION
This greatly speeds up the loading time after a crash with a large number of route points
in a track to add.  For example if my computer ran out of power after a few days,
the next boot of opencpn trying to apply navobj.xml.changes would take about a minute
which is a very long time.  Now it is less than a second.

Similar logic could be applied for deleting points or other operations, but
maybe it's not really useful.

Conflicts:
	src/NavObjectCollection.cpp