### PR TITLE
Overloaded virtual

### DIFF
--- a/include/cm93.h
+++ b/include/cm93.h
@@ -317,7 +317,7 @@ class cm93chart : public s57chart
             void ResetSubcellKey(){ m_loadcell_key = '0'; }
 
             double GetNormalScaleMin(double canvas_scale_factor, bool b_allow_overzoom);
-            double GetNormalScaleMax(double canvas_scale_factor);
+            double GetNormalScaleMax(double canvas_scale_factor, int canvas_width);
 
             bool AdjustVP(ViewPort &vp_last, ViewPort &vp_proposed);
             void SetVPParms(const ViewPort &vpt);

--- a/src/cm93.cpp
+++ b/src/cm93.cpp
@@ -1998,8 +1998,14 @@ double cm93chart::GetNormalScaleMin ( double canvas_scale_factor, bool b_allow_o
       return 1.0;
 }
 
-double cm93chart::GetNormalScaleMax ( double canvas_scale_factor )
+double cm93chart::GetNormalScaleMax ( double canvas_scale_factor, int canvas_width )
 {
+      /* 
+         XXX previous declaration hides overloaded virtual function 
+            and it was calling:
+         s57chart::GetNormalScaleMax( canvas_scale_factor, canvas_width )
+         should we restore this behavior?
+      */
       switch ( GetNativeScale() )
       {
             case 20000000: return 50000000.;          // Z

--- a/src/wxcurl/dialog.cpp
+++ b/src/wxcurl/dialog.cpp
@@ -260,7 +260,7 @@ void wxCurlTransferDialog::CreateControls(const wxString &url, const wxString &m
     main->SetSizeHints(this);
 }
 
-void wxCurlTransferDialog::EndModal(wxCurlDialogReturnFlag retCode)
+void wxCurlTransferDialog::EndModal(int retCode)
 {
     wxDialog::EndModal(retCode);
 

--- a/src/wxcurl/wx/curl/dialog.h
+++ b/src/wxcurl/wx/curl/dialog.h
@@ -130,9 +130,10 @@ public:
     bool IsVerbose() const
         { return m_bVerbose; }
 
+    virtual void EndModal(int retCode);
+
 protected:     // internal utils
 
-    virtual void EndModal(wxCurlDialogReturnFlag retCode);
 
     wxStaticText *AddSizerRow(wxSizer *sz, const wxString &name);
     void CreateControls(const wxString &url, const wxString &msg, 


### PR DESCRIPTION
Hi,
c++ is a mess, overloaded virtual functions call the one in the base class not the derived one.

I'm not sure the new cm93 scale behavior is the right one as cm93chart::GetNormalScaleMax was never called.

There's another one but a Sean patch remove it (use vectors for track https://github.com/OpenCPN/OpenCPN/pull/638 )

Regards
Didier
