### PR TITLE
Really use the latest GRIB file (V2)

### DIFF
--- a/plugins/grib_pi/src/GribUIDialog.h
+++ b/plugins/grib_pi/src/GribUIDialog.h
@@ -153,7 +153,7 @@ private:
 	void OnShowCursorData( wxCommandEvent& event );
 
     wxDateTime MinTime();
-    wxString GetNewestFileInDirectory();
+    wxArrayString GetFilesInDirectory();
     void SetGribTimelineRecordSet(GribTimelineRecordSet *pTimelineSet);
     int GetNearestIndex(wxDateTime time, int model);
     int GetNearestValue(wxDateTime time, int model);
@@ -191,7 +191,7 @@ private:
 class GRIBFile {
 public:
 
-    GRIBFile( const wxArrayString & file_names, bool CumRec, bool WaveRec );
+    GRIBFile( const wxArrayString & file_names, bool CumRec, bool WaveRec, bool newestFile = false );
     ~GRIBFile();
 
     bool IsOK( void )


### PR DESCRIPTION
We want to use the latest GRIB file at startup.  However, we were
finding files based on suffix and simply using the newest, even if that
was not a valid GRIB file.  Now we instead use the latest valid GRIB
file.

This is an enhancement of the previous pull request that is stricter about
file names and handles the "no valid GRIB file" scenario correctly.