### PR TITLE
Prevent grib particle being positioned outside the grid.

### DIFF
--- a/plugins/grib_pi/src/GribRecord.cpp
+++ b/plugins/grib_pi/src/GribRecord.cpp
@@ -1309,6 +1309,8 @@ bool GribRecord::getInterpolatedValues(double &M, double &A,
     unsigned int i1 = pi+1, j1 = pj+1;
     if(i1 >= GRX->Ni)
         i1 -= GRX->Ni;
+    if(j1 >= GRX->Nj)
+        j1 -= GRX->Nj;
 
     // distances to 00
     double dx = pi-i0;


### PR DESCRIPTION
This fixes crashes with large grib particle maps.

The random particle generator located particles on the very edge of the grid.  So getInterpolatedValues tried to use a value outside the grid.