### PR TITLE
Add log message indicating the type of icons being used. This is requ…

### DIFF
--- a/src/styles.cpp
+++ b/src/styles.cpp
@@ -697,6 +697,11 @@ StyleManager::StyleManager(void)
     Init( g_Platform->GetHomeDir() );
     Init( g_Platform->GetHomeDir() + _T(".opencpn") + wxFileName::GetPathSeparator() );
     SetStyle( _T("") );
+#ifdef ocpnUSE_SVG
+    wxLogMessage("Using SVG Icons");
+#else
+    wxLogMessage("Using PNG Icons");
+#endif    
 }
 
 StyleManager::StyleManager(const wxString & configDir)


### PR DESCRIPTION
…ired as if a plugin is using SVG but OCPN is not the plugin fails to load but there is no information about why. With this change the log will show if SVG or PNG is being used.