### PR TITLE
toggle quilt, only unlock quilt charts

### DIFF
--- a/include/Quilt.h
+++ b/include/Quilt.h
@@ -96,6 +96,7 @@ public:
     void EnableHighDefinitionZoom( bool value ) { m_b_hidef = value;}
     
     bool BuildExtendedChartStackAndCandidateArray(bool b_fullscreen, int ref_db_index, ViewPort &vp_in);
+    void UnlockQuilt();
     bool Compose( const ViewPort &vp );
     bool IsComposed() {
         return m_bcomposed;

--- a/include/chcanv.h
+++ b/include/chcanv.h
@@ -212,6 +212,7 @@ public:
 
       wxBitmap &GetTideBitmap(){ return m_cTideBitmap; }
       
+      void UnlockQuilt();
       void SetQuiltMode(bool b_quilt);
       bool GetQuiltMode(void);
       ArrayOfInts GetQuiltIndexArray(void);

--- a/src/Quilt.cpp
+++ b/src/Quilt.cpp
@@ -1319,6 +1319,20 @@ double Quilt::GetBestStartScale(int dbi_ref_hint, const ViewPort &vp_in)
     return cc1->GetCanvasScaleFactor() / proposed_scale_onscreen;
 }
 
+void Quilt::UnlockQuilt()
+{
+    wxASSERT(m_bbusy == false);
+    ChartData->UnLockCache();
+    // unlocked only charts owned by the Quilt
+    for(unsigned int ir = 0; ir < m_pcandidate_array->GetCount(); ir++ ) {
+        QuiltCandidate *pqc = m_pcandidate_array->Item( ir );
+        if (pqc->b_locked == true) {
+            ChartData->UnLockCacheChart(pqc->dbIndex);
+            pqc->b_locked = false;
+        }
+    }
+}
+
 bool Quilt::Compose( const ViewPort &vp_in )
 {
     if( !ChartData )
@@ -1330,18 +1344,9 @@ bool Quilt::Compose( const ViewPort &vp_in )
     if( m_bbusy )
         return false;
 
+    // XXX call before setting m_bbusy for wxASSERT in UnlockQuilt
+    UnlockQuilt();
     m_bbusy = true;
-
-    ChartData->UnLockCache();
-    // unlocked only charts owned by the Quilt
-    for(unsigned int ir = 0; ir < m_pcandidate_array->GetCount(); ir++ ) {
-        QuiltCandidate *pqc = m_pcandidate_array->Item( ir );
-        if (pqc->b_locked == true) {
-            ChartData->UnLockCacheChart(pqc->dbIndex);
-            pqc->b_locked = false;
-        }
-    }
-
 
     ViewPort vp_local = vp_in;                   // need a non-const copy
 

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -5837,8 +5837,7 @@ void MyFrame::SetupQuiltMode( void )
     //    When shifting from quilt to single chart mode, select the "best" single chart to show
     if( !cc1->GetQuiltMode() ) {
         if( ChartData && ChartData->IsValid() ) {
-            ChartData->UnLockCache();
-            ChartData->UnLockAllCacheCharts();
+            cc1->UnlockQuilt();
 
             double tLat, tLon;
             if( cc1->m_bFollow == true ) {

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -1253,6 +1253,11 @@ bool ChartCanvas::IsQuiltDelta()
     return m_pQuilt->IsQuiltDelta( VPoint );
 }
 
+void ChartCanvas::UnlockQuilt()
+{
+    m_pQuilt->UnlockQuilt();
+}
+
 ArrayOfInts ChartCanvas::GetQuiltIndexArray( void )
 {
     return m_pQuilt->GetQuiltIndexArray();;


### PR DESCRIPTION
Hi,
When toggling quilt off only unlock charts in the quilt not all charts, some charts can also be locked by texture background processes and unlocking them  can kill ocpn.

Regards
Didier