### PR TITLE
Return NULL if route or track are not found

### DIFF
--- a/include/routeman.h
+++ b/include/routeman.h
@@ -74,8 +74,8 @@ public:
 
       bool IsRouteValid(Route *pRoute);
 
-      Route *FindRouteByGUID(wxString &guid);
-      Track *FindTrackByGUID(wxString &guid);
+      Route *FindRouteByGUID(const wxString &guid);
+      Track *FindTrackByGUID(const wxString &guid);
       Route *FindRouteContainingWaypoint(RoutePoint *pWP);
       wxArrayPtrVoid *GetRouteArrayContaining(RoutePoint *pWP);
       bool DoesRouteContainSharedPoints( Route *pRoute );

--- a/src/routeman.cpp
+++ b/src/routeman.cpp
@@ -1006,34 +1006,32 @@ wxString Routeman::GetRouteReverseMessage( void )
             _("Waypoints can be renamed to reflect the new order, the names will be '001', '002' etc.\n\nDo you want to rename the waypoints?") );
 }
 
-Route *Routeman::FindRouteByGUID(wxString &guid)
+Route *Routeman::FindRouteByGUID(const wxString &guid)
 {
-    Route *pRoute = NULL;
     wxRouteListNode *node1 = pRouteList->GetFirst();
     while( node1 ) {
-        pRoute = node1->GetData();
+        Route *pRoute = node1->GetData();
         
         if( pRoute->m_GUID == guid )
-            break;
+            return pRoute;
         node1 = node1->GetNext();
     }
  
-    return pRoute;
+    return NULL;
 }
 
-Track *Routeman::FindTrackByGUID(wxString &guid)
+Track *Routeman::FindTrackByGUID(const wxString &guid)
 {
-    Track *pTrack = NULL;
     wxTrackListNode *node1 = pTrackList->GetFirst();
     while( node1 ) {
-        pTrack = node1->GetData();
+        Track *pTrack = node1->GetData();
         
         if( pTrack->m_GUID == guid )
-            break;
+            return pTrack;
         node1 = node1->GetNext();
     }
  
-    return pTrack;
+    return NULL;
 }
 
 void Routeman::ZeroCurrentXTEToActivePoint()


### PR DESCRIPTION
This fixes the problem that if no route/track with the GUID
exists the method simply returns the last route/track.