### PR TITLE
Fix double bullet in chart group menu on Windows.

### DIFF
--- a/src/canvasMenu.cpp
+++ b/src/canvasMenu.cpp
@@ -495,14 +495,10 @@ void CanvasMenuHandler::CanvasPopupMenu( int x, int y, int seltype )
     if( g_pGroupArray->GetCount() ) {
 
 #ifdef __WXMSW__
-          const wxString l[] = { _T(" "), wxString::Format( _T("\u2022") ) };
           wxMenuItem* subItem1 = subMenuChart->AppendRadioItem( wxID_CANCEL , _T("temporary") );
           SetMenuItemFont1(subItem1);
 #endif
           wxMenuItem* subItem0 = subMenuChart->AppendRadioItem( ID_DEF_MENU_GROUPBASE ,
-#ifdef __WXMSW__
-                  ( g_GroupIndex == 0 ? l[1] : l[0] ) +
-#endif
                   _("All Active Charts") );
 
 
@@ -511,9 +507,6 @@ void CanvasMenuHandler::CanvasPopupMenu( int x, int y, int seltype )
 
         for( unsigned int i = 0; i < g_pGroupArray->GetCount(); i++ ) {
             subItem0 = subMenuChart->AppendRadioItem( ID_DEF_MENU_GROUPBASE + i + 1,
-#ifdef __WXMSW__
-                     ( i == g_GroupIndex - 1 ? l[1] : l[0] ) +
-#endif
                      g_pGroupArray->Item( i )->m_group_name );
             SetMenuItemFont1(subItem0);
         }


### PR DESCRIPTION
Currently, in modern Windows environments, such as Windows 7 + wxWidgets 3.0, an extra bullet is displayed in “Chart Groups” context menu, — because the bullet character is explicitly added to menu item string by OpenCPN specifically for Windows.

Perhaps this quirk was required for some older Windows and/or wxWidgets version, but is superfluous now; not checked whether *Windows XP* is affected though. However, no other occurrence of that bullet character is found elsewhere in source tree, which makes me suspect that this case was really unique.