### PR TITLE
only write cache catalog if we actually update the cache

### DIFF
--- a/include/glTexCache.h
+++ b/include/glTexCache.h
@@ -110,8 +110,8 @@ public:
 
     bool PrepareTexture( int base_level, const wxRect &rect, ColorScheme color_scheme, bool b_throttle_thread = true );
     int GetTextureLevel( glTextureDescriptor *ptd, const wxRect &rect, int level,  ColorScheme color_scheme );
-    void UpdateCacheLevel( const wxRect &rect, int level, ColorScheme color_scheme, bool write_catalog = true );
-    void UpdateCacheAllLevels( const wxRect &rect, ColorScheme color_scheme );
+    bool UpdateCacheLevel( const wxRect &rect, int level, ColorScheme color_scheme, bool write_catalog = true );
+    bool UpdateCacheAllLevels( const wxRect &rect, ColorScheme color_scheme );
     bool IsCompressedArrayComplete( int base_level, const wxRect &rect);
     bool IsCompressedArrayComplete( int base_level, glTextureDescriptor *ptd);
     bool IsLevelInCache( int level, const wxRect &rect, ColorScheme color_scheme );


### PR DESCRIPTION
Hi,
my previous was PR f22a182edff8f3d84d0d51bf98ee0381c36e869b was from an older patch and I forgot one 'little' thing when updating it:

 UpdateCacheLevel is often called with the texture already in the cache file, in this case ocpn must not write a new catalog.
This PR deal with this case. If no UpdateCacheLevel write something don't write a new catalog.

Regards
Didier