### PR TITLE
Correct number of decimals in Options Arrival Circle Radius

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -4887,7 +4887,7 @@ void options::SetInitialSettings(void) {
       wxString::Format(_T("%.1f"), g_n_gps_antenna_offset_y));
   m_pOSMinSize->SetValue(wxString::Format(_T("%d"), g_n_ownship_min_mm));
   m_pText_ACRadius->SetValue(
-      wxString::Format(_T("%.2f"), g_n_arrival_circle_radius));
+      wxString::Format(_T("%.3f"), g_n_arrival_circle_radius));
 
   wxString buf;
   if (g_iNavAidRadarRingsNumberVisible > 10)


### PR DESCRIPTION
WP Arrival circle radius is set to a minimum value at 0.001 in option.cpp : 4889:
g_n_arrival_circle_radius = wxMax(g_n_arrival_circle_radius, .001);

But the value for m_pText_ACRadius in options.cpp row 722 is set from g_n_arrival_circle_radius but with only two decimals thus new WPs will get 0.00 and "following a route" will never arrive and the AP will be set to turn around when a WP is passed.