### PR TITLE
Partially fix FS#1465 by removing scan limit.

### DIFF
--- a/src/chartdbs.cpp
+++ b/src/chartdbs.cpp
@@ -1576,15 +1576,6 @@ bool ChartDatabase::DetectDirChange(const wxString & dir_path, const wxString & 
       wxDir dir(dir_path);
       int n_files = dir.GetAllFiles(dir_path, &FileList);
 
-      //    Arbitrarily, we decide if the dir has more than a specified number of files
-      //    then don't scan it.  Takes too long....
-
-      if(n_files > 10000)
-      {
-            new_magic = _T("");
-            return true;
-      }
-
       //Traverse the list of files, getting their interesting stuff to add to accumulator
       for(int ifile=0 ; ifile < n_files ; ifile++)
       {


### PR DESCRIPTION
There is an implicit threshold in `ChartDatabase::DetectDirChange()`, empirically set to 10'000 files, that triggers speedy termination with a result that means “This directory contents has changed, it needs
to be re-processed again”. Therefore, instead of improving performance by avoiding some large and unnecessary job, it results in doing even larger, much more superfluous and complex processing (which
also needs to be fixed, by the way). I suggest to remove this artificial and non-configurable limitation.

Are there any situations where this limit may indeed provide some sanity safeguard? As far as I understand, chart stores of “special” types like CM-93/2 are explicitly excluded from such detection and thus will not suffer from this change; moreover, CM charts in particular are not stored in flat way, i. e. with all files in a single directory.

PS. By “fixing the import process” I mean that, even if some directory is found to be modified, it does not mean that every chart in it must be re-imported from scratch regardless of whether the very same version is already present in database.