### PR TITLE
Remove LUP first by index then destroy.

### DIFF
--- a/src/chartsymbols.cpp
+++ b/src/chartsymbols.cpp
@@ -658,8 +658,8 @@ void ChartSymbols::BuildLookup( Lookup &lookup )
     while( index < pLUPARRAYtyped->GetCount() ) {
         LUPrec *pLUPCandidate = pLUPARRAYtyped->Item( index );
         if( LUP->RCID == pLUPCandidate->RCID ) {
-            plib->DestroyLUP( pLUPCandidate ); // empties the LUP
-            pLUPARRAYtyped->Remove( pLUPCandidate );
+            pLUPARRAYtyped->RemoveAt(index);
+            plib->DestroyLUP(pLUPCandidate); // empties the LUP
             break;
         }
         index++;


### PR DESCRIPTION
I think it is an error to destroy the LUP data before removing the pointer from the array. Also, the index is known so is probably a better idea to remove it by index instead of by binary search.