### PR TITLE
save plib noshow array when building thumbnail

### DIFF
--- a/include/s52plib.h
+++ b/include/s52plib.h
@@ -192,6 +192,8 @@ public:
     void AddObjNoshow( const char *objcl);
     void RemoveObjNoshow( const char *objcl);
     void ClearNoshow(void);
+    void SaveObjNoshow() { m_saved_noshow = m_noshow_array; };
+    void RestoreObjNoshow() { m_noshow_array = m_saved_noshow; };
     
     //Todo accessors
     LUPname m_nSymbolStyle;
@@ -358,6 +360,7 @@ private:
     bool m_benableGLLS;
     DisCat m_nDisplayCategory;
     ArrayOfNoshow m_noshow_array;
+    ArrayOfNoshow m_saved_noshow;
 };
 
 

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -3203,6 +3203,9 @@ bool s57chart::BuildThumbnail( const wxString &bmpname )
 
 //      Also, save some other settings
     bool bsavem_bShowSoundgp = ps52plib->m_bShowSoundg;
+    
+    // SetDisplayCategory may clear Noshow array
+    ps52plib->SaveObjNoshow();
 
 //      Now, set up what I want for this render
     for( iPtr = 0; iPtr < OBJLCount; iPtr++ ) {
@@ -3240,6 +3243,8 @@ bool s57chart::BuildThumbnail( const wxString &bmpname )
     }
 
     ps52plib->SetDisplayCategory(dsave);
+    ps52plib->RestoreObjNoshow();
+
     ps52plib->m_bShowSoundg = bsavem_bShowSoundgp;
 
 //      Reset the color scheme


### PR DESCRIPTION
Hi,

Or after thumbnail creation lights 'L' and anchors 'A' setting are reset to 'on' in display ALL mode. 

Regards
Didier
