### PR TITLE
Trivial speedup

### DIFF
--- a/src/ais.cpp
+++ b/src/ais.cpp
@@ -1057,11 +1057,12 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
 
     transrot_pts(4, ais_quad_icon, sin_theta, cos_theta);
 
-    
-    dc.SetPen( wxPen( GetGlobalColor( _T ( "UBLCK" ) ) ) );
+    wxColour UBLCK = GetGlobalColor( _T ( "UBLCK" ));
+    dc.SetPen( wxPen( UBLCK ) );
 
     // Default color is green
-    wxBrush target_brush = wxBrush( GetGlobalColor( _T ( "UINFG" ) ) );
+    wxColour UINFG = GetGlobalColor( _T ( "UINFG" ));
+    wxBrush target_brush = wxBrush( UINFG );
 
     // Euro Inland targets render slightly differently
     if( td->b_isEuroInland )
@@ -1072,15 +1073,16 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
         target_brush = wxBrush( GetGlobalColor( _T ( "GREEN5" ) ) );
             
     //and....
+    wxColour URED = GetGlobalColor( _T ( "URED" ));
     if( !td->b_nameValid )
         target_brush = wxBrush( GetGlobalColor( _T ( "CHYLW" ) ) );
     if( ( td->Class == AIS_DSC ) && ( td->ShipType == 12 ) )                    // distress
-        target_brush = wxBrush( GetGlobalColor( _T ( "URED" ) ) );
+        target_brush = wxBrush( URED );
     if( td->b_SarAircraftPosnReport )
-        target_brush = wxBrush( GetGlobalColor( _T ( "UINFG" ) ) );
+        target_brush = wxBrush( UINFG );
 
     if( ( td->n_alert_state == AIS_ALERT_SET ) && ( td->bCPA_Valid ) )
-        target_brush = wxBrush( GetGlobalColor( _T ( "URED" ) ) );
+        target_brush = wxBrush( URED );
 
     if( td->b_positionDoubtful ) target_brush = wxBrush( GetGlobalColor( _T ( "UINFF" ) ) );
 
@@ -1098,7 +1100,7 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
                                                        &tCPAPoint.y, 0, cc1->GetVP().pix_width, 0, cc1->GetVP().pix_height );
 
         if( res != Invisible ) {
-            wxPen ppPen2( GetGlobalColor( _T ( "URED" ) ), 2, wxPENSTYLE_USER_DASH );
+            wxPen ppPen2( URED, 2, wxPENSTYLE_USER_DASH );
             ppPen2.SetDashes( 2, dash_long );
             dc.SetPen( ppPen2 );
 
@@ -1135,7 +1137,7 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
             dc.SetPen( wxPen( yellow, 4 ) );
             dc.StrokeLine( tCPAPoint.x, tCPAPoint.y, oCPAPoint.x, oCPAPoint.y );
 
-            wxPen ppPen2( GetGlobalColor( _T ( "URED" ) ), 2, wxPENSTYLE_USER_DASH );
+            wxPen ppPen2( URED, 2, wxPENSTYLE_USER_DASH );
             ppPen2.SetDashes( 2, dash_long );
             dc.SetPen( ppPen2 );
             dc.StrokeLine( tCPAPoint.x, tCPAPoint.y, oCPAPoint.x, oCPAPoint.y );
@@ -1143,7 +1145,7 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
             //        Draw little circles at the ends of the CPA alert line
             wxBrush br( GetGlobalColor( _T ( "BLUE3" ) ) );
             dc.SetBrush( br );
-            dc.SetPen( wxPen( GetGlobalColor( _T ( "UBLK" ) ) ) );
+            dc.SetPen( wxPen( UBLCK ) );
 
             //  Using the true ends, not the clipped ends
             dc.StrokeCircle( tCPAPoint_unclipped.x, tCPAPoint_unclipped.y, 5 );
@@ -1160,29 +1162,27 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
                                                            0, cc1->GetVP().pix_width, 0, cc1->GetVP().pix_height );
 
         if ( ownres != Invisible ) {
-            wxPen ppPen2 ( GetGlobalColor ( _T ( "URED" )), 2, wxPENSTYLE_USER_DASH );
+            wxPen ppPen2 ( URED, 2, wxPENSTYLE_USER_DASH );
             ppPen2.SetDashes( 2, dash_long );
             dc.SetPen(ppPen2);
 
             dc.StrokeLine ( oShipPoint.x, oShipPoint.y, oCPAPoint.x, oCPAPoint.y );
         } //TR : till here
 
-        dc.SetPen( wxPen( GetGlobalColor( _T ( "UBLCK" ) ) ) );
-        dc.SetBrush( wxBrush( GetGlobalColor( _T ( "URED" ) ) ) );
+        dc.SetPen( wxPen( UBLCK ) );
+        dc.SetBrush( wxBrush( URED ) );
     }
 
     //  Highlight the AIS target symbol if an alert dialog is currently open for it
     if( g_pais_alert_dialog_active && g_pais_alert_dialog_active->IsShown() ) {
         if( g_pais_alert_dialog_active->Get_Dialog_MMSI() == td->MMSI )
-            cc1->JaggyCircle( dc, wxPen( GetGlobalColor( _T ( "URED" ) ), 2 ),
-                              TargetPoint.x, TargetPoint.y, 100 );
+            cc1->JaggyCircle( dc, wxPen( URED , 2 ), TargetPoint.x, TargetPoint.y, 100 );
     }
 
     //  Highlight the AIS target symbol if a query dialog is currently open for it
     if( g_pais_query_dialog_active && g_pais_query_dialog_active->IsShown() ) {
         if( g_pais_query_dialog_active->GetMMSI() == td->MMSI )
-            TargetFrame( dc, wxPen( GetGlobalColor( _T ( "UBLCK" ) ), 2 ),
-                         TargetPoint.x, TargetPoint.y, 25 );
+            TargetFrame( dc, wxPen( UBLCK , 2 ), TargetPoint.x, TargetPoint.y, 25 );
     }
     
     //       Render the COG line if the speed is greater than moored speed defined by ais options dialog
@@ -1210,7 +1210,7 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
 
                     if( g_ais_cog_predictor_width > 1 ) {
                         //    Draw a 1 pixel wide black line
-                        wxPen narrow_pen( GetGlobalColor( _T ( "UBLCK" ) ), 1 );
+                        wxPen narrow_pen( UBLCK, 1 );
                         dc.SetPen( narrow_pen );
                         dc.StrokeLine( pixx, pixy, pixx1, pixy1 );
                     }
@@ -1302,7 +1302,7 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
 
     //        Actually Draw the target
     if( td->Class == AIS_ARPA ) {
-        wxPen target_pen( GetGlobalColor( _T ( "UBLCK" ) ), 2 );
+        wxPen target_pen( UBLCK, 2 );
 
         dc.SetPen( target_pen );
         dc.SetBrush( target_brush );
@@ -1311,19 +1311,17 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
         dc.StrokeCircle( TargetPoint.x, TargetPoint.y, 1 );
         //        Draw the inactive cross-out line
         if( !td->b_active ) {
-            dc.SetPen( wxPen( GetGlobalColor( _T ( "UBLCK" ) ), 2 ) );
+            dc.SetPen( wxPen( UBLCK, 2 ) );
             dc.StrokeLine( TargetPoint.x - 14, TargetPoint.y, TargetPoint.x + 14, TargetPoint.y );
-            dc.SetPen( wxPen( GetGlobalColor( _T ( "UBLCK" ) ), 1 ) );
+            dc.SetPen( wxPen( UBLCK, 1 ) );
         }
     } else if( td->Class == AIS_ATON ) {                   // Aid to Navigation
         AtoN_Diamond( dc, TargetPoint.x, TargetPoint.y, 12, td );
     } else if( td->Class == AIS_BASE ) {                      // Base Station
-        Base_Square( dc, wxPen( GetGlobalColor( _T ( "UBLCK" ) ), 2 ), TargetPoint.x,
-                     TargetPoint.y, 8 );
+        Base_Square( dc, wxPen( UBLCK , 2 ), TargetPoint.x, TargetPoint.y, 8 );
     } else if( td->Class == AIS_SART ) {                      // SART Target
         if( td->NavStatus == 14 )       // active
-            SART_Render( dc, wxPen( GetGlobalColor( _T ( "URED" ) ), 2 ), TargetPoint.x,
-                         TargetPoint.y, 8 );
+            SART_Render( dc, wxPen( URED , 2 ), TargetPoint.x, TargetPoint.y, 8 );
         else
             SART_Render( dc, wxPen( GetGlobalColor( _T ( "UGREN" ) ), 2 ),
                          TargetPoint.x, TargetPoint.y, 8 );
@@ -1363,9 +1361,9 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
             dc.StrokePolygon( 3, ais_tri_icon, TargetPoint.x, TargetPoint.y );
         }
 
-        wxPen target_outline_pen( GetGlobalColor( _T ( "UBLCK" ) ), 2 );
+        wxPen target_outline_pen( UBLCK, 2 );
         dc.SetPen( target_outline_pen );
-        dc.SetBrush( wxBrush( GetGlobalColor( _T ( "UBLCK" ) ), wxBRUSHSTYLE_TRANSPARENT ) );
+        dc.SetBrush( wxBrush( UBLCK, wxBRUSHSTYLE_TRANSPARENT ) );
         dc.StrokePolygon( 9, SarRot, TargetPoint.x, TargetPoint.y );
 
         // second half
@@ -1386,11 +1384,11 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
         }
 
         dc.SetPen( target_outline_pen );
-        dc.SetBrush( wxBrush( GetGlobalColor( _T ( "UBLCK" ) ), wxBRUSHSTYLE_TRANSPARENT ) );
+        dc.SetBrush( wxBrush( UBLCK, wxBRUSHSTYLE_TRANSPARENT ) );
         dc.StrokePolygon( 9, SarRot, TargetPoint.x, TargetPoint.y );
 
     } else {         // ship class A or B or a Buddy or DSC
-        wxPen target_pen( GetGlobalColor( _T ( "UBLCK" ) ), 1 );
+        wxPen target_pen( UBLCK, 1 );
 
         dc.SetBrush( target_brush );
 
@@ -1421,7 +1419,7 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
 
         if (g_bDrawAISSize && bcan_draw_size)
         {
-            dc.SetBrush( wxBrush( GetGlobalColor( _T ( "UBLCK" ) ), wxBRUSHSTYLE_TRANSPARENT ) );
+            dc.SetBrush( wxBrush( UBLCK, wxBRUSHSTYLE_TRANSPARENT ) );
             dc.StrokePolygon( 6, ais_real_size, TargetPoint.x, TargetPoint.y, scale_factor );
         }
 
@@ -1500,7 +1498,7 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc )
             wxPoint p1 = transrot( wxPoint( -14, 0 ), sin_theta, cos_theta, TargetPoint );
             wxPoint p2 = transrot( wxPoint( 14, 0 ), sin_theta, cos_theta, TargetPoint );
 
-            dc.SetPen( wxPen( GetGlobalColor( _T ( "UBLCK" ) ), 2 ) );
+            dc.SetPen( wxPen( UBLCK, 2 ) );
             dc.StrokeLine( p1.x, p1.y, p2.x, p2.y );
         }
 

--- a/src/chartdbs.cpp
+++ b/src/chartdbs.cpp
@@ -2610,6 +2610,8 @@ bool  ChartDatabase::IsChartAvailable(int dbIndex)
 
 void ChartDatabase::ApplyGroupArray(ChartGroupArray *pGroupArray)
 {
+    wxString separator(wxFileName::GetPathSeparator());
+
     for(unsigned int ic=0 ; ic < active_chartTable.GetCount(); ic++)
       {
             ChartTableEntry *pcte = &active_chartTable[ic];
@@ -2630,7 +2632,7 @@ void ChartDatabase::ApplyGroupArray(ChartGroupArray *pGroupArray)
                         //  Otherwise, append a sep character so that similar paths are distinguished.
                         //  See FS#1060
                         if(!chart_full_path->IsSameAs(element_root))
-                            element_root.Append(wxFileName::GetPathSeparator());	// Prevent comingling similar looking path names
+                            element_root.Append(separator);	// Prevent comingling similar looking path names
                         if(chart_full_path->StartsWith(element_root))
                         {
                               bool b_add = true;


### PR DESCRIPTION
Hi,
a2f1349 only matter with a lot of charts but  GetPathSeparator is  slow.
 
94fb3a4 in AIS , keep most used colors around rather than calling GetGlobalColor each time.

Regards
Didier