### PR TITLE
Jumptoposition

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -5243,6 +5243,7 @@ void MyFrame::JumpToPosition( double lat, double lon, double scale )
         lon -= 360.0;
     vLat = lat;
     vLon = lon;
+    cc1->StopMovement();
     cc1->m_bFollow = false;
 
     //  is the current chart available at the target location?

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -5239,6 +5239,8 @@ void MyFrame::ToggleToolbar( bool b_smooth )
 
 void MyFrame::JumpToPosition( double lat, double lon, double scale )
 {
+    if (lon > 180.0)
+        lon -= 360.0;
     vLat = lat;
     vLon = lon;
     cc1->m_bFollow = false;


### PR DESCRIPTION
Hi,

- Most functions call by JumpToPosition expect -180 .. 180  longitude, enforce it.

for example NOAA nam grid  afwaca is using 0 .. 360 
  latitudeOfFirstGridPointInDegrees = 30.054;
  longitudeOfFirstGridPointInDegrees = 260;
  latitudeOfLastGridPointInDegrees = 0.138;
  longitudeOfLastGridPointInDegrees = 299.852;

[NOAA NAM Caribbean/Central America](http://nomads.ncep.noaa.gov/cgi-bin/filter_nam_crb.pl?file=nam.t00z.afwaca00.grb2.tm00&lev_10_m_above_ground=on&lev_2_mb=on&lev_entire_atmosphere_%5C%28considered_as_a_single_layer%5C%29=on&lev_mean_sea_level=on&lev_surface=on&var_APCP=on&var_PRMSL=on&var_TCDC=on&var_TMP=on&var_UGRD=on&var_VGRD=on&var_WTMP=on&leftlon=0&rightlon=360&toplat=90&bottomlat=-90&dir=%2Fnam.20160523)

if open in ocpn and click on 'Zoom To Center' it will display the grib but without (or with mission features for cm) background chart.

- Stop movement, for example with a slow computer display a grib,  zoom in/out and quickly click on 'Zoom To Center' the grib is displayed zoom and center and then the timer kicks in and zooms in/out again.
 
Regards 
Didier