### PR TITLE
Don't propage idle events in option dialog if not shown it's really slow

### DIFF
--- a/include/options.h
+++ b/include/options.h
@@ -229,7 +229,7 @@ class options : private Uncopyable,
                    long style = SYMBOL_OPTIONS_STYLE);
 
   ~options(void);
-
+  bool SendIdleEvents(wxIdleEvent &event );
   void SetInitialPage(int page_sel);
   void Finish(void);
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -917,6 +917,13 @@ options::~options(void) {
   
 }
 
+// with AIS it's called very often
+bool options::SendIdleEvents(wxIdleEvent &event )  { 
+   if (IsShown())
+       return wxDialog::SendIdleEvents(event);
+   return false;
+}
+
 void options::RecalculateSize(void) {
   if (!g_bresponsive) {
     wxSize canvas_size = cc1->GetSize();


### PR DESCRIPTION
Hi,
A regression, sort of.

wx SendIdleEvents is always traversing the whole widgets tree even the hidden ones, I have double checked with wx source code. When the options dialog is populated there's a lot of widgets.

NMEA can emit many idle events...

For example on my small box when replaying a capture at 200 messages/seconds OCPN CPU usage is around 85%, with this patch it's 30%.

On the other hand this patch may have unwanted side effects.
  
Regards
Didier