### PR TITLE
route, fix use after freed

### DIFF
--- a/include/Select.h
+++ b/include/Select.h
@@ -45,6 +45,7 @@ public:
 
     void SetSelectPixelRadius(int radius){ pixelRadius = radius; }
 
+    bool IsSelectableRoutePointValid(RoutePoint *pRoutePoint );
     bool AddSelectableRoutePoint( float slat, float slon, RoutePoint *pRoutePointAdd );
     bool AddSelectableRouteSegment( float slat1, float slon1, float slat2, float slon2,
             RoutePoint *pRoutePointAdd1, RoutePoint *pRoutePointAdd2, Route *pRoute );

--- a/src/Select.cpp
+++ b/src/Select.cpp
@@ -49,6 +49,22 @@ Select::~Select()
 
 }
 
+bool Select::IsSelectableRoutePointValid(RoutePoint *pRoutePoint )
+{
+    SelectItem *pFindSel;
+
+//    Iterate on the select list
+    wxSelectableItemListNode *node = pSelectList->GetFirst();
+
+    while( node ) {
+        pFindSel = node->GetData();
+        if( pFindSel->m_seltype == SELTYPE_ROUTEPOINT  && (RoutePoint *) pFindSel->m_pData1 == pRoutePoint)
+            return true;
+        node = node->GetNext();
+    }
+    return false;
+}
+
 bool Select::AddSelectableRoutePoint( float slat, float slon, RoutePoint *pRoutePointAdd )
 {
     SelectItem *pSelItem = new SelectItem;
@@ -569,6 +585,21 @@ SelectItem *Select::FindSelection( float slat, float slon, int fseltype )
 
 bool Select::IsSelectableSegmentSelected( float slat, float slon, SelectItem *pFindSel )
 {
+    bool valid = false;
+    wxSelectableItemListNode *node = pSelectList->GetFirst();
+
+    while( node ) {
+        if( pFindSel == node->GetData() ) {
+            valid = true;
+            break;
+        }
+        node = node->GetNext();
+    }
+
+    if (valid == false) {
+        // not in the list anymore
+        return false;
+    }
     CalcSelectRadius();
 
     float a = pFindSel->m_slat;

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -6240,15 +6240,16 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
             if( !bseltc ){
                 InvokeCanvasMenu(x, y, seltype);
                 
-                // Clean up
-                if( ( m_pSelectedRoute ) ) {
+                // Clean up if not deleted in InvokeCanvasMenu
+                if( m_pSelectedRoute && g_pRouteMan->IsRouteValid(m_pSelectedRoute) ) {
                     m_pSelectedRoute->m_bRtIsSelected = false;
                 }
                 
                 m_pSelectedRoute = NULL;
                 
                 if( m_pFoundRoutePoint ) {
-                    m_pFoundRoutePoint->m_bPtIsSelected = false;
+                    if (pSelect->IsSelectableRoutePointValid(m_pFoundRoutePoint))
+                        m_pFoundRoutePoint->m_bPtIsSelected = false;
                 }
                 m_pFoundRoutePoint = NULL;
                 


### PR DESCRIPTION
Hi,

Code in chcanv.c is keeping references to route/waypoint and may use them after they have been deleted.

It's using a slow linear search. It could be an issue in  IsSelectableSegmentSelected if there's a lot of waypoints, it's called from the buble timer callback.

Regards
Didier