### PR TITLE
grib add LV_ATMOS_ALL from zyGrib for cloud cover

### DIFF
--- a/plugins/grib_pi/src/GribRecord.h
+++ b/plugins/grib_pi/src/GribRecord.h
@@ -94,6 +94,7 @@ Elément de base d'un fichier GRIB
 #define LV_MSL       102
 #define LV_ABOV_GND  105
 #define LV_SIGMA     107
+#define LV_ATMOS_ENT  10
 #define LV_ATMOS_ALL 200
 //---------------------------------------------------------
 enum DataCenterModel {

--- a/plugins/grib_pi/src/GribV1Record.cpp
+++ b/plugins/grib_pi/src/GribV1Record.cpp
@@ -52,6 +52,11 @@ void  GribV1Record::translateDataType()
             && levelType == LV_GND_SURF
             && levelValue == 0) dataType = GRB_WTMP;
 
+        // altitude level (entire atmosphere vs entire atmosphere considered as 1 level)
+        if (levelType == LV_ATMOS_ENT) {
+            levelType = LV_ATMOS_ALL;
+        }
+                                                                                
 	}
     //------------------------
 	//DNMI-NEurope.grb


### PR DESCRIPTION
Hi,
Zygrib NOAA is using  LV_ATMOS_ENT for cloud cover records, convert it to LV_ATMOS_ALL so grib_pi can display them.

Regards
Didier