### PR TITLE
Findorcreatefont

### DIFF
--- a/include/FontMgr.h
+++ b/include/FontMgr.h
@@ -31,6 +31,8 @@
 
 #include "FontDesc.h"
 
+class OCPNwxFontList;
+
 /**
  * Manages the font list.
  *
@@ -57,6 +59,12 @@ class FontMgr
         void LoadFontNative(wxString *pConfigString, wxString *pNativeDesc);
         bool SetFont(const wxString &TextElement, wxFont *pFont, wxColour color);
         void ScrubList( );
+
+        wxFont* FindOrCreateFont( int point_size, wxFontFamily family, 
+                    wxFontStyle style, wxFontWeight weight, bool underline = false,
+                    const wxString &facename = wxEmptyString,
+                    wxFontEncoding encoding = wxFONTENCODING_DEFAULT );
+
         
         static void Shutdown();
         
@@ -70,7 +78,8 @@ class FontMgr
         wxString GetSimpleNativeFont(int size, wxString face);
     
         static FontMgr * instance;
-    
+
+        OCPNwxFontList  *m_wxFontCache;
         FontList *m_fontlist;
         wxFont   *pDefFont;
         wxArrayString m_AuxKeyArray;

--- a/src/AISTargetAlertDialog.cpp
+++ b/src/AISTargetAlertDialog.cpp
@@ -161,7 +161,7 @@ bool AISTargetAlertDialog::Create( int target_mmsi, wxWindow *parent, AIS_Decode
 #ifdef __WXGTK__
     face = _T("Monospace");
 #endif
-    wxFont *fp_font = wxTheFontList->FindOrCreateFont( font_size, wxFONTFAMILY_MODERN,
+    wxFont *fp_font = FontMgr::Get().FindOrCreateFont( font_size, wxFONTFAMILY_MODERN,
             wxFONTSTYLE_NORMAL, dFont->GetWeight(), false, face );
 
     SetFont( *fp_font );

--- a/src/AISTargetQueryDialog.cpp
+++ b/src/AISTargetQueryDialog.cpp
@@ -202,7 +202,7 @@ bool AISTargetQueryDialog::Create( wxWindow* parent, wxWindowID id, const wxStri
 #ifdef __WXGTK__
     face = _T("Monospace");
 #endif
-    m_basefont = wxTheFontList->FindOrCreateFont( font_size, wxFONTFAMILY_MODERN,
+    m_basefont = FontMgr::Get().FindOrCreateFont( font_size, wxFONTFAMILY_MODERN,
                       wxFONTSTYLE_NORMAL, dFont->GetWeight(), false, face );
 
     SetFont( *m_basefont );
@@ -251,7 +251,7 @@ void AISTargetQueryDialog::RecalculateSize()
     #ifdef __WXGTK__
     face = _T("Monospace");
     #endif
-    m_basefont = wxTheFontList->FindOrCreateFont( font_size, wxFONTFAMILY_MODERN,
+    m_basefont = FontMgr::Get().FindOrCreateFont( font_size, wxFONTFAMILY_MODERN,
                                                   wxFONTSTYLE_NORMAL, dFont->GetWeight(), false, face );
     
     SetFont( *m_basefont );
@@ -426,7 +426,7 @@ void AISTargetQueryDialog::AdjustBestSize( AIS_Target_Data *td )
         wxSize psz = g_Platform->getDisplaySize();
         
         wxScreenDC dc;
-        wxFont *tFont = wxTheFontList->FindOrCreateFont( m_control_font_size, wxFONTFAMILY_MODERN,
+        wxFont *tFont = FontMgr::Get().FindOrCreateFont( m_control_font_size, wxFONTFAMILY_MODERN,
                                                            wxFONTSTYLE_NORMAL, m_basefont->GetWeight(), false,
                                                            m_basefont->GetFaceName() );
         dc.SetFont(*tFont);
@@ -440,7 +440,7 @@ void AISTargetQueryDialog::AdjustBestSize( AIS_Target_Data *td )
             
             float font_size = m_control_font_size / delta;
 
-            wxFont *fp_font = wxTheFontList->FindOrCreateFont( font_size, wxFONTFAMILY_MODERN,
+            wxFont *fp_font = FontMgr::Get().FindOrCreateFont( font_size, wxFONTFAMILY_MODERN,
                                               wxFONTSTYLE_NORMAL, m_basefont->GetWeight(), false,
                                               m_basefont->GetFaceName() );
             
@@ -484,7 +484,7 @@ void AISTargetQueryDialog::AdjustBestSize( AIS_Target_Data *td )
 void AISTargetQueryDialog::RenderHTMLQuery(AIS_Target_Data *td)
 {
     int font_size = m_adjustedFontSize; 
-    wxFont *fp_font = wxTheFontList->FindOrCreateFont( font_size, wxFONTFAMILY_MODERN,
+    wxFont *fp_font = FontMgr::Get().FindOrCreateFont( font_size, wxFONTFAMILY_MODERN,
                                                        wxFONTSTYLE_NORMAL, m_basefont->GetWeight(),
                                                        false, m_basefont->GetFaceName() );
     

--- a/src/FontMgr.cpp
+++ b/src/FontMgr.cpp
@@ -54,7 +54,8 @@ void FontMgr::Shutdown()
 }
 
 FontMgr::FontMgr()
-    : m_fontlist(NULL)
+    : m_wxFontCache(NULL)
+    ,m_fontlist(NULL)
     , pDefFont(NULL)
 {
     //    Create the list of fonts
@@ -64,7 +65,7 @@ FontMgr::FontMgr()
     s_locale = g_locale;
     
     //    Get a nice generic font as default
-    pDefFont = wxTheFontList->FindOrCreateFont( 12, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, FALSE,
+    pDefFont = FindOrCreateFont( 12, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, FALSE,
             wxString( _T ( "" ) ), wxFONTENCODING_SYSTEM );
 
 }
@@ -350,6 +351,100 @@ void FontMgr::LoadFontNative( wxString *pConfigString, wxString *pNativeDesc )
 
     }
 }
+class  OCPNwxFontList: public wxGDIObjListBase
+{
+public:
+    wxFont *FindOrCreateFont(int pointSize,
+                             wxFontFamily family,
+                             wxFontStyle style,
+                             wxFontWeight weight,
+                             bool underline = false,
+                             const wxString& face = wxEmptyString,
+                             wxFontEncoding encoding = wxFONTENCODING_DEFAULT);
+};
+
+wxFont* FontMgr::FindOrCreateFont( int point_size, wxFontFamily family, 
+                    wxFontStyle style, wxFontWeight weight, bool underline,
+                    const wxString &facename,
+                    wxFontEncoding encoding)
+{
+    if (m_wxFontCache == 0)
+        m_wxFontCache = new OCPNwxFontList;
+    return m_wxFontCache->FindOrCreateFont( point_size, family, style, weight,
+        underline, facename, encoding);
+}        
+
+wxFont *OCPNwxFontList::FindOrCreateFont(int pointSize,
+                                     wxFontFamily family,
+                                     wxFontStyle style,
+                                     wxFontWeight weight,
+                                     bool underline,
+                                     const wxString& facename,
+                                     wxFontEncoding encoding)
+{
+    // from wx source code
+    // In all ports but wxOSX, the effective family of a font created using
+    // wxFONTFAMILY_DEFAULT is wxFONTFAMILY_SWISS so this is what we need to
+    // use for comparison.
+    //
+    // In wxOSX the original wxFONTFAMILY_DEFAULT seems to be kept and it uses
+    // a different font than wxFONTFAMILY_SWISS anyhow so we just preserve it.
+#ifndef __WXOSX__
+    if ( family == wxFONTFAMILY_DEFAULT )
+        family = wxFONTFAMILY_SWISS;
+#endif // !__WXOSX__
+
+    wxFont *font;
+    wxList::compatibility_iterator node;
+    for (node = list.GetFirst(); node; node = node->GetNext())
+    {
+        font = (wxFont *)node->GetData();
+        if (
+             font->GetPointSize () == pointSize &&
+             font->GetStyle () == style &&
+             font->GetWeight () == weight &&
+             font->GetUnderlined () == underline )
+        {
+            bool same = font->GetFamily() == family;
+
+            // empty facename matches anything at all: this is bad because
+            // depending on which fonts are already created, we might get back
+            // a different font if we create it with empty facename, but it is
+            // still better than never matching anything in the cache at all
+            // in this case
+            if ( same && !facename.empty() )
+            {
+                const wxString& fontFace = font->GetFaceName();
+
+                // empty facename matches everything
+                same = !fontFace || fontFace == facename;
+            }
+
+            if ( same && (encoding != wxFONTENCODING_DEFAULT) )
+            {
+                // have to match the encoding too
+                same = font->GetEncoding() == encoding;
+            }
+
+            if ( same )
+            {
+                return font;
+            }
+        }
+    }
+
+    // font not found, create the new one
+    font = NULL;
+    wxFont fontTmp(pointSize, family, style, weight, underline, facename, encoding);
+    if (fontTmp.IsOk())
+    {
+        font = new wxFont(fontTmp);
+        list.Append(font);
+    }
+
+    return font;
+}
+
 
 wxString FontCandidates[] = {
     _T("AISTargetAlert"), 

--- a/src/FontMgr.cpp
+++ b/src/FontMgr.cpp
@@ -394,21 +394,24 @@ bool OCPNwxFontList::isSame(wxFont *font, int pointSize, wxFontFamily family,
          font->GetWeight () == weight &&
          font->GetUnderlined () == underline )
     {
-        bool same = font->GetFamily() == family;
+        bool same;
 
         // empty facename matches anything at all: this is bad because
         // depending on which fonts are already created, we might get back
         // a different font if we create it with empty facename, but it is
         // still better than never matching anything in the cache at all
         // in this case
-        if ( same && !facename.empty() )
+        if ( !facename.empty() )
         {
             const wxString& fontFace = font->GetFaceName();
 
             // empty facename matches everything
             same = !fontFace || fontFace == facename;
         }
-
+        else 
+        {
+            same = font->GetFamily() == family;
+        }
         if ( same && (encoding != wxFONTENCODING_DEFAULT) )
         {
             // have to match the encoding too

--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -1238,7 +1238,7 @@ double OCPNPlatform::getFontPointsperPixel( void )
     //  Make a measurement...
     wxScreenDC dc;
     
-    wxFont *f = wxTheFontList->FindOrCreateFont( 12, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, FALSE,
+    wxFont *f = FontMgr::Get().FindOrCreateFont( 12, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, FALSE,
                                                 wxString( _T ( "" ) ), wxFONTENCODING_SYSTEM );
     dc.SetFont(*f);
     

--- a/src/RolloverWin.cpp
+++ b/src/RolloverWin.cpp
@@ -159,7 +159,7 @@ void RolloverWin::SetBestPosition( int x, int y, int off_x, int off_y, int rollo
     }
 
     int font_size = wxMax(8, dFont->GetPointSize());
-    m_plabelFont = wxTheFontList->FindOrCreateFont( font_size, dFont->GetFamily(),
+    m_plabelFont = FontMgr::Get().FindOrCreateFont( font_size, dFont->GetFamily(),
                          dFont->GetStyle(), dFont->GetWeight(), false, dFont->GetFaceName() );
 
     if(m_plabelFont && m_plabelFont->IsOk()) {

--- a/src/TCWin.cpp
+++ b/src/TCWin.cpp
@@ -175,13 +175,13 @@ TCWin::TCWin( ChartCanvas *parent, int x, int y, void *pvIDX )
     wxFont *dlg_font = FontMgr::Get().GetFont( _("Dialog") );
     int dlg_font_size = dlg_font->GetPointSize();
 
-    pSFont = wxTheFontList->FindOrCreateFont( dlg_font_size-2, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
+    pSFont = FontMgr::Get().FindOrCreateFont( dlg_font_size-2, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
                                                     wxFONTWEIGHT_NORMAL, FALSE, wxString( _T ( "Arial" ) ) );
-    pSMFont = wxTheFontList->FindOrCreateFont( dlg_font_size-1, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
+    pSMFont = FontMgr::Get().FindOrCreateFont( dlg_font_size-1, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
                                                        wxFONTWEIGHT_NORMAL, FALSE, wxString( _T ( "Arial" ) ) );
-    pMFont = wxTheFontList->FindOrCreateFont( dlg_font_size, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD,
+    pMFont = FontMgr::Get().FindOrCreateFont( dlg_font_size, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD,
                                                       FALSE, wxString( _T ( "Arial" ) ) );
-    pLFont = wxTheFontList->FindOrCreateFont( dlg_font_size+1, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD,
+    pLFont = FontMgr::Get().FindOrCreateFont( dlg_font_size+1, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD,
                                                       FALSE, wxString( _T ( "Arial" ) ) );
 
     pblack_1 = wxThePenList->FindOrCreatePen( GetGlobalColor( _T ( "UINFD" ) ), 1,

--- a/src/about.cpp
+++ b/src/about.cpp
@@ -403,7 +403,7 @@ void about::CreateControls( void )
 
     wxFont *qFont = GetOCPNScaledFont(_("Dialog"));
     
-    wxFont *headerFont = wxTheFontList->FindOrCreateFont( 14, wxFONTFAMILY_DEFAULT,
+    wxFont *headerFont = FontMgr::Get().FindOrCreateFont( 14, wxFONTFAMILY_DEFAULT,
                                                           qFont->GetStyle(), wxFONTWEIGHT_BOLD, false,
                                                           qFont->GetFaceName() );
     pST1->SetFont( *headerFont );

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -3627,7 +3627,7 @@ void MyFrame::ODoSetSize( void )
 #endif
 
 
-        wxFont *pstat_font = wxTheFontList->FindOrCreateFont( font_size,
+        wxFont *pstat_font = FontMgr::Get().FindOrCreateFont( font_size,
               wxFONTFAMILY_DEFAULT, templateFont->GetStyle(), templateFont->GetWeight(), false,
               templateFont->GetFaceName() );
 
@@ -11688,7 +11688,7 @@ wxFont *GetOCPNScaledFont( wxString item, int default_size )
             if(req_size >= nscaled_font_size)
                 return dFont;
             else{
-                wxFont *qFont = wxTheFontList->FindOrCreateFont( nscaled_font_size,
+                wxFont *qFont = FontMgr::Get().FindOrCreateFont( nscaled_font_size,
                                                              dFont->GetFamily(),
                                                              dFont->GetStyle(),
                                                              dFont->GetWeight());

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -916,7 +916,7 @@ ChartCanvas::ChartCanvas ( wxFrame *frame ) :
         m_pQuilt->EnableHighDefinitionZoom( true );
 #endif    
 
-    m_pgridFont = wxTheFontList->FindOrCreateFont( 8, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
+    m_pgridFont = FontMgr::Get().FindOrCreateFont( 8, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
          wxFONTWEIGHT_NORMAL, FALSE, wxString( _T ( "Arial" ) ) );
         
 }
@@ -2223,7 +2223,7 @@ wxBitmap ChartCanvas::CreateDimBitmap( wxBitmap &Bitmap, double factor )
 
 void ChartCanvas::ShowBrightnessLevelTimedPopup( int brightness, int min, int max )
 {
-    wxFont *pfont = wxTheFontList->FindOrCreateFont( 40, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD );
+    wxFont *pfont = FontMgr::Get().FindOrCreateFont( 40, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD );
 
     if( !m_pBrightPopup ) {
         //    Calculate size
@@ -10385,7 +10385,7 @@ void ChartCanvas::DrawAllTidesInBBox( ocpnDC& dc, LLBBox& BBox )
     wxFont *dFont = FontMgr::Get().GetFont( _("ExtendedTideIcon") );
     dc.SetTextForeground( FontMgr::Get().GetFontColor( _("ExtendedTideIcon") ) );
     int font_size = wxMax(8, dFont->GetPointSize());
-    wxFont *plabelFont = wxTheFontList->FindOrCreateFont( font_size, dFont->GetFamily(),
+    wxFont *plabelFont = FontMgr::Get().FindOrCreateFont( font_size, dFont->GetFamily(),
                          dFont->GetStyle(), dFont->GetWeight() );
 
     dc.SetPen( *pblack_pen );

--- a/src/concanv.cpp
+++ b/src/concanv.cpp
@@ -101,7 +101,7 @@ long style = wxSIMPLE_BORDER | wxCLIP_CHILDREN;
 
     wxFont *qFont = GetOCPNScaledFont(_("Dialog"));
     
-    wxFont *pThisLegFont = wxTheFontList->FindOrCreateFont( 10, wxFONTFAMILY_DEFAULT,
+    wxFont *pThisLegFont = FontMgr::Get().FindOrCreateFont( 10, wxFONTFAMILY_DEFAULT,
                                                           qFont->GetStyle(), wxFONTWEIGHT_BOLD, false,
                                                           qFont->GetFaceName() );
     pThisLegText->SetFont( *pThisLegFont );
@@ -454,9 +454,9 @@ AnnunText::AnnunText( wxWindow *parent, wxWindowID id, const wxString& LegendEle
     m_label = _T("Label");
     m_value = _T("-----");
 
-    m_plabelFont = wxTheFontList->FindOrCreateFont( 14, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, FALSE,
+    m_plabelFont = FontMgr::Get().FindOrCreateFont( 14, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD, FALSE,
             wxString( _T("Arial Bold") ) );
-    m_pvalueFont = wxTheFontList->FindOrCreateFont( 24, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD,
+    m_pvalueFont = FontMgr::Get().FindOrCreateFont( 24, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD,
             FALSE, wxString( _T("helvetica") ), wxFONTENCODING_ISO8859_1 );
 
     m_LegendTextElement = LegendElement;

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -523,7 +523,7 @@ void BuildCompressedCache()
     wxSize csz = GetOCPNCanvasWindow()->GetClientSize();
     if(csz.x < 600 || csz.y < 600){
         wxFont *qFont = GetOCPNScaledFont(_("Dialog"));         // to get type, weight, etc...
-        wxFont *sFont = wxTheFontList->FindOrCreateFont( 10, qFont->GetFamily(), qFont->GetStyle(), qFont->GetWeight());
+        wxFont *sFont = FontMgr::Get().FindOrCreateFont( 10, qFont->GetFamily(), qFont->GetStyle(), qFont->GetWeight());
         pprog->SetFont( *sFont );
     }
     
@@ -2674,7 +2674,7 @@ void glChartCanvas::DrawCloseMessage(wxString msg)
 {
     if(1){
         
-        wxFont *pfont = wxTheFontList->FindOrCreateFont(12, wxFONTFAMILY_DEFAULT,
+        wxFont *pfont = FontMgr::Get().FindOrCreateFont(12, wxFONTFAMILY_DEFAULT,
                                                         wxFONTSTYLE_NORMAL,
                                                         wxFONTWEIGHT_NORMAL);
         

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4545,7 +4545,7 @@ void options::CreateControls(void) {
     wxListView* lv = m_pListbook->GetListView();
     wxFont* qFont = dialogFont;  // to get type, weight, etc...
 
-    wxFont* sFont = wxTheFontList->FindOrCreateFont(
+    wxFont* sFont = FontMgr::Get().FindOrCreateFont(
         10, qFont->GetFamily(), qFont->GetStyle(), qFont->GetWeight());
     lv->SetFont(*sFont);
   }

--- a/src/s52plib.cpp
+++ b/src/s52plib.cpp
@@ -1647,7 +1647,7 @@ bool s52plib::RenderText( wxDC *pdc, S52_TextC *ptext, int x, int y, wxRect *pRe
   
             int old_size = ptext->pFont->GetPointSize();
             int new_size = old_size * scale_factor;
-            scaled_font = wxTheFontList->FindOrCreateFont( new_size, ptext->pFont->GetFamily(),
+            scaled_font = FontMgr::Get().FindOrCreateFont( new_size, ptext->pFont->GetFamily(),
                                                            ptext->pFont->GetStyle(), ptext->pFont->GetWeight(), false,
                                                            ptext->pFont->GetFaceName() );
             wxScreenDC sdc;
@@ -1884,7 +1884,7 @@ bool s52plib::RenderText( wxDC *pdc, S52_TextC *ptext, int x, int y, wxRect *pRe
                 wxFont *pf = ptext->pFont;
                 int old_size = pf->GetPointSize();
                 int new_size = old_size * scale_factor;
-                wxFont *scaled_font = wxTheFontList->FindOrCreateFont( new_size, pf->GetFamily(),
+                wxFont *scaled_font = FontMgr::Get().FindOrCreateFont( new_size, pf->GetFamily(),
                                                                        pf->GetStyle(), pf->GetWeight(), false,
                                                                        pf->GetFaceName() );
                 pdc->SetFont( *scaled_font);
@@ -2044,7 +2044,7 @@ int s52plib::RenderT_All( ObjRazRules *rzRules, Rules *rules, ViewPort *vp, bool
                     else
                         fontweight = wxFONTWEIGHT_BOLD;
 
-                text->pFont = wxTheFontList->FindOrCreateFont( text->bsize, wxFONTFAMILY_SWISS,
+                text->pFont = FontMgr::Get().FindOrCreateFont( text->bsize, wxFONTFAMILY_SWISS,
                         wxFONTSTYLE_NORMAL, fontweight );
             } else {
                 int spec_weight = text->weight - 0x30;
@@ -2080,7 +2080,7 @@ int s52plib::RenderT_All( ObjRazRules *rzRules, Rules *rules, ViewPort *vp, bool
                 // In no case should font size be less than 10, since it becomes unreadable
                 fontSize = wxMax(10, fontSize);
 
-                text->pFont = wxTheFontList->FindOrCreateFont( fontSize, wxFONTFAMILY_SWISS,
+                text->pFont = FontMgr::Get().FindOrCreateFont( fontSize, wxFONTFAMILY_SWISS,
                         templateFont->GetStyle(), fontweight, false, templateFont->GetFaceName() );
             }
         }


### PR DESCRIPTION
Hi
A try for fixing the font cache issue.

It's a copy of wx code with two changes:

1) don't test family if there's a font name, a font name can only have one family and in wxcode they use it first.

2) a wxASSERT for testing if the cache round trip, after testing on windows  it should be remove;
 
Regards
Didier
