### PR TITLE
Protect against access to unallocated memory while decoding JPEG2000

### DIFF
--- a/plugins/grib_pi/src/GribV2Record.cpp
+++ b/plugins/grib_pi/src/GribV2Record.cpp
@@ -774,7 +774,7 @@ static bool unpackDS(GRIBMessage *grib_msg,int grid_num)
 	len=len-5;
 	jvals=(int *)malloc(grib_msg->md.ny*grib_msg->md.nx*sizeof(int));
 	(grib_msg->grids[grid_num]).gridpoints= new double[grib_msg->md.ny *grib_msg->md.nx];
-	if (len > 0)
+	if (len > 0 && sizeof(grib_msg->buffer) >=∫ grib_msg->offset / 8 + 5 + len)
 	  dec_jpeg2000((char *)&grib_msg->buffer[grib_msg->offset/8+5],len,jvals);
 	cnt=0;
 	for (n=0; n < grib_msg->md.ny*grib_msg->md.nx; n++) {


### PR DESCRIPTION
I have observed crashes with the French AROME 0.01 degree gribs from https://donneespubliques.meteofrance.fr/?fond=produit&id_produit=131&id_rubrique=51. Let's make sure we are not going to look out of the buffer data before trying to decode JPEG2000, otherwise we crash badly in Jasper code.