### PR TITLE
fix case where plugin requesting crossings crashes opencpn when no gs…

### DIFF
--- a/src/gshhs.cpp
+++ b/src/gshhs.cpp
@@ -184,6 +184,9 @@ fail:
 
 void GshhsPolyCell::ReadPolygonFile()
 {
+    if(!fpoly)
+        return;
+
     int pos_data;
     int tab_data;
 


### PR DESCRIPTION
…hhs data exists