### PR TITLE
Prevent compiler warnings (well, most of).

### DIFF
--- a/plugins/chartdldr_pi/src/unrar/coder.cpp
+++ b/plugins/chartdldr_pi/src/unrar/coder.cpp
@@ -20,7 +20,10 @@ void RangeCoder::InitDecoder(Unpack *UnpackRead)
 // (int) cast before "low" added only to suppress compiler warnings.
 #define ARI_DEC_NORMALIZE(code,low,range,read)                           \
 {                                                                        \
-  while ((low^(low+range))<TOP || range<BOT && ((range=-(int)low&(BOT-1)),1)) \
+  while (                                                                \
+    ((low ^ (low + range)) < TOP) ||                                     \
+    ((range < BOT) && ((range = -static_cast<int>(low) & (BOT-1)), 1))   \
+  )                                                                      \
   {                                                                      \
     code=(code << 8) | read->GetChar();                                  \
     range <<= 8;                                                         \

--- a/plugins/chartdldr_pi/src/unrar/extract.cpp
+++ b/plugins/chartdldr_pi/src/unrar/extract.cpp
@@ -323,7 +323,7 @@ bool CmdExtract::ExtractCurrentFile(Archive &Arc,size_t HeaderSize,bool &Repeat)
       if (Cmd->VersionControl==0)
         MatchFound=false;
       int Version=ParseVersionFileName(ArcFileName,false);
-      if (Cmd->VersionControl-1==Version)
+      if (Cmd->VersionControl-1==static_cast<uint>(Version))
         ParseVersionFileName(ArcFileName,true);
       else
         MatchFound=false;

--- a/plugins/chartdldr_pi/src/unrar/file.cpp
+++ b/plugins/chartdldr_pi/src/unrar/file.cpp
@@ -324,10 +324,10 @@ bool File::Write(const void *Data,size_t Size)
       Success=WriteFile(hFile,Data,(DWORD)Size,&Written,NULL)==TRUE;
 #else
 #ifdef FILE_USE_OPEN
-    ssize_t Written=write(hFile,Data,Size);
+    size_t Written=static_cast<size_t>(write(hFile,Data,Size));
     Success=Written==Size;
 #else
-    int Written=fwrite(Data,1,Size,hFile);
+    size_t Written=fwrite(Data,1,Size,hFile);
     Success=Written==Size && !ferror(hFile);
 #endif
 #endif

--- a/plugins/chartdldr_pi/src/unrar/filefn.cpp
+++ b/plugins/chartdldr_pi/src/unrar/filefn.cpp
@@ -58,7 +58,7 @@ bool CreatePath(const wchar *Path,bool SkipLastName)
   for (const wchar *s=Path;*s!=0;s++)
   {
     wchar DirName[NM];
-    if (s-Path>=ASIZE(DirName))
+    if (static_cast<size_t>(s - Path) >= ASIZE(DirName))
       break;
 
     // Process all kinds of path separators, so user can enter Unix style

--- a/plugins/chartdldr_pi/src/unrar/list.cpp
+++ b/plugins/chartdldr_pi/src/unrar/list.cpp
@@ -270,6 +270,8 @@ void ListFileHeader(Archive &Arc,FileHeader &hd,bool &TitleShown,bool Verbose,bo
       if (hd.RedirType!=FSREDIR_NONE)
         switch(hd.RedirType)
         {
+          case FSREDIR_NONE:
+                                    break;
           case FSREDIR_UNIXSYMLINK:
             Type=St(MListUSymlink); break;
           case FSREDIR_WINSYMLINK:
@@ -295,7 +297,7 @@ void ListFileHeader(Archive &Arc,FileHeader &hd,bool &TitleShown,bool Verbose,bo
           }
           else
           {
-            int DataSize=(int)Min(hd.PackSize,ASIZE(LinkTargetA)-1);
+            int DataSize=(int)Min(static_cast<size_t>(hd.PackSize),ASIZE(LinkTargetA)-1);
             Arc.Read(LinkTargetA,DataSize);
             LinkTargetA[DataSize > 0 ? DataSize : 0] = 0;
           }

--- a/plugins/chartdldr_pi/src/unrar/rarvm.cpp
+++ b/plugins/chartdldr_pi/src/unrar/rarvm.cpp
@@ -854,8 +854,8 @@ VM_StandardFilters RarVM::IsStandardFilter(byte *Code,uint CodeSize)
 {
   struct StandardFilterSignature
   {
-    int Length;
-    uint CRC;
+    size_t Length;
+    uint32 CRC;
     VM_StandardFilters Type;
   } static StdList[]={
     {53, 0xad576887, VMSF_E8},
@@ -865,8 +865,8 @@ VM_StandardFilters RarVM::IsStandardFilter(byte *Code,uint CodeSize)
    {149, 0x1c2c5dc8, VMSF_RGB},
    {216, 0xbc85e701, VMSF_AUDIO}
   };
-  uint CodeCRC=CRC32(0xffffffff,Code,CodeSize)^0xffffffff;
-  for (uint I=0;I<ASIZE(StdList);I++)
+  uint32 CodeCRC=CRC32(0xffffffff,Code,CodeSize)^0xffffffff;
+  for (size_t I=0;I<ASIZE(StdList);I++)
     if (StdList[I].CRC==CodeCRC && StdList[I].Length==CodeSize)
       return(StdList[I].Type);
   return(VMSF_NONE);
@@ -1070,7 +1070,7 @@ void RarVM::ExecuteStandardFilter(VM_StandardFilters FilterType)
             {
               uint MinDif=Dif[0],NumMinDif=0;
               Dif[0]=0;
-              for (int J=1;J<sizeof(Dif)/sizeof(Dif[0]);J++)
+              for (size_t J=1;J<sizeof(Dif)/sizeof(Dif[0]);J++)
               {
                 if (Dif[J]<MinDif)
                 {

--- a/plugins/chartdldr_pi/src/unrar/rijndael.cpp
+++ b/plugins/chartdldr_pi/src/unrar/rijndael.cpp
@@ -94,6 +94,10 @@ void Rijndael::Init(bool Encrypt,const byte *key,uint keyLen,const byte * initVe
       uKeyLenInBytes = 32;
       m_uRounds = 14;
       break;
+    default:
+      uKeyLenInBytes = 0;
+      m_uRounds = 0;
+      break;
   }
 
   byte keyMatrix[_MAX_KEY_COLUMNS][4];
@@ -339,7 +343,7 @@ void Rijndael::GenerateTables()
     w ^=  (w << 1) ^ (w & ff_hi ? ff_poly : 0);
   } while (w != 1);
  
-  for (int i = 0,w = 1; i < sizeof(rcon)/sizeof(rcon[0]); i++)
+  for (size_t i = 0,w = 1; i < sizeof(rcon)/sizeof(rcon[0]); i++)
   {
     rcon[i] = w;
     w = (w << 1) ^ (w & ff_hi ? ff_poly : 0);

--- a/plugins/chartdldr_pi/src/unrar/timefn.cpp
+++ b/plugins/chartdldr_pi/src/unrar/timefn.cpp
@@ -247,7 +247,7 @@ void RarTime::SetIsoText(const wchar *TimeText)
   for (uint DigitCount=0;*TimeText!=0;TimeText++)
     if (IsDigit(*TimeText))
     {
-      int FieldPos=DigitCount<4 ? 0:(DigitCount-4)/2+1;
+      size_t FieldPos=DigitCount<4 ? 0:(DigitCount-4)/2+1;
       if (FieldPos<ASIZE(Field))
         Field[FieldPos]=Field[FieldPos]*10+*TimeText-'0';
       DigitCount++;

--- a/plugins/chartdldr_pi/src/unrar/ulinks.cpp
+++ b/plugins/chartdldr_pi/src/unrar/ulinks.cpp
@@ -41,7 +41,7 @@ bool ExtractUnixLink30(CommandData *Cmd,ComprDataIO &DataIO,Archive &Arc,const w
   char Target[NM];
   if (IsLink(Arc.FileHead.FileAttr))
   {
-    size_t DataSize=Min(Arc.FileHead.PackSize,ASIZE(Target)-1);
+    size_t DataSize=Min(static_cast<size_t>(Arc.FileHead.PackSize),ASIZE(Target)-1);
     DataIO.UnpRead((byte *)Target,DataSize);
     Target[DataSize]=0;
 

--- a/plugins/chartdldr_pi/src/unrar/unicode.cpp
+++ b/plugins/chartdldr_pi/src/unrar/unicode.cpp
@@ -142,7 +142,7 @@ bool WideToCharMap(const wchar *Src,char *Dest,size_t DestSize,bool &Success)
     {
       mbstate_t ps;
       memset(&ps,0,sizeof(ps));
-      if (wcrtomb(Dest+DestPos,Src[SrcPos],&ps)==-1)
+      if (wcrtomb(Dest+DestPos,Src[SrcPos],&ps)==static_cast<size_t>(-1))
         Success=false;
       SrcPos++;
       memset(&ps,0,sizeof(ps));
@@ -176,7 +176,7 @@ void CharToWideMap(const char *Src,wchar *Dest,size_t DestSize,bool &Success)
     }
     mbstate_t ps;
     memset(&ps,0,sizeof(ps));
-    if (mbrtowc(Dest+DestPos,Src+SrcPos,MB_CUR_MAX,&ps)==-1)
+    if (mbrtowc(Dest+DestPos,Src+SrcPos,MB_CUR_MAX,&ps)==static_cast<size_t>(-1))
     {
       // For security reasons we do not want to map low ASCII characters,
       // so we do not have additional .. and path separator codes.

--- a/plugins/chartdldr_pi/src/unrar/unpack20.cpp
+++ b/plugins/chartdldr_pi/src/unrar/unpack20.cpp
@@ -167,7 +167,7 @@ bool Unpack::ReadTables20()
 {
   byte BitLength[BC20];
   byte Table[MC20*4];
-  int TableSize,N,I;
+  size_t TableSize,N,I;
   if (Inp.InAddr>ReadTop-25)
     if (!UnpReadBuf())
       return(false);
@@ -238,7 +238,7 @@ bool Unpack::ReadTables20()
   if (Inp.InAddr>ReadTop)
     return(true);
   if (UnpAudioBlock)
-    for (I=0;I<UnpChannels;I++)
+    for (I=0;I<static_cast<size_t>(UnpChannels);I++)
       MakeDecodeTables(&Table[I*MC20],&MD[I],MC20);
   else
   {
@@ -317,7 +317,7 @@ byte Unpack::DecodeAudio(int Delta)
   {
     unsigned int MinDif=V->Dif[0],NumMinDif=0;
     V->Dif[0]=0;
-    for (int I=1;I<sizeof(V->Dif)/sizeof(V->Dif[0]);I++)
+    for (size_t I=1;I<sizeof(V->Dif)/sizeof(V->Dif[0]);I++)
     {
       if (V->Dif[I]<MinDif)
       {

--- a/plugins/chartdldr_pi/src/unrar/unpack30.cpp
+++ b/plugins/chartdldr_pi/src/unrar/unpack30.cpp
@@ -27,7 +27,7 @@ void Unpack::Unpack29(bool Solid)
   if (DDecode[1]==0)
   {
     int Dist=0,BitLength=0,Slot=0;
-    for (int I=0;I<ASIZE(DBitLengthCounts);I++,BitLength++)
+    for (size_t I=0;I<ASIZE(DBitLengthCounts);I++,BitLength++)
       for (int J=0;J<DBitLengthCounts[I];J++,Slot++,Dist+=(1<<BitLength))
       {
         DDecode[Slot]=Dist;
@@ -723,7 +723,7 @@ bool Unpack::ReadTables30()
     memset(UnpOldTable,0,sizeof(UnpOldTable));
   Inp.faddbits(2);
 
-  for (int I=0;I<BC;I++)
+  for (size_t I=0;I<BC;I++)
   {
     int Length=(byte)(Inp.fgetbits() >> 12);
     Inp.faddbits(4);

--- a/plugins/chartdldr_pi/src/unrar/unpack50.cpp
+++ b/plugins/chartdldr_pi/src/unrar/unpack50.cpp
@@ -559,7 +559,7 @@ bool Unpack::ReadTables(BitInput &Inp,UnpackBlockHeader &Header,UnpackBlockTable
       return false;
 
   byte BitLength[BC];
-  for (int I=0;I<BC;I++)
+  for (size_t I=0;I<BC;I++)
   {
     int Length=(byte)(Inp.fgetbits() >> 12);
     Inp.faddbits(4);

--- a/plugins/grib_pi/src/jasper/jpc/jpc_cs.c
+++ b/plugins/grib_pi/src/jasper/jpc/jpc_cs.c
@@ -902,6 +902,7 @@ static int jpc_qcc_getparms(jpc_ms_t *ms, jpc_cstate_t *cstate, jas_stream_t *in
 	uint_fast8_t tmp;
 	int len;
 	len = ms->len;
+    tmp = 0;
 	if (cstate->numcomps <= 256) {
 		jpc_getuint8(in, &tmp);
 		qcc->compno = tmp;
@@ -969,6 +970,7 @@ static int jpc_qcx_getcompparms(jpc_qcxcp_t *compparms, jpc_cstate_t *cstate,
 
 	/* Eliminate compiler warning about unused variables. */
 	cstate = 0;
+    tmp = 0;
 
 	n = 0;
 	jpc_getuint8(in, &tmp);

--- a/plugins/grib_pi/src/jasper/jpc/jpc_dec.c
+++ b/plugins/grib_pi/src/jasper/jpc/jpc_dec.c
@@ -2154,7 +2154,7 @@ void jpc_ppxstab_destroy(jpc_ppxstab_t *tab)
 int jpc_ppxstab_grow(jpc_ppxstab_t *tab, int maxents)
 {
 	jpc_ppxstabent_t **newents;
-	if (tab->maxents < maxents) {
+	if ((size_t)tab->maxents < (size_t)maxents) {
 		newents = (tab->ents) ? jas_realloc(tab->ents, maxents *
 		  sizeof(jpc_ppxstabent_t *)) : jas_malloc(maxents * sizeof(jpc_ppxstabent_t *));
 		if (!newents) {

--- a/plugins/grib_pi/src/jasper/jpc/jpc_mqenc.c
+++ b/plugins/grib_pi/src/jasper/jpc/jpc_mqenc.c
@@ -385,8 +385,8 @@ int jpc_mqenc_dump(jpc_mqenc_t *mqenc, FILE *out)
 {
 	fprintf(out, "AREG = %08x, CREG = %08x, CTREG = %" PRIuFAST32 "\n",
 	  (unsigned int)mqenc->areg, (unsigned int)mqenc->creg, mqenc->ctreg);
-	fprintf(out, "IND = %02d, MPS = %d, QEVAL = %04x\n",
-	  *mqenc->curctx - jpc_mqstates, (*mqenc->curctx)->mps,
+	fprintf(out, "IND = %02u, MPS = %d, QEVAL = %04x\n",
+	  (unsigned int)(*mqenc->curctx - jpc_mqstates), (*mqenc->curctx)->mps,
 	  (unsigned int)(*mqenc->curctx)->qeval);
 	return 0;
 }

--- a/src/chartimg.cpp
+++ b/src/chartimg.cpp
@@ -4384,7 +4384,7 @@ int   ChartBaseBSB::BSBGetScanline( unsigned char *pLineBuf, int y, int xs, int 
               unsigned char *offset = lp - 1;
               if(byNext == 0 || lp == end) {
                   // finished early...corrupt?
-                  while(tileindex < Size_X/TILE_SIZE + 1) {
+                  while(tileindex < static_cast<size_t>(Size_X)/TILE_SIZE + 1u) {
                       pt->pTileOffset[tileindex].offset = pt->pTileOffset[0].offset;
                       pt->pTileOffset[tileindex].pixel = 0;
                       tileindex++;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -5691,7 +5691,7 @@ void options::OnApplyClick(wxCommandEvent& event) {
   //  to facility identification and allow stop and restart of the stream
   wxString lastAddr;
   int lastPort = 0;
-  NetworkProtocol lastNetProtocol;
+  NetworkProtocol lastNetProtocol = PROTO_UNDEFINED;
   
   if (itemIndex >= 0) {
     int params_index = m_lcSources->GetItemData(itemIndex);

--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -537,7 +537,8 @@ OCPNRegion ViewPort::GetVPRegionIntersect( const OCPNRegion &Region, size_t nPoi
 
     
     wxPoint p = GetPixFromLL( pfp[0], pfp[1] );
-    int poly_x_max, poly_y_max, poly_x_min, poly_y_min;
+    int poly_x_max = INVALID_COORD, poly_y_max = INVALID_COORD,
+        poly_x_min = INVALID_COORD, poly_y_min = INVALID_COORD;
     
     bool valid = false;
     for( unsigned int ip = 0; ip < nPoints; ip++ ) {


### PR DESCRIPTION
Unfortunately, code smell mostly comes from third-party sources,
like Jasper and Unrar, which may be re-imported again in the future.

Warnings that were left:

* Use of `tmpnam()` in Jasper.
* Possible wrapping of `localtime_r()` for multi-threaded wxWidgets.