### PR TITLE
Solution for the "swinging heading" problem, the heading of the own s…

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -9145,9 +9145,9 @@ void MyFrame::OnEvtOCPN_NMEA( OCPN_DataStreamEvent & event )
                 gCog = gpd.kCog;
                 gSog = gpd.kSog;
 
-                gHdt = gpd.kHdt;
                 if( !wxIsNaN(gpd.kHdt) )
                 {
+                    gHdt = gpd.kHdt;
                     g_bHDT_Rx = true;
                     gHDT_Watchdog = gps_watchdog_timeout_ticks;
                 }


### PR DESCRIPTION
…hip symbol may swing between HDT and COG. The problem occurs when a HDT data stream is present and also an AIVDO data stream.

Besides reading the HDT data stream, OCPN also reads the HDT from the VDO stream. When there is no HDT in the VDO stream, which is normally the case, HDT is given the value NAN (not a number), overriding the value from the HDT stream. Lacking a HDT, the own-ship symbol is mapped according to COG in the next display cycle.

The issue is solved by only applying the HDT value from the VDO stream when it is valid.