### PR TITLE
Improve grib Ctrl Bar & cursor data positioning

### DIFF
--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -674,7 +674,7 @@ void GRIBUICtrlBar::SetDialogsStyleSizePosition( bool force_recompute )
             m_gGRIBUICData->Update();
             m_gGRIBUICData->Show();
 
-            pPlugIn->MoveDialog( m_gGRIBUICData, pPlugIn->GetCursorDataXY(), wxPoint(20, 170) );
+			pPlugIn->MoveDialog(m_gGRIBUICData, pPlugIn->GetCursorDataXY() );
         }
 
     }
@@ -683,7 +683,7 @@ void GRIBUICtrlBar::SetDialogsStyleSizePosition( bool force_recompute )
     SetMinSize( GetBestSize() );
     SetSize( GetBestSize() );
     Update();
-    pPlugIn->MoveDialog( this, pPlugIn->GetCtrlBarXY(), wxPoint(20, 60) );
+    pPlugIn->MoveDialog( this, pPlugIn->GetCtrlBarXY() );
     m_old_DialogStyle = m_DialogStyle;
 }
 

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -344,19 +344,19 @@ bool grib_pi::QualifyCtrlBarPosition( wxPoint position, wxSize size )
     return !b_reset_pos;
 }
 
-void grib_pi::MoveDialog( wxDialog *dialog, wxPoint position, wxPoint dfault )
+void grib_pi::MoveDialog(wxDialog *dialog, wxPoint position)
 {
-    wxPoint p = position;
+	wxPoint p = GetOCPNCanvasWindow()->ScreenToClient(position);
     //Check and ensure there is always a "grabb" zone always visible wathever the dialoue size is.
-    if( p.x + dialog->GetSize().GetX() > GetOCPNCanvasWindow()->GetClientSize().GetX() || p.x < 0 )
-        p.x = wxMin( (GetOCPNCanvasWindow()->GetClientSize().GetX() - dialog->GetSize().GetX()), dfault.x );
-    if( p.y + dialog->GetSize().GetY() > GetOCPNCanvasWindow()->GetClientSize().GetY() )
-        p.y = dfault.y;
+	if (p.x + dialog->GetSize().GetX() > GetOCPNCanvasWindow()->GetClientSize().GetX())
+		p.x = GetOCPNCanvasWindow()->GetClientSize().GetX() - dialog->GetSize().GetX();
+	if (p.y + dialog->GetSize().GetY() > GetOCPNCanvasWindow()->GetClientSize().GetY())
+		p.y = GetOCPNCanvasWindow()->GetClientSize().GetY() - dialog->GetSize().GetY();
 
 #ifdef __WXGTK__
     dialog->Move(0, 0);
 #endif
-    dialog->Move(p);
+	dialog->Move(GetOCPNCanvasWindow()->ClientToScreen(p));
 }
 
 void grib_pi::OnToolbarToolCallback(int id)
@@ -409,9 +409,9 @@ void grib_pi::OnToolbarToolCallback(int id)
             m_pGribCtrlBar->SetDialogsStyleSizePosition( true );
             m_pGribCtrlBar->Refresh();
         } else {
-            MoveDialog( m_pGribCtrlBar, GetCtrlBarXY(), wxPoint( 20, 60) );
+			MoveDialog(m_pGribCtrlBar, GetCtrlBarXY());
             if( m_DialogStyle >> 1 == SEPARATED ) {
-                MoveDialog( m_pGribCtrlBar->GetCDataDialog(), GetCursorDataXY(), wxPoint( 20, 170));
+				MoveDialog(m_pGribCtrlBar->GetCDataDialog(), GetCursorDataXY());
                 m_pGribCtrlBar->GetCDataDialog()->Show( m_pGribCtrlBar->m_CDataIsShown );
                 }
         }

--- a/plugins/grib_pi/src/grib_pi.h
+++ b/plugins/grib_pi/src/grib_pi.h
@@ -94,7 +94,7 @@ public:
       void ShowPreferencesDialog( wxWindow* parent );
       void OnToolbarToolCallback(int id);
       bool QualifyCtrlBarPosition( wxPoint position, wxSize size );
-      void MoveDialog( wxDialog *dialog, wxPoint position, wxPoint dfault );
+	  void MoveDialog(wxDialog *dialog, wxPoint position);
 
 // Other public methods
       void SetCtrlBarXY   (wxPoint p){ m_CtrlBarxy = p;}


### PR DESCRIPTION
The dialogue position was not always kept when toggle show/hide plugin
For example if you put it on the bottom/right side of the  canvas, it jumps to the top/left (in fact to the arbitrary default position.) This new code ovoid this boring behaviour