### PR TITLE
Reset m_zout_family whent setting a valid reference chart

### DIFF
--- a/include/Quilt.h
+++ b/include/Quilt.h
@@ -163,6 +163,9 @@ public:
     }
     void SetReferenceChart( int dbIndex ) {
         m_refchart_dbIndex = dbIndex;
+        if (dbIndex >= 0) {
+            m_zout_family = -1;
+        }
     }
     int GetRefChartdbIndex( void ) {
         return m_refchart_dbIndex;


### PR DESCRIPTION
Hi,
Fix the following:
select with the piano a raster chart, zoom out until it switches
to cm93 or gshhs chart, select a S57 chart and then zoom in,
raster are back.

Regards
Didier
