### PR TITLE
Optimize chart database updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -997,6 +997,7 @@ SET(HDRS
                 include/canvasMenu.h
                 include/OCPNPlatform.h
                 include/S57Sector.h
+                include/FlexHash.h
 )
 
 SET(SRCS
@@ -1088,6 +1089,7 @@ SET(SRCS
                 src/viewport.cpp
                 src/canvasMenu.cpp
                 src/OCPNPlatform.cpp 
+                src/FlexHash.cpp
     )
 
 IF(NOT WIN32 AND NOT APPLE AND NOT QT_ANDROID)

--- a/include/FlexHash.h
+++ b/include/FlexHash.h
@@ -1,0 +1,58 @@
+
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  Hash of arbitrary length
+ * Author:   Anton Samsonov
+ *
+ ***************************************************************************
+ *   Copyright (C) 2010 by David S. Register                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ *
+ */
+
+#ifndef __FLEXHASH_H__
+#define __FLEXHASH_H__
+
+#include <vector>
+#include "ssl/sha1.h"
+
+class FlexHash {
+
+public:
+
+    FlexHash( size_t output_octets );
+
+    void Reset( void );
+    void Update( const void* input, size_t input_octets );
+    void Finish( void );
+    void Receive( void* output );
+
+    void Compute( const void* input, size_t input_octets, void* output );
+    static void Compute( const void* input, size_t input_octets, void* output, size_t output_octets );
+
+    static bool Test( void );
+
+protected:
+
+    sha1_context m_Context;
+    std::vector<unsigned char> m_Output;
+
+};
+
+#endif

--- a/src/FlexHash.cpp
+++ b/src/FlexHash.cpp
@@ -1,0 +1,108 @@
+
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  Hash of arbitrary length
+ * Author:   Anton Samsonov
+ *
+ ***************************************************************************
+ *   Copyright (C) 2010 by David S. Register                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ *
+ */
+
+#include <vector>
+#include <memory.h>
+#include "FlexHash.h"
+
+#define FLEXHASH_INTERNAL_SIZE static_cast<size_t>(20)
+
+FlexHash::FlexHash( size_t output_octets ) :
+    m_Output( output_octets )
+{
+}
+
+void FlexHash::Reset( void )
+{
+    sha1_starts( &this->m_Context );
+}
+
+void FlexHash::Update( const void* input, size_t input_octets )
+{
+    sha1_update( &this->m_Context, reinterpret_cast< const unsigned char* >( input ), input_octets );
+}
+
+void FlexHash::Finish( void )
+{
+    unsigned char output[ FLEXHASH_INTERNAL_SIZE ];
+    sha1_finish( &this->m_Context, output );
+    if ( this->m_Output.size() <= FLEXHASH_INTERNAL_SIZE ) {
+        memcpy( &this->m_Output[0], output, this->m_Output.size() );
+    } else {
+        memcpy( &this->m_Output[0], output, FLEXHASH_INTERNAL_SIZE );
+        size_t available_octets = FLEXHASH_INTERNAL_SIZE;
+        size_t remaining_octets = this->m_Output.size() - available_octets;
+        while ( remaining_octets )
+        {
+            size_t current_octets = ( ( remaining_octets > FLEXHASH_INTERNAL_SIZE ) ? FLEXHASH_INTERNAL_SIZE : remaining_octets );
+            sha1_starts( &this->m_Context );
+            sha1_update( &this->m_Context, reinterpret_cast< const unsigned char* >( &this->m_Output[0] ), available_octets );
+            sha1_finish( &this->m_Context, output );
+            memcpy( &this->m_Output[available_octets], output, current_octets );
+            available_octets += FLEXHASH_INTERNAL_SIZE;
+            remaining_octets -= current_octets;
+        }
+    }
+}
+
+void FlexHash::Receive( void* output )
+{
+    memcpy( output, &this->m_Output[0], this->m_Output.size() );
+}
+
+void FlexHash::Compute( const void* input, size_t input_octets, void* output )
+{
+    this->Reset();
+    this->Update( input, input_octets );
+    this->Finish();
+    this->Receive( output );
+}
+
+void FlexHash::Compute( const void* input, size_t input_octets, void* output, size_t output_octets )
+{
+    FlexHash hasher( output_octets );
+    hasher.Compute( input, input_octets, output );
+}
+
+bool FlexHash::Test( void )
+{
+    // Input test vector for "The quick brown fox jumps over the lazy dog".
+    static unsigned char input[] = {
+        0x54, 0x68, 0x65, 0x20, 0x71, 0x75, 0x69, 0x63, 0x6b, 0x20, 0x62, 0x72, 0x6f, 0x77, 0x6e, 0x20,
+        0x66, 0x6f, 0x78, 0x20, 0x6a, 0x75, 0x6d, 0x70, 0x73, 0x20, 0x6f, 0x76, 0x65, 0x72, 0x20, 0x74,
+        0x68, 0x65, 0x20, 0x6c, 0x61, 0x7a, 0x79, 0x20, 0x64, 0x6f, 0x67
+    };
+    // Output test vector for SHA-1 engine and 256-bit result.
+    static unsigned char output_reference[] = {
+        0x2f, 0xd4, 0xe1, 0xc6, 0x7a, 0x2d, 0x28, 0xfc, 0xed, 0x84, 0x9e, 0xe1, 0xbb, 0x76, 0xe7, 0x39,
+        0x1b, 0x93, 0xeb, 0x12, 0xa4, 0xe4, 0xd2, 0x6f, 0xd0, 0xc6, 0x45, 0x5e, 0x23, 0xe2, 0x18, 0x7c
+    };
+    char output_current[ ( sizeof output_reference )];
+    Compute( input, ( sizeof input ), output_current, ( sizeof output_current ) );
+    return ( memcmp( output_current, output_reference, ( sizeof output_reference ) ) == 0 );
+}

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -5542,6 +5542,7 @@ int MyFrame::DoOptionsDialog()
     rr = g_options->GetReturnCode();
     if( rr ) {
         ProcessOptionsDialog( rr,  g_options->GetWorkDirListPtr() );
+        ChartData->GetChartDirArray() = *(g_options->GetWorkDirListPtr()); // Perform a deep copy back to main database.
         ret_val = true;
     }
 

--- a/src/chartdbs.cpp
+++ b/src/chartdbs.cpp
@@ -40,6 +40,7 @@
 #include "chartbase.h"
 #include "pluginmanager.h"
 #include "mygeom.h"                     // For DouglasPeucker();
+#include "FlexHash.h"
 #ifndef UINT32
 #define UINT32 unsigned int
 #endif
@@ -1523,12 +1524,9 @@ int ChartDatabase::TraverseDirAndAddCharts(ChartDirInfo& dir_info, wxProgressDia
             {
 
                 wxFileName fn(wxString(active_chartTable[ic].GetpFullPath(), wxConvUTF8));
-                  wxString t = fn.GetPath();
-
 
                   while(fn.GetDirCount() >= dir_path_count)
                   {
-                        t = fn.GetPath();
                         if(fn.GetPath() == dir_path)
                         {
                             active_chartTable[ic].SetValid(true);
@@ -1571,6 +1569,10 @@ bool ChartDatabase::DetectDirChange(const wxString & dir_path, const wxString & 
       wxArrayString FileList;
       wxDir dir(dir_path);
       int n_files = dir.GetAllFiles(dir_path, &FileList);
+      FileList.Sort();  // Ensure persistent order of items being hashed.
+
+      FlexHash hash( sizeof nacc );
+      hash.Reset();
 
       //Traverse the list of files, getting their interesting stuff to add to accumulator
       for(int ifile=0 ; ifile < n_files ; ifile++)
@@ -1580,23 +1582,26 @@ bool ChartDatabase::DetectDirChange(const wxString & dir_path, const wxString & 
 
             wxFileName file(FileList.Item(ifile));
 
+            // NOTE. Do not ever try to optimize this code by combining `wxString` calls.
+            // Otherwise `fileNameUTF8` will point to a stale buffer overwritten by garbage.
+            wxString fileNameNative = file.GetFullPath();
+            wxScopedCharBuffer fileNameUTF8 = fileNameNative.ToUTF8();
+            hash.Update( fileNameUTF8.data(), fileNameUTF8.length() );
+
             //    File Size;
             wxULongLong size = file.GetSize();
-            if(wxInvalidSize != size)
-                  nacc = nacc + size;
+            wxULongLong fileSize = ( ( size != wxInvalidSize ) ? size : 0 );
+            hash.Update( &fileSize, ( sizeof fileSize ) );
 
             //    Mod time, in ticks
             wxDateTime t = file.GetModificationTime();
-            nacc += t.GetTicks();
-
-            //    File name
-            wxString n = file.GetFullName();
-            for(unsigned int in=0 ; in < n.Len() ; in++)
-            {
-                  nacc += (unsigned char)n[in];
-            }
+            wxULongLong fileTime = t.GetTicks();
+            hash.Update( &fileTime, ( sizeof fileTime ) );
 
       }
+
+      hash.Finish();
+      hash.Receive( &nacc );
 
       //    Return the calculated magic number
       new_magic = nacc.ToString();
@@ -1821,6 +1826,8 @@ int ChartDatabase::SearchDirAndAddCharts(wxString& dir_name_base,
       wxString dir_name = dir_name_base;
       wxString filespec = chart_desc.m_search_mask.Upper();
       wxString lowerFileSpec = chart_desc.m_search_mask.Lower();
+      wxString filespecXZ = filespec + _T(".xz");
+      wxString lowerFileSpecXZ = lowerFileSpec + _T(".xz");
       wxString filename;
 
 //    Count the files
@@ -1847,35 +1854,18 @@ int ChartDatabase::SearchDirAndAddCharts(wxString& dir_name_base,
 
       if(!b_found_cm93)
       {
+            // Note that `wxDir::GetAllFiles()` appends to the list rather than replaces existing contents.
             wxDir dir(dir_name);
             dir.GetAllFiles(dir_name, &FileList, filespec, gaf_flags);
-
-            // add xz compressed files;
-            wxArrayString compressedFileList;
-            dir.GetAllFiles(dir_name, &compressedFileList, filespec+_T(".xz"), gaf_flags);
-            for (wxArrayString::const_iterator item = compressedFileList.begin(); item != compressedFileList.end(); item++)
-                FileList.Add(*item);
-
+            dir.GetAllFiles(dir_name, &FileList, filespecXZ, gaf_flags);
 #ifndef __WXMSW__
-
-            
             if (filespec != lowerFileSpec)
             {
-                // add lowercase filespec files too
-                wxArrayString lowerFileList;
-                dir.GetAllFiles(dir_name, &lowerFileList, lowerFileSpec, gaf_flags);
-                for (wxArrayString::const_iterator item = lowerFileList.begin(); item != lowerFileList.end(); item++)
-                    FileList.Add(*item);
-
-
-                dir.GetAllFiles(dir_name, &compressedFileList, lowerFileSpec+_T(".xz"), gaf_flags);
-                for (wxArrayString::const_iterator item = compressedFileList.begin(); item != compressedFileList.end(); item++)
-                    FileList.Add(*item);
+                dir.GetAllFiles(dir_name, &FileList, lowerFileSpec, gaf_flags);
+                dir.GetAllFiles(dir_name, &FileList, lowerFileSpecXZ, gaf_flags);
             }
-
-
-            
 #endif
+            FileList.Sort();    // Sorted processing order makes the progress bar more meaningful to the user.
       }
       else {                            // This is a cm93 dataset, specified as yada/yada/cm93
             wxString dir_plus = dir_name;
@@ -1910,6 +1900,9 @@ int ChartDatabase::SearchDirAndAddCharts(wxString& dir_name_base,
           collision_map[table_file.GetFullName()] = i;
       }
 
+      int nFileProgressQuantum = wxMax( nFile / 100, 2 );
+      double rFileProgressRatio = 100.0 / wxMax( nFile, 1 );
+
       for(int ifile=0 ; ifile < nFile ; ifile++)
       {
             wxFileName file(FileList.Item(ifile));
@@ -1918,97 +1911,120 @@ int ChartDatabase::SearchDirAndAddCharts(wxString& dir_name_base,
             //    Validate the file name again, considering MSW's semi-random treatment of case....
             // TODO...something fishy here - may need to normalize saved name?
             if(!file_name.Matches(lowerFileSpec) && !file_name.Matches(filespec) &&
-               !file_name.Matches(lowerFileSpec+_T(".xz")) && !file_name.Matches(filespec+_T(".xz")) &&
+               !file_name.Matches(lowerFileSpecXZ) && !file_name.Matches(filespecXZ) &&
                !b_found_cm93) {
                 wxLogMessage(_T("FileSpec test failed for:") + file_name);
                 continue;
             }
 
-            if(pprog && (ifile % (nFile / 60 + 1)) == 0)
-                  pprog->Update(wxMin((ifile * 100) / nFile, 100), full_name);
+            if( pprog && ( ( ifile % nFileProgressQuantum ) == 0 ) )
+                  pprog->Update( static_cast<int>( ifile * rFileProgressRatio ), full_name );
 
             ChartTableEntry *pnewChart = NULL;
             bool bAddFinal = true;
             int b_add_msg = 0;
 
-            pnewChart = CreateChartTableEntry(full_name, chart_desc);
-            if(!pnewChart)
-            {
-                  bAddFinal = false;
-                  wxString msg = _T("   CreateChartTableEntry() failed for file: ");
-                  msg.Append(full_name);
-                  wxLogMessage(msg);
-            }
-            else         // check the collisions map looking for duplicates, and choosing the right one
-            {
-                if(collision_map.find(file_name) != collision_map.end()) {
-                    int isearch = collision_map[file_name];
-                    wxString table_file_name(active_chartTable[isearch].GetpFullPath(), wxConvUTF8);
+            // Check the collisions map looking for duplicates, and choosing the right one.
+            ChartCollisionsHashMap::const_iterator collision_ptr = collision_map.find( file_name );
+            bool collision = ( collision_ptr != collision_map.end() );
+            bool file_path_is_same = false;
+            bool file_time_is_same = false;
+            ChartTableEntry *pEntry = NULL;
+            wxString table_file_name;
 
-                    //    If the chart full file paths are exactly the same, select the newer one
-                    if(bthis_dir_in_dB && full_name.IsSameAs(table_file_name))
+            if( collision ) {
+                pEntry = &active_chartTable[collision_ptr->second];
+                table_file_name = wxString::FromUTF8(pEntry->GetpFullPath());
+                file_path_is_same = bthis_dir_in_dB && full_name.IsSameAs(table_file_name);
+
+                // If the chart full file paths are exactly the same, select the newer one.
+                if( file_path_is_same ) {
+                    b_add_msg++;
+
+                    //    Check the file modification time
+                    time_t t_oldFile = pEntry->GetFileTime();
+                    time_t t_newFile = file.GetModificationTime().GetTicks();
+
+                    if( t_newFile <= t_oldFile )
                     {
-                        b_add_msg++;
-
-                        //    Check the file modification time
-                        time_t t_oldFile = active_chartTable[isearch].GetFileTime();
-                        time_t t_newFile = file.GetModificationTime().GetTicks();
-                        
-                        if( t_newFile <= t_oldFile )
-                        {
-                            bAddFinal = false;
-                            active_chartTable[isearch].SetValid(true);
-                        }
-                        else
-                        {
-                            bAddFinal = true;
-                            active_chartTable[isearch].SetValid(false);
-                            wxString msg = _T("   Replacing older chart file of same path: ");
-                            msg.Append(full_name);
-                            wxLogMessage(msg);
-                        }
-                    } else {
-                    
-                        //  Look at the chart file name (without directory prefix) for a further check for duplicates
-                        //  This catches the case in which the "same" chart is in different locations,
-                        //  and one may be newer than the other.
-                        b_add_msg++;
-                        
-                        if(pnewChart->IsEarlierThan(active_chartTable[isearch]))
-                        {
-                            wxFileName table_file(table_file_name);
-                            //    Make sure the compare file actually exists
-                            if(table_file.IsFileReadable())
-                            {
-                                active_chartTable[isearch].SetValid(true);
-                                bAddFinal = false;
-                                wxString msg = _T("   Retaining newer chart file of same name: ");
-                                msg.Append(full_name);
-                                wxLogMessage(msg);
-
-                            }
-                        }
-                        else if(pnewChart->IsEqualTo(active_chartTable[isearch]))
-                        {
-                            //    The file names (without dir prefix) are identical,
-                            //    and the mod times are identical
-                            //    Prsume that this is intentional, in order to facilitate
-                            //    having the same chart in multiple groups.
-                            //    So, add this chart.
-                            bAddFinal = true;
-                        }
-
-                        else
-                        {
-                            active_chartTable[isearch].SetValid(false);
-                            bAddFinal = true;
-                            wxString msg = _T("   Replacing older chart file of same name: ");
-                            msg.Append(full_name);
-                            wxLogMessage(msg);
-                        }
+                        file_time_is_same = true;
+                        bAddFinal = false;
+                        pEntry->SetValid(true);
+                    }
+                    else
+                    {
+                        bAddFinal = true;
+                        pEntry->SetValid(false);
                     }
                 }
             }
+
+            if( file_time_is_same ) {
+                // Produce the same output without actually calling `CreateChartTableEntry()`.
+                wxString msg = wxT("Loading chart data for ");
+                msg.Append(full_name);
+                wxLogMessage(msg);
+            } else {
+                pnewChart = CreateChartTableEntry(full_name, chart_desc);
+                if(!pnewChart)
+                {
+                    bAddFinal = false;
+                    wxString msg = _T("   CreateChartTableEntry() failed for file: ");
+                    msg.Append(full_name);
+                    wxLogMessage(msg);
+                }
+            }
+
+            if ( !collision || !pnewChart )
+            {
+                // Do nothing.
+            }
+            else if( file_path_is_same )
+            {
+                wxString msg = _T("   Replacing older chart file of same path: ");
+                msg.Append(full_name);
+                wxLogMessage(msg);
+            }
+            else if( !file_time_is_same )
+            {
+                //  Look at the chart file name (without directory prefix) for a further check for duplicates
+                //  This catches the case in which the "same" chart is in different locations,
+                //  and one may be newer than the other.
+                b_add_msg++;
+
+                if( pnewChart->IsEarlierThan(*pEntry) )
+                {
+                    wxFileName table_file(table_file_name);
+                    //    Make sure the compare file actually exists
+                    if( table_file.IsFileReadable() )
+                    {
+                        pEntry->SetValid(true);
+                        bAddFinal = false;
+                        wxString msg = _T("   Retaining newer chart file of same name: ");
+                        msg.Append(full_name);
+                        wxLogMessage(msg);
+
+                    }
+                }
+                else if( pnewChart->IsEqualTo(*pEntry) )
+                {
+                    //    The file names (without dir prefix) are identical,
+                    //    and the mod times are identical
+                    //    Prsume that this is intentional, in order to facilitate
+                    //    having the same chart in multiple groups.
+                    //    So, add this chart.
+                    bAddFinal = true;
+                }
+                else
+                {
+                    pEntry->SetValid(false);
+                    bAddFinal = true;
+                    wxString msg = _T("   Replacing older chart file of same name: ");
+                    msg.Append(full_name);
+                    wxLogMessage(msg);
+                }
+            }
+
 
             if(bAddFinal)
             {
@@ -2024,7 +2040,8 @@ int ChartDatabase::SearchDirAndAddCharts(wxString& dir_name_base,
             }
             else
             {
-                delete pnewChart;
+                if (pnewChart)
+                    delete pnewChart;
 //                  wxString msg = _T("   Not adding chart file: ");
 //                  msg.Append(full_name);
 //                  wxLogMessage(msg);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6110,7 +6110,8 @@ void options::OnApplyClick(wxCommandEvent& event) {
 
   if (event.GetId() == ID_APPLY) {
     gFrame->ProcessOptionsDialog(m_returnChanges, m_pWorkDirList);
-    
+    m_CurrentDirList = *m_pWorkDirList; // Perform a deep copy back to main database.
+
     //  We can clear a few flag bits on "Apply", so they won't be recognised at the "OK" click.
     //  Their actions have already been accomplished once...
     m_returnChanges &= ~( FORCE_UPDATE | SCAN_UPDATE );


### PR DESCRIPTION
This is a single-commit version of PR #721.

* Adjusted the conditions under which chart header is loaded from file on directory scanning, changing it from mandatory to on-demand only, thus avoiding that costly loading procedure for unchanged documents.
* Fixed a newly discovered bug of not saving directories' new magic numbers in memory, which resulted in unnecessary updates until program restart. (That is, updated directory hashes were saved to config file, but immediately discarded from in-memory database, thus reverting to their previous values on subsequent scans during the same session.)
* Changed the method of directory's magic number calculation, replacing an addition-based checksum (susceptible to collisions) with cryptographic-grade hash, while retaining the original storage format.
* Introduced `FlexHash` class that can produce output of any given size. This is intended to be opaque, being currently based on SHA-1.

Testers are more than welcome, as I only checked this against S-57 charts.