### PR TITLE
options: only call SetInitialVectorSettings once

### DIFF
--- a/include/options.h
+++ b/include/options.h
@@ -566,6 +566,7 @@ class options : private Uncopyable,
   int m_fontHeight, m_scrollRate, m_BTscanning, m_btNoChangeCounter;
   int m_btlastResultCount;
   bool m_bfontChanged;
+  bool m_bVectorInit;
   
   DECLARE_EVENT_TABLE()
 };

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1000,6 +1000,7 @@ void options::Init(void) {
   m_BTscanning = 0;
 
   dialogFont = GetOCPNScaledFont(_("Dialog"));
+  m_bVectorInit = false;
 
   // This variable is used by plugin callback function AddOptionsPage
   g_pOptions = this;
@@ -4997,6 +4998,8 @@ void options::SetInitialVectorSettings(void)
     
     //    Diplay Category
     if (ps52plib) {
+        m_bVectorInit = true;
+    
         if (ps57CtlListBox) {
             //    S52 Primary Filters
             ps57CtlListBox->Clear();
@@ -6242,7 +6245,8 @@ void options::OnChartsPageChange(wxListbookEvent& event) {
   }
   else if(1 == i){              // Vector charts panel
     LoadS57();
-    SetInitialVectorSettings();
+    if (!m_bVectorInit)
+        SetInitialVectorSettings();
   }
 
   event.Skip();  // Allow continued event processing


### PR DESCRIPTION
Hi,
don't call SetInitialVectorSettings each time the panel is displayed but only if it wasn't previously  called.

- it was slower
- if you made changes, switch panel and back, these changes were lost.

Regards
Didier
