### PR TITLE
Apply grib_pi scaled gui  from core

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -996,6 +996,7 @@ extern DECL_EXP wxBitmap GetIcon_PlugIn(const wxString & name);
 extern DECL_EXP void SetCursor_PlugIn( wxCursor *pPlugin_Cursor = NULL );
 extern DECL_EXP wxFont *GetOCPNScaledFont_PlugIn(wxString TextElement, int default_size = 0);
 extern DECL_EXP wxFont GetOCPNGUIScaledFont_PlugIn(wxString item);
+extern DECL_EXP double GetOCPNGUIToolScaleFactor_PlugIn(int GUIScaledFactor);
 extern DECL_EXP wxColour GetFontColour_PlugIn(wxString TextElement);
 
 extern DECL_EXP double GetCanvasTilt();

--- a/plugins/grib_pi/src/GrabberWin.cpp
+++ b/plugins/grib_pi/src/GrabberWin.cpp
@@ -135,26 +135,20 @@ void GribGrabberWin::OnMouseEvent( wxMouseEvent& event )
 void GribGrabberWin::OnPaint( wxPaintEvent& event )
 {
     wxPaintDC dc( this );
-    dc.DrawBitmap( m_bitmap, 0, 0, true );
+    dc.DrawBitmap( m_bitmap, 0, 5, true );
 
 }
 
-int GribGrabberWin::Size( int height )
+void GribGrabberWin::Size( double factor )
 
 {
- //   int margin = 8;     //bitmap y will be always extended at least by 8 pix
-
     wxBitmap bitmap = (wxBitmap( grabber ));
-    int width = bitmap.GetWidth();
-
-/*    if( height < bitmap.GetHeight() + margin )
-        bitmap = bitmap.GetSubBitmap( wxRect(0, 0, width, height - margin) );*/
+    int width = (int)(bitmap.GetWidth() * factor);
+    int height = (int)(bitmap.GetHeight() * factor);
 
     wxImage scaled_image = bitmap.ConvertToImage();
     m_bitmap = wxBitmap(scaled_image.Scale(width, height, wxIMAGE_QUALITY_HIGH));
 
-    SetSize( wxSize( width, height ));
-    SetMinSize( wxSize( width, height ));
-
-    return width;
+    SetSize(wxSize(width, height + 10));
+    SetMinSize(wxSize(width, height + 10));
 }

--- a/plugins/grib_pi/src/GrabberWin.h
+++ b/plugins/grib_pi/src/GrabberWin.h
@@ -47,7 +47,7 @@ class GribGrabberWin: public wxPanel
 public:
     GribGrabberWin( wxWindow *parent );
     void OnPaint( wxPaintEvent& event );
-    int Size( int height );
+    void Size( double factor );
 private:
     void OnMouseEvent( wxMouseEvent& event );
 

--- a/plugins/grib_pi/src/GribRequestDialog.cpp
+++ b/plugins/grib_pi/src/GribRequestDialog.cpp
@@ -603,7 +603,7 @@ void GribRequestSetting::OnTimeRangeChange(wxCommandEvent &event)
         if( m_pTimeRange->GetCurrentSelection() > 6 ) {         //time range more than 8 days
             m_pWaves->SetValue(0);
             m_pWaves->Enable(false);
-            OCPNMessageBox_PlugIn(this, _("You request a forecast for more than 8 days horizon.\nThis is conflicting with Wave data which will be removed from your request.\nDon't forget that beyond the first 8 days, the resolution will be only 2.5\u00B0x2.5\u00B0 and the time intervall 12 hours."),
+            OCPNMessageBox_PlugIn(this, _("You request a forecast for more than 8 days horizon.\nThis is conflicting with Wave data which will be removed from your request.\nDon't forget that beyond the first 8 days, the resolution will be only 2.5\u00B0x2.5\u00B0\nand the time intervall 12 hours."),
                 _("Warning!") );
         } else
             m_pWaves->Enable(true);

--- a/plugins/grib_pi/src/GribSettingsDialog.cpp
+++ b/plugins/grib_pi/src/GribSettingsDialog.cpp
@@ -813,7 +813,7 @@ void GribSettingsDialog::OnApply( wxCommandEvent& event )
 void GribSettingsDialog::OnIntepolateChange( wxCommandEvent& event )
 {
     if( m_cInterpolate->IsChecked() ) {
-        OCPNMessageBox_PlugIn(this, _("You have chosen to authorize interpolation.\nDon't forget that data displayed will not be real but recomputed and this can decrease accuracy!"),
+        OCPNMessageBox_PlugIn(this, _("You have chosen to authorize interpolation.\nDon't forget that data displayed will not be real but recomputed\nThis can decrease accuracy!"),
                             _("Warning!") );
         m_tSlicesPerUpdate->Show();
         m_sSlicesPerUpdate->Show();
@@ -851,7 +851,7 @@ void GribSettingsDialog::OnSpacingModeChange( wxCommandEvent& event )
     }
 
     if( message ) {
-        OCPNMessageBox_PlugIn(this, _("This option imply you authorize intrepolation\nDon't forget that data displayed will not be real but recomputed and this can decrease accuracy!"),
+        OCPNMessageBox_PlugIn(this, _("This option imply you authorize intrepolation\nDon't forget that data displayed will not be real but recomputed\nThis can decrease accuracy!"),
                             _("Warning!") );
     }
 }

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -256,20 +256,6 @@ GRIBUICtrlBar::GRIBUICtrlBar(wxWindow *parent, wxWindowID id, const wxString& ti
     //init zone selection parameters
     m_ZoneSelMode = m_OldZoneSelMode ? START_SELECTION : AUTO_SELECTION;                       ////init zone selection parameters
 
-    double scale_factor = 1.0;
-   //set buttons bitmap
-    m_bpPrev->SetBitmapLabel(GetScaledBitmap( prev, scale_factor ));
-    m_bpNext->SetBitmapLabel(GetScaledBitmap( next, scale_factor ));
-    m_bpAltitude->SetBitmapLabel(GetScaledBitmap( altitude, scale_factor ));
-    m_bpNow->SetBitmapLabel(GetScaledBitmap( now, scale_factor ));
-    m_bpZoomToCenter->SetBitmapLabel(GetScaledBitmap( zoomto , scale_factor));
-    m_bpPlay->SetBitmapLabel(GetScaledBitmap( play, scale_factor ));
-    m_bpShowCursorData->SetBitmapLabel(GetScaledBitmap( m_CDataIsShown ? curdata : ncurdata, scale_factor ));
-    m_bpOpenFile->SetBitmapLabel(GetScaledBitmap( openfile, scale_factor ));
-    m_bpSettings->SetBitmapLabel(GetScaledBitmap( setting, scale_factor ));
-
-    SetRequestBitmap( m_ZoneSelMode );
-
     //connect Timer
     m_tPlayStop.Connect(wxEVT_TIMER, wxTimerEventHandler( GRIBUICtrlBar::OnPlayStopTimer ), NULL, this);
     //connect functions
@@ -314,27 +300,47 @@ GRIBUICtrlBar::~GRIBUICtrlBar()
     delete m_pTimelineSet;
 }
 
+void GRIBUICtrlBar::SetScaledBitmap( double factor )
+{
+    m_ScaledFactor = factor > 1 ? factor * 1.2: factor;
+   //set buttons bitmap
+    m_bpPrev->SetBitmapLabel(GetScaledBitmap( prev, m_ScaledFactor ));
+    m_bpNext->SetBitmapLabel(GetScaledBitmap( next, m_ScaledFactor ));
+    m_bpAltitude->SetBitmapLabel(GetScaledBitmap( altitude, m_ScaledFactor ));
+    m_bpNow->SetBitmapLabel(GetScaledBitmap( now, m_ScaledFactor ));
+    m_bpZoomToCenter->SetBitmapLabel(GetScaledBitmap( zoomto , m_ScaledFactor));
+    m_bpPlay->SetBitmapLabel(GetScaledBitmap( play, m_ScaledFactor ));
+    m_bpShowCursorData->SetBitmapLabel(GetScaledBitmap( m_CDataIsShown ? curdata : ncurdata, m_ScaledFactor ));
+    m_bpOpenFile->SetBitmapLabel(GetScaledBitmap( openfile, m_ScaledFactor ));
+    m_bpSettings->SetBitmapLabel(GetScaledBitmap( setting, m_ScaledFactor ));
+    SetRequestBitmap( m_ZoneSelMode );
+
+    m_sTimeline->SetSize( wxSize( 90 * m_ScaledFactor , -1 ) );
+    m_sTimeline->SetMinSize( wxSize( 90 * m_ScaledFactor , -1 ) );
+
+}
+
 void GRIBUICtrlBar::SetRequestBitmap( int type )
 {
     switch( type ) {
     case AUTO_SELECTION:
     case START_SELECTION:
-        m_bpRequest->SetBitmapLabel(wxBitmap( request));
+        m_bpRequest->SetBitmapLabel( GetScaledBitmap( request, m_ScaledFactor));
         m_bpRequest->SetToolTip(_("Start a request"));
         break;
     case DRAW_SELECTION:
-        m_bpRequest->SetBitmapLabel(wxBitmap( selzone ));
+        m_bpRequest->SetBitmapLabel( GetScaledBitmap( selzone, m_ScaledFactor));
         m_bpRequest->SetToolTip(_("Stop request"));
         break;
     case COMPLETE_SELECTION:
-        m_bpRequest->SetBitmapLabel(wxBitmap(request_end));
+        m_bpRequest->SetBitmapLabel(GetScaledBitmap(request_end, m_ScaledFactor));
         m_bpRequest->SetToolTip(_("Valid request"));
     }
 }
 
 void GRIBUICtrlBar::OpenFile(bool newestFile)
 {
-    m_bpPlay->SetBitmapLabel(wxBitmap( play ));
+    m_bpPlay->SetBitmapLabel( GetScaledBitmap( play, m_ScaledFactor ) );
     m_cRecordForecast->Clear();
     pPlugIn->GetGRIBOverlayFactory()->ClearParticles();
 	m_Altitude = 0;
@@ -502,7 +508,7 @@ void GRIBUICtrlBar::OnShowCursorData( wxCommandEvent& event )
 {
 	m_CDataIsShown = !m_CDataIsShown;
 
-	m_bpShowCursorData->SetBitmapLabel(wxBitmap( m_CDataIsShown ? curdata : ncurdata ));
+	m_bpShowCursorData->SetBitmapLabel(GetScaledBitmap( m_CDataIsShown ? curdata : ncurdata, m_ScaledFactor ));
 
     SetDialogsStyleSizePosition( true );
 }
@@ -545,7 +551,7 @@ void GRIBUICtrlBar::SetDialogsStyleSizePosition( bool force_recompute )
 
     if( (m_DialogStyle >> 1 == SEPARATED || !m_CDataIsShown) && !m_HasCaption ) {                   // Size and show grabber if necessary
         Fit();                                                                                      // each time CtrlData dialog will be alone
-        m_gGrabber->Size( GetSize().y );                                                            // or separated
+        m_gGrabber->Size( m_ScaledFactor );                                                            // or separated
 	    m_gGrabber->Show();
     }
 
@@ -804,6 +810,18 @@ void GRIBUICtrlBar::OnSize( wxSizeEvent& event )
     event.Skip();
 }
 
+void GRIBUICtrlBar::OnPaint( wxPaintEvent& event )
+{
+    wxWindowListNode *node =  this->GetChildren().GetFirst();
+    wxPaintDC dc( this );
+    while( node ) {
+        wxWindow *win = node->GetData();
+        if( win->IsKindOf(CLASSINFO(wxBitmapButton)) )
+                dc.DrawBitmap(((wxBitmapButton*) win)->GetBitmap() , 5, 5, false );
+        node = node->GetNext();
+	}
+}
+
 void GRIBUICtrlBar::OnRequest(  wxCommandEvent& event )
 {
     if( m_tPlayStop.IsRunning() ) return;                            // do nothing when play back is running !
@@ -903,7 +921,7 @@ void GRIBUICtrlBar::OnPlayStop( wxCommandEvent& event )
     if( m_tPlayStop.IsRunning() ) {
         StopPlayBack();
     } else {
-        m_bpPlay->SetBitmapLabel(wxBitmap( stop ));
+        m_bpPlay->SetBitmapLabel( GetScaledBitmap( stop, m_ScaledFactor ) );
         m_bpPlay->SetToolTip( _("Stop play back") );
         m_tPlayStop.Start( 1000/m_OverlaySettings.m_UpdatesPerSecond, wxTIMER_CONTINUOUS );
         m_InterpolateMode = m_OverlaySettings.m_bInterpolate;
@@ -939,7 +957,7 @@ void GRIBUICtrlBar::StopPlayBack()
 {
     if( m_tPlayStop.IsRunning() ) {
         m_tPlayStop.Stop();
-        m_bpPlay->SetBitmapLabel(wxBitmap( play ));
+        m_bpPlay->SetBitmapLabel( GetScaledBitmap( play, m_ScaledFactor ) );
         m_bpPlay->SetToolTip( _("Start play back") );
     }
 }

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -466,8 +466,8 @@ wxString GRIBUICtrlBar::GetNewestFileInDirectory()
     wxArrayString file_array;
     int m_n_files = 0;
     m_n_files = wxDir::GetAllFiles( m_grib_dir, &file_array, _T ( "*.grb" ), wxDIR_FILES );
-    m_n_files += wxDir::GetAllFiles( m_grib_dir, &file_array, _T ( "*.bz2" ),
-        wxDIR_FILES );
+    m_n_files += wxDir::GetAllFiles( m_grib_dir, &file_array, _T ( "*.bz2" ), wxDIR_FILES );
+    m_n_files += wxDir::GetAllFiles( m_grib_dir, &file_array, _T ( "*.gz" ), wxDIR_FILES );
     if( m_n_files ) {
         file_array.Sort( CompareFileStringTime );              //sort the files by File Modification Date
 
@@ -1178,7 +1178,7 @@ void GRIBUICtrlBar::OnOpenFile( wxCommandEvent& event )
     }
 
     wxFileDialog *dialog = new wxFileDialog(NULL, _("Select a GRIB file"), m_grib_dir,
-        _T(""), wxT ( "Grib files (*.grb;*.bz2)|*.grb;*.bz2|All files (*)|*.*"), wxFD_OPEN, wxDefaultPosition,
+        _T(""), wxT ( "Grib files (*.grb;*.bz2;*.gz)|*.grb;*.bz2;*.gz|All files (*)|*.*"), wxFD_OPEN, wxDefaultPosition,
         wxDefaultSize, _T("File Dialog") );
 
     if( dialog->ShowModal() == wxID_OK ) {

--- a/plugins/grib_pi/src/GribUIDialog.h
+++ b/plugins/grib_pi/src/GribUIDialog.h
@@ -111,6 +111,7 @@ public:
     void OnMouseEvent( wxMouseEvent& event );
     GRIBUICData *GetCDataDialog() { return m_gGRIBUICData; }
     bool InDataPlot (int id) { return id > wxID_ANY && id < (int)GribOverlaySettings::GEO_ALTITUDE; }
+    void SetScaledBitmap( double factor );
 
     wxWindow *pParent;
     GribOverlaySettings m_OverlaySettings;
@@ -128,6 +129,7 @@ public:
 private:
     void OnClose( wxCloseEvent& event );
     void OnSize( wxSizeEvent& event );
+    void OnPaint( wxPaintEvent& event );
     void OnSettings( wxCommandEvent& event );
     void OnPlayStop( wxCommandEvent& event );
     void OnPlayStopTimer( wxTimerEvent & event);
@@ -170,6 +172,7 @@ private:
     bool m_InterpolateMode;
     bool m_pNowMode;
     bool m_HasAltitude;
+    double m_ScaledFactor;
 
     bool             m_SelectionIsSaved;
     int              m_Selection_index;

--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -75,7 +75,6 @@ GRIBUICtrlBarBase::GRIBUICtrlBarBase( wxWindow* parent, wxWindowID id, const wxS
 	m_sTimeline = new wxSlider( this, ID_TIMELINE, 1, 0, 10, wxDefaultPosition, wxSize( 90,-1 ), wxSL_HORIZONTAL );
         fgSizer51->Add( m_sTimeline, 0, wxEXPAND, 1 );
 
-
         fgSizer51->Add( 0, 0, 1, wxEXPAND|wxLEFT|wxRIGHT, 1 );
 
 	m_bpOpenFile = new wxBitmapButton( this, ID_BTNOPENFILE, wxNullBitmap, wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
@@ -250,6 +249,7 @@ GRIBUICtrlBarBase::GRIBUICtrlBarBase( wxWindow* parent, wxWindowID id, const wxS
 	this->Connect( wxEVT_ENTER_WINDOW, wxMouseEventHandler( GRIBUICtrlBarBase::OnMouseEvent ) );
 	this->Connect( wxEVT_MOUSEWHEEL, wxMouseEventHandler( GRIBUICtrlBarBase::OnMouseEvent ) );
 	this->Connect( wxEVT_SIZE, wxSizeEventHandler( GRIBUICtrlBarBase::OnSize ) );
+    this->Connect( wxEVT_PAINT, wxPaintEventHandler( GRIBUICtrlBarBase::OnPaint ) );
 	m_bpPrev->Connect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GRIBUICtrlBarBase::OnPrev ), NULL, this );
 	m_bpPrev->Connect( wxEVT_RIGHT_DOWN, wxMouseEventHandler( GRIBUICtrlBarBase::OnMouseEvent ), NULL, this );
 	m_cRecordForecast->Connect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( GRIBUICtrlBarBase::OnRecordForecast ), NULL, this );
@@ -302,6 +302,7 @@ GRIBUICtrlBarBase::~GRIBUICtrlBarBase()
 	this->Disconnect( wxEVT_ENTER_WINDOW, wxMouseEventHandler( GRIBUICtrlBarBase::OnMouseEvent ) );
 	this->Disconnect( wxEVT_MOUSEWHEEL, wxMouseEventHandler( GRIBUICtrlBarBase::OnMouseEvent ) );
 	this->Disconnect( wxEVT_SIZE, wxSizeEventHandler( GRIBUICtrlBarBase::OnSize ) );
+	this->Disconnect( wxEVT_PAINT, wxPaintEventHandler( GRIBUICtrlBarBase::OnPaint ) );
 	m_bpPrev->Disconnect( wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler( GRIBUICtrlBarBase::OnPrev ), NULL, this );
 	m_bpPrev->Disconnect( wxEVT_RIGHT_DOWN, wxMouseEventHandler( GRIBUICtrlBarBase::OnMouseEvent ), NULL, this );
 	m_cRecordForecast->Disconnect( wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler( GRIBUICtrlBarBase::OnRecordForecast ), NULL, this );

--- a/plugins/grib_pi/src/GribUIDialogBase.h
+++ b/plugins/grib_pi/src/GribUIDialogBase.h
@@ -120,6 +120,7 @@ class GRIBUICtrlBarBase : public wxDialog
 		virtual void OnClose( wxCloseEvent& event ) { event.Skip(); }
 		virtual void OnMouseEvent( wxMouseEvent& event ) { event.Skip(); }
 		virtual void OnSize( wxSizeEvent& event ) { event.Skip(); }
+        virtual void OnPaint( wxPaintEvent& event) { event.Skip(); }
 		virtual void OnPrev( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnRecordForecast( wxCommandEvent& event ) { event.Skip(); }
 		virtual void OnNext( wxCommandEvent& event ) { event.Skip(); }

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -633,7 +633,7 @@ void grib_pi::SendTimelineMessage(wxDateTime time)
 void GribPreferencesDialog::OnStartOptionChange( wxCommandEvent& event )
 {
     if(m_rbStartOptions->GetSelection() == 2) {
-        OCPNMessageBox_PlugIn(this, _("You have chosen to authorize interpolation.\nDon't forget that data displayed at current time will not be real but Recomputed and this can decrease accuracy!"),
+        OCPNMessageBox_PlugIn(this, _("You have chosen to authorize interpolation.\nDon't forget that data displayed at current time will not be real but Recomputed\nThis can decrease accuracy!"),
                 _("Warning!"));
     }
 }

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -341,12 +341,25 @@ void grib_pi::OnToolbarToolCallback(int id)
     if( !::wxIsBusy() ) ::wxBeginBusyCursor();
 
     bool starting = false;
+
+    wxFileConfig *pConf = (wxFileConfig *)m_pconfig;
+    int scale_factor = 1;
+    bool isResponsive = true;
+    if(pConf) {
+        pConf->SetPath( _T ( "/Settings" ) );
+        pConf->Read( _T ( "GUIScaleFactor" ), &scale_factor, 1 );
+        pConf->Read( _T ( "ResponsiveGraphics" ), &isResponsive, 1 );
+    }
+    if( !isResponsive ) scale_factor = 1;
+    if( scale_factor != m_GUIScaleFactor ) starting = true;
+
     if(!m_pGribCtrlBar)
     {
         starting = true;
         long style = m_DialogStyle == ATTACHED_HAS_CAPTION ? wxCAPTION|wxCLOSE_BOX|wxSYSTEM_MENU : wxBORDER_NONE|wxSYSTEM_MENU;
         m_pGribCtrlBar = new GRIBUICtrlBar(m_parent_window, wxID_ANY, wxEmptyString, wxDefaultPosition,
                 wxDefaultSize, style, this);
+
         wxMenu* dummy = new wxMenu(_T("Plugin"));
         wxMenuItem* table = new wxMenuItem( dummy, wxID_ANY, wxString( _("Weather table") ), wxEmptyString, wxITEM_NORMAL );
 #ifdef __WXMSW__
@@ -366,13 +379,17 @@ void grib_pi::OnToolbarToolCallback(int id)
 
     }
 
+    if( m_pGribCtrlBar->GetFont() != *OCPNGetFont(_("Dialog"), 10) ) starting = true;
+
     //Toggle GRIB overlay display
     m_bShowGrib = !m_bShowGrib;
 
     //    Toggle dialog?
     if(m_bShowGrib) {
-        if( m_pGribCtrlBar->GetFont() != *OCPNGetFont(_("Dialog"), 10) || starting) {
+        if( starting ) {
+            m_GUIScaleFactor = scale_factor;
             SetDialogFont( m_pGribCtrlBar );
+            m_pGribCtrlBar->SetScaledBitmap( GetOCPNGUIToolScaleFactor_PlugIn(m_GUIScaleFactor) );
             m_pGribCtrlBar->SetDialogsStyleSizePosition( true );
         } else {
             MoveDialog( m_pGribCtrlBar, GetCtrlBarXY(), wxPoint( 20, 60) );

--- a/plugins/grib_pi/src/grib_pi.h
+++ b/plugins/grib_pi/src/grib_pi.h
@@ -152,6 +152,7 @@ private:
       wxString         m_bMailFromAddress;
       wxString         m_ZyGribLogin;
       wxString         m_ZyGribCode;
+      int              m_GUIScaleFactor;
 
       bool             m_bGRIBShowIcon;
 

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -1988,6 +1988,11 @@ wxFont *GetOCPNScaledFont_PlugIn(wxString TextElement, int default_size)
     return GetOCPNScaledFont( TextElement, default_size );
 }
 
+double GetOCPNGUIToolScaleFactor_PlugIn(int GUIScaleFactor)
+{
+    return g_Platform->GetToolbarScaleFactor(GUIScaleFactor);
+}
+
 wxFont GetOCPNGUIScaledFont_PlugIn(wxString item)
 {
     return GetOCPNGUIScaledFont( item );
@@ -1997,7 +2002,6 @@ bool AddPersistentFontKey(wxString TextElement)
 {
     return FontMgr::Get().AddAuxKey( TextElement );
 }
-
 
 wxColour GetFontColour_PlugIn(wxString TextElement)
 {


### PR DESCRIPTION
To do that is needed
- If scaled graphic interface is set
- the scaled GUI factor value set by the user
- compute the scaled factor as it is done in OCPNPlateform.cpp:GetToolbarScaleFactor
The two parameters are easy to get from reading the config file
To compute the factor, there is two choices : duplicate the code or include the function access in the plugin API , that is what I propose.