### PR TITLE
Correct grib area manual drawing when crossing 180/-180 longitude line

### DIFF
--- a/plugins/grib_pi/src/GribRequestDialog.h
+++ b/plugins/grib_pi/src/GribRequestDialog.h
@@ -100,6 +100,7 @@ private:
       int  m_MailError_Nb;
       int  m_SendMethod;
       bool m_AllowSend;
+	  bool  m_IsMaxLong;
 };
 
 #endif


### PR DESCRIPTION
It was impossible to send a request when manually drawing the requested area  crossing the 180°
longitude line. There was also a fault in estimated area size in this case
Sorry to have seen this bug and corrected it so late
jean pierre