### PR TITLE
Missing cast, causing "compare signed to unsigned" warning

### DIFF
--- a/src/chartimg.cpp
+++ b/src/chartimg.cpp
@@ -4384,7 +4384,7 @@ int   ChartBaseBSB::BSBGetScanline( unsigned char *pLineBuf, int y, int xs, int 
               unsigned char *offset = lp - 1;
               if(byNext == 0 || lp == end) {
                   // finished early...corrupt?
-                  while(tileindex < Size_X/TILE_SIZE + 1) {
+                  while(tileindex < (unsigned int)Size_X/TILE_SIZE + 1) {
                       pt->pTileOffset[tileindex].offset = pt->pTileOffset[0].offset;
                       pt->pTileOffset[tileindex].pixel = 0;
                       tileindex++;


### PR DESCRIPTION
Added the cast.  The better fix would be to make SIZE_X etc. unsigned
but that would be a much more intrusive patch because there are tons
of comparisons with signed integers (many of which propably should be
unsinged as well).