### PR TITLE
in case cpus count is not constant

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -305,6 +305,7 @@ wxProgressDialog *pprog;
 bool b_skipout;
 wxSize pprog_size;
 int pprog_count;
+int pprog_threads;
 wxArrayString compress_msg_array;
 
 //  TODO why are these static?
@@ -1143,6 +1144,11 @@ void ChartCanvas::SetDisplaySizeMM( double size )
 void ChartCanvas::OnEvtCompressProgress( OCPN_CompressProgressEvent & event )
 {
     wxString msg(event.m_string.c_str(), wxConvUTF8);
+    // if cpus are removed between runs
+    if(pprog_threads > 0 && compress_msg_array.GetCount() >  (unsigned int)pprog_threads) {
+        compress_msg_array.RemoveAt(pprog_threads, compress_msg_array.GetCount() - pprog_threads);
+    }
+
     if(compress_msg_array.GetCount() > (unsigned int)event.thread )
     {
         compress_msg_array.RemoveAt(event.thread);

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -228,6 +228,7 @@ extern wxProgressDialog *pprog;
 extern bool b_skipout;
 extern wxSize pprog_size;
 extern int pprog_count;
+extern int pprog_threads;
 
 //#if defined(__MSVC__) && !defined(ocpnUSE_GLES) /* this compiler doesn't support vla */
 //const
@@ -502,9 +503,17 @@ void BuildCompressedCache()
 #endif
 
     int thread_count = 0;
+    pprog_threads = 0;
     CompressedCacheWorkerThread **workers = NULL;
     if(ramonly) {
         thread_count = wxThread::GetCPUCount();
+        // XXX if only 1 or unknown set ramonly to false?
+        if (thread_count < 1) {
+            // obviously there's a least one CPU!
+            thread_count = 1;
+        }
+        pprog_threads = thread_count;
+
         workers = new CompressedCacheWorkerThread*[thread_count];
         for(int t = 0; t < thread_count; t++)
             workers[t] = NULL;


### PR DESCRIPTION
Hi,
If CPUS are removed we have to remove them in  compress_msg_array 
eg:
Rebuild the cache, skip
in a terminal 
echo 0 > /sys/devices/system/cpu/cpu1/online
Rebuild the cache
cf:
http://www.cruisersforum.com/forums/f134/opencpn-rc-4-1-1301-release-158718-16.html#post2014864

These global variables aren't nice though.
Regards
Didier