### PR TITLE
Grib2 cleanup

### DIFF
--- a/plugins/grib_pi/src/GribReader.cpp
+++ b/plugins/grib_pi/src/GribReader.cpp
@@ -142,7 +142,11 @@ void GribReader::readAllGribRecords()
         {
               b_EOF = rec->isEof();
 
-        	if (rec->isDataKnown())
+        	if (!rec->isDataKnown())
+        	{
+        	    delete rec;
+        	}
+        	else
         	{
 				ok = true;   // au moins 1 record ok
 

--- a/plugins/grib_pi/src/GribV1Record.cpp
+++ b/plugins/grib_pi/src/GribV1Record.cpp
@@ -251,7 +251,7 @@ GribV1Record::~GribV1Record()
 }
 
 //----------------------------------------------
-zuint GribV1Record::readPackedBits(zuchar *buf, zuint first, zuint nbBits)
+static zuint readPackedBits(zuchar *buf, zuint first, zuint nbBits)
 {
     zuint oct = first / 8;
     zuint bit = first % 8;

--- a/plugins/grib_pi/src/GribV1Record.h
+++ b/plugins/grib_pi/src/GribV1Record.h
@@ -103,7 +103,6 @@ class GribV1Record : public GribRecord
         zuint  readInt3(ZUFILE* file);
         double readFloat4(ZUFILE* file);
 
-        zuint  readPackedBits(zuchar *buf, zuint first, zuint nbBits);
         zuint  makeInt3(zuchar a, zuchar b, zuchar c);
         zuint  makeInt2(zuchar b, zuchar c);
 

--- a/plugins/grib_pi/src/GribV2Record.cpp
+++ b/plugins/grib_pi/src/GribV2Record.cpp
@@ -1376,18 +1376,6 @@ bool GribV2Record::readGribSection0_IS(ZUFILE* file, bool b_skip_initial_GRIB) {
 //==============================================================
 // Fonctions utiles
 //==============================================================
-zuint GribV2Record::readPackedBits(zuchar *buf, zuint first, zuint nbBits)
-{
-    zuint oct = first / 8;
-    zuint bit = first % 8;
-
-    zuint val = (buf[oct]<<24) + (buf[oct+1]<<16) + (buf[oct+2]<<8) + (buf[oct+3]);
-    val = val << bit;
-    val = val >> (32-nbBits);
-    return val;
-}
-
-//----------------------------------------------
 zuint GribV2Record::periodSeconds(zuchar unit,zuint P1,zuchar P2,zuchar range) {
     zuint res, dur;
 

--- a/plugins/grib_pi/src/GribV2Record.cpp
+++ b/plugins/grib_pi/src/GribV2Record.cpp
@@ -889,7 +889,7 @@ static zuchar GRBV2_TO_DATA(int productDiscipline, int dataCat, int dataNum)
         }
         break;
     }
-#if 0    
+#if 1
     if (ret == 255) {
         printf("unknown %d %d %d\n", productDiscipline,  dataCat,dataNum);
     }
@@ -1043,7 +1043,7 @@ GribV2Record::GribV2Record(ZUFILE* file, int id_)
     BMSbits = NULL;
     hasBMS = false;
     eof     = false;
-    knownData = true;
+    knownData = false;
     IsDuplicated = false;
     long start = seekStart;
     
@@ -1241,8 +1241,11 @@ printf("isScanIpositive=%d isScanJpositive=%d isAdjacentI=%d\n",isScanIpositive,
 printf("hasBMS=%d\n", hasBMS);
 }
     if (ok) {
+        if (!skip) 
+        {
 		translateDataType();
 		setDataType(dataType);
+        }
     }
     delete grib_msg;
     grib_msg = 0;

--- a/plugins/grib_pi/src/GribV2Record.h
+++ b/plugins/grib_pi/src/GribV2Record.h
@@ -96,12 +96,6 @@ class GribV2Record : public GribRecord
         //---------------------------------------------
         bool readGribSection0_IS (ZUFILE* file, bool b_skip_initial_GRIB);
 
-        //---------------------------------------------
-        // Utility functions
-        //---------------------------------------------
-
-        zuint  readPackedBits(zuchar *buf, zuint first, zuint nbBits);
-
 };
 
 


### PR DESCRIPTION
hi,
remove unused GribV2Record::readPackedBits and make it a static function in V1, it doesn't use grib object members.

grib v2: bailout quickly if the decoded attribute is not used ( it was using uninitialized value) 

