### PR TITLE
Update for Visual Studio 2013 to allow 'min' to work

### DIFF
--- a/src/routeprop.cpp
+++ b/src/routeprop.cpp
@@ -56,6 +56,9 @@
 #include <QtWidgets/QScroller>
 #endif
 
+#ifdef __WXMSW__
+#include <algorithm>
+#endif
 
 extern double             gLat, gLon, gSog, gCog;
 extern double             g_PlanSpeed;


### PR DESCRIPTION
Fix to allow 'min' to work in Visual Studio 2013