### PR TITLE
Correct order of arguments to SetCellBackgroundColour().

### DIFF
--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -910,8 +910,8 @@ void GRIBUICtrlBar::ContextMenuItemCallback(int id)
     int i = 0,vcol = GetNearestIndex( GetNow(), 0);
     wxColour colour;
     GetGlobalColor(_T("GREEN1"), &colour);
-    table->m_pGribTable->SetCellBackgroundColour( colour, 0, vcol ); //mark current column
-    table->m_pGribTable->SetCellBackgroundColour( colour, 1, vcol );
+    table->m_pGribTable->SetCellBackgroundColour( 0, vcol, colour ); //mark current column
+    table->m_pGribTable->SetCellBackgroundColour( 1, vcol, colour );
     while( table->m_pGribTable->IsVisible( 0, i, true) ) {           //ensure it's visible
         i++;
     }


### PR DESCRIPTION
This is a trivial patch. Colour is the last argument to SetCellBackgroundColour() not the first.