### PR TITLE
Be robust when a plugin creates its own OpenGL contexts

### DIFF
--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -907,6 +907,9 @@ void glChartCanvas::OnSize( wxSizeEvent& event )
     // this is also necessary to update the context on some platforms
 #if !wxCHECK_VERSION(3,0,0)    
     wxGLCanvas::OnSize( event );
+#else
+    // OnSize can be called with a different OpenGL context (when a plugin uses a different GL context).
+    SetCurrent(*m_pcontext);
 #endif
     
     /* expand opengl widget to fill viewport */

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -2578,7 +2578,7 @@ void glChartCanvas::DrawFloatingOverlayObjects( ocpnDC &dc )
 
     if( g_pi_manager ) {
         g_pi_manager->SendViewPortToRequestingPlugIns( vp );
-        g_pi_manager->RenderAllGLCanvasOverlayPlugIns( NULL, vp );
+        g_pi_manager->RenderAllGLCanvasOverlayPlugIns( m_pcontext, vp );
     }
 
     // all functions called with cc1-> are still slow because they go through ocpndc


### PR DESCRIPTION
When a plugin uses one or more OpenGL contexts then the `glChartCanvas::OnSize()` method can be called with the plugin context still active. It then proceeds to clobber the plugin OpenGL context and not store the FBO properly. So both the plugin and main chart displays get corrupted.

My proposed fix is quite simple: switch back to the OpenCPN OpenGL context in `glChartCanvas::OnSize()`.

Note that I'm also able to work around it in my BR24radar_pi plugin, but that is a bit of a hack as I have to store the `wxGLContext` passed to the plugin in `RenderGLOverlay()` and then switch back to that context in my own drawing code. This strategy only works because OpenCPN itself only uses a single OpenGL context.