### PR TITLE
Fixes for gcc 5 compile

### DIFF
--- a/include/triangulate.h
+++ b/include/triangulate.h
@@ -254,6 +254,9 @@ extern inline int int_less_than(ipoint_t *v0, ipoint_t *v1);
 extern inline int int_locate_endpoint_a(ipoint_t *v, ipoint_t *vo, int r);
 #endif
 extern inline int int_locate_endpoint(ipoint_t *v, ipoint_t *vo, int r);
+extern inline int int_is_left_of(int segnum, ipoint_t *v);
+extern inline int int_max(ipoint_t *yval, ipoint_t *v0, ipoint_t *v1);
+extern inline int int_min(ipoint_t *yval, ipoint_t *v0, ipoint_t *v1);
 #endif
 
 #endif /* triangulate_h */


### PR DESCRIPTION
Without these extra lines opencpn will not complie/link under Ubuntu 16.04 (linux mint 18) using gcc 5.3.1