### PR TITLE
lock chart in cache when compressing in the foreground

### DIFF
--- a/include/chartdb.h
+++ b/include/chartdb.h
@@ -131,6 +131,7 @@ public:
       ChartBase *OpenChartFromStack(ChartStack *pStack, int StackEntry, ChartInitFlag iflag = FULL_INIT);
       ChartBase *OpenChartFromDB(int index, ChartInitFlag init_flag);
       ChartBase *OpenChartFromDBAndLock(int index, ChartInitFlag init_flag , bool lock = true);
+      ChartBase *OpenChartFromDBAndLock(wxString chart_path, ChartInitFlag init_flag);
       ChartBase *OpenChartFromDB(wxString chart_path, ChartInitFlag init_flag);
       
       void ApplyColorSchemeToCachedCharts(ColorScheme cs);

--- a/src/chartdb.cpp
+++ b/src/chartdb.cpp
@@ -1007,6 +1007,12 @@ ChartBase *ChartDB::OpenChartFromDBAndLock( int index, ChartInitFlag init_flag, 
     return pret;
 }
 
+ChartBase *ChartDB::OpenChartFromDBAndLock(wxString chart_path, ChartInitFlag init_flag)
+{
+    int dbii = FinddbIndex( chart_path );
+    return OpenChartFromDBAndLock(dbii, init_flag);
+}
+
 CacheEntry *ChartDB::FindOldestDeleteCandidate( bool blog)
 {
     CacheEntry *pret = 0;
@@ -1392,6 +1398,7 @@ ChartBase *ChartDB::OpenChartUsingCache(int dbindex, ChartInitFlag init_flag)
       return NULL;
 }
 
+// 
 bool ChartDB::DeleteCacheChart(ChartBase *pDeleteCandidate)
 {
     bool retval = false;
@@ -1414,8 +1421,13 @@ bool ChartDB::DeleteCacheChart(ChartBase *pDeleteCandidate)
 
             if(pce)
             {
-                  DeleteCacheEntry( pce);
-                  retval = true;
+                  if(pce->n_lock > 0)
+                    pce->n_lock--;
+
+                  if( pce->n_lock == 0) {
+                      DeleteCacheEntry( pce);
+                      retval = true;
+                  }
             }
       }
       

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -539,7 +539,7 @@ void BuildCompressedCache()
         wxString CompressedCacheFilePath = CompressedCachePath(filename);
         double distance = ct_array.Item(j).distance;
 
-        ChartBase *pchart = ChartData->OpenChartFromDB( filename, FULL_INIT );
+        ChartBase *pchart = ChartData->OpenChartFromDBAndLock( filename, FULL_INIT );
         if(!pchart) /* probably a corrupt chart */
             continue;
 


### PR DESCRIPTION
Hi,
foreground compression task can yield and the rendering logic
under memory pressure can free cache entries.

DeleteCacheChart: decrement lock counter by one and only delete
in cache if it's 0.

Regards
Didier
