### PR TITLE
Do not rotate viewport with NaN as the COG.

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -7079,6 +7079,9 @@ void MyFrame::DoCOGSet( void )
     if(!cc1)
         return;
 
+    if (wxIsNaN(g_COGAvg))
+        return;
+
     double old_VPRotate = g_VPRotate;
     g_VPRotate = -g_COGAvg * PI / 180.;
 


### PR DESCRIPTION
The COG filter algorithm "signals" loss of data by making the filtered COG a NaN. So if that happens we should not use it to rotate the VP. That can put the VP into a bit of a tizzy because other things depend on a valid rotation angle and for speed they don't check each time they use the rotation angle.