### PR TITLE
Thumbnail overlapping piano

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -7470,7 +7470,7 @@ void MyFrame::SetChartThumbnail( int index )
                 
                 // Simplistic overlap avoidance works best when toolbar is horizontal near the top of screen.
                 // Other difficult cases simply center the thumbwin on the canvas....
-                if( g_FloatingToolbarDialog ){
+                if( g_FloatingToolbarDialog && !g_FloatingToolbarDialog->isSubmergedToGrabber()){
                     if( g_FloatingToolbarDialog->GetScreenRect().Intersects( tRect ) ) {
                         wxPoint tbpos = cc1->ScreenToClient(g_FloatingToolbarDialog->GetPosition());
                         pos = wxPoint(4, g_FloatingToolbarDialog->GetSize().y + tbpos.y + 4);

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -7474,6 +7474,7 @@ void MyFrame::SetChartThumbnail( int index )
                     if( g_FloatingToolbarDialog->GetScreenRect().Intersects( tRect ) ) {
                         wxPoint tbpos = cc1->ScreenToClient(g_FloatingToolbarDialog->GetPosition());
                         pos = wxPoint(4, g_FloatingToolbarDialog->GetSize().y + tbpos.y + 4);
+                        tLocn = ClientToScreen(pos);
                     }
                 }
                 
@@ -7482,7 +7483,7 @@ void MyFrame::SetChartThumbnail( int index )
                     int piano_height = g_Piano->GetHeight() + 4;
                     wxPoint cbarLocn = ClientToScreen(wxPoint(0, cc1->GetCanvasHeight() - piano_height));
                     wxRect cbarRect = wxRect(cbarLocn.x, cbarLocn.y, cc1->GetCanvasWidth(), piano_height);
-                    if( cbarRect.Intersects( wxRect(pos.x, pos.y, pthumbwin->GetSize().x, pthumbwin->GetSize().y))){
+                    if( cbarRect.Intersects( wxRect(tLocn.x, tLocn.y, pthumbwin->GetSize().x, pthumbwin->GetSize().y))){
                         pos = wxPoint((cc1->GetCanvasWidth() - pthumbwin->GetSize().x)/2,
                                       (cc1->GetCanvasHeight() - pthumbwin->GetSize().y)/2);
                     }

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -3721,7 +3721,7 @@ void MyFrame::ODoSetSize( void )
     }
 
     if( pthumbwin )
-        pthumbwin->SetMaxSize( cc1->GetParent()->GetSize() );
+        pthumbwin->SetMaxSize( cc1->GetParent()->GetClientSize() );
 
     //  Reset the options dialog size logic
     options_lastWindowSize = wxSize(0,0);
@@ -7485,7 +7485,7 @@ void MyFrame::SetChartThumbnail( int index )
                     wxRect cbarRect = wxRect(cbarLocn.x, cbarLocn.y, cc1->GetCanvasWidth(), piano_height);
                     if( cbarRect.Intersects( wxRect(tLocn.x, tLocn.y, pthumbwin->GetSize().x, pthumbwin->GetSize().y))){
                         pos = wxPoint((cc1->GetCanvasWidth() - pthumbwin->GetSize().x)/2,
-                                      (cc1->GetCanvasHeight() - pthumbwin->GetSize().y)/2);
+                                      (cc1->GetCanvasHeight() - pthumbwin->GetSize().y)/2 - piano_height);
                     }
                 }
                 pthumbwin->Move( pos );


### PR DESCRIPTION
Hi
follow up on 52e94890e4e444f45ef215338c5a72c064f1b2e2
'Correct fault on single-chart thumbnail overlap of Chartbar.'

- There's a mismatch between screen and client coordinates.
- If the toolbar is reduced don't bother with overlap.
- Use the canvas client size not full size for the thumbnail maximum size or the status bar heigh is not subtracted.
- When centring move the thumbnail up the piano size,some river charts as 4/1 ratio and the thumbnail is really big and they still overlap!

Regards
Didier
