### PR TITLE
Fix search path for string translations in Unix

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -45,6 +45,7 @@
 #include <wx/clrpicker.h>
 #include "wx/tokenzr.h"
 #include "wx/dir.h"
+#include <wx/filename.h>
 
 #include <wx/dialog.h>
 
@@ -1652,6 +1653,20 @@ bool MyApp::OnInit()
 #ifdef __WXMSW__
     wxString locale_location = g_Platform->GetSharedDataDir();
     locale_location += _T("share/locale");
+    wxLocale::AddCatalogLookupPathPrefix( locale_location );
+#elif defined(unix) || defined(__unix__) || defined(__unix) || defined(__UNIX__)
+    // On Unix, wxWidgets defaults to installation prefix of its own, usually "/usr".
+    // On the other hand, canonical installation prefix for OpenCPN is "/usr/local".
+    wxString locale_location;
+    if( !wxGetEnv( _T("OPENCPN_PREFIX"), &locale_location ) )
+    {
+        locale_location = _T("/usr/local");
+    }
+    wxFileName location;
+    location.AssignDir( locale_location );
+    location.AppendDir( _T("share") );
+    location.SetName( _T("locale") );
+    locale_location = location.GetFullPath();
     wxLocale::AddCatalogLookupPathPrefix( locale_location );
 #endif
 


### PR DESCRIPTION
When searching for translation catalogs in Unix systems, wxWidgets defaults to _`$prefix`/share/locale_, where installation prefix refers to its own — wxWidgets' prefix (usually _/usr_ for packages provided by system), — not the application's one. On the other hand, canonical installation prefix for OpenCPN is _/usr/local_, even when installed from package. Such a mismatch provokes inability to locate _.mo_ files.

This patch explicitly adds _/usr/local_ to wxWidget search list. Alternative installation prefix may be specified in `OPENCPN_PREFIX` environment variable.
