### PR TITLE
Do not clear GPXIODir if user presses CANCEL button in file open dialog.

### DIFF
--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -3004,9 +3004,6 @@ bool MyConfig::ExportGPXRoutes( wxWindow* parent, RouteList *pRoutes, const wxSt
                                                      wxT ( "*.gpx" )
     );
     
-    wxFileName fn( path );
-    m_gpx_path = fn.GetPath();
-    
 #if 0    
     wxFileDialog *psaveDialog = new wxFileDialog( NULL, _( "Export GPX file" ), m_gpx_path, suggestedName,
             wxT ( "GPX files (*.gpx)|*.gpx" ), wxFD_SAVE );
@@ -3027,13 +3024,15 @@ bool MyConfig::ExportGPXRoutes( wxWindow* parent, RouteList *pRoutes, const wxSt
 #endif
 
     wxString path = psaveDialog->GetPath();
-    wxFileName fn( path );
-    m_gpx_path = fn.GetPath();
+//    wxFileName fn( path );
+//    m_gpx_path = fn.GetPath();
     delete psaveDialog;
 #endif
     
     if( response == wxID_OK ) {
-        fn.SetExt( _T ( "gpx" ) );
+        wxFileName fn(path);
+        m_gpx_path = fn.GetPath();
+        fn.SetExt(_T("gpx"));
 
         if( wxFileExists( fn.GetFullPath() ) ) {
             int answer = OCPNMessageBox( NULL, _("Overwrite existing file?"), _T("Confirm"),
@@ -3062,9 +3061,6 @@ bool MyConfig::ExportGPXWaypoints( wxWindow* parent, RoutePointList *pRoutePoint
                                                      wxT ( "*.gpx" )
                                                      );
 
-    wxFileName fn( path );
-    m_gpx_path = fn.GetPath();
-    
 
 #if 0        
     wxFileDialog *psaveDialog = new wxFileDialog( NULL, _( "Export GPX file" ), m_gpx_path, suggestedName,
@@ -3076,13 +3072,15 @@ bool MyConfig::ExportGPXWaypoints( wxWindow* parent, RoutePointList *pRoutePoint
     int response = psaveDialog->ShowModal();
 
     wxString path = psaveDialog->GetPath();
-    wxFileName fn( path );
-    m_gpx_path = fn.GetPath();
+//    wxFileName fn( path );
+//    m_gpx_path = fn.GetPath();
     delete psaveDialog;
 #endif
     
     if( response == wxID_OK ) {
-        fn.SetExt( _T ( "gpx" ) );
+        wxFileName fn( path );
+        m_gpx_path = fn.GetPath();
+        fn.SetExt(_T("gpx"));
 
         if( wxFileExists( fn.GetFullPath() ) ) {
             int answer = OCPNMessageBox(NULL,  _("Overwrite existing file?"), _T("Confirm"),
@@ -3111,8 +3109,6 @@ void MyConfig::ExportGPX( wxWindow* parent, bool bviz_only, bool blayer )
                                                      wxT ( "*.gpx" )
     );
     
-    wxFileName fn( path );
-    m_gpx_path = fn.GetPath();
     
     
 #if 0    
@@ -3131,7 +3127,9 @@ void MyConfig::ExportGPX( wxWindow* parent, bool bviz_only, bool blayer )
 #endif
     
     if( response == wxID_OK ) {
-        fn.SetExt( _T ( "gpx" ) );
+        wxFileName fn(path);
+        m_gpx_path = fn.GetPath();
+        fn.SetExt(_T("gpx"));
 
         if( wxFileExists( fn.GetFullPath() ) ) {
             int answer = OCPNMessageBox( NULL, _("Overwrite existing file?"), _T("Confirm"),


### PR DESCRIPTION
If the users presses CANCEL some of the export functions would set the persistent GPXIODir variable in opencpn.ini to empty string. This is probably not what the user expects and is inconsistent with other export and import functions.