### PR TITLE
protect against trying to launch multiple options dialog (double click)

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -4224,6 +4224,9 @@ void MyFrame::setStringVP(wxString VPS)
 
 void MyFrame::DoSettings()
 {
+    if (g_boptionsactive)
+        return;
+
     bool bnewtoolbar = !( DoOptionsDialog() == 0 );
 
     //              Apply various system settings
@@ -5123,6 +5126,9 @@ void MyFrame::JumpToPosition( double lat, double lon, double scale )
 
 int MyFrame::DoOptionsDialog()
 {
+    if (g_boptionsactive)
+        return 0;
+
     g_boptionsactive = true;
 
 
@@ -5252,7 +5258,6 @@ int MyFrame::DoOptionsDialog()
 
     Refresh( false );
 
-    g_boptionsactive = false;
 
     if (NMEALogWindow::Get().Active())
         NMEALogWindow::Get().GetTTYWindow()->Raise();
@@ -5263,6 +5268,7 @@ int MyFrame::DoOptionsDialog()
         g_options = NULL;
     }
 
+    g_boptionsactive = false;
     return ret_val;
 }
 


### PR DESCRIPTION
Hi
On a slow box it's rather easy to click twice on the toolbar with weird results like being unable to close OCPN and so on.

Regards
Didier
