### PR TITLE
Charts downloader fix

### DIFF
--- a/plugins/chartdldr_pi/src/chartcatalog.cpp
+++ b/plugins/chartdldr_pi/src/chartcatalog.cpp
@@ -51,7 +51,7 @@ bool ChartCatalog::LoadFromFile( wxString path, bool headerOnly )
     if (ret)
         ret = LoadFromXml( doc, headerOnly );
     else
-        charts->Clear();
+        charts.Clear();
     doc->Clear();
     wxDELETE(doc);
 
@@ -60,13 +60,10 @@ bool ChartCatalog::LoadFromFile( wxString path, bool headerOnly )
 
 ChartCatalog::ChartCatalog()
 {
-    charts = new wxArrayOfCharts();
 }
 
 ChartCatalog::~ChartCatalog()
 {
-    charts->Clear();
-    wxDELETE(charts);
 }
 
 wxDateTime ChartCatalog::GetReleaseDate()
@@ -90,7 +87,7 @@ bool ChartCatalog::LoadFromXml( TiXmlDocument * doc, bool headerOnly )
 {
     TiXmlElement * root = doc->RootElement();
     wxString rootName = wxString::FromUTF8( root->Value() );
-    charts->Clear();
+    charts.Clear();
 
     if( rootName.StartsWith( _T("RncProductCatalog") ) )
     {
@@ -104,7 +101,7 @@ bool ChartCatalog::LoadFromXml( TiXmlDocument * doc, bool headerOnly )
         for ( child = root->FirstChildElement()->NextSibling(); child != 0; child = child->NextSibling() )
         {
             if( _T("chart") == wxString::FromUTF8( child->Value() ) )
-                charts->Add(new RasterChart(child));
+                charts.Add(new RasterChart(child));
         }
     }
     else if( rootName.StartsWith(_T("EncProductCatalog")) )
@@ -118,7 +115,7 @@ bool ChartCatalog::LoadFromXml( TiXmlDocument * doc, bool headerOnly )
         for( child = root->FirstChildElement()->NextSibling(); child != 0; child = child->NextSibling() )
         {
             if( _T("cell") == wxString::FromUTF8( child->Value() ) )
-                charts->Add( new EncCell(child) );
+                charts.Add( new EncCell(child) );
         }
     }
     else if( rootName.StartsWith(_T("IENCU37ProductCatalog")) )
@@ -133,7 +130,7 @@ bool ChartCatalog::LoadFromXml( TiXmlDocument * doc, bool headerOnly )
         for( child = root->FirstChildElement()->NextSibling(); child != 0; child = child->NextSibling())
         {
             if( _T("Cell") == wxString::FromUTF8( child->Value() ) )
-                charts->Add(new IEncCell(child));
+                charts.Add(new IEncCell(child));
         }
     }
     else
@@ -226,8 +223,6 @@ Chart::~Chart()
     wxDELETE(regions);
     wxDELETE(nm);
     wxDELETE(lnm);
-    coverage->Clear();
-    wxDELETE(coverage);
 }
 
 Chart::Chart( TiXmlNode * xmldata )
@@ -237,7 +232,6 @@ Chart::Chart( TiXmlNode * xmldata )
     regions = new wxArrayString();
     nm = NULL;
     lnm = NULL;
-    coverage = new wxArrayOfPanels();
     TiXmlNode *child;
     target_filename = wxEmptyString;
     reference_file = wxEmptyString;
@@ -323,7 +317,7 @@ Chart::Chart( TiXmlNode * xmldata )
             TiXmlNode *mychild;
             for( mychild = child->FirstChild(); mychild != 0; mychild = mychild->NextSibling() )
             {
-                coverage->Add(new Panel(mychild));
+                coverage.Add(new Panel(mychild));
             }
         }
         else if( s == _T("target_filename") )
@@ -709,7 +703,6 @@ NoticeToMariners::NoticeToMariners( TiXmlNode * xmldata )
 Panel::Panel( TiXmlNode * xmldata )
 {
     panel_no = -1;
-    vertexes = new wxArrayOfVertexes();
     TiXmlNode *child;
     for( child = xmldata->FirstChild(); child != 0; child = child->NextSibling() )
     {
@@ -721,15 +714,13 @@ Panel::Panel( TiXmlNode * xmldata )
         }
         else if( s == _T("vertex") )
         {
-            vertexes->Add(new Vertex(child));
+            vertexes.Add(new Vertex(child));
         }
     }
 }
 
 Panel::~Panel()
 {
-    vertexes->Clear();
-    wxDELETE(vertexes);
 }
 
 RncPanel::RncPanel( TiXmlNode * xmldata ) : Panel( xmldata )

--- a/plugins/chartdldr_pi/src/chartcatalog.h
+++ b/plugins/chartdldr_pi/src/chartcatalog.h
@@ -71,7 +71,7 @@ public:
     wxString ref_spec;
     wxString ref_spec_vers;
     wxString s62AgencyCode;
-    wxArrayOfCharts *charts;
+    wxArrayOfCharts charts;
 private:
     bool ParseNoaaHeader( TiXmlElement * xmldata );
 };
@@ -80,7 +80,7 @@ class Chart
 {
 public:
     Chart( TiXmlNode * xmldata );
-    ~Chart();
+    virtual ~Chart();
     // public methods
     virtual wxString GetChartTitle() { return title; }
     virtual wxString GetDownloadLocation() { return zipfile_location; }
@@ -105,7 +105,7 @@ public:
 
     NoticeToMariners *nm;
     NoticeToMariners *lnm;
-    wxArrayOfPanels *coverage;
+    wxArrayOfPanels coverage;
 };
 
 class RasterChart : public Chart //<chart>
@@ -228,6 +228,7 @@ class Vertex
 {
 public:
     Vertex( TiXmlNode * xmldata );
+    virtual ~Vertex() {};
     // public methods
 
     //public properties
@@ -239,12 +240,12 @@ class Panel
 {
 public:
     Panel( TiXmlNode * xmldata );
-    ~Panel();
+    virtual ~Panel();
     // public methods
 
     //public properties
     int panel_no;
-    wxArrayOfVertexes *vertexes;
+    wxArrayOfVertexes vertexes;
 };
 
 class RncPanel : public Panel

--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -1330,6 +1330,7 @@ bool chartdldr_pi::ExtractRarFiles( const wxString& aRarFile, const wxString& aT
     strncpy(target, (const char*)aTargetDir.mb_str(wxConvUTF8), 1023);
     char *argv[] = {const_cast<char *>("unrar"), command, const_cast<char *>("-y"), file, target};
 #ifdef _UNIX
+    // XXX is setlocale need?
     setlocale(LC_ALL,"");
 #endif
 
@@ -1425,6 +1426,12 @@ bool chartdldr_pi::ExtractRarFiles( const wxString& aRarFile, const wxString& aT
 
     if( aRemoveRar )
         wxRemoveFile(aRarFile);
+
+#ifdef _UNIX
+    // reset LC_NUMERIC locale, some locales use a comma for decimal point
+    // and it corrupts navobj.xml file
+    setlocale(LC_NUMERIC, "C");
+#endif
 
     return true;
 }

--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -1472,7 +1472,8 @@ bool chartdldr_pi::ExtractZipFiles( const wxString& aZipFile, const wxString& aT
                 //fn.SetPath(aTargetDir);
                 //name = fn.GetFullPath();
                 /* Or only remove the first dir (eg. ENC_ROOT) */
-                fn.RemoveDir(0);
+                if (fn.GetDirCount() > 0)
+                    fn.RemoveDir(0);
                 name = aTargetDir + wxFileName::GetPathSeparator() + fn.GetFullPath();
             }
             else

--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -1324,10 +1324,16 @@ bool chartdldr_pi::ExtractRarFiles( const wxString& aRarFile, const wxString& aT
 
     char command[2];
     strncpy(command, (const char*)cmd.mb_str(wxConvUTF8), 1);
+    command[1] = 0;
+
     char file[1024];
     strncpy(file, (const char*)aRarFile.mb_str(wxConvUTF8), 1023);
+    file[1023] = 0;
+
     char target[1024];
     strncpy(target, (const char*)aTargetDir.mb_str(wxConvUTF8), 1023);
+    target[1023] = 0;
+
     char *argv[] = {const_cast<char *>("unrar"), command, const_cast<char *>("-y"), file, target};
 #ifdef _UNIX
     // XXX is setlocale need?

--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -50,7 +50,6 @@
 #include "unrar/rar.hpp"
 
 #include <wx/arrimpl.cpp>
-    WX_DEFINE_OBJARRAY(wxArrayOfChartSources);
     WX_DEFINE_OBJARRAY(wxArrayOfDateTime);
 
 #include <fstream>
@@ -363,7 +362,11 @@ ChartSource::ChartSource( wxString name, wxString url, wxString localdir )
     m_url = url;
     m_dir = localdir;
     m_update_data.clear();
-    
+}
+
+ChartSource::~ChartSource()
+{
+    m_update_data.clear();
 }
 
 #define ID_MNU_SELALL 2001
@@ -542,15 +545,15 @@ void ChartDldrPanelImpl::FillFromFile( wxString url, wxString dir, bool selnew, 
         m_clCharts->DeleteAllItems();
         size_t updated_charts = 0;
         size_t new_charts = 0;
-        for( size_t i = 0; i < pPlugIn->m_pChartCatalog->charts->Count(); i++ )
+        for( size_t i = 0; i < pPlugIn->m_pChartCatalog->charts.Count(); i++ )
         {
             wxListItem li;
             li.SetId(i);
-            li.SetText(pPlugIn->m_pChartCatalog->charts->Item(i).GetChartTitle());
+            li.SetText(pPlugIn->m_pChartCatalog->charts.Item(i).GetChartTitle());
             long x = m_clCharts->InsertItem(li);
-            m_clCharts->SetItem(x, 0, pPlugIn->m_pChartCatalog->charts->Item(i).GetChartTitle());
-            wxString file = pPlugIn->m_pChartCatalog->charts->Item(i).GetChartFilename(true);
-            if( !pPlugIn->m_pChartSource->ExistsLocaly(pPlugIn->m_pChartCatalog->charts->Item(i).number, file) )
+            m_clCharts->SetItem(x, 0, pPlugIn->m_pChartCatalog->charts.Item(i).GetChartTitle());
+            wxString file = pPlugIn->m_pChartCatalog->charts.Item(i).GetChartFilename(true);
+            if( !pPlugIn->m_pChartSource->ExistsLocaly(pPlugIn->m_pChartCatalog->charts.Item(i).number, file) )
             {
                 new_charts++;
                 m_clCharts->SetItem(x, 1, _("New"));
@@ -559,7 +562,7 @@ void ChartDldrPanelImpl::FillFromFile( wxString url, wxString dir, bool selnew, 
             }
             else
             {
-                if( pPlugIn->m_pChartSource->IsNewerThanLocal(pPlugIn->m_pChartCatalog->charts->Item(i).number, file, pPlugIn->m_pChartCatalog->charts->Item(i).GetUpdateDatetime()) )
+                if( pPlugIn->m_pChartSource->IsNewerThanLocal(pPlugIn->m_pChartCatalog->charts.Item(i).number, file, pPlugIn->m_pChartCatalog->charts.Item(i).GetUpdateDatetime()) )
                 {
                     updated_charts++;
                     m_clCharts->SetItem(x, 1, _("Update available"));
@@ -571,9 +574,9 @@ void ChartDldrPanelImpl::FillFromFile( wxString url, wxString dir, bool selnew, 
                     m_clCharts->SetItem(x, 1, _("Up to date"));
                 }
             }
-            m_clCharts->SetItem(x, 2, pPlugIn->m_pChartCatalog->charts->Item(i).GetUpdateDatetime().Format(_T("%Y-%m-%d %H:%M")));
+            m_clCharts->SetItem(x, 2, pPlugIn->m_pChartCatalog->charts.Item(i).GetUpdateDatetime().Format(_T("%Y-%m-%d %H:%M")));
         }
-        m_stCatalogInfo->SetLabel( wxString::Format( _("%lu charts total, %lu updated, %lu new"), pPlugIn->m_pChartCatalog->charts->Count(), updated_charts, new_charts ) );
+        m_stCatalogInfo->SetLabel( wxString::Format( _("%lu charts total, %lu updated, %lu new"), pPlugIn->m_pChartCatalog->charts.Count(), updated_charts, new_charts ) );
         m_stCatalogInfo->Show( true );
     }
 }
@@ -987,20 +990,20 @@ void ChartDldrPanelImpl::DownloadCharts()
             m_totalsize = _("Unknown");
             m_transferredsize = _T("0");
             downloading++;
-            if( pPlugIn->m_pChartCatalog->charts->Item(i).NeedsManualDownload() )
+            if( pPlugIn->m_pChartCatalog->charts.Item(i).NeedsManualDownload() )
             {
                 if( wxYES ==
                         wxMessageBox(
                                 wxString::Format( _("The selected chart '%s' can't be downloaded automatically, do you want me to open a browser window and download them manually?\n\n \
-After downloading the charts, please extract them to %s"), pPlugIn->m_pChartCatalog->charts->Item(i).title.c_str(), pPlugIn->m_pChartSource->GetDir().c_str() ), _("Chart Downloader"), wxYES_NO | wxCENTRE | wxICON_QUESTION ) )
+After downloading the charts, please extract them to %s"), pPlugIn->m_pChartCatalog->charts.Item(i).title.c_str(), pPlugIn->m_pChartSource->GetDir().c_str() ), _("Chart Downloader"), wxYES_NO | wxCENTRE | wxICON_QUESTION ) )
                 {
-                    wxLaunchDefaultBrowser( pPlugIn->m_pChartCatalog->charts->Item(i).GetManualDownloadUrl() );
+                    wxLaunchDefaultBrowser( pPlugIn->m_pChartCatalog->charts.Item(i).GetManualDownloadUrl() );
                 }
             }
             else
             {
                 //download queue
-                wxURI url(pPlugIn->m_pChartCatalog->charts->Item(i).GetDownloadLocation());
+                wxURI url(pPlugIn->m_pChartCatalog->charts.Item(i).GetDownloadLocation());
                 if( url.IsReference() )
                 {
                     wxMessageBox(wxString::Format(_("Error, the URL to the chart (%s) data seems wrong."), url.BuildURI().c_str()), _("Error"));
@@ -1008,14 +1011,14 @@ After downloading the charts, please extract them to %s"), pPlugIn->m_pChartCata
                     return;
                 }
                 //construct local file path
-                wxString file = pPlugIn->m_pChartCatalog->charts->Item(i).GetChartFilename();
+                wxString file = pPlugIn->m_pChartCatalog->charts.Item(i).GetChartFilename();
                 wxFileName fn;
                 fn.SetFullName(file);
                 fn.SetPath(cs->GetDir());
                 wxString path = fn.GetFullPath();
                 if( wxFileExists( path ) )
                     wxRemoveFile( path );
-                wxString title = pPlugIn->m_pChartCatalog->charts->Item(i).GetChartTitle();
+                wxString title = pPlugIn->m_pChartCatalog->charts.Item(i).GetChartTitle();
 
                 //  Ready to start download
 #ifdef __OCPN__ANDROID__
@@ -1045,8 +1048,8 @@ After downloading the charts, please extract them to %s"), pPlugIn->m_pChartCata
                 if( m_bTransferSuccess && !cancelled )
                 {
                     wxFileName myfn(path);
-                    pPlugIn->ProcessFile(path, myfn.GetPath(), true, pPlugIn->m_pChartCatalog->charts->Item(i).GetUpdateDatetime());
-                    cs->ChartUpdated( pPlugIn->m_pChartCatalog->charts->Item(i).number, pPlugIn->m_pChartCatalog->charts->Item(i).GetUpdateDatetime().GetTicks() );
+                    pPlugIn->ProcessFile(path, myfn.GetPath(), true, pPlugIn->m_pChartCatalog->charts.Item(i).GetUpdateDatetime());
+                    cs->ChartUpdated( pPlugIn->m_pChartCatalog->charts.Item(i).number, pPlugIn->m_pChartCatalog->charts.Item(i).GetUpdateDatetime().GetTicks() );
                 } else {
                     if( wxFileExists( path ) )
                         wxRemoveFile( path );

--- a/plugins/chartdldr_pi/src/chartdldr_pi.h
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.h
@@ -62,7 +62,7 @@ class ChartSource;
 class ChartDldrPanelImpl;
 class ChartDldrGuiAddSourceDlg;
 
-WX_DECLARE_OBJARRAY(ChartSource *, wxArrayOfChartSources);
+WX_DEFINE_ARRAY_PTR(ChartSource *, wxArrayOfChartSources);
 WX_DECLARE_OBJARRAY(wxDateTime, wxArrayOfDateTime);
 
 //----------------------------------------------------------------------------------------------------------
@@ -129,6 +129,8 @@ class ChartSource : public wxTreeItemData
 {
 public:
     ChartSource( wxString name, wxString url, wxString localdir );
+    ~ChartSource();
+    
     wxString        GetName() { return m_name; }
     wxString        GetUrl() { return m_url; }
     wxString        GetDir() { return m_dir; }

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -5342,8 +5342,7 @@ void OCPN_cancelDownloadFileBackground( long handle )
 #else
     if( g_pi_manager->m_pCurlThread )
     {
-        if (g_pi_manager->m_pCurlThread->IsAlive())
-            g_pi_manager->m_pCurlThread->Abort();
+        g_pi_manager->m_pCurlThread->Abort();
         delete (g_pi_manager->m_pCurlThread->GetOutputStream());
         wxDELETE(g_pi_manager->m_pCurlThread);
         g_pi_manager->m_download_evHandler = NULL;
@@ -5405,8 +5404,7 @@ void PlugInManager::OnEndPerformCurlDownload(wxCurlEndPerformEvent &ev)
     
     if( m_pCurlThread )
     {
-        if (m_pCurlThread->IsAlive())
-            m_pCurlThread->Wait();
+        m_pCurlThread->Wait();
         if(!m_pCurlThread->IsAborting()){
             delete (m_pCurlThread->GetOutputStream());
             wxDELETE(m_pCurlThread);

--- a/src/wxcurl/dialog.cpp
+++ b/src/wxcurl/dialog.cpp
@@ -268,8 +268,7 @@ void wxCurlTransferDialog::EndModal(wxCurlDialogReturnFlag retCode)
     // otherwise it will try to send events to a non-existent handler
     // NB: this must be done *after* calling wxDialog::EndModal
     //     so that while we wait we are hidden
-    if (m_pThread->IsAlive())
-        HandleCurlThreadError(m_pThread->Wait(), m_pThread);
+    HandleCurlThreadError(m_pThread->Wait(), m_pThread);
 }
 
 void wxCurlTransferDialog::UpdateLabels(wxCurlProgressBaseEvent *ev)

--- a/src/wxcurl/thread.cpp
+++ b/src/wxcurl/thread.cpp
@@ -99,7 +99,6 @@ void wxCurlBaseThread::OnExit()
     if (m_pCurl->IsVerbose())
         wxLogDebug(wxS("wxCurlBaseThread - exiting"));
 
-    wxDELETE(m_pCurl);
 }
 
 bool wxCurlBaseThread::TestDestroy()

--- a/src/wxcurl/wx/curl/thread.h
+++ b/src/wxcurl/wx/curl/thread.h
@@ -87,6 +87,11 @@ public:
         m_bAbort = false;
     }
 
+    ~wxCurlBaseThread() 
+    {
+            wxDELETE(m_pCurl);
+    }
+
 public:     // thread execution management
 
     //! Returns true if this thread is ready to be started using e.g. #StartTransfer.


### PR DESCRIPTION
Hi,
- a558926: I'm not sure setlocale (LC_ALL) is needed at all but without resetting LC_NUMERIC it trashes navobj.xml if in user default locale decimal point is a comma.

- 51352fe: not all zip downloaded have directories (triggered a wxAssert)

- without fa6cf11 I was unable to download the full US ENC set on a 32 bits system, memory reached 
3 GB twice.

Regards
Didier