### PR TITLE
Toolbar tweaks

### DIFF
--- a/src/styles.cpp
+++ b/src/styles.cpp
@@ -459,7 +459,7 @@ wxBitmap Style::BuildPluginIcon( const wxBitmap* bm, int iconType )
         case TOOLICON_NORMAL: {
             if( hasBackground ) {
                 wxBitmap bg = GetNormalBG();
-                bg = SetBitmapBrightness( bg );
+
                 wxSize offset = wxSize( bg.GetWidth() - bm->GetWidth(), bg.GetHeight() - bm->GetHeight() );
                 offset /= 2;
                 iconbm = MergeBitmaps( bg, *bm, offset );
@@ -479,8 +479,11 @@ wxBitmap Style::BuildPluginIcon( const wxBitmap* bm, int iconType )
             iconbm = MergeBitmaps( GetToggledBG(), *bm, wxSize( 0, 0 ) );
             break;
         }
+        default:
+            return wxNullBitmap;
+            break;
     }
-    return iconbm;
+    return SetBitmapBrightness( iconbm );
 }
 
 wxBitmap Style::SetBitmapBrightness( wxBitmap& bitmap )

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -1888,6 +1888,7 @@ void ocpnToolBarSimple::DrawTool( wxDC& dc, wxToolBarToolBase *toolBase )
                     wxSVGDocument svgDoc;
                     if( svgDoc.Load(svgFile) ){
                         bmp = wxBitmap( svgDoc.Render( tool->m_width, tool->m_height, NULL, true, true ) );
+                        bmp = m_style->SetBitmapBrightness(bmp);
                     }
                     else
                         bmp = m_style->BuildPluginIcon( tool->pluginNormalIcon, TOOLICON_NORMAL );
@@ -1915,7 +1916,6 @@ void ocpnToolBarSimple::DrawTool( wxDC& dc, wxToolBarToolBase *toolBase )
                     }
                 }
             }
-            bmp = m_style->SetBitmapBrightness(bmp);
             tool->SetNormalBitmap( bmp );
             tool->bitmapOK = true;
         } else {

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -408,8 +408,6 @@ void ocpnFloatingToolbarDialog::SetColorScheme( ColorScheme cs )
     ClearBackground();
 
     if( m_ptoolbar ) {
-        wxColour back_color = GetGlobalColor( _T("GREY2") );
-
         //  Set background
         m_ptoolbar->SetBackgroundColour( back_color );
         m_ptoolbar->ClearBackground();

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -1091,6 +1091,9 @@ void ToolTipWin::SetColorScheme( ColorScheme cs )
 {
     m_back_color = GetGlobalColor( _T ( "UIBCK" ) );
     m_text_color = FontMgr::Get().GetFontColor( _("ToolTips") );
+    // assume black is the default 
+    if (m_text_color == *wxBLACK)
+       m_text_color = GetGlobalColor( _T ( "UITX1" ) );
 
     m_cs = cs;
 }


### PR DESCRIPTION
Hi,
- if the user hasn't defined a color for tooltips text uses  UITX1, black on dark UIBCK is unreadable, same as piano roll over.

- Tweak icon colors dimming in dusk and night modes, IMO it's still too dark for icons with a background (wmm journey style) but I'm unable to find a combination where vdr raster icons in traditional style aren't too bright.

Regards
Didier