### PR TITLE
escape HTML entities in AIS target query dialog

### DIFF
--- a/src/AIS_Target_Data.cpp
+++ b/src/AIS_Target_Data.cpp
@@ -65,6 +65,23 @@ static wxString FormatTimeAdaptive( int seconds )
     return wxString::Format( _T("%2dh %02dmin"), h, m );
 }
 
+static wxString html_escape ( const wxString &src)
+{
+  // Escape &, <, > as well as single and double quotes for HTML.
+  wxString ret = src;
+
+  ret.Replace(_T("<"), _T("&lt;"));
+  ret.Replace(_T(">"), _T("&gt;"));
+
+  // only < and > in 6 bits AIS ascii
+  // ret.Replace(_T("\""), _T("&quot;"));
+  // ret.Replace(_T("&"), _T("&amp;"));
+  // ret.Replace(_T("'"), _T("&#39;"));
+
+  // Do we care about multiple spaces?
+  //   ret.Replace(_T(" "), _T("&nbsp;"));
+  return ret;
+}
 
 AIS_Target_Data::AIS_Target_Data()
 {
@@ -510,7 +527,7 @@ wxString AIS_Target_Data::BuildQueryResult( void )
                  << rowStartH << _T("<b>");
                  wxString dest =  trimAISField( Destination );
                  if(dest.Length() )
-                     html << dest;
+                     html << html_escape(dest);
                  else
                      html << _("---");
                  html << _T("</b></td><td nowrap align=right><b>");


### PR DESCRIPTION
Hi,
cf:
FS#2145 - '4.4.0 doens't correctly handle destination' data:
!AIVDM,1,1,,A,139J0t000tPDIAVMvRVWWV;J0<00,0_09
!AIVDM,2,1,1,A,539J0t02;a3<@lhl001<<PhE=LTNlPti=@DTp01529t<<78@:?45E51h,0_68
!AIVDM,2,2,1,A,DQ1Cg?TSiA0V@08,2*2B

OCPN must escape HTML entities, likely also need in s57 obj INFORM text.

Regards
Didier
