### PR TITLE
Grib overlay

### DIFF
--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -540,6 +540,11 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
     wxPoint pmax;
     int width;
     int height;
+
+    int maxx = wxMin(1024, pGR->getNi() );
+    int maxy = wxMin(1024, pGR->getNj() );
+    int maxt = wxMax(maxx, maxy);
+    maxt = wxMax(256, maxt);
     // find the biggest texture
     do {
         GetCanvasPixLL( &uvp, &porg, pGR->getLatMax(), pGR->getLonMin() );
@@ -551,7 +556,7 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
         if (settings != GribOverlaySettings::CURRENT && settings != GribOverlaySettings::WAVE)
             break;
 #endif            
-        if( width > 1024 || height > 1024 ) {
+        if( width > maxt || height > maxt ) {
             if (tp_scale == scalef)
                 break;
             tp_scale /= 2.0;

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -584,12 +584,19 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
             unsigned char r, g, b, a;
             if( v != GRIB_NOTDEF ) {
                 v = m_Settings.CalibrateValue(settings, v);
-                wxColour c = GetGraphicColor(settings, v);
-                r = c.Red();
-                g = c.Green();
-                b = c.Blue();
                 //set full transparency if no rain or no clouds at all
-                a = ( ( settings == GribOverlaySettings::PRECIPITATION || GribOverlaySettings::CLOUD ) && v < 0.01 ) ? 0 : m_Settings.m_iOverlayTransparency;
+                if (( settings == GribOverlaySettings::PRECIPITATION || settings == GribOverlaySettings::CLOUD ) && v < 0.01) 
+                {
+                    r = g = b = 255;
+                    a = 0;
+                }
+                else {
+                    a = m_Settings.m_iOverlayTransparency;
+                    wxColour c = GetGraphicColor(settings, v);
+                    r = c.Red();
+                    g = c.Green();
+                    b = c.Blue();
+                }
             } else {
                 r = 255;
                 g = 255;


### PR DESCRIPTION
Hi,
Speedup a little grib overlay rendering by using a smaller texture for small file.
try to use a texture size close to the grid size with a minimum size  of 128 and a maximum size of 1024.
 
Regards
didier