### PR TITLE
Raster datum wgs84

### DIFF
--- a/include/georef.h
+++ b/include/georef.h
@@ -83,7 +83,7 @@ struct GeoRef {
 #define DEGREE    (PI/180.0)
 #define RADIAN    (180.0/PI)
 
-#define DATUM_INDEX_WGS84     100
+#define DATUM_INDEX_WGS84     101
 #define DATUM_INDEX_UNKNOWN   -1
 
 

--- a/src/chartimg.cpp
+++ b/src/chartimg.cpp
@@ -1523,10 +1523,7 @@ InitReturn ChartKAP::Init( const wxString& name, ChartInitFlag init_flags )
           double dlat = 0;
           double dlon = 0;
           
-          if(m_datum_index == DATUM_INDEX_WGS84){
-          }
-          
-          else if(m_datum_index == DATUM_INDEX_UNKNOWN)
+          if(m_datum_index == DATUM_INDEX_WGS84 || m_datum_index == DATUM_INDEX_UNKNOWN)
           {
               dlon = m_dtm_lon / 3600.;
               dlat = m_dtm_lat / 3600.;
@@ -3023,13 +3020,7 @@ void ChartBaseBSB::SetVPRasterParms(const ViewPort &vpt)
 {
       //    Calculate the potential datum offset parameters for this viewport, if not WGS84
 
-      if(m_datum_index == DATUM_INDEX_WGS84)
-      {
-            m_lon_datum_adjust = 0.;
-            m_lat_datum_adjust = 0.;
-      }
-
-      else if(m_datum_index == DATUM_INDEX_UNKNOWN)
+      if(m_datum_index == DATUM_INDEX_WGS84 || m_datum_index == DATUM_INDEX_UNKNOWN)
       {
             m_lon_datum_adjust = (-m_dtm_lon) / 3600.;
             m_lat_datum_adjust = (-m_dtm_lat) / 3600.;

--- a/src/georef.cpp
+++ b/src/georef.cpp
@@ -278,13 +278,37 @@ static int datumNameCmp(const char *n1, const char *n2)
 	return 0;	// String match
 }
 
+static int isWGS84(int i)
+{
+    // DATUM_INDEX_WGS84 is an optimization
+    // but there's more than on in gDatum table
+    if (i == DATUM_INDEX_WGS84)
+        return i;
+
+    if (gDatum[i].ellipsoid != gDatum[DATUM_INDEX_WGS84].ellipsoid)
+        return i;
+
+    if (gDatum[i].dx != gDatum[DATUM_INDEX_WGS84].dx)
+        return i;
+
+    if (gDatum[i].dy != gDatum[DATUM_INDEX_WGS84].dy)
+        return i;
+
+    if (gDatum[i].dz != gDatum[DATUM_INDEX_WGS84].dz)
+        return i;
+        
+    return DATUM_INDEX_WGS84;
+}
+
 int GetDatumIndex(const char *str)
 {
       int i = 0;
       while (i < (int)nDatums)
       {
             if(!datumNameCmp(str, gDatum[i].name))
-                  return i;
+            {
+                  return isWGS84(i);
+            }
             i++;
       }
 


### PR DESCRIPTION
Hi,

The code tried to not use adjustment with WGS84 datum but it was testing against  wgs72, fix it. Nonetheless it seems that
- a lot off homebrew charts are using wgs84 with a DTM  
- some other softwares don't use GD but only DTM.

So still keep the old behaviour, should be a little bit faster .

Regards
Didier