### PR TITLE
only write raster cache catalog once, not after writing every level

### DIFF
--- a/include/glTexCache.h
+++ b/include/glTexCache.h
@@ -110,7 +110,8 @@ public:
 
     bool PrepareTexture( int base_level, const wxRect &rect, ColorScheme color_scheme, bool b_throttle_thread = true );
     int GetTextureLevel( glTextureDescriptor *ptd, const wxRect &rect, int level,  ColorScheme color_scheme );
-    void UpdateCacheLevel( const wxRect &rect, int level, ColorScheme color_scheme );
+    void UpdateCacheLevel( const wxRect &rect, int level, ColorScheme color_scheme, bool write_catalog = true );
+    void UpdateCacheAllLevels( const wxRect &rect, ColorScheme color_scheme );
     bool IsCompressedArrayComplete( int base_level, const wxRect &rect);
     bool IsCompressedArrayComplete( int base_level, glTextureDescriptor *ptd);
     bool IsLevelInCache( int level, const wxRect &rect, ColorScheme color_scheme );
@@ -139,9 +140,9 @@ private:
     bool WriteCatalogAndHeader();
 
     bool UpdateCache(unsigned char *data, int data_size, glTextureDescriptor *ptd, int level,
-                                   ColorScheme color_scheme);
+                                   ColorScheme color_scheme, bool write_catalog = true);
     bool UpdateCachePrecomp(unsigned char *data, int data_size, glTextureDescriptor *ptd, int level,
-                                          ColorScheme color_scheme);
+                                          ColorScheme color_scheme, bool write_catalog = true);
     
     void DeleteSingleTexture( glTextureDescriptor *ptd );
 

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -306,9 +306,7 @@ bool CompressChart(wxThread *pThread, ChartBase *pchart, wxString CompressedCach
                 if(b_needCompress){
                     b_compressed = true;
                     tex_fact->DoImmediateFullCompress(rect);
-                    for(int level = 0; level < g_mipmap_max_level + 1; level++ ) {
-                        tex_fact->UpdateCacheLevel( rect, level, global_color_scheme );
-                    }
+                    tex_fact->UpdateCacheAllLevels( rect, global_color_scheme );
                 }
 
                 //      Free all possible memory


### PR DESCRIPTION
Hi,
small speedup, OCPN always write to disk all texture levels, don't write the catalog after every level but only once, it increases the window for cache corruption a little if OCPN crashes when writing the cache but then the data saved is dubious anyway. if it's a computer crash it does change nothing as OCPN  only sync the stream  not the disk.

Regards
Didier