### PR TITLE
Svg 

### DIFF
--- a/src/styles.cpp
+++ b/src/styles.cpp
@@ -55,12 +55,9 @@ void bmdump(wxBitmap bm, wxString name)
 #ifdef ocpnUSE_SVG
 static wxBitmap LoadSVG( const wxString filename, unsigned int width, unsigned int height )
 {
-    unsigned char *data = NULL;
-    wxBitmap ret;
-    
-    wxSVGDocument* svgDoc = new wxSVGDocument;
-    if( svgDoc->Load(filename) )
-        return wxBitmap( svgDoc->Render( width, height, NULL, true, true ) );
+    wxSVGDocument svgDoc;
+    if( svgDoc.Load(filename) )
+        return wxBitmap( svgDoc.Render( width, height, NULL, true, true ) );
     else
         return wxBitmap(width, height);
 }

--- a/src/wxsvg/src/SVGCanvas.cpp
+++ b/src/wxsvg/src/SVGCanvas.cpp
@@ -180,9 +180,14 @@ unsigned int wxSVGCanvas::GetGradientStops(const wxSVGSVGElement& svgElem, wxSVG
 	stop_elem = (wxSVGStopElement*) gradElem->GetChildren();
 	int i = 0;
 	while (stop_elem) {
-		if (stop_elem->GetDtd() == wxSVG_STOP_ELEMENT)
+		if (stop_elem->GetDtd() == wxSVG_STOP_ELEMENT) {
+		        wxSVGColor color = stop_elem->GetStopColor();
+		        // no color, default is black
+		        if (color.GetColorType() == wxSVG_COLORTYPE_UNKNOWN)
+                                color = wxSVGColor(0,0,0);
 			SetStopValue(i++, stop_elem->GetOffset(), stop_elem->GetStopOpacity() * opacity,
-					stop_elem->GetStopColor().GetRGBColor());
+					color.GetRGBColor());
+                }
 		stop_elem = (wxSVGStopElement*) stop_elem->GetNext();
 	}
 	return stop_count;


### PR DESCRIPTION
Hi,
- a memory leak, it's a one off but it's in the 10 MB range.

- the color assert, if there's no color use black, cf https://svgwg.org/svg2-draft/types.html#definitions
and https://svgwg.org/svg2-draft/pservers.html#StopColorProperties. I will try to double check with the svg author.

There's still many errors in valgrind related to alpha, not sure if they are relevant ...

Regards
Didier