### PR TITLE
Display the Busy cursor if texture cache is empty.

### DIFF
--- a/include/glTexCache.h
+++ b/include/glTexCache.h
@@ -163,6 +163,7 @@ private:
     int         m_catalog_offset;
     bool        m_hdrOK;
     bool        m_catalogOK;
+    bool        m_newCatalog;
 
     bool	m_catalogCorrupted;
     

--- a/src/CM93DSlide.cpp
+++ b/src/CM93DSlide.cpp
@@ -126,11 +126,8 @@ void CM93DSlide::OnChangeValue( wxScrollEvent& event )
 {
     g_cm93_zoom_factor = m_pCM93DetailSlider->GetValue();
 
-    OCPNPlatform::ShowBusySpinner();
-
     cc1->ReloadVP();
     cc1->Refresh( false );
 
-    OCPNPlatform::HideBusySpinner();
 }
 

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -5207,12 +5207,10 @@ int MyFrame::DoOptionsDialog()
 
     g_boptionsactive = true;
 
-
-    g_Platform->ShowBusySpinner();
-
-    if(NULL == g_options)
+    if(NULL == g_options) {
+        g_Platform->ShowBusySpinner();
         g_options = new options( this, -1, _("Options") );
-
+    }
     g_Platform->HideBusySpinner();
 
 //    Set initial Chart Dir

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -8365,7 +8365,6 @@ void pupHandler_PasteWaypoint() {
 
     cc1->InvalidateGL();
     cc1->Refresh( false );
-    OCPNPlatform::HideBusySpinner();
 }
 
 void pupHandler_PasteRoute() {
@@ -8483,7 +8482,6 @@ void pupHandler_PasteRoute() {
         cc1->Refresh( false );
     }
 
-    OCPNPlatform::HideBusySpinner();
 }
 
 void pupHandler_PasteTrack() {
@@ -8534,7 +8532,6 @@ void pupHandler_PasteTrack() {
 
     cc1->InvalidateGL();
     cc1->Refresh( false );
-    OCPNPlatform::HideBusySpinner();
 }
 
 bool ChartCanvas::InvokeCanvasMenu(int x, int y, int seltype)
@@ -9555,7 +9552,7 @@ void ChartCanvas::OnPaint( wxPaintEvent& event )
     dc.DestroyClippingRegion();
 
     PaintCleanup();
-
+    OCPNPlatform::HideBusySpinner();
 //      CALLGRIND_STOP_INSTRUMENTATION
 
 }

--- a/src/cm93.cpp
+++ b/src/cm93.cpp
@@ -101,8 +101,6 @@ WX_DEFINE_OBJARRAY ( Array_Of_M_COVR_Desc );
 WX_DEFINE_LIST ( List_Of_M_COVR_Desc );
 
 
-bool s_b_busy_shown;
-
 void appendOSDirSep ( wxString* pString )
 {
       wxChar sep = wxFileName::GetPathSeparator();
@@ -2238,10 +2236,6 @@ void cm93chart::SetVPParms ( const ViewPort &vpt )
       if (recalc_depth) {
           ClearDepthContourArray();
           BuildDepthContourArray();
-      }
-      if( s_b_busy_shown){
-          OCPNPlatform::HideBusySpinner();
-          s_b_busy_shown = false;
       }
 }
 
@@ -4557,10 +4551,7 @@ int cm93chart::loadsubcell ( int cellindex, wxChar sub_char )
 
       //    File is known to exist
 
-      if(!s_b_busy_shown) {
-          ::wxBeginBusyCursor();
-          s_b_busy_shown = true;
-      }
+      OCPNPlatform::ShowBusySpinner();
       
       wxString msg ( _T ( "Loading CM93 cell " ) );
       msg += file;

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -4238,7 +4238,7 @@ void glChartCanvas::Render()
                             m_canvasregion = OCPNRegion( m_fbo_offsetx, m_fbo_offsety, sx, sy );
                             
                             if(m_cache_vp.view_scale_ppm != VPoint.view_scale_ppm )
-                                g_Platform->ShowBusySpinner();
+                                OCPNPlatform::ShowBusySpinner();
                             
                             RenderCanvasBackingChart(gldc, m_canvasregion);
                         }
@@ -4461,7 +4461,7 @@ void glChartCanvas::Render()
     FactoryCrunch(0.6);
     
     cc1->PaintCleanup();
-    g_Platform->HideBusySpinner();
+    OCPNPlatform::HideBusySpinner();
     
     n_render++;
 }

--- a/src/glTexCache.cpp
+++ b/src/glTexCache.cpp
@@ -1463,7 +1463,10 @@ bool glTexFactory::PrepareTexture( int base_level, const wxRect &rect, ColorSche
         //    Upload to GPU?
         if( level >= base_level ) {
             int status = GetTextureLevel( ptd, rect, level, color_scheme );
- 
+            if (m_newCatalog) {
+                 // it's an empty catalog, odd it's going to be slow
+                 OCPNPlatform::ShowBusySpinner();
+            }
             if(g_GLOptions.m_bTextureCompression) {
                 if( (COMPRESSED_BUFFER_OK == status) && (ptd->nGPU_compressed != GPU_TEXTURE_UNCOMPRESSED ) ){
                     ptd->nGPU_compressed = GPU_TEXTURE_COMPRESSED;
@@ -2060,6 +2063,7 @@ bool glTexFactory::AddCacheEntryValue(const CatalogEntry &p)
 
 bool glTexFactory::LoadCatalog(void)
 {
+    m_newCatalog = false;
     if(m_catalogOK)
         return true;
 
@@ -2069,6 +2073,7 @@ bool glTexFactory::LoadCatalog(void)
     if (n_catalog_entries == 0) {
         // new empty header
         m_catalogOK = true;
+        m_newCatalog = true;
         return true;
     }
     

--- a/src/glTexCache.cpp
+++ b/src/glTexCache.cpp
@@ -915,6 +915,7 @@ glTexFactory::glTexFactory(ChartBase *chart, int raster_format)
     m_CompressedCacheFilePath = CompressedCachePath(chart->GetFullPath());
     m_hdrOK = false;
     m_catalogOK = false;
+    m_newCatalog = true;
 
     m_catalogCorrupted = false;
 
@@ -1464,8 +1465,9 @@ bool glTexFactory::PrepareTexture( int base_level, const wxRect &rect, ColorSche
         if( level >= base_level ) {
             int status = GetTextureLevel( ptd, rect, level, color_scheme );
             if (m_newCatalog) {
-                 // it's an empty catalog, odd it's going to be slow
+                 // it's an empty catalog or it's not used, odds it's going to be slow
                  OCPNPlatform::ShowBusySpinner();
+                 m_newCatalog = false;
             }
             if(g_GLOptions.m_bTextureCompression) {
                 if( (COMPRESSED_BUFFER_OK == status) && (ptd->nGPU_compressed != GPU_TEXTURE_UNCOMPRESSED ) ){

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -2899,7 +2899,6 @@ InitReturn s57chart::Init( const wxString& name, ChartInitFlag flags )
             } else
                 ret_value = PostInit( flags, m_global_color_scheme );
 
-            OCPNPlatform::HideBusySpinner();
         }
 
     }
@@ -2909,8 +2908,6 @@ InitReturn s57chart::Init( const wxString& name, ChartInitFlag flags )
 
         m_SENCFileName = name;
         ret_value = PostInit( flags, m_global_color_scheme );
-
-        OCPNPlatform::HideBusySpinner();
 
     }
 


### PR DESCRIPTION
Hi,
In this case, zoom/panning is going to be choppy.
Have to remove most HideBusySpinner and move it into OnPaint.
Test with linux, DC and openGL modes.

Regards,
Didier