### PR TITLE
Fix search path for string translations in Unix.

### DIFF
--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -566,19 +566,36 @@ void OCPNPlatform::OnExit_2( void ){
 void OCPNPlatform::SetLocaleSearchPrefixes( void )
 {
 #if wxUSE_XLOCALE
-    
     // Add a new prefixes for search order.
-    #ifdef __WXMSW__
+    #if defined(__WINDOWS__)
+
     wxString locale_location = GetSharedDataDir();
     locale_location += _T("share/locale");
     wxLocale::AddCatalogLookupPathPrefix( locale_location );
-    #endif
-    
-    #ifdef __OCPN__ANDROID__ 
+
+    #elif defined(__OCPN__ANDROID__)
+
     wxString locale_location = GetSharedDataDir() + _T("locale");
     wxLocale::AddCatalogLookupPathPrefix( locale_location );
-    #endif    
-    
+
+    #elif defined(__UNIX__) && !defined(__WINE__)
+
+    // On Unix, wxWidgets defaults to installation prefix of its own, usually "/usr".
+    // On the other hand, canonical installation prefix for OpenCPN is "/usr/local".
+    wxString locale_location;
+    if( !wxGetEnv( _T("OPENCPN_PREFIX"), &locale_location ) )
+    {
+        locale_location = _T("/usr/local");
+    }
+    wxFileName location;
+    location.AssignDir( locale_location );
+    location.AppendDir( _T("share") );
+    location.SetName( _T("locale") );
+    locale_location = location.GetFullPath();
+    wxLocale::AddCatalogLookupPathPrefix( locale_location );
+
+    #endif
+
 #endif
 }
 


### PR DESCRIPTION
When searching for translation catalogs in Unix systems, wxWidgets defaults to *`$prefix`/share/locale*, where installation prefix refers to its own — wxWidgets' prefix (usually */usr* for packages provided by system), — not the application's one. On the other hand, canonical installation prefix for OpenCPN is */usr/local*, even when installed from package. Such a mismatch provokes inability to locate *.mo* files.

This patch explicitly adds */usr/local* to wxWidget search list. Alternative installation prefix may be specified in `OPENCPN_PREFIX` environment variable.

This is a rework of PR #724 atop of commit 3ab2bc457c976e5d4f1fa7cd1821345e4f640648.