### PR TITLE
Initialize show/hide ENC tool tip text string per actual persistent state

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -2747,7 +2747,17 @@ ocpnToolBarSimple *MyFrame::CreateAToolbar()
             style->GetToolIcon( _T("settings"), TOOLICON_NORMAL ), tipString, wxITEM_NORMAL );
 
     CheckAndAddPlugInTool( tb );
-    tipString = wxString( _("Show ENC Text") ) << _T(" (T)");
+    bool gs = false;
+#ifdef USE_S57
+    if (ps52plib)
+        gs = ps52plib->GetShowS57Text();
+#endif
+
+    if (gs)
+        tipString = wxString( _("Hide ENC Text") ) << _T(" (T)");
+    else
+        tipString = wxString(_("Show ENC Text")) << _T(" (T)");
+
     if( _toolbarConfigMenuUtil( ID_ENC_TEXT, tipString ) )
         tb->AddTool( ID_ENC_TEXT, _T("text"),
             style->GetToolIcon( _T("text"), TOOLICON_NORMAL ),

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -2756,7 +2756,7 @@ ocpnToolBarSimple *MyFrame::CreateAToolbar()
     if (gs)
         tipString = wxString( _("Hide ENC Text") ) << _T(" (T)");
     else
-        tipString = wxString(_("Show ENC Text")) << _T(" (T)");
+        tipString = wxString( _("Show ENC Text") ) << _T(" (T)");
 
     if( _toolbarConfigMenuUtil( ID_ENC_TEXT, tipString ) )
         tb->AddTool( ID_ENC_TEXT, _T("text"),


### PR DESCRIPTION
A lot of newbies get hung up because the initial tool tip of the ENC text toolbar button is wrong. It was hard coded instead of looking at the persistent state of the button. Now it follows the persistent state from the previous run of O.