### PR TITLE
More GCC6 inspired indentation fixes

### DIFF
--- a/plugins/chartdldr_pi/src/unrar/extract.cpp
+++ b/plugins/chartdldr_pi/src/unrar/extract.cpp
@@ -592,16 +592,16 @@ bool CmdExtract::ExtractCurrentFile(Archive &Arc,size_t HeaderSize,bool &Repeat)
             LinkSuccess=false;
           }
           
-          if (!LinkSuccess || (Arc.Format==RARFMT15 && !FileCreateMode))
-          {
-            // RAR 5.x links have a valid data checksum even in case of
-            // failure, because they do not store any data.
-            // We do not want to display "OK" in this case.
-            // For 4.x symlinks we verify the checksum only when extracting,
-            // but not when testing an archive.
-            ShowChecksum=false;
-          }
-          PrevExtracted=FileCreateMode && LinkSuccess;
+        if (!LinkSuccess || (Arc.Format==RARFMT15 && !FileCreateMode))
+        {
+          // RAR 5.x links have a valid data checksum even in case of
+          // failure, because they do not store any data.
+          // We do not want to display "OK" in this case.
+          // For 4.x symlinks we verify the checksum only when extracting,
+          // but not when testing an archive.
+          ShowChecksum=false;
+        }
+        PrevExtracted=FileCreateMode && LinkSuccess;
       }
       else
         if (!Arc.FileHead.SplitBefore && !WrongPassword)

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -422,23 +422,23 @@ void GRIBOverlayFactory::SettingsIdToGribId(int i, int &idx, int &idy, bool &pol
     case GribOverlaySettings::WIND:
         idx = Idx_WIND_VX + m_Altitude, idy = Idx_WIND_VY + m_Altitude; break;
     case GribOverlaySettings::WIND_GUST:
-        if( !m_Altitude ) idx = Idx_WIND_GUST; break;
+        if( !m_Altitude ) { idx = Idx_WIND_GUST; } break;
     case GribOverlaySettings::PRESSURE:
-        if( !m_Altitude ) idx = Idx_PRESSURE; break;
+        if( !m_Altitude ) { idx = Idx_PRESSURE; } break;
     case GribOverlaySettings::WAVE:
         if( !m_Altitude ) { idx = Idx_HTSIGW, idy = Idx_WVDIR, polar = true; } break;
     case GribOverlaySettings::CURRENT:
         if( !m_Altitude ) {  idx = Idx_SEACURRENT_VX, idy = Idx_SEACURRENT_VY; } break;
     case GribOverlaySettings::PRECIPITATION:
-        if( !m_Altitude ) idx = Idx_PRECIP_TOT; break;
+        if( !m_Altitude ) { idx = Idx_PRECIP_TOT; } break;
     case GribOverlaySettings::CLOUD:
-        if( !m_Altitude ) idx = Idx_CLOUD_TOT; break;
+        if( !m_Altitude ) { idx = Idx_CLOUD_TOT; } break;
     case GribOverlaySettings::AIR_TEMPERATURE:
-        if( !m_Altitude ) idx = Idx_AIR_TEMP; break;
+        if( !m_Altitude ) { idx = Idx_AIR_TEMP; } break;
     case GribOverlaySettings::SEA_TEMPERATURE:
-        if( !m_Altitude ) idx = Idx_SEA_TEMP; break;
+        if( !m_Altitude ) { idx = Idx_SEA_TEMP; } break;
     case GribOverlaySettings::CAPE:
-        if( !m_Altitude ) idx = Idx_CAPE; break;
+        if( !m_Altitude ) { idx = Idx_CAPE; } break;
     }
 }
 
@@ -1237,8 +1237,8 @@ void GRIBOverlayFactory::RenderGribDirectionArrows( int settings, GribRecord **p
     else
         arrowSize = 16;
 
-	//set default colour
-	wxColour colour;
+    //set default colour
+    wxColour colour;
     GetGlobalColor( _T ( "DILG3" ), &colour );
 
 #ifdef ocpnUSE_GL

--- a/plugins/grib_pi/src/GribRequestDialog.cpp
+++ b/plugins/grib_pi/src/GribRequestDialog.cpp
@@ -854,7 +854,7 @@ int GribRequestSetting::EstimateFileSize( double *size )
     double maxlat = m_spMaxLat->GetValue(), minlat = m_spMinLat->GetValue();
     if( maxlat - minlat < 0 )
         return 3;                               // maxlat must be > minlat
-	double wlon = (maxlon > minlon ? 0 : 360) + maxlon - minlon;
+    double wlon = (maxlon > minlon ? 0 : 360) + maxlon - minlon;
     if (wlon > 180 || ( maxlat - minlat > 180 ))
         return 4;                           //ovoid too big area
 

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -3045,7 +3045,7 @@ void glChartCanvas::RenderCharts(ocpnDC &dc, const OCPNRegion &rect_region)
                 for(int i=1; i<8; i+=2)
                     if(ll[i] < 0)
                         ll[i] += 360;
-                    break;
+                break;
             }
             
         chart_region = LLRegion(4, ll);
@@ -3553,15 +3553,15 @@ void glChartCanvas::Render()
                     if( GL_TEXTURE_RECTANGLE_ARB != g_texture_rectangle_format )
                         tx1 /= sx, tx2 /= sx, ty1 /= sy, ty2 /= sy;
 
-                        glBegin( GL_QUADS );
-                        glTexCoord2f( tx1, ty1 );  glVertex2f( x2, y2 );
-                        glTexCoord2f( tx2, ty1 );  glVertex2f( x2 + ow, y2 );
-                        glTexCoord2f( tx2, ty2 );  glVertex2f( x2 + ow, y2 + oh );
-                        glTexCoord2f( tx1, ty2 );  glVertex2f( x2, y2 + oh );
-                        glEnd();
+                    glBegin( GL_QUADS );
+                    glTexCoord2f( tx1, ty1 );  glVertex2f( x2, y2 );
+                    glTexCoord2f( tx2, ty1 );  glVertex2f( x2 + ow, y2 );
+                    glTexCoord2f( tx2, ty2 );  glVertex2f( x2 + ow, y2 + oh );
+                    glTexCoord2f( tx1, ty2 );  glVertex2f( x2, y2 + oh );
+                    glEnd();
 
-                        //   Done with cached texture "blit"
-                        glDisable( g_texture_rectangle_format );
+                    //   Done with cached texture "blit"
+                    glDisable( g_texture_rectangle_format );
                 }
 
                 } else { // must redraw the entire screen

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -1284,10 +1284,9 @@ bool PlugInManager::SendKeyEventToPlugins( wxKeyEvent &event)
                         case 113:
                         {
                             opencpn_plugin_113 *ppi = dynamic_cast<opencpn_plugin_113*>(pic->m_pplugin);
-                            if(ppi)
-                                if(ppi->KeyboardEventHook( event ))
-                                    bret = true;
-                                break;
+                            if(ppi && ppi->KeyboardEventHook( event ))
+                                bret = true;
+                            break;
                         }
                         
                         default:


### PR DESCRIPTION
Another set of fixes for mis-indentation flagged by
recenty GCC6.  Most were fixed by changing the indentation,
and a few by adding explicit {}.