### PR TITLE
Abort build configuration if include/version.h exists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ ENDIF(APPLE)
 
 INCLUDE( ${CMAKE_SOURCE_DIR}/VERSION.cmake )
 SET(PACKAGE_VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}" )
+IF(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include/version.h")
+    MESSAGE(FATAL_ERROR "There exists a relic 'include/version.h' in the source tree! Remove it.")
+ENDIF(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include/version.h")
+
 
 #Red Hat:   /etc/redhat-release
 #Slackware: /etc/slackware-version


### PR DESCRIPTION
Currently, when an ancient *version.h* somehow gets in the source tree, it takes over any automatically generated header file of same name, which may cause all kind of build issues:

* an incorrect version string get inserted into the main executable;
* compilation of certain plugins cannot complete because of missing `PLUGIN_VERSION_MAJOR` etc.

With the proposed patch, whenever *include/version.h* is discovered in the root source tree, the user will be explicitly told to remove that file before proceeding with build configuration.