### PR TITLE
On exit don't recompute a new toolbar

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -2994,8 +2994,14 @@ bool MyFrame::AddDefaultPositionPlugInTools( ocpnToolBarSimple *tb )
     return bret;
 }
 
+static bool b_inCloseWindow;
+
 void MyFrame::RequestNewToolbar(bool bforcenew)
 {
+    if( b_inCloseWindow ) {
+        return;
+    }
+    
     bool b_reshow = true;
     if( g_FloatingToolbarDialog ) {
         b_reshow = g_FloatingToolbarDialog->IsShown();
@@ -3131,8 +3137,6 @@ void MyFrame::OnExit( wxCommandEvent& event )
     quitflag++;                             // signal to the timer loop
 
 }
-
-static bool b_inCloseWindow;
 
 void MyFrame::OnCloseWindow( wxCloseEvent& event )
 {


### PR DESCRIPTION
hi,

On exit plugins are unloaded and it triggers  a new toolbar each time, this toolbar is never displayed.
With SVG it's slow, all icons are recomputed.

On my (slow) box with 4/5 plugins enabled it adds 2 seconds to the exit time.

Regards
Didier