### PR TITLE
Fix `USE_GL=OFF` builds (FS#1841) in a dumb way.

### DIFF
--- a/src/s52plib.cpp
+++ b/src/s52plib.cpp
@@ -1097,6 +1097,7 @@ void s52plib::FlushSymbolCaches( void )
         }
     }
     
+#ifdef ocpnUSE_GL
     //    OpenGL Hashmaps
     CARC_Hash::iterator ita;
     for( ita = m_CARC_hashmap.begin(); ita != m_CARC_hashmap.end(); ++ita ) {
@@ -1111,7 +1112,8 @@ void s52plib::FlushSymbolCaches( void )
         glDeleteLists( list, 1 );
     }
     m_CARC_DL_hashmap.clear();
-    
+#endif
+
 }
 
 void s52plib::DestroyPattRules( RuleHash *rh )


### PR DESCRIPTION
* Proper fix in `s52plib.cpp` by adding conditional compilation block as already used in similar snippet. It definitely should be merged, as long as the original block was correct.
* Straight-through removal of undefined references by conditional compilation in `LLRegion.cpp`. Works, but should be thoroughly reviewed by LLRegion developer.

Overall, it compiles and runs fine for me — no glitches observed in basic chart display, but I am not sure that was the right way to do it. The more so that **quilting does not work** in this mode: when it is toggled on, all chart overlays totally disappear, leaving the wallpaper background only.