### PR TITLE
SelectCatalog calls SetSource indirectly as an event

### DIFF
--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -1120,7 +1120,6 @@ ChartDldrPanelImpl::ChartDldrPanelImpl( chartdldr_pi* plugin, wxWindow* parent, 
         AppendCatalog(pPlugIn->m_chartSources->Item(i));
     }
     SelectCatalog(pPlugIn->GetSourceId());
-    SetSource(pPlugIn->GetSourceId());
     m_populated = true;
     
     
@@ -1136,7 +1135,6 @@ void ChartDldrPanelImpl::OnPaint( wxPaintEvent& event )
             AppendCatalog(pPlugIn->m_chartSources->Item(i));
         }
         SelectCatalog(pPlugIn->GetSourceId());
-        SetSource(pPlugIn->GetSourceId());
     }
     event.Skip();
 }


### PR DESCRIPTION
Hi,
SelectCatalog sets  m_lbChartSources selected item which fires a wxEVT_COMMAND_LIST_ITEM_SELECTED event ie SetSource so no reason to call it again (it's slow).

Only tested on linux.

Regards
Didier

