### PR TITLE
Fix skewed chart problems.

### DIFF
--- a/src/ais.cpp
+++ b/src/ais.cpp
@@ -885,8 +885,6 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
         //    If the target reported a valid HDG, then use it for icon
         if( (int) ( td->HDG ) != 511 ) {
             theta = ( ( td->HDG - 90 ) * PI / 180. ) + cc1->GetVP().rotation;
-            if (!g_bopengl && !g_bskew_comp)
-                theta += cc1->GetVP().skew;
         } else {
             // question: why can we not compute similar to above using COG instead of HDG?
             //  Calculate the relative angle for this chart orientation

--- a/src/ais.cpp
+++ b/src/ais.cpp
@@ -59,6 +59,7 @@ extern ChartCanvas      *cc1;
 extern MyFrame          *gFrame;
 extern MyConfig         *pConfig;
 extern bool              g_bskew_comp;
+extern bool              g_bopengl;
 
 int                      g_ais_cog_predictor_width;
 extern AIS_Decoder              *g_pAIS;
@@ -884,7 +885,7 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
         //    If the target reported a valid HDG, then use it for icon
         if( (int) ( td->HDG ) != 511 ) {
             theta = ( ( td->HDG - 90 ) * PI / 180. ) + cc1->GetVP().rotation;
-            if( !g_bskew_comp )
+            if (!g_bopengl && !g_bskew_comp)
                 theta += cc1->GetVP().skew;
         } else {
             // question: why can we not compute similar to above using COG instead of HDG?

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -4500,7 +4500,7 @@ void MyFrame::ToggleCourseUp( void )
         g_COGAvg = stuff;
         gFrame->FrameCOGTimer.Start( 100, wxTIMER_CONTINUOUS );
     } else {
-        if (g_bopengl && !g_bskew_comp && (fabs(cc1->GetVPSkew()) > 0.0001))
+        if ( !g_bskew_comp && (fabs(cc1->GetVPSkew()) > 0.0001))
             cc1->SetVPRotation(cc1->GetVPSkew());
         else
             cc1->SetVPRotation(0); /* reset to north up */
@@ -6672,8 +6672,6 @@ void MyFrame::DoCOGSet( void )
 
     double old_VPRotate = g_VPRotate;
     g_VPRotate = -g_COGAvg * PI / 180.;
-    if (!g_bopengl && !g_bskew_comp)
-        g_VPRotate -= cc1->GetVPSkew();
 
     cc1->SetVPRotation( g_VPRotate );
     bool bnew_chart = DoChartUpdate();
@@ -7084,14 +7082,13 @@ void MyFrame::SelectChartFromStack( int index, bool bDir, ChartTypeEnum New_Type
         double oldskew = cc1->GetVPSkew();
         double newskew = Current_Ch->GetChartSkew() * PI / 180.0;
 
-        if (g_bopengl){
-            if (!g_bskew_comp) {
-                if (fabs(oldskew) > 0.0001)
-                    rotation = 0.0;
-                if (fabs(newskew) > 0.0001)
-                    rotation = newskew;
-            }
+        if (!g_bskew_comp) {
+            if (fabs(oldskew) > 0.0001)
+                rotation = 0.0;
+            if (fabs(newskew) > 0.0001)
+                rotation = newskew;
         }
+
         cc1->SetViewPoint( zLat, zLon, best_scale, newskew, rotation );
 
         SetChartUpdatePeriod( cc1->GetVP() );
@@ -7167,7 +7164,7 @@ void MyFrame::SetChartUpdatePeriod( ViewPort &vp )
     g_ChartUpdatePeriod = 1;            // General default
 
     if (!g_bopengl && !vp.b_quilt)
-        if (g_bskew_comp && fabs(vp.skew) > 0.0001)
+        if ( fabs(vp.skew) > 0.0001)
             g_ChartUpdatePeriod = g_SkewCompUpdatePeriod;
 
     m_ChartUpdatePeriod = g_ChartUpdatePeriod;

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -2539,7 +2539,7 @@ void ChartCanvas::GetDoubleCanvasPointPixVP( ViewPort &vp, double rlat, double r
     // then fall back to Viewport Projection estimate from canvas parameters
     if(!g_bopengl && Current_Ch && ( Current_Ch->GetChartFamily() == CHART_FAMILY_RASTER )
         && ( ( ( fabs( vp.rotation ) < .0001 ) &&
-               ( ( !g_bskew_comp || ( fabs( vp.skew ) < .0001 ) ) ) )
+               ( (  ( fabs( vp.skew ) < .0001 ) ) ) )
              || ( ( Current_Ch->GetChartProjectionType() != PROJECTION_MERCATOR )
                   && ( Current_Ch->GetChartProjectionType() != PROJECTION_TRANSVERSE_MERCATOR )
                   && ( Current_Ch->GetChartProjectionType() != PROJECTION_POLYCONIC ) ) )
@@ -2610,7 +2610,7 @@ void ChartCanvas::GetCanvasPixPoint( double x, double y, double &lat, double &lo
 
     if(!g_bopengl && Current_Ch && ( Current_Ch->GetChartFamily() == CHART_FAMILY_RASTER )
         && ( ( ( fabs( GetVP().rotation ) < .0001 ) &&
-               ( ( !g_bskew_comp || ( fabs( GetVP().skew ) < .0001 ) ) ) )
+               ( (  ( fabs( GetVP().skew ) < .0001 ) ) ) )
              || ( ( Current_Ch->GetChartProjectionType() != PROJECTION_MERCATOR )
                   && ( Current_Ch->GetChartProjectionType() != PROJECTION_TRANSVERSE_MERCATOR )
                   && ( Current_Ch->GetChartProjectionType() != PROJECTION_POLYCONIC ) ) )
@@ -3766,8 +3766,6 @@ void ChartCanvas::ShipDraw( ocpnDC& dc )
                              (float) ( osd_head_point.x - lShipMidPoint.x ) );
     icon_rad += (float)PI;
     double rotate = GetVP().rotation;
-    if (!g_bskew_comp)
-        rotate += GetVP().skew;
 
     if (pSog < 0.2) icon_rad = ((icon_hdt + 90.) * PI / 180) + rotate;
 
@@ -4060,7 +4058,7 @@ wxString CalcGridText( float latlon, float spacing, bool bPostfix )
 void ChartCanvas::GridDraw( ocpnDC& dc )
 {
     if( !( g_bDisplayGrid && ( fabs( GetVP().rotation ) < 1e-5 )
-            && ( ( fabs( GetVP().skew ) < 1e-9 ) || g_bskew_comp ) ) ) return;
+            ) ) return;
 
     double nlat, elon, slat, wlon;
     float lat, lon;
@@ -4180,8 +4178,7 @@ void ChartCanvas::ScaleBarDraw( ocpnDC& dc )
 
     GetCanvasPixPoint( x_origin, y_origin, blat, blon );
     double rotation = -VPoint.rotation;
-    if(!g_bskew_comp)
-        rotation -= VPoint.skew;
+
     ll_gc_ll( blat, blon, rotation * 180 / PI, dist, &tlat, &tlon );
     GetCanvasPointPix( tlat, tlon, &r );
     int l1 = ( y_origin - r.y ) / count;
@@ -9185,7 +9182,7 @@ void ChartCanvas::OnPaint( wxPaintEvent& event )
     b_rcache_ok = !b_newview;
 
     //  If in skew compensation mode, with a skewed VP shown, we may be able to use the cached rotated bitmap
-    if( g_bskew_comp && ( fabs( VPoint.skew ) > 0.01 ) ) b_rcache_ok = !b_newview;
+    if(  fabs( VPoint.skew ) > 0.01 ) b_rcache_ok = !b_newview;
 
     //  Make a special VP
     if( VPoint.b_MercatorProjectionOverride ) VPoint.SetProjectionType( PROJECTION_MERCATOR );
@@ -9395,10 +9392,8 @@ void ChartCanvas::OnPaint( wxPaintEvent& event )
 
             ocpnDC bgdc( temp_dc );
             double r = VPoint.rotation;
-            if (g_bskew_comp)
-                SetVPRotation(VPoint.skew);
-            else
-                SetVPRotation(0.0);
+            SetVPRotation(VPoint.skew);
+
             pWorldBackgroundChart->RenderViewOnDC( bgdc, VPoint );
             SetVPRotation( r );
         }
@@ -9424,19 +9419,14 @@ void ChartCanvas::OnPaint( wxPaintEvent& event )
 
             //    Use a local static image rotator to improve wxWidgets code profile
             //    Especially, on GTK the wxRound and wxRealPoint functions are very expensive.....
-            double angle;
-            angle = -GetVP().rotation;
-            if(g_bskew_comp)
-                angle += GetVP().skew;
 
+            double angle = GetVP().skew - GetVP().rotation;
             wxImage ri;
             bool b_rot_ok = false;
             if( base_image.IsOk() ) {
                 ViewPort rot_vp = GetVP();
 
                 m_b_rot_hidef = false;
-//                              if(g_bskew_comp && (fabs(GetVP().skew) > 0.01))
-//                                    m_b_rot_hidef = true;
 
                 ri = Image_Rotate( base_image, angle,
                                    wxPoint( GetVP().rv_rect.width / 2, GetVP().rv_rect.height / 2 ),
@@ -10650,10 +10640,6 @@ void ChartCanvas::DrawAllCurrentsInBBox( ocpnDC& dc, LLBBox& BBox )
                             wxBRUSHSTYLE_SOLID );
 
     double skew_angle = GetVPRotation();
-    if (!g_bopengl) {
-        if (!g_bskew_comp)
-            skew_angle += GetVPSkew();
-    }
 
     pTCFont = FontMgr::Get().GetFont( _("CurrentValue") );
     

--- a/src/compass.cpp
+++ b/src/compass.cpp
@@ -225,10 +225,6 @@ void ocpnCompass::CreateBmp( bool newColorScheme )
 
     if( ( fabs( cc1->GetVPRotation() ) > .01 ) || ( fabs( cc1->GetVPSkew() ) > .01 ) ) {
         rose_angle = -cc1->GetVPRotation();
-
-        if( !g_bopengl && !g_bskew_comp )
-            rose_angle -= cc1->GetVPSkew();
-
     } else
         rose_angle = 0.;
 

--- a/src/compass.cpp
+++ b/src/compass.cpp
@@ -226,7 +226,7 @@ void ocpnCompass::CreateBmp( bool newColorScheme )
     if( ( fabs( cc1->GetVPRotation() ) > .01 ) || ( fabs( cc1->GetVPSkew() ) > .01 ) ) {
         rose_angle = -cc1->GetVPRotation();
 
-        if( !g_bskew_comp )
+        if( !g_bopengl && !g_bskew_comp )
             rose_angle -= cc1->GetVPSkew();
 
     } else

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -1578,8 +1578,7 @@ void glChartCanvas::MultMatrixViewPort(ViewPort &vp, float lat, float lon)
     }
 
     double rotation = vp.rotation;
-    if (!g_bskew_comp && vp.skew)
-        rotation += vp.skew;
+
     if (rotation)
         glRotatef(rotation*180/PI, 0, 0, 1);
 }
@@ -1899,10 +1898,8 @@ void glChartCanvas::GridDraw( )
 
     ViewPort &vp = cc1->GetVP();
 
-    if (!g_bskew_comp && (fabs(vp.skew) > 0.0001)) return;
-
     // TODO: make minor grid work all the time
-    bool minorgrid = fabs( vp.rotation ) < 0.0001 && ( g_bskew_comp || fabs( vp.skew ) < 0.0001) &&
+    bool minorgrid = fabs( vp.rotation ) < 0.0001 &&
         vp.m_projection_type == PROJECTION_MERCATOR;
 
     double nlat, elon, slat, wlon;
@@ -2664,8 +2661,6 @@ void glChartCanvas::DrawCloseMessage(wxString msg)
 void glChartCanvas::RotateToViewPort(const ViewPort &vp)
 {
     float angle = vp.rotation;
-    if(g_bskew_comp)
-        angle -= vp.skew;
 
     if( fabs( angle ) > 0.0001 )
     {
@@ -3049,9 +3044,6 @@ void glChartCanvas::RenderRasterChartRegionGL( ChartBase *chart, ViewPort &vp, L
 {
     ChartBaseBSB *pBSBChart = dynamic_cast<ChartBaseBSB*>( chart );
     if( !pBSBChart ) return;
-
-    double skew_norm = chart->GetChartSkew();
-    if( skew_norm > 180. ) skew_norm -= 360.;
 
     double scalefactor = pBSBChart->GetRasterScaleFactor(vp);
 
@@ -4091,8 +4083,7 @@ void glChartCanvas::Render()
 //               && (VPoint.b_quilt || (Current_Ch && Current_Ch->GetChartFamily() == CHART_FAMILY_VECTOR))
                && (VPoint.m_projection_type == PROJECTION_MERCATOR ||
                    VPoint.m_projection_type == PROJECTION_EQUIRECTANGULAR) 
-               && m_cache_vp.pix_height == VPoint.pix_height
-               /* && (!g_bskew_comp || fabs( VPoint.skew ) == 0.0 )*/) {
+               && m_cache_vp.pix_height == VPoint.pix_height) {
                 wxPoint2DDouble c_old = VPoint.GetDoublePixFromLL( VPoint.clat, VPoint.clon );
                 wxPoint2DDouble c_new = m_cache_vp.GetDoublePixFromLL( VPoint.clat, VPoint.clon );
 

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -254,8 +254,6 @@ wxPoint2DDouble ViewPort::GetDoublePixFromLL( double lat, double lon )
 
     //    Apply VP Rotation
     double angle = rotation;
-    if (!g_bopengl && !g_bskew_comp)
-        angle += skew;
 
     if( angle ) {
         dxr = epix * cos( angle ) + npix * sin( angle );
@@ -275,8 +273,6 @@ void ViewPort::GetLLFromPix( const wxPoint2DDouble &p, double *lat, double *lon 
 
     //    Apply VP Rotation
     double angle = rotation;
-    if (!g_bopengl && !g_bskew_comp)
-        angle += skew;
 
     if( angle ) {
         xpr = ( dx * cos( angle ) ) - ( dy * sin( angle ) );
@@ -863,13 +859,8 @@ void ViewPort::SetBoxes( void )
         double lpixh = pix_height;
         double lpixw = pix_width;
 
-        if (!g_bopengl && (fabs(skew) > 0.0001))
-            if (g_bskew_comp)
-                rotator -= skew;
-            else {
-                lpixh = wxMax(lpixh, (fabs(pix_height * cos(skew)) + fabs(pix_width * sin(skew))));
-                lpixw = wxMax(lpixw, (fabs(pix_width * cos(skew)) + fabs(pix_height * sin(skew))));
-            }
+        lpixh = wxMax(lpixh, (fabs(pix_height * cos(skew)) + fabs(pix_width * sin(skew))));
+        lpixw = wxMax(lpixw, (fabs(pix_width * cos(skew)) + fabs(pix_height * sin(skew))));
 
         int dy = wxRound(
                      fabs( lpixh * cos( rotator ) ) + fabs( lpixw * sin( rotator ) ) );
@@ -884,18 +875,14 @@ void ViewPort::SetBoxes( void )
         int inflate_y = wxMax(( dy - pix_height ) / 2, 0);
         
         //  Grow the source rectangle appropriately
-        if( fabs( rotator ) > .0001 || fabs( skew ) > .0001)
-            rv_rect.Inflate( inflate_x, inflate_y );
+        rv_rect.Inflate( inflate_x, inflate_y );
     }
 
     //  Compute Viewport lat/lon reference points for co-ordinate hit testing
 
     //  This must be done in unrotated space with respect to full unrotated screen space calculated above
     double rotation_save = rotation;
-    if (!g_bopengl &&!g_bskew_comp)
-        SetRotationAngle(-skew);
-    else
-        SetRotationAngle(0.0);
+    SetRotationAngle(0.0);
 
     wxPoint ul( rv_rect.x, rv_rect.y ), lr( rv_rect.x + rv_rect.width, rv_rect.y + rv_rect.height );
     double dlat_min, dlat_max, dlon_min, dlon_max;

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -118,7 +118,7 @@ extern sigjmp_buf           env;                    // the context saved by sigs
 extern void catch_signals(int signo);
 
 extern bool             g_bskew_comp;
-
+extern bool             g_bopengl;
 
 //------------------------------------------------------------------------------
 //    ViewPort Implementation
@@ -254,7 +254,7 @@ wxPoint2DDouble ViewPort::GetDoublePixFromLL( double lat, double lon )
 
     //    Apply VP Rotation
     double angle = rotation;
-    if(!g_bskew_comp)
+    if (!g_bopengl && !g_bskew_comp)
         angle += skew;
 
     if( angle ) {
@@ -275,7 +275,7 @@ void ViewPort::GetLLFromPix( const wxPoint2DDouble &p, double *lat, double *lon 
 
     //    Apply VP Rotation
     double angle = rotation;
-    if(!g_bskew_comp)
+    if (!g_bopengl && !g_bskew_comp)
         angle += skew;
 
     if( angle ) {
@@ -857,16 +857,24 @@ void ViewPort::SetBoxes( void )
     rv_rect = wxRect( 0, 0, pix_width, pix_height );
 
     //  Specify the minimum required rectangle in unrotated screen space which will supply full screen data after specified rotation
-    if( ( g_bskew_comp && ( fabs( skew ) > .001 ) ) || ( fabs( rotation ) > .001 ) ) {
+    if (( fabs( skew ) > .0001 ) || (fabs(rotation )>.0001 )) {
 
         double rotator = rotation;
-        if(g_bskew_comp)
-            rotator -= skew;
+        double lpixh = pix_height;
+        double lpixw = pix_width;
+
+        if (!g_bopengl && (fabs(skew) > 0.0001))
+            if (g_bskew_comp)
+                rotator -= skew;
+            else {
+                lpixh = wxMax(lpixh, (fabs(pix_height * cos(skew)) + fabs(pix_width * sin(skew))));
+                lpixw = wxMax(lpixw, (fabs(pix_width * cos(skew)) + fabs(pix_height * sin(skew))));
+            }
 
         int dy = wxRound(
-                     fabs( pix_height * cos( rotator ) ) + fabs( pix_width * sin( rotator ) ) );
+                     fabs( lpixh * cos( rotator ) ) + fabs( lpixw * sin( rotator ) ) );
         int dx = wxRound(
-                     fabs( pix_width * cos( rotator ) ) + fabs( pix_height * sin( rotator ) ) );
+                     fabs( lpixw * cos( rotator ) ) + fabs( lpixh * sin( rotator ) ) );
 
         //  It is important for MSW build that viewport pixel dimensions be multiples of 4.....
         if( dy % 4 ) dy += 4 - ( dy % 4 );
@@ -876,16 +884,18 @@ void ViewPort::SetBoxes( void )
         int inflate_y = wxMax(( dy - pix_height ) / 2, 0);
         
         //  Grow the source rectangle appropriately
-        if( fabs( rotator ) > .001 )
+        if( fabs( rotator ) > .0001 || fabs( skew ) > .0001)
             rv_rect.Inflate( inflate_x, inflate_y );
-
     }
 
     //  Compute Viewport lat/lon reference points for co-ordinate hit testing
 
     //  This must be done in unrotated space with respect to full unrotated screen space calculated above
     double rotation_save = rotation;
-    SetRotationAngle( 0. );
+    if (!g_bopengl &&!g_bskew_comp)
+        SetRotationAngle(-skew);
+    else
+        SetRotationAngle(0.0);
 
     wxPoint ul( rv_rect.x, rv_rect.y ), lr( rv_rect.x + rv_rect.width, rv_rect.y + rv_rect.height );
     double dlat_min, dlat_max, dlon_min, dlon_max;


### PR DESCRIPTION
This removes skew compensation from opengl skewed raster charts,  Normal rotation is used to display skewed charts chart-up.

Non-opengl displayed skewed raster charts have many fixes but still use skew compensation.