### PR TITLE
Optimize chart database updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -997,6 +997,7 @@ SET(HDRS
                 include/canvasMenu.h
                 include/OCPNPlatform.h
                 include/S57Sector.h
+                include/FlexHash.h
 )
 
 SET(SRCS
@@ -1088,6 +1089,7 @@ SET(SRCS
                 src/viewport.cpp
                 src/canvasMenu.cpp
                 src/OCPNPlatform.cpp 
+                src/FlexHash.cpp
     )
 
 IF(NOT WIN32 AND NOT APPLE AND NOT QT_ANDROID)

--- a/include/FlexHash.h
+++ b/include/FlexHash.h
@@ -1,0 +1,58 @@
+
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  Hash of arbitrary length
+ * Author:   Anton Samsonov
+ *
+ ***************************************************************************
+ *   Copyright (C) 2010 by David S. Register                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ *
+ */
+
+#ifndef __FLEXHASH_H__
+#define __FLEXHASH_H__
+
+#include <vector>
+#include "ssl/sha1.h"
+
+class FlexHash {
+
+public:
+
+    FlexHash( size_t output_octets );
+
+    void Reset( void );
+    void Update( const void* input, size_t input_octets );
+    void Finish( void );
+    void Receive( void* output );
+
+    void Compute( const void* input, size_t input_octets, void* output );
+    static void Compute( const void* input, size_t input_octets, void* output, size_t output_octets );
+
+    static bool Test( void );
+
+protected:
+
+    sha1_context m_Context;
+    std::vector<unsigned char> m_Output;
+
+};
+
+#endif

--- a/src/FlexHash.cpp
+++ b/src/FlexHash.cpp
@@ -1,0 +1,108 @@
+
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  Hash of arbitrary length
+ * Author:   Anton Samsonov
+ *
+ ***************************************************************************
+ *   Copyright (C) 2010 by David S. Register                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ *
+ */
+
+#include <vector>
+#include <memory.h>
+#include "FlexHash.h"
+
+#define FLEXHASH_INTERNAL_SIZE static_cast<size_t>(20)
+
+FlexHash::FlexHash( size_t output_octets ) :
+    m_Output( output_octets )
+{
+}
+
+void FlexHash::Reset( void )
+{
+    sha1_starts( &this->m_Context );
+}
+
+void FlexHash::Update( const void* input, size_t input_octets )
+{
+    sha1_update( &this->m_Context, reinterpret_cast< const unsigned char* >( input ), input_octets );
+}
+
+void FlexHash::Finish( void )
+{
+    unsigned char output[ FLEXHASH_INTERNAL_SIZE ];
+    sha1_finish( &this->m_Context, output );
+    if ( this->m_Output.size() <= FLEXHASH_INTERNAL_SIZE ) {
+        memcpy( &this->m_Output[0], output, this->m_Output.size() );
+    } else {
+        memcpy( &this->m_Output[0], output, FLEXHASH_INTERNAL_SIZE );
+        size_t available_octets = FLEXHASH_INTERNAL_SIZE;
+        size_t remaining_octets = this->m_Output.size() - available_octets;
+        while ( remaining_octets )
+        {
+            size_t current_octets = ( ( remaining_octets > FLEXHASH_INTERNAL_SIZE ) ? FLEXHASH_INTERNAL_SIZE : remaining_octets );
+            sha1_starts( &this->m_Context );
+            sha1_update( &this->m_Context, reinterpret_cast< const unsigned char* >( &this->m_Output[0] ), available_octets );
+            sha1_finish( &this->m_Context, output );
+            memcpy( &this->m_Output[available_octets], output, current_octets );
+            available_octets += FLEXHASH_INTERNAL_SIZE;
+            remaining_octets -= current_octets;
+        }
+    }
+}
+
+void FlexHash::Receive( void* output )
+{
+    memcpy( output, &this->m_Output[0], this->m_Output.size() );
+}
+
+void FlexHash::Compute( const void* input, size_t input_octets, void* output )
+{
+    this->Reset();
+    this->Update( input, input_octets );
+    this->Finish();
+    this->Receive( output );
+}
+
+void FlexHash::Compute( const void* input, size_t input_octets, void* output, size_t output_octets )
+{
+    FlexHash hasher( output_octets );
+    hasher.Compute( input, input_octets, output );
+}
+
+bool FlexHash::Test( void )
+{
+    // Input test vector for "The quick brown fox jumps over the lazy dog".
+    static unsigned char input[] = {
+        0x54, 0x68, 0x65, 0x20, 0x71, 0x75, 0x69, 0x63, 0x6b, 0x20, 0x62, 0x72, 0x6f, 0x77, 0x6e, 0x20,
+        0x66, 0x6f, 0x78, 0x20, 0x6a, 0x75, 0x6d, 0x70, 0x73, 0x20, 0x6f, 0x76, 0x65, 0x72, 0x20, 0x74,
+        0x68, 0x65, 0x20, 0x6c, 0x61, 0x7a, 0x79, 0x20, 0x64, 0x6f, 0x67
+    };
+    // Output test vector for SHA-1 engine and 256-bit result.
+    static unsigned char output_reference[] = {
+        0x2f, 0xd4, 0xe1, 0xc6, 0x7a, 0x2d, 0x28, 0xfc, 0xed, 0x84, 0x9e, 0xe1, 0xbb, 0x76, 0xe7, 0x39,
+        0x1b, 0x93, 0xeb, 0x12, 0xa4, 0xe4, 0xd2, 0x6f, 0xd0, 0xc6, 0x45, 0x5e, 0x23, 0xe2, 0x18, 0x7c
+    };
+    char output_current[ ( sizeof output_reference )];
+    Compute( input, ( sizeof input ), output_current, ( sizeof output_current ) );
+    return ( memcmp( output_current, output_reference, ( sizeof output_reference ) ) == 0 );
+}

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -5542,6 +5542,7 @@ int MyFrame::DoOptionsDialog()
     rr = g_options->GetReturnCode();
     if( rr ) {
         ProcessOptionsDialog( rr,  g_options->GetWorkDirListPtr() );
+        ChartData->GetChartDirArray() = *(g_options->GetWorkDirListPtr()); // Perform a deep copy back to main database.
         ret_val = true;
     }
 

--- a/src/chartdbs.cpp
+++ b/src/chartdbs.cpp
@@ -1569,7 +1569,7 @@ bool ChartDatabase::DetectDirChange(const wxString & dir_path, const wxString & 
       wxArrayString FileList;
       wxDir dir(dir_path);
       int n_files = dir.GetAllFiles(dir_path, &FileList);
-      FileList.Sort();
+      FileList.Sort();  // Ensure persistent order of items being hashed.
 
       FlexHash hash( sizeof nacc );
       hash.Reset();
@@ -1865,7 +1865,7 @@ int ChartDatabase::SearchDirAndAddCharts(wxString& dir_name_base,
                 dir.GetAllFiles(dir_name, &FileList, lowerFileSpecXZ, gaf_flags);
             }
 #endif
-            FileList.Sort();
+            FileList.Sort();    // Sorted processing order makes the progress bar more meaningful to the user.
       }
       else {                            // This is a cm93 dataset, specified as yada/yada/cm93
             wxString dir_plus = dir_name;
@@ -1928,7 +1928,7 @@ int ChartDatabase::SearchDirAndAddCharts(wxString& dir_name_base,
             ChartCollisionsHashMap::const_iterator collision_ptr = collision_map.find( file_name );
             bool collision = ( collision_ptr != collision_map.end() );
             bool file_path_is_same = false;
-            bool file_data_is_same = false;
+            bool file_time_is_same = false;
             ChartTableEntry *pEntry = NULL;
             wxString table_file_name;
 
@@ -1947,7 +1947,7 @@ int ChartDatabase::SearchDirAndAddCharts(wxString& dir_name_base,
 
                     if( t_newFile <= t_oldFile )
                     {
-                        file_data_is_same = true;
+                        file_time_is_same = true;
                         bAddFinal = false;
                         pEntry->SetValid(true);
                     }
@@ -1959,7 +1959,7 @@ int ChartDatabase::SearchDirAndAddCharts(wxString& dir_name_base,
                 }
             }
 
-            if( file_data_is_same ) {
+            if( file_time_is_same ) {
                 // Produce the same output without actually calling `CreateChartTableEntry()`.
                 wxString msg = wxT("Loading chart data for ");
                 msg.Append(full_name);
@@ -1985,7 +1985,7 @@ int ChartDatabase::SearchDirAndAddCharts(wxString& dir_name_base,
                 msg.Append(full_name);
                 wxLogMessage(msg);
             }
-            else if( !file_data_is_same )
+            else if( !file_time_is_same )
             {
                 //  Look at the chart file name (without directory prefix) for a further check for duplicates
                 //  This catches the case in which the "same" chart is in different locations,

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6110,7 +6110,8 @@ void options::OnApplyClick(wxCommandEvent& event) {
 
   if (event.GetId() == ID_APPLY) {
     gFrame->ProcessOptionsDialog(m_returnChanges, m_pWorkDirList);
-    
+    m_CurrentDirList = *m_pWorkDirList; // Perform a deep copy back to main database.
+
     //  We can clear a few flag bits on "Apply", so they won't be recognised at the "OK" click.
     //  Their actions have already been accomplished once...
     m_returnChanges &= ~( FORCE_UPDATE | SCAN_UPDATE );


### PR DESCRIPTION
Major improvements:

* Chart header is now only loaded from file when really necessary, avoiding this costly procedure for unchanged documents.

* Fixed a newly discovered bug of not saving new magic numbers in memory, which resulted in unnecessary updates until program restart. (That is, updated directory hashes were saved to config file, but immediately discarded from in-memory database, thus reverting to their previous values on subsequent scans during the same session.)

* Magic number calculation was migrated from a simple checksum (susceptible to collisions) to a cryptographically-strong hash, while retaining the original storage format.

Testers are more than welcome, as I only checked this against S-57 charts.