### PR TITLE
Fix misplaced brace

### DIFF
--- a/src/gshhs.cpp
+++ b/src/gshhs.cpp
@@ -1217,10 +1217,9 @@ int GshhsReader::GSHHS_scaledPoints( GshhsPolygon *pol, wxPoint *pts, double dec
     for( itp = ( pol->lsPoints ).begin(); itp != ( pol->lsPoints ).end(); itp++ ) {
         x = ( *itp )->lon + declon;
         y = ( *itp )->lat;
-                                    {
         wxPoint2DDouble p = GetDoublePixFromLL(vp,  y, x );
         xx = p.m_x, yy = p.m_y;
-        if( j == 0 || ( oxx != xx || oyy != yy ) )  // Remove close points
+        if( j == 0 || ( oxx != xx || oyy != yy ) ) { // Remove close points
             oxx = xx;
             oyy = yy;
             pts[j].x = xx;


### PR DESCRIPTION
This fixes a bug introduced in commit 05c95b5d by Sean.  I emailed
him about this and he replied:

> I think you are right, it is misplaced.
> The reason nobody noticed or cared is this function is never called anymore.
> You could change it back to fix the warning...