### PR TITLE
Quilt, only unlock chart owned by it.

### DIFF
--- a/include/Quilt.h
+++ b/include/Quilt.h
@@ -58,6 +58,7 @@ public:
     {
         b_include = false;
         b_eclipsed = false;
+        b_locked = false;
     }
 
     LLRegion &GetCandidateRegion();
@@ -66,6 +67,7 @@ public:
     int ChartScale;
     bool b_include;
     bool b_eclipsed;
+    bool b_locked;
     
 private:    
     LLRegion candidate_region;

--- a/include/chartdb.h
+++ b/include/chartdb.h
@@ -130,7 +130,7 @@ public:
 
       ChartBase *OpenChartFromStack(ChartStack *pStack, int StackEntry, ChartInitFlag iflag = FULL_INIT);
       ChartBase *OpenChartFromDB(int index, ChartInitFlag init_flag);
-      ChartBase *OpenChartFromDBAndLock(int index, ChartInitFlag init_flag );
+      ChartBase *OpenChartFromDBAndLock(int index, ChartInitFlag init_flag , bool lock = true);
       ChartBase *OpenChartFromDB(wxString chart_path, ChartInitFlag init_flag);
       
       void ApplyColorSchemeToCachedCharts(ColorScheme cs);
@@ -144,7 +144,7 @@ public:
       bool IsCacheLocked(){ return m_b_locked; }
       wxXmlDocument GetXMLDescription(int dbIndex, bool b_getGeom);
 
-      void LockCacheChart( int index );
+      bool LockCacheChart( int index );
       bool IsChartLocked( int index );
       
       void UnLockCacheChart( int index );

--- a/src/chartdb.cpp
+++ b/src/chartdb.cpp
@@ -920,23 +920,26 @@ bool ChartDB::IsChartLocked( int index )
     return false;
 }
     
-void ChartDB::LockCacheChart( int index )
+bool ChartDB::LockCacheChart( int index )
 {
     //    Search the cache
+    bool ret = false;
     if( wxMUTEX_NO_ERROR == m_cache_mutex.Lock() ){
         
         unsigned int nCache = pChartCache->GetCount();
         for(unsigned int i=0 ; i<nCache ; i++)
         {
             CacheEntry *pce = (CacheEntry *)(pChartCache->Item(i));
-            if(pce->dbIndex == index)
+            if(pce->dbIndex == index )
             {
                 pce->n_lock++;
+                ret = true;
                 break;
             }
         }
         m_cache_mutex.Unlock();
     }
+    return ret;
 }
 
 void ChartDB::UnLockCacheChart( int index )
@@ -995,11 +998,12 @@ ChartBase *ChartDB::OpenChartFromStack(ChartStack *pStack, int StackEntry, Chart
     return OpenChartUsingCache(pStack->GetDBIndex(StackEntry), init_flag);
 }
 
-ChartBase *ChartDB::OpenChartFromDBAndLock( int index, ChartInitFlag init_flag )
+ChartBase *ChartDB::OpenChartFromDBAndLock( int index, ChartInitFlag init_flag, bool lock )
 {
     wxCriticalSectionLocker locker(m_critSect);
     ChartBase *pret = OpenChartUsingCache(index, init_flag);
-    LockCacheChart( index );
+    if (lock && pret)
+        LockCacheChart( index );
     return pret;
 }
 
@@ -1060,6 +1064,7 @@ ChartBase *ChartDB::OpenChartUsingCache(int dbindex, ChartInitFlag init_flag)
       
       ChartBase *Ch = NULL;
       CacheEntry *pce = NULL;
+      int old_lock = 0;
 
       bool bInCache = false;
       m_ticks++;
@@ -1099,13 +1104,15 @@ ChartBase *ChartDB::OpenChartUsingCache(int dbindex, ChartInitFlag init_flag)
                     if(pthumbwin && pthumbwin->pThumbChart == Ch)
                        pthumbwin->pThumbChart = NULL;
                     delete Ch;                                  // chart is not useable
-                    
+                    // but may be locked in quilt
                     if( wxMUTEX_NO_ERROR == m_cache_mutex.Lock() ){
+                        old_lock = pce->n_lock;
                         pChartCache->Remove(pce);                   // so remove it
+                        delete pce;
                         m_cache_mutex.Unlock();
                     }
+                    // XXX and if there's a mutex error?
                         
-                    delete pce;
                     bInCache = false;
               }
           }
@@ -1338,7 +1345,7 @@ ChartBase *ChartDB::OpenChartUsingCache(int dbindex, ChartInitFlag init_flag)
                               pce->dbIndex = dbindex;
 //                              printf("    Adding chart %d\n", dbindex);
                               pce->RecentTime = m_ticks;
-                              pce->n_lock = 0;
+                              pce->n_lock = old_lock;
 
                               if( wxMUTEX_NO_ERROR == m_cache_mutex.Lock() ){
                                 pChartCache->Add((void *)pce);


### PR DESCRIPTION
Hi,
Charts can (or should) be locked by other tasks and they shouldn't be unlocked when recomputing the quilt stack .

Regards
Didier

