### PR TITLE
Allow longer waypoint names in Send to GPS

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -702,6 +702,7 @@ int              g_chart_zoom_modifier;
 int              g_NMEAAPBPrecision;
 
 wxString         g_TalkerIdText;
+int              g_maxWPNameLength;
 
 bool             g_bAdvanceRouteWaypointOnArrivalOnly;
 

--- a/src/multiplexer.cpp
+++ b/src/multiplexer.cpp
@@ -38,6 +38,7 @@ extern bool             g_bWplIsAprsPosition;
 extern wxArrayOfConnPrm  *g_pConnectionParams;
 extern bool             g_bserial_access_checked;
 extern bool             g_b_legacy_input_filter_behaviour;
+extern int              g_maxWPNameLength;
 
 extern "C" bool CheckSerialAccess( void );
 
@@ -629,7 +630,7 @@ ret_point:
                         else
                             oNMEA0183.Wpl.Position.Longitude.Set ( prp->m_lon, _T ( "E" ) );
 
-                        oNMEA0183.Wpl.To = prp->GetName().Truncate ( 6 );
+                        oNMEA0183.Wpl.To = prp->GetName().Truncate ( g_maxWPNameLength );
 
                         oNMEA0183.Wpl.Write ( snt );
 
@@ -650,7 +651,7 @@ ret_point:
 
                         wxString name = prp->GetName();
                         name += _T("000000");
-                        name.Truncate( 6 );
+                        name.Truncate( g_maxWPNameLength );
                         oNMEA0183.GPwpl.To = name;
 
                         oNMEA0183.GPwpl.Write ( snt );
@@ -664,10 +665,12 @@ ret_point:
                     // a delay is needed and a new string of waypoints may be sent.
                     // To ensure all waypoints will arrive, we can simply send each one twice.
                     // This ensures that the gps  will get the waypoint and also allows us to send as many as we like
-                    payload += _T("\r\n") + payload;
+                    //payload += _T("\r\n") + payload;
                     
-                    if( dstr->SendSentence( payload ) )
+                    if( dstr->SendSentence( payload ) ) {
+                        dstr->SendSentence( payload );
                         LogOutputMessage( snt.Sentence, dstr->GetPort(), false );
+                    }
 
                     wxString msg(_T("-->GPS Port:"));
                     msg += com_name;
@@ -726,13 +729,13 @@ ret_point:
             while ( node )
             {
                 RoutePoint *prp = node->GetData();
-                wxString name = prp->GetName().Truncate ( 6 );
+                wxString name = prp->GetName().Truncate ( g_maxWPNameLength );
 
                 if(g_GPS_Ident == _T("FurunoGP3X"))
                 {
                     name = prp->GetName();
                     name += _T("000000");
-                    name.Truncate( 6 );
+                    name.Truncate( g_maxWPNameLength );
                     name .Prepend( _T(" "));        // What Furuno calls "Skip Code", space means use the WP
                 }
 
@@ -783,7 +786,7 @@ ret_point:
                 while ( node )
                 {
                     RoutePoint *prp = node->GetData();
-                    unsigned int name_len = prp->GetName().Truncate ( 6 ).Len();
+                    unsigned int name_len = prp->GetName().Truncate ( g_maxWPNameLength ).Len();
                     if(g_GPS_Ident == _T("FurunoGP3X"))
                         name_len = 7;           // six chars, with leading space for "Skip Code"
 
@@ -822,12 +825,12 @@ ret_point:
                 while ( node )
                 {
                     RoutePoint *prp = node->GetData();
-                    wxString name = prp->GetName().Truncate ( 6 );
+                    wxString name = prp->GetName().Truncate ( g_maxWPNameLength );
                     if(g_GPS_Ident == _T("FurunoGP3X"))
                     {
                         name = prp->GetName();
                         name += _T("000000");
-                        name.Truncate( 6 );
+                        name.Truncate( g_maxWPNameLength );
                         name .Prepend( _T(" "));        // What Furuno calls "Skip Code", space means use the WP
                     }
 
@@ -1149,7 +1152,7 @@ int Multiplexer::SendWaypointToGPS(RoutePoint *prp, const wxString &com_name, wx
             else
                 oNMEA0183.Wpl.Position.Longitude.Set ( prp->m_lon, _T ( "E" ) );
 
-            oNMEA0183.Wpl.To = prp->GetName().Truncate ( 6 );
+            oNMEA0183.Wpl.To = prp->GetName().Truncate ( g_maxWPNameLength );
 
             oNMEA0183.Wpl.Write ( snt );
         }
@@ -1170,7 +1173,7 @@ int Multiplexer::SendWaypointToGPS(RoutePoint *prp, const wxString &com_name, wx
 
             wxString name = prp->GetName();
             name += _T("000000");
-            name.Truncate( 6 );
+            name.Truncate( g_maxWPNameLength );
 
             oNMEA0183.GPwpl.To = name;
 

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -366,6 +366,7 @@ extern int              g_chart_zoom_modifier;
 extern int              g_NMEAAPBPrecision;
 
 extern wxString         g_TalkerIdText;
+extern int              g_maxWPNameLength;
 
 extern bool             g_bAdvanceRouteWaypointOnArrivalOnly;
 extern double           g_display_size_mm;
@@ -1301,6 +1302,7 @@ int MyConfig::LoadMyConfig()
     Read( _T( "NMEAAPBPrecision" ), &g_NMEAAPBPrecision, 3 );
     
     Read( _T( "TalkerIdText" ), &g_TalkerIdText, _T("EC") );
+    Read( _T( "MaxWaypointNameLength" ), &g_maxWPNameLength, 6 );
 
     /* opengl options */
 #ifdef ocpnUSE_GL


### PR DESCRIPTION
Allow the use of setting MaxWaypointNameLength in opencpn.ini to enable sending longer than 6 character waypoint names to GPS