### PR TITLE
convert grib2 isobaric level to hectoPascal (grib1 unit)

### DIFF
--- a/plugins/grib_pi/src/GribV2Record.cpp
+++ b/plugins/grib_pi/src/GribV2Record.cpp
@@ -1012,6 +1012,12 @@ void  GribV2Record::translateDataType()
     //translate significant wave height and dir
     if (this->knownData) {
         switch (levelType) {
+            case 100: // LV_ISOBARIC
+                /* GRIB1 is in hectoPascal 
+                   GRIB2 in Pascal, convert to GRIB1
+                */
+                levelValue = levelValue /100;
+                break;
             case 103: levelType = LV_ABOV_GND;break;
             case 101: levelType = LV_MSL;break;
         }


### PR DESCRIPTION
Hi,

GRIB2 and GRIB1 don't use the same unit for isobaric level... Convert GRIB2 Pascal to GRIB1 hectoPascal, used by geopotential heights.

Regards
Didier
