### PR TITLE
fix a wxAssert in RouteFromTrack

### DIFF
--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -957,8 +957,8 @@ Route *Track::RouteFromTrack( wxProgressDialog *pprog )
         if( !( ( delta_dist > ( g_TrackDeltaDistance ) ) && !prp_OK ) ) {
             prpnode = prpnode->GetNext(); //RoutePoint
             next_ic++;
+            ic++;
         }
-        ic++;
         if( pprog ) pprog->Update( ( ic * 100 ) / nPoints );
     }
 


### PR DESCRIPTION
Hi
'Route from track' can loop more than there's points in the track and it trigger trivial wxAssert iwwx dialog code:
```
../src/generic/progdlgg.cpp(435): assert "value <= m_maximum" failed in Update(): invalid progress value
../src/gtk/gauge.cpp(95): assert "pos <= m_rangeMax" failed in SetValue(): invalid value in wxGauge::SetValue()

```
Attach a track from weather routing showing this issue when trying to use 'route from track' button.
[track.zip](https://github.com/OpenCPN/OpenCPN/files/254929/track.zip)


Regards
Didier


