### PR TITLE
Adapt `.gitignore` to in-tree builds on Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,15 @@ cscope.out
 *.kdev*
 *.patch
 crowdin.yaml
+buildwin/NSIS_Unicode/Include/Langstrings_*.nsh
+buildwin/crashrpt/CrashRpt1402.dll
+buildwin/crashrpt/CrashSender1402.exe
+buildwin/crashrpt/dbghelp.dll
+buildwin/expat*/
+buildwin/gtk*/
+buildwin/libcurl.dll
+buildwin/ocpn_gltest1.exe
+buildwin/vc/
+buildwin/wxWidgets/
+buildwin/zlib1.dll
+src/opencpn.rc


### PR DESCRIPTION
Since building on Windows requires to put additional files into source tree, and some files are also automatically generated there by make-scripts, this fix will ensure that none of that garbage will ever be committed by accident.