### PR TITLE
Add OCPNGetScaledFont_PlugIn api call

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -995,6 +995,7 @@ extern DECL_EXP bool CheckEdgePan_PlugIn( int x, int y, bool dragging, int margi
 extern DECL_EXP wxBitmap GetIcon_PlugIn(const wxString & name);
 extern DECL_EXP void SetCursor_PlugIn( wxCursor *pPlugin_Cursor = NULL );
 extern DECL_EXP wxFont *OCPNGetScaledFont_PlugIn(wxString TextElement, int default_size);
+extern DECL_EXP wxFont GetOCPNGUIScaledFont_PlugIn(wxString item);
 
 extern DECL_EXP double GetCanvasTilt();
 extern DECL_EXP void SetCanvasTilt(double tilt);

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -994,6 +994,7 @@ extern DECL_EXP bool GetSingleWaypoint( wxString GUID, PlugIn_Waypoint *pwaypoin
 extern DECL_EXP bool CheckEdgePan_PlugIn( int x, int y, bool dragging, int margin, int delta );
 extern DECL_EXP wxBitmap GetIcon_PlugIn(const wxString & name);
 extern DECL_EXP void SetCursor_PlugIn( wxCursor *pPlugin_Cursor = NULL );
+extern DECL_EXP wxFont *OCPNGetScaledFont_PlugIn(wxString TextElement, int default_size);
 
 extern DECL_EXP double GetCanvasTilt();
 extern DECL_EXP void SetCanvasTilt(double tilt);

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -1988,6 +1988,11 @@ wxFont *OCPNGetScaledFont_PlugIn(wxString TextElement, int default_size)
     return GetOCPNScaledFont( TextElement, default_size );
 }
 
+wxFont GetOCPNGUIScaledFont_PlugIn(wxString item)
+{
+    return GetOCPNGUIScaledFont( item );
+}
+
 wxString *GetpSharedDataLocation(void)
 {
     return g_Platform->GetSharedDataDirPtr();

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -1983,6 +1983,11 @@ wxFont *OCPNGetFont(wxString TextElement, int default_size)
     return FontMgr::Get().GetFont(TextElement, default_size);
 }
 
+wxFont *OCPNGetScaledFont_PlugIn(wxString TextElement, int default_size)
+{
+    return GetOCPNScaledFont( TextElement, default_size );
+}
+
 wxString *GetpSharedDataLocation(void)
 {
     return g_Platform->GetSharedDataDirPtr();


### PR DESCRIPTION
This is an attempt to allow scalable fonts to be used in plugins. There is an issue with high resolution screens and the use of popups. The fonts are not being scaled correctly