### PR TITLE
Do not distinguish between stable and beta version in NSIS

### DIFF
--- a/NSIS.template.in
+++ b/NSIS.template.in
@@ -3767,26 +3767,26 @@ Var Patch_Date
 		${If} $0 != $1
 			${StrFilter} "$Patch_Version" "-2" "" "" $PATCH_ND
 			${If} $1 == 3
-				StrCpy $Version_Unified "b${YEAR}0$Patch_Version"
+				StrCpy $Version_Unified "s${YEAR}0$Patch_Version"
 			${ElseIf} $1 == 2
 				StrCpy $Version_Unified "s${YEAR}00$Patch_Version"
 			${ElseIf} $1 == 1
 				StrCpy $Version_Unified "s${YEAR}000$Patch_Version"
 			${Else}
-				StrCpy $Version_Unified "b${YEAR}$Patch_Version"
+				StrCpy $Version_Unified "s${YEAR}$Patch_Version"
 			${EndIf}
 			${VersionConvert} $Version_Unified "" $Patch_Date
 			StrCpy $VERSION_DATE "@CPACK_PACKAGE_VERSION_MAJOR@.@CPACK_PACKAGE_VERSION_MINOR@.$Patch_Date"
 		;# Patch version contains only digits
 		${Else}
 			${If} $0 == 3
-				StrCpy $Version_Unified "b${YEAR}0$Patch_Version"
+				StrCpy $Version_Unified "s${YEAR}0$Patch_Version"
 			${ElseIf} $0 == 2
 				StrCpy $Version_Unified "s${YEAR}00$Patch_Version"
 			${ElseIf} $0 == 1
 				StrCpy $Version_Unified "s${YEAR}000$Patch_Version"
 			${Else}
-				StrCpy $Version_Unified "b${YEAR}$Patch_Version"
+				StrCpy $Version_Unified "s${YEAR}$Patch_Version"
 			${EndIf}
 			${VersionConvert} $Version_Unified "" $Patch_Date
 			StrCpy $VERSION_DATE "@CPACK_PACKAGE_VERSION_MAJOR@.@CPACK_PACKAGE_VERSION_MINOR@.$Patch_Date.00"


### PR DESCRIPTION
based on length of patch version number as it causes 4.2.xxxx to be considered a downgrade from 4.2.0

@bdbcat do you remember why we use this? Shall we apply it to the master as well? It will of course make a versioning cycle like 4.2.0 -> 4.2.2xxx -> 4.2.2 impossible due to being considered a downgrade, but IMHO will be less weird.