### PR TITLE
Prevent needless entries in the log file when no TCP server is reachable.

### DIFF
--- a/src/datastream.cpp
+++ b/src/datastream.cpp
@@ -608,7 +608,8 @@ void DataStream::OnSocketEvent(wxSocketEvent& event)
         {
             //          wxSocketError e = m_sock->LastError();          // this produces wxSOCKET_WOULDBLOCK.
             if(m_net_protocol == TCP || m_net_protocol == GPSD) {
-                wxLogMessage( wxString::Format(_T("Datastream connection lost: %s"), m_portstring.c_str()) );
+				if (m_brx_connect_event)
+					wxLogMessage(wxString::Format(_T("Datastream connection lost: %s"), m_portstring.c_str()));
                 if (m_socket_server) {
                     m_sock->Destroy();
                     m_sock=0;


### PR DESCRIPTION
If there is no TCP server then at least on Windows the wxSOCKET_LOST event is issued every 5 seconds and generates an endless stream of messages in the log file.