### PR TITLE
Correct coordinate calculation for raster charts

### DIFF
--- a/include/chartimg.h
+++ b/include/chartimg.h
@@ -228,6 +228,7 @@ protected:
       InitReturn PreInit( const wxString& name, ChartInitFlag init_flags, ColorScheme cs );
       InitReturn PostInit(void);
 
+      double AdjustLongitude(double lon);
 
 
 //    Protected Data
@@ -315,8 +316,6 @@ protected:
 
       double      m_ppm_avg;              // Calculated true scale factor of the 1X chart,
                                         // pixels per meter
-      bool      m_bIDLcross;
-
       OCPNRegion  m_last_region;
 
       int       m_b_cdebug;

--- a/src/chartimg.cpp
+++ b/src/chartimg.cpp
@@ -1643,8 +1643,6 @@ ChartBaseBSB::ChartBaseBSB()
       m_dtm_lat = 0.;
       m_dtm_lon = 0.;
 
-      m_bIDLcross = false;
-
       m_dx = 0.;
       m_dy = 0.;
       m_proj_lat = 0.;
@@ -2668,11 +2666,7 @@ int ChartBaseBSB::latlong_to_pix_vp(double lat, double lon, double &pixx, double
           alon = lon + m_lon_datum_adjust;
           alat = lat + m_lat_datum_adjust;
 
-          if(m_bIDLcross)
-          {
-                if(alon < 0.)
-                      alon += 360.;
-          }
+          AdjustLongitude(alon);
 
           if(1)
           {
@@ -2752,11 +2746,7 @@ int ChartBaseBSB::latlong_to_pix_vp(double lat, double lon, double &pixx, double
 
                 //      Get e/n from  Projection
                 xlon = alon;
-                if(m_bIDLcross)
-                {
-                      if(xlon < 0.)
-                            xlon += 360.;
-                }
+                AdjustLongitude(xlon);
                 toSM_ECC(alat, xlon, m_proj_lat, m_proj_lon, &easting, &northing);
 
                 //      Apply poly solution to target point
@@ -2765,11 +2755,7 @@ int ChartBaseBSB::latlong_to_pix_vp(double lat, double lon, double &pixx, double
 
                 //      Apply poly solution to vp center point
                 double xlonc = vp.clon;
-                if(m_bIDLcross)
-                {
-                      if(xlonc < 0.)
-                            xlonc += 360.;
-                }
+                AdjustLongitude(xlonc);
 
                 toSM_ECC(vp.clat + m_lat_datum_adjust, xlonc + m_lon_datum_adjust, m_proj_lat, m_proj_lon, &easting, &northing);
                 double xc = polytrans( cPoints.wpx, easting, northing );
@@ -2793,12 +2779,7 @@ int ChartBaseBSB::latlong_to_pix_vp(double lat, double lon, double &pixx, double
                 alat = lat + m_lat_datum_adjust;
 
                 //      Get e/n from  Projection
-                xlon = alon;
-                if(m_bIDLcross)
-                {
-                      if(xlon < 0.)
-                            xlon += 360.;
-                }
+                xlon = AdjustLongitude(alon);
                 toPOLY(alat, xlon, m_proj_lat, m_proj_lon, &easting, &northing);
 
                 //      Apply poly solution to target point
@@ -2806,12 +2787,7 @@ int ChartBaseBSB::latlong_to_pix_vp(double lat, double lon, double &pixx, double
                 double yd = polytrans( cPoints.wpy, easting, northing );
 
                 //      Apply poly solution to vp center point
-                double xlonc = vp.clon;
-                if(m_bIDLcross)
-                {
-                      if(xlonc < 0.)
-                            xlonc += 360.;
-                }
+                double xlonc = AdjustLongitude(vp.clon);
 
                 toPOLY(vp.clat + m_lat_datum_adjust, xlonc + m_lon_datum_adjust, m_proj_lat, m_proj_lon, &easting, &northing);
                 double xc = polytrans( cPoints.wpx, easting, northing );
@@ -2860,12 +2836,7 @@ void ChartBaseBSB::latlong_to_chartpix(double lat, double lon, double &pixx, dou
             alon = lon + m_lon_datum_adjust;
             alat = lat + m_lat_datum_adjust;
 
-            if(m_bIDLcross)
-            {
-                  if(alon < 0.)
-                        alon += 360.;
-            }
-
+            alon = AdjustLongitude(alon);
 
             /* change longitude phase (CPH) */
             double lonp = (alon < 0) ? alon + m_cph : alon - m_cph;
@@ -2901,12 +2872,8 @@ void ChartBaseBSB::latlong_to_chartpix(double lat, double lon, double &pixx, dou
                   alat = lat + m_lat_datum_adjust;
 
                 //      Get e/n from  Projection
-                  xlon = alon;
-                  if(m_bIDLcross)
-                  {
-                        if(xlon < 0.)
-                              xlon += 360.;
-                  }
+                  xlon = AdjustLongitude(xlon);
+
                   toSM_ECC(alat, xlon, m_proj_lat, m_proj_lon, &easting, &northing);
 
                 //      Apply poly solution to target point
@@ -2923,12 +2890,7 @@ void ChartBaseBSB::latlong_to_chartpix(double lat, double lon, double &pixx, dou
                   alat = lat + m_lat_datum_adjust;
 
                 //      Get e/n from  Projection
-                  xlon = alon;
-                  if(m_bIDLcross)
-                  {
-                        if(xlon < 0.)
-                              xlon += 360.;
-                  }
+                  xlon = AdjustLongitude(alon);
                   toPOLY(alat, xlon, m_proj_lat, m_proj_lon, &easting, &northing);
 
                 //      Apply poly solution to target point
@@ -4826,7 +4788,6 @@ bool ChartBaseBSB::AnalyzeSkew(void)
                     nlatmax = n;
                 }
             }
-            m_bIDLcross = true;
         }
     }
     
@@ -5049,7 +5010,6 @@ int   ChartBaseBSB::AnalyzeRefpoints(bool b_testSolution)
                               nlatmax = n;
                         }
                   }
-                  m_bIDLcross = true;
             }
       }
 
@@ -5493,6 +5453,15 @@ int   ChartBaseBSB::AnalyzeRefpoints(bool b_testSolution)
 
 }
 
+double ChartBaseBSB::AdjustLongitude(double lon)
+{
+    double lond = (m_LonMin + m_LonMax)/2 - lon;
+    if(lond > 180)
+        return lon + 360;
+    else if(lond < -180)
+        return lon - 360;
+    return lon;
+}
 
 /*
 *  Extracted from bsb_io.c - implementation of libbsb reading and writing


### PR DESCRIPTION
Before this was handled when the chart crossed the IDL,
but in the case where the viewport did and the chart did not,
the calculation used to be incorrect giving black charts in quilts
and failing to render single chart mode in dc-mode