### PR TITLE
S52 speedup

### DIFF
--- a/include/s52s57.h
+++ b/include/s52s57.h
@@ -511,8 +511,55 @@ WX_DECLARE_HASH_MAP( int, int, wxIntegerHash, wxIntegerEqual, VectorHelperHash )
 
 WX_DECLARE_HASH_MAP( unsigned int, VE_Element *, wxIntegerHash, wxIntegerEqual, VE_Hash );
 WX_DECLARE_HASH_MAP( unsigned int, VC_Element *, wxIntegerHash, wxIntegerEqual, VC_Hash );
-WX_DECLARE_STRING_HASH_MAP( connector_segment *, connected_segment_hash );
 
+class connector_key
+{
+public:
+    connector_key() 
+    {
+      memset(k, 0 , sizeof k);
+    }
+        
+    connector_key(SegmentType t, int a, int b)
+    {
+      set(t,a,b);
+    }   
 
+    void set(SegmentType t, int a, int b) 
+    {
+      memcpy(k, &a, sizeof a);
+      memcpy(&k[sizeof a], &b, sizeof b);
+      k[sizeof (a) + sizeof (b)] = (unsigned char)t;      
+    }
+
+    unsigned long hash() const;
+ 
+    unsigned char k[sizeof(int) + sizeof(int) + sizeof(char)];
+};
+
+class connHash
+{
+public:
+  connHash() { }
+  unsigned long operator()( const connector_key& k ) const
+  { return k.hash(); }
+  
+  connHash& operator=(const connHash&) { return *this; }
+};
+
+// comparison operator
+class connEqual
+{
+public:
+connEqual() { }
+bool operator()( const connector_key& a, const connector_key& b ) const
+{
+  return memcmp(a.k, b.k, sizeof b.k) == 0; 
+}
+
+connEqual& operator=(const connEqual&) { return *this; }
+};
+
+WX_DECLARE_HASH_MAP( connector_key, connector_segment *, connHash, connEqual, connected_segment_hash );
 
 #endif

--- a/include/s52s57.h
+++ b/include/s52s57.h
@@ -483,8 +483,8 @@ public:
     float               lat_min;
     float               lon_max;
     float               lon_min;
-    void                *private0;
     int                 type;
+    void                *private0;
     
     line_segment_element *next;
 };

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -1637,18 +1637,18 @@ void s57chart::AssembleLineGeometry( void )
                             
                             //  Get the edge
                             unsigned int venode = *index_run++;
-                            VE_Element *pedge = 0;
+                            VE_Element *pedge;
                             pedge = m_ve_hash[venode];
                             
                             //  Get end connected node
                             unsigned int enode = *index_run++;
                             
                             //  Get first connected node
-                            VC_Element *ipnode = 0;
+                            VC_Element *ipnode;
                             ipnode = m_vc_hash[inode];
                             
                             //  Get end connected node
-                            VC_Element *epnode = 0;
+                            VC_Element *epnode;
                             epnode = m_vc_hash[enode];
                             
                             double e0, n0, e1, n1;
@@ -1766,7 +1766,6 @@ void s57chart::AssembleLineGeometry( void )
                     connected_segment_hash::iterator itc;
                     for( itc = m_connector_hash.begin(); itc != m_connector_hash.end(); ++itc )
                     {
-                        wxString key = itc->first;
                         connector_segment *pcs = itc->second;
                         
                         switch(pcs->type){
@@ -1857,18 +1856,18 @@ void s57chart::AssembleLineGeometry( void )
                                     
                                     //  Get the edge
                                     unsigned int venode = *index_run++;
-                                    VE_Element *pedge = 0;
+                                    VE_Element *pedge;
                                     pedge = m_ve_hash[venode];
                                     
                                     //  Get end connected node
                                     unsigned int enode = *index_run++;
                                     
                                     //  Get first connected node
-                                    VC_Element *ipnode = 0;
+                                    VC_Element *ipnode;
                                     ipnode = m_vc_hash[inode];
                                     
                                     //  Get end connected node
-                                    VC_Element *epnode = 0;
+                                    VC_Element *epnode;
                                     epnode = m_vc_hash[enode];
                                     
                                     double e0=0, n0=0, e1, n1;

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -146,6 +146,58 @@ static bool s_ProgressCallBack( void )
     return ret;
 }
 
+static uint64_t hash_fast64(const void *buf, size_t len, uint64_t seed)
+{
+    const uint64_t	m = 0x880355f21e6d1965ULL;
+    const uint64_t *pos = (const uint64_t *)buf;
+    const uint64_t *end = pos + (len >> 3);
+    const unsigned char *pc;
+    uint64_t h = len * m ^ seed;
+    uint64_t v;
+    while (pos != end) {
+        v = *pos++;
+        v ^= v >> 23;
+        v *= 0x2127599bf4325c37ULL;
+        h ^= v ^ (v >> 47);
+        h *= m;
+    }
+    pc = (const unsigned char*)pos;
+    v = 0;
+    switch (len & 7) {
+        case 7: v ^= (uint64_t)pc[6] << 48;
+        case 6: v ^= (uint64_t)pc[5] << 40;
+        case 5: v ^= (uint64_t)pc[4] << 32;
+        case 4: v ^= (uint64_t)pc[3] << 24;
+        case 3: v ^= (uint64_t)pc[2] << 16;
+        case 2: v ^= (uint64_t)pc[1] << 8;
+        case 1: v ^= (uint64_t)pc[0];
+            v ^= v >> 23;
+            v *= 0x2127599bf4325c37ULL;
+            h ^= v ^ (v >> 47);
+            h *= m;
+    }
+
+    h ^= h >> 23;
+    h *= 0x2127599bf4325c37ULL;
+    h ^= h >> 47;
+    return h;
+}
+
+static uint32_t hash_fast32(const void *buf, size_t len, uint32_t seed)
+{
+    uint64_t h = hash_fast64(buf, len, seed);
+    /* The following trick converts the 64-bit hashcode to a
+     * residue over a Fermat Number, in which information from
+     * both the higher and lower parts of hashcode shall be
+     * retained. */
+    return h - (h >> 32);
+}
+
+unsigned long connector_key::hash() const
+{
+    return hash_fast32(k, sizeof k, 0);
+}
+
 //----------------------------------------------------------------------------------
 //      S57Obj CTOR
 //----------------------------------------------------------------------------------
@@ -1617,8 +1669,8 @@ void s57chart::AssembleLineGeometry( void )
                     nPoints += pedge->nCount;
                 }
             }
-            
-            
+
+            connector_key key;            
             int ndelta = 0;
             //  Get the end node connected segments.  To do this, we
             //  walk the Feature array and process each feature that potetially has a LINE type element
@@ -1663,9 +1715,7 @@ void s57chart::AssembleLineGeometry( void )
                                     n1 = pedge->pPoints[1];
                                     
                                     //      The initial node exists and connects to the start of an edge
-                                    wxString key;
-                                    key.Printf(_T("CE%d%d"), inode, venode);
-                                    
+                                    key.set(TYPE_CE, inode, venode);
                                     if(m_connector_hash.find( key ) == m_connector_hash.end()){
                                         ndelta += 2;
                                         connector_segment *pcs = new connector_segment;
@@ -1692,8 +1742,7 @@ void s57chart::AssembleLineGeometry( void )
                                 if(ipnode){
                                     if(pedge && pedge->nCount){
                                         
-                                        wxString key;
-                                        key.Printf(_T("EC%d%d"), venode, enode);
+                                        key.set(TYPE_EC, venode, enode);
 
                                         if(m_connector_hash.find( key ) == m_connector_hash.end()){
                                             ndelta += 2;
@@ -1705,8 +1754,7 @@ void s57chart::AssembleLineGeometry( void )
                                         }
                                     }
                                     else {
-                                        wxString key;
-                                        key.Printf(_T("CC%d%d"), inode, enode);
+                                        key.set(TYPE_CC, inode, enode);
                                         
                                         if(m_connector_hash.find( key ) == m_connector_hash.end()){
                                             ndelta += 2;
@@ -1879,8 +1927,7 @@ void s57chart::AssembleLineGeometry( void )
                                         
                                         if(pedge && pedge->nCount)
                                         {
-                                            wxString key;
-                                            key.Printf(_T("CE%d%d"), inode, venode);
+                                            key.set(TYPE_CE, inode, venode);
                                             
                                             connected_segment_hash::iterator itcs = m_connector_hash.find( key );
                                             if(itcs != m_connector_hash.end()){
@@ -1949,8 +1996,7 @@ void s57chart::AssembleLineGeometry( void )
                                         if(ipnode){
                                             if(pedge && pedge->nCount){
                                                 
-                                                wxString key;
-                                                key.Printf(_T("EC%d%d"), venode, enode);
+                                                key.set(TYPE_EC, venode, enode);
                                                 
                                                 connected_segment_hash::iterator itcs = m_connector_hash.find( key );
                                                 if(itcs != m_connector_hash.end()){
@@ -1981,8 +2027,7 @@ void s57chart::AssembleLineGeometry( void )
                                                 }
                                             }
                                             else {
-                                                wxString key;
-                                                key.Printf(_T("CC%d%d"), inode, enode);
+                                                key.set(TYPE_CC, inode, enode);
                                                 
                                                 connected_segment_hash::iterator itcs = m_connector_hash.find( key );
                                                 if(itcs != m_connector_hash.end()){

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -1694,7 +1694,7 @@ void s57chart::AssembleLineGeometry( void )
                                         
                                         wxString key;
                                         key.Printf(_T("EC%d%d"), venode, enode);
-                                        
+
                                         if(m_connector_hash.find( key ) == m_connector_hash.end()){
                                             ndelta += 2;
                                             connector_segment *pcs = new connector_segment;
@@ -1882,9 +1882,10 @@ void s57chart::AssembleLineGeometry( void )
                                             wxString key;
                                             key.Printf(_T("CE%d%d"), inode, venode);
                                             
-                                            if(m_connector_hash.find( key ) != m_connector_hash.end()){
+                                            connected_segment_hash::iterator itcs = m_connector_hash.find( key );
+                                            if(itcs != m_connector_hash.end()){
                                                 
-                                                connector_segment *pcs = m_connector_hash[key];
+                                                connector_segment *pcs = itcs->second;
                                                 
                                                 line_segment_element *pls = new line_segment_element;
                                                 pls->next = 0;
@@ -1951,8 +1952,9 @@ void s57chart::AssembleLineGeometry( void )
                                                 wxString key;
                                                 key.Printf(_T("EC%d%d"), venode, enode);
                                                 
-                                                if(m_connector_hash.find( key ) != m_connector_hash.end()){
-                                                    connector_segment *pcs = m_connector_hash[key];
+                                                connected_segment_hash::iterator itcs = m_connector_hash.find( key );
+                                                if(itcs != m_connector_hash.end()){
+                                                    connector_segment *pcs = itcs->second;
                                                     
                                                     line_segment_element *pls = new line_segment_element;
                                                     pls->next = 0;
@@ -1982,8 +1984,9 @@ void s57chart::AssembleLineGeometry( void )
                                                 wxString key;
                                                 key.Printf(_T("CC%d%d"), inode, enode);
                                                 
-                                                if(m_connector_hash.find( key ) != m_connector_hash.end()){
-                                                    connector_segment *pcs = m_connector_hash[key];
+                                                connected_segment_hash::iterator itcs = m_connector_hash.find( key );
+                                                if(itcs != m_connector_hash.end()){
+                                                    connector_segment *pcs = itcs->second;
                                                     
                                                     line_segment_element *pls = new line_segment_element;
                                                     pls->next = 0;


### PR DESCRIPTION
Hi,
until we have a more efficient SENC format replace the slow wxString hash with a faster one:

callgrind Incl. (with callees) instructions count for AssembleLineGeometry (four charts quilt)
before with wx 3.0
3  900 000 000
after
280 000 000


Regards
Didier