### PR TITLE
Nmea tag

### DIFF
--- a/include/AIS_Decoder.h
+++ b/include/AIS_Decoder.h
@@ -78,7 +78,6 @@ public:
     
 private:
     wxString GetShipNameFromFile(int nmmsi);
-    wxString ProcessNMEA4Tags( wxString msg);
     
     void OnActivate(wxActivateEvent& event);
     void OnTimerAIS(wxTimerEvent& event);

--- a/include/OCPN_DataStreamEvent.h
+++ b/include/OCPN_DataStreamEvent.h
@@ -45,6 +45,8 @@ public:
     // required for sending with wxPostEvent()
     wxEvent *Clone() const;
 
+    wxString ProcessNMEA4Tags();
+
 private:
     std::string m_NMEAstring;
     DataStream *m_pDataStream;

--- a/include/multiplexer.h
+++ b/include/multiplexer.h
@@ -64,7 +64,6 @@ class Multiplexer : public wxEvtHandler
         int SendWaypointToGPS(RoutePoint *prp, const wxString &com_name, wxGauge *pProgress);
 
         void OnEvtStream(OCPN_DataStreamEvent& event);
-        wxString ProcessNMEA4Tags( wxString msg);
         
         void LogOutputMessage(const wxString &msg, wxString stream_name, bool b_filter);
         void LogOutputMessageColor(const wxString &msg, const wxString & stream_name, const wxString & color);

--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -256,37 +256,12 @@ void AIS_Decoder::BuildERIShipTypeHash(void)
       make_hash_ERI(1910, _("Hydrofoil"));
 }
 
-
-//----------------------------------------------------------------------------------
-//     Strip NMEA V4 tags from message
-//----------------------------------------------------------------------------------
-wxString AIS_Decoder::ProcessNMEA4Tags( wxString msg)
-{
-    int idxFirst =  msg.Find('\\');
-    
-    if(wxNOT_FOUND == idxFirst)
-        return msg;
-    
-    if(idxFirst < (int)msg.Length()-1){
-        int idxSecond = msg.Mid(idxFirst + 1).Find('\\') + 1;
-        if(wxNOT_FOUND != idxSecond){
-            if(idxSecond < (int)msg.Length()-1){
-                
-               // wxString tag = msg.Mid(idxFirst+1, (idxSecond - idxFirst) -1);
-                return msg.Mid(idxSecond + 1);
-            }
-        }
-    }
-    
-    return msg;
-}
-
 //----------------------------------------------------------------------------------
 //     Handle events from AIS DataStream
 //----------------------------------------------------------------------------------
 void AIS_Decoder::OnEvtAIS( OCPN_DataStreamEvent& event )
 {
-    wxString message = ProcessNMEA4Tags(wxString(event.GetNMEAString().c_str(), wxConvUTF8) );
+    wxString message = event.ProcessNMEA4Tags();
 
     int nr = 0;
     if( !message.IsEmpty() )

--- a/src/OCPN_DataStreamEvent.cpp
+++ b/src/OCPN_DataStreamEvent.cpp
@@ -34,6 +34,33 @@ OCPN_DataStreamEvent::~OCPN_DataStreamEvent()
 {
 }
 
+//----------------------------------------------------------------------------------
+//     Strip NMEA V4 tags from message
+//----------------------------------------------------------------------------------
+wxString OCPN_DataStreamEvent::ProcessNMEA4Tags()
+{
+    wxString msg = wxString(GetNMEAString().c_str(), wxConvUTF8);
+   
+    int idxFirst =  msg.Find('\\');
+    
+    if(wxNOT_FOUND == idxFirst)
+        return msg;
+    
+    if(idxFirst < (int)msg.Length()-1){
+        int idxSecond = msg.Mid(idxFirst + 1).Find('\\') + 1;
+        if(wxNOT_FOUND != idxSecond){
+            if(idxSecond < (int)msg.Length()-1){
+                
+               // wxString tag = msg.Mid(idxFirst+1, (idxSecond - idxFirst) -1);
+                return msg.Mid(idxSecond + 1);
+            }
+        }
+    }
+    
+    return msg;
+}
+
+
 wxEvent* OCPN_DataStreamEvent::Clone() const
 {
     OCPN_DataStreamEvent *newevent=new OCPN_DataStreamEvent(*this);

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -8765,7 +8765,7 @@ void MyFrame::OnEvtOCPN_NMEA( OCPN_DataStreamEvent & event )
     bool bis_recognized_sentence = true;
     bool ll_valid = true;
 
-    wxString str_buf = wxString(event.GetNMEAString().c_str(), wxConvUTF8);
+    wxString str_buf = event.ProcessNMEA4Tags();
 
     if( g_nNMEADebug && ( g_total_NMEAerror_messages < g_nNMEADebug ) )
     {

--- a/src/multiplexer.cpp
+++ b/src/multiplexer.cpp
@@ -243,30 +243,9 @@ void Multiplexer::SetGPSHandler(wxEvtHandler *handler)
     m_gpsconsumer = handler;
 }
 
-wxString Multiplexer::ProcessNMEA4Tags( wxString msg)
-{
-    int idxFirst =  msg.Find('\\');
-    
-    if(wxNOT_FOUND == idxFirst)
-        return msg;
-    
-    if(idxFirst < (int)msg.Length()-1){
-        int idxSecond = msg.Mid(idxFirst + 1).Find('\\') + 1;
-        if(wxNOT_FOUND != idxSecond){
-            if(idxSecond < (int)msg.Length()-1){
-                
-                //wxString tag = msg.Mid(idxFirst+1, (idxSecond - idxFirst) -1);
-                return msg.Mid(idxSecond + 1);
-            }
-        }
-    }
-    
-    return msg;
-}
-
 void Multiplexer::OnEvtStream(OCPN_DataStreamEvent& event)
 {
-    wxString message = ProcessNMEA4Tags(wxString(event.GetNMEAString().c_str(), wxConvUTF8) );
+    wxString message = event.ProcessNMEA4Tags();
     
     DataStream *stream = event.GetStream();
     wxString port(_T("Virtual:"));


### PR DESCRIPTION
Hi,
previous commit 07f5438766c9e77a2fafc450ee23a24915e13686 missed a code path and NMEA tags aren't removed in GPS sentences received on a serial link:

Example on linux, emulate a serial link on ttyS10 (configured as input in OCPN):
sudo socat PTY,link=/dev/ttyS10,user=didier,raw,echo=0 PTY,link=/dev/ttyS11,user=didier,raw,echo=0

send a sentence:
echo '\s:MX75-1*42\$GPGLL,5542.9608,N,01235.4858,E,151149,A,A*4B' > /dev/ttyS11



Regards
Didier