### PR TITLE
furuno UDP use ascii null char before NMEA sentences

### DIFF
--- a/src/datastream.cpp
+++ b/src/datastream.cpp
@@ -532,9 +532,6 @@ void DataStream::OnSocketEvent(wxSocketEvent& event)
             //    Disable input event notifications to preclude re-entrancy on non-blocking socket
             //           m_sock->SetNotify(wxSOCKET_LOST_FLAG);
 
-            //          Read the reply, one character at a time, looking for 0x0a (lf)
-            //          If the reply contains no lf, break on the buffer full
-
             std::vector<char> data(RD_BUF_SIZE+1);
             event.GetSocket()->Read(&data.front(),RD_BUF_SIZE);
             if(!event.GetSocket()->Error())
@@ -542,9 +539,10 @@ void DataStream::OnSocketEvent(wxSocketEvent& event)
                 size_t count = event.GetSocket()->LastCount();
                 if(count)
                 {
-                    data[count]=0;
-//                    m_sock_buffer.Append(data);
-                    m_sock_buffer += (&data.front());
+                    // XXX FIXME: is it reliable?
+                    // copy all received bytes
+                    // there's 0 in furuno UDP tags before NMEA sentences.
+                    m_sock_buffer.append(&data.front(), count);
                 }
             }
 


### PR DESCRIPTION
hi,
Over UDP Furuno adds a proprietary header which includes null bytes.
Copy the whole stuff from the socket not NMEA headers are removed later.

Caveat: a std:string with embedded null is asking for trouble, maybe it should be change to a vector.

Regards
Didier
