### PR TITLE
Fix plugin installation path for openSUSE.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,10 @@ IF (NOT WIN32)
     #    SET (PACKAGE_DEPS  "libwx_baseu-2_8-0-wxcontainer MesaGLw libbz2-1 portaudio")
     IF (CMAKE_SIZEOF_VOID_P MATCHES "8")
       SET (ARCH "x86_64")
-      SET (LIB_INSTALL_DIR "lib64")
+      SET (LIB_INSTALL_DIR "lib")
+        # In recent openSUSE versions (as of 2016), lib64 is mostly used when there are both 32-bit and 64-bit versions, although not limited to that.
+        # This CMake variable only affects the location of OpenCPN plugins at installation time, and nothing more than that.
+        # At run time, the plugin directory is determined by wxStandardPaths::GetPluginsDir(), which returns "lib", so this can be considered canonical.
     ELSE (CMAKE_SIZEOF_VOID_P MATCHES "8")
       SET (ARCH "i386")
       SET (LIB_INSTALL_DIR "lib")


### PR DESCRIPTION
Currently, plugins get installed to */usr/local/lib64/opencpn* in openSUSE by default, while at run time they are being searched for in */usr/local/lib/opencpn* by wxWidgets. This patch fixes the installation path in the corresponding section of *CMakeLists.txt*.