### PR TITLE
compute the right value for accumulation records

### DIFF
--- a/plugins/grib_pi/src/GribReader.cpp
+++ b/plugins/grib_pi/src/GribReader.cpp
@@ -489,6 +489,56 @@ void  GribReader::InterpolateMissingRecords (int dataType, int levelType, int le
 }
 #endif
 
+void  GribReader::computeAccumulationRecords (int dataType, int levelType, int levelValue)
+{
+	std::set<time_t>  setdates = getListDates();
+	std::set<time_t>::reverse_iterator rit;
+    GribRecord *prev = 0;
+    int p1 = 0, p2 = 0;
+
+    if (setdates.empty())
+        return;
+
+	// XXX only work if P2 -P1 === time
+    for (rit = setdates.rbegin(); rit != setdates.rend(); ++rit)
+    {
+		time_t date = *rit;
+		GribRecord *rec = getGribRecord( dataType, levelType, levelValue, date );
+		if ( rec && rec->isOk() ) {
+		    
+		    // XXX double check reference date and timerange 
+		    if (prev != 0 )
+		    {
+		        double sec = 0.0;
+		        if (p2 > p1) {
+		            // seconds in one period   
+		            sec = prev->getPeriodSec()/(p2 -p1);
+                }
+		        if (rec->getTimeRange() == 4 && prev->getPeriodP1() == rec->getPeriodP1()) {
+		            // printf("substract %d %d %d\n", prev->getPeriodP1(), prev->getPeriodP2(), prev->getPeriodSec());
+		            prev->Substract(*rec);
+		            p1 = rec->getPeriodP2();
+                }
+                // printf (" %d %d %f\n", p1, p2, sec);
+                // convert to mm/h
+                if (p2 > p1) {
+                    //prev->multiplyAllData( 3600.0/sec/(p2 -p1) );
+                    prev->multiplyAllData( 1.0/(p2 -p1) );
+                }
+                p2 = p1 = 0;
+            }
+		    prev = rec;
+            p1 = prev->getPeriodP1();
+		    p2 = prev->getPeriodP2();
+		}
+	}
+	if (prev != 0 && p2 > p1) {
+	    // the last one
+        prev->multiplyAllData( 1.0/(p2 -p1) );
+	}
+	    
+}
+
 //---------------------------------------------------------------------------------
 void  GribReader::copyFirstCumulativeRecord()
 {
@@ -523,6 +573,7 @@ void GribReader::readGribFileContent()
 
     createListDates();
 //    hoursBetweenRecords = computeHoursBeetweenGribRecords();
+
 
 	//-----------------------------------------------------
 	// Are dewpoint data in file ?

--- a/plugins/grib_pi/src/GribReader.cpp
+++ b/plugins/grib_pi/src/GribReader.cpp
@@ -509,20 +509,13 @@ void  GribReader::computeAccumulationRecords (int dataType, int levelType, int l
 		    // XXX double check reference date and timerange 
 		    if (prev != 0 )
 		    {
-		        double sec = 0.0;
-		        if (p2 > p1) {
-		            // seconds in one period   
-		            sec = prev->getPeriodSec()/(p2 -p1);
-                }
 		        if (rec->getTimeRange() == 4 && prev->getPeriodP1() == rec->getPeriodP1()) {
 		            // printf("substract %d %d %d\n", prev->getPeriodP1(), prev->getPeriodP2(), prev->getPeriodSec());
 		            prev->Substract(*rec);
 		            p1 = rec->getPeriodP2();
                 }
-                // printf (" %d %d %f\n", p1, p2, sec);
                 // convert to mm/h
                 if (p2 > p1) {
-                    //prev->multiplyAllData( 3600.0/sec/(p2 -p1) );
                     prev->multiplyAllData( 1.0/(p2 -p1) );
                 }
                 p2 = p1 = 0;

--- a/plugins/grib_pi/src/GribReader.h
+++ b/plugins/grib_pi/src/GribReader.h
@@ -92,7 +92,6 @@ class GribReader
       //void  removeFirstCumulativeRecord (int dataType,int levelType,int levelValue);
       void  copyMissingWaveRecords (int dataType,int levelType,int levelValue);
 
-      void  InterpolateMissingRecords (int dataType, int levelType, int levelValue);
       void  computeAccumulationRecords (int dataType, int levelType, int levelValue);
 
       std::map < std::string, std::vector<GribRecord *>* > * getGribMap(){ return  &mapGribRecords; }              //dsr

--- a/plugins/grib_pi/src/GribReader.h
+++ b/plugins/grib_pi/src/GribReader.h
@@ -92,6 +92,9 @@ class GribReader
       //void  removeFirstCumulativeRecord (int dataType,int levelType,int levelValue);
       void  copyMissingWaveRecords (int dataType,int levelType,int levelValue);
 
+      void  InterpolateMissingRecords (int dataType, int levelType, int levelValue);
+      void  computeAccumulationRecords (int dataType, int levelType, int levelValue);
+
       std::map < std::string, std::vector<GribRecord *>* > * getGribMap(){ return  &mapGribRecords; }              //dsr
 
     private:

--- a/plugins/grib_pi/src/GribRecord.cpp
+++ b/plugins/grib_pi/src/GribRecord.cpp
@@ -353,8 +353,8 @@ void GribRecord::Substract(const GribRecord &rec)
     if (Ni != rec.Ni || Nj != rec.Nj) 
         return;
         
-    int size = Ni *Nj;
-    for (int i=0; i<size; i++) {
+    zuint size = Ni *Nj;
+    for (zuint i=0; i<size; i++) {
         if (rec.data[i] == GRIB_NOTDEF)
            continue; 
         if (data[i] == GRIB_NOTDEF) {

--- a/plugins/grib_pi/src/GribRecord.cpp
+++ b/plugins/grib_pi/src/GribRecord.cpp
@@ -341,6 +341,36 @@ GribRecord *GribRecord::MagnitudeRecord(const GribRecord &rec1, const GribRecord
     return rec;
 }
 
+void GribRecord::Substract(const GribRecord &rec)
+{
+    // for now only substract records of same size
+    if (rec.data == 0 || !rec.isOk())
+        return;
+
+    if (data == 0 || !isOk())
+        return;
+        
+    if (Ni != rec.Ni || Nj != rec.Nj) 
+        return;
+        
+    int size = Ni *Nj;
+    for (int i=0; i<size; i++) {
+        if (rec.data[i] == GRIB_NOTDEF)
+           continue; 
+        if (data[i] == GRIB_NOTDEF) {
+            data[i] = -rec.data[i];
+            if (BMSbits != 0) {
+                if (BMSsize > i) {
+                    BMSbits[i >>3] |= 1 << (i&7);
+                }
+            }
+        }
+        else
+            data[i] -= rec.data[i];
+    } 
+}
+
+
 //------------------------------------------------------------------------------
 void  GribRecord::setDataType(const zuchar t)
 {

--- a/plugins/grib_pi/src/GribRecord.cpp
+++ b/plugins/grib_pi/src/GribRecord.cpp
@@ -341,7 +341,7 @@ GribRecord *GribRecord::MagnitudeRecord(const GribRecord &rec1, const GribRecord
     return rec;
 }
 
-void GribRecord::Substract(const GribRecord &rec)
+void GribRecord::Substract(const GribRecord &rec, bool pos)
 {
     // for now only substract records of same size
     if (rec.data == 0 || !rec.isOk())
@@ -367,6 +367,10 @@ void GribRecord::Substract(const GribRecord &rec)
         }
         else
             data[i] -= rec.data[i];
+        if (data[i] < 0. && pos) {
+            // data type should be positive...
+            data[i] = 0.;
+        }
     } 
 }
 

--- a/plugins/grib_pi/src/GribRecord.h
+++ b/plugins/grib_pi/src/GribRecord.h
@@ -143,7 +143,7 @@ class GribRecord
         static GribRecord *MagnitudeRecord(const GribRecord &rec1, const GribRecord &rec2);
 
         void   multiplyAllData(double k);
-        void Substract(const GribRecord &rec);
+        void Substract(const GribRecord &rec, bool positive=true);
 
         bool  isOk()  const   {return ok;};
         bool  isDataKnown()  const   {return knownData;};

--- a/plugins/grib_pi/src/GribRecord.h
+++ b/plugins/grib_pi/src/GribRecord.h
@@ -142,6 +142,9 @@ class GribRecord
 
         static GribRecord *MagnitudeRecord(const GribRecord &rec1, const GribRecord &rec2);
 
+        void   multiplyAllData(double k);
+        void Substract(const GribRecord &rec);
+
         bool  isOk()  const   {return ok;};
         bool  isDataKnown()  const   {return knownData;};
         bool  isEof() const   {return eof;};
@@ -166,6 +169,8 @@ class GribRecord
         //-----------------------------------------
         int    getPeriodP1() const  { return periodP1; }
         int    getPeriodP2() const  { return periodP2; }
+        zuint  getPeriodSec() const  { return periodsec; }
+        zuchar getTimeRange() const { return timeRange; }
 
         // Number of points in the grid
         int    getNi() const     { return Ni; }
@@ -282,7 +287,6 @@ class GribRecord
         // SECTION 5: END SECTION (ES)
 
         time_t makeDate(zuint year,zuint month,zuint day,zuint hour,zuint min,zuint sec);
-        void   multiplyAllData(double k);
 
 //        void   print();
 };

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -1622,6 +1622,10 @@ GRIBFile::GRIBFile( const wxArrayString & file_names, bool CumRec, bool WaveRec 
 
     m_FileNames = file_names;
 
+    // fixup Accumulation records
+    m_pGribReader->computeAccumulationRecords(GRB_PRECIP_TOT, LV_GND_SURF, 0);
+
+
     if( CumRec ) m_pGribReader->copyFirstCumulativeRecord();            //add missing records if option selected
     if( WaveRec ) m_pGribReader->copyMissingWaveRecords ();             //  ""                   ""
 

--- a/plugins/grib_pi/src/GribV1Record.cpp
+++ b/plugins/grib_pi/src/GribV1Record.cpp
@@ -40,13 +40,8 @@ void  GribV1Record::translateDataType()
 		&& (idGrid==4 || idGrid==255))		// Saildocs
 	{
         dataCenterModel = NOAA_GFS;
-		if (dataType == GRB_PRECIP_TOT) {	// mm/period -> mm/h
-			if (periodP2 > periodP1)
-				multiplyAllData( 1.0/(periodP2-periodP1) );
-		}
 		if (dataType == GRB_PRECIP_RATE) {	// mm/s -> mm/h
-			if (periodP2 > periodP1)
-				multiplyAllData( 3600.0 );
+            multiplyAllData( 3600.0 );
         }
         if (dataType == GRB_TEMP                        //gfs Water surface Temperature
             && levelType == LV_GND_SURF
@@ -72,13 +67,8 @@ void  GribV1Record::translateDataType()
 	else if (idCenter==7 && idModel==89 && idGrid==255)
     {
         // dataCenterModel ??
-		if (dataType == GRB_PRECIP_TOT) {	// mm/period -> mm/h
-			if (periodP2 > periodP1)
-				multiplyAllData( 1.0/(periodP2-periodP1) );
-		}
 		if (dataType == GRB_PRECIP_RATE) {	// mm/s -> mm/h
-			if (periodP2 > periodP1)
-				multiplyAllData( 3600.0 );
+            multiplyAllData( 3600.0 );
 		}
 
 
@@ -736,18 +726,22 @@ zuint GribV1Record::periodSeconds(zuchar unit,zuchar P1,zuchar P2,zuchar range) 
     }
     grib_debug("id=%d: PDS unit %d (time range) b21=%d %d P1=%d P2=%d\n",id,unit, range,res,P1,P2);
     dur = 0;
+    // (grib1/5.table)
     switch (range) {
         case 0:
             dur = (zuint)P1; break;
         case 1:
             dur = 0; break;
+
         case 2:
-        case 3:
+        case 3:  // Average  (reference time + P1 to reference time + P2)
             // dur = ((zuint)P1+(zuint)P2)/2; break;     // TODO
             dur = (zuint)P2; break;
-         case 4:
+
+         case 4: // Accumulation  (reference time + P1 to reference time + P2)
             dur = (zuint)P2; break;
-        case 10:
+
+        case 10: // P1 occupies octets 19 and 20; product valid at reference time + P1 
             dur = ((zuint)P1<<8) + (zuint)P2; break;
         default:
             erreur("id=%d: unknown time range in PDS b21=%d",id,range);

--- a/plugins/grib_pi/src/GribV2Record.cpp
+++ b/plugins/grib_pi/src/GribV2Record.cpp
@@ -905,7 +905,10 @@ void  GribV2Record::translateDataType()
 	//------------------------
 	// NOAA GFS
 	//------------------------
-	if (   idCenter==7
+    if (dataType == GRB_PRECIP_RATE) {	// mm/s -> mm/h
+				multiplyAllData( 3600.0 );
+    }
+	else if (   idCenter==7
 		&& (idModel==96 || idModel==81)		// NOAA
 		&& (idGrid==4 || idGrid==255))		// Saildocs
 	{
@@ -914,10 +917,6 @@ void  GribV2Record::translateDataType()
 			if (periodP2 > periodP1)
 				multiplyAllData( 1.0/(periodP2-periodP1) );
 		}
-		if (dataType == GRB_PRECIP_RATE) {	// mm/s -> mm/h
-			if (periodP2 > periodP1)
-				multiplyAllData( 3600.0 );
-        }
         if (dataType == GRB_TEMP                        //gfs Water surface Temperature
             && levelType == LV_GND_SURF
             && levelValue == 0) dataType = GRB_WTMP;
@@ -946,12 +945,6 @@ void  GribV2Record::translateDataType()
 			if (periodP2 > periodP1)
 				multiplyAllData( 1.0/(periodP2-periodP1) );
 		}
-		if (dataType == GRB_PRECIP_RATE) {	// mm/s -> mm/h
-			if (periodP2 > periodP1)
-				multiplyAllData( 3600.0 );
-		}
-
-
 	}
     else if ( idCenter==7 && idModel==88 && idGrid==255 ) {  // saildocs
 		dataCenterModel = NOAA_NCEP_WW3;


### PR DESCRIPTION
Hi
Compute the right value for accumulation records, ie subtract the previous value if it overlaps.

It was mostly ok for zyGrib NOAA total precipitation data, they are reset every 6 hours (cf stepRange column):
grib_ls output

```
edition      centre       typeOfLevel  level        dataDate     stepRange    shortName    packingType  gridType     
1            kwbc         surface      0            20160411     0-3          tp          grid_simple  regular_ll  
1            kwbc         surface      0            20160411     0-6          tp          grid_simple  regular_ll  
1            kwbc         surface      0            20160411     6-9          tp          grid_simple  regular_ll  
1            kwbc         surface      0            20160411     6-12         tp          grid_simple  regular_ll  
1            kwbc         surface      0            20160411     12-15        tp          grid_simple  regular_ll  
1            kwbc         surface      0            20160411     12-18        tp          grid_simple  regular_ll  
1            kwbc         surface      0            20160411     18-21        tp          grid_simple  regular_ll  
1            kwbc         surface      0            20160411     18-24        tp          grid_simple  regular_ll  
  
```
but not so for french grib which is summing  from the start.
```
edition      centre       date         dataType     gridType     stepRange    typeOfLevel  level        shortName    packingType
1            lfpw         20160411     not_found    regular_ll   0-6          surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-7          surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-8          surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-9          surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-10         surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-11         surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-12         surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-13         surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-14         surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-15         surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-16         surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-17         surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-18         surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-19         surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-20         surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-21         surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-22         surface      0            tp           grid_simple 
1            lfpw         20160411     not_found    regular_ll   0-23         surface      0            tp           grid_simple 

```
Currently only compute values for tp (same for tcc ?)
  
Ex. 2 MB file: 
[tp.zip](https://github.com/OpenCPN/OpenCPN/files/213636/tp.zip)

french total precipitation  (format grib v1, slightly modified for being readable by  zyGrib, even if it's unable to display this grib correctly)
 
from 
[parameters description (in french)](https://donneespubliques.meteofrance.fr/client/document/description_parametres_modeles-arpege-arome-v2_185.pdf)


> INFO sorties «CUMUL»
> : il s’agit d’un cumul des valeurs du champ considéré depuis le début de la simulation de ARPEGE ou AROME. Ce cumul est obtenu en faisant la somme (pour chaque pas de temps) des produits du champ par le pas de temps du modèle (ARPEGE ou AROME). Mais il n’est  pas nécessaire de connaître la valeur du pas de temps utilisé par le modèle. Par exemple, si on veut la moyenne entre 6h et 18h des précipitations totale (PRECIP), il  suffit de retrancher la valeur à 18h de celle à 6h, puis de diviser le résultat par 12 x 3600 = 43200s.
> Si on veut connaître le cumul des précipitations entre 6h et 18h, il suffit de retrancher la valeur à
> 18h par celle à 6h