### PR TITLE
route/track speedup deletion

### DIFF
--- a/src/Select.cpp
+++ b/src/Select.cpp
@@ -123,16 +123,13 @@ bool Select::DeleteAllSelectableRouteSegments( Route *pr )
 
             if( (Route *) pFindSel->m_pData3 == pr ) {
                 delete pFindSel;
-                pSelectList->DeleteNode( node );   //delete node;
-
-                node = pSelectList->GetFirst();     // reset the top node
-
-                goto got_next_outer_node;
+                wxSelectableItemListNode *d = node;
+                node = node->GetNext();
+                pSelectList->DeleteNode( d );   //delete node;
             }
         }
-
-        node = node->GetNext();
-        got_next_outer_node: continue;
+        else 
+            node = node->GetNext();
     }
 
     return true;
@@ -434,18 +431,16 @@ bool Select::DeleteAllSelectableTrackSegments( Track *pt )
 
     while( node ) {
         pFindSel = node->GetData();
-        if( pFindSel->m_seltype == SELTYPE_TRACKSEGMENT ) {
-
-            if( (Track *) pFindSel->m_pData3 == pt ) {
-                delete pFindSel;
-                pSelectList->DeleteNode( node );   //delete node;
-
-                node = pSelectList->GetFirst();     // reset the top node
-                goto got_next_outer_node;
-            }
+        if( pFindSel->m_seltype == SELTYPE_TRACKSEGMENT && 
+          (Track *) pFindSel->m_pData3 == pt  ) 
+        {
+            delete pFindSel;
+            wxSelectableItemListNode *d = node;
+            node = node->GetNext();
+            pSelectList->DeleteNode( d );   //delete node;
         }
-        node = node->GetNext();
-        got_next_outer_node: continue;
+        else 
+            node = node->GetNext();
     }
     return true;
 }


### PR DESCRIPTION
Hi,

Don't restart from the start after deleting a track/route. This logic is already use elsewhere in opencpn
cf. FS#2101

There's still speed issue with really big track lists, at least on linux opening the track dialog box is next to impossible.

Regards
Didier
