### PR TITLE
Make tide rectangles' displayed size depend screen resolution

### DIFF
--- a/include/chcanv.h
+++ b/include/chcanv.h
@@ -497,7 +497,8 @@ private:
       bool        warp_flag;
 
 
-      float       current_draw_scaler;
+      float       current_draw_scaler; // Affect displayed size of current arrows
+      float       tide_draw_scaler;    // Affect displayed size of tide rectangles
 
 
       wxTimer     *pPanTimer;       // This timer used for auto panning on route creation and edit

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -386,6 +386,7 @@ double                    g_ownship_predictor_minutes;
 double                    g_ownship_HDTpredictor_miles;
 
 int                       g_current_arrow_scale;
+int                       g_tide_rectangle_scale;
 
 Multiplexer               *g_pMUX;
 

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -280,6 +280,7 @@ extern ChartGroupArray  *g_pGroupArray;
 extern wxString         g_default_wp_icon;
 
 extern int              g_current_arrow_scale;
+extern int              g_tide_rectangle_scale;
 
 extern S57QueryDialog   *g_pObjectQueryDialog;
 extern ocpnStyle::StyleManager* g_StyleManager;
@@ -1051,8 +1052,15 @@ void ChartCanvas::SetDisplaySizeMM( double size )
     m_pix_per_mm = ( max_physical ) / ( (double) m_display_size_mm );
     m_canvas_scale_factor = ( max_physical ) / (m_display_size_mm /1000.);
     
-    int mm_per_knot = 10;
-    current_draw_scaler = mm_per_knot * m_pix_per_mm * g_current_arrow_scale / 100.0;
+    // set values of tide_draw_scaler, current_draw_scaler
+    // each "scaler" is intended to be about unity on a 100 dpi display,
+    // when its respective scale parameter is 100
+    // parameter g_tide_rectangle_scale is set in config file as value of TideRectangleScale
+    // parameter g_current_arrow_scale is set in config file as value of CurrentArrowScale
+    g_tide_rectangle_scale = wxMax(g_tide_rectangle_scale,0);
+    tide_draw_scaler = m_pix_per_mm * 0.254 * g_tide_rectangle_scale / 100.0;
+    g_current_arrow_scale = wxMax(g_current_arrow_scale,0);
+    current_draw_scaler = m_pix_per_mm * 0.254 * g_current_arrow_scale / 100.0;
     
 #ifdef USE_S57
     if( ps52plib )
@@ -5042,11 +5050,9 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
     //    Calculate meaningful SelectRadius
     float SelectRadius;
     int sel_rad_pix = 8;
-    if(g_btouch)
-        sel_rad_pix = 50;
-    
+    if(g_btouch) sel_rad_pix = 50;
     SelectRadius = sel_rad_pix / ( m_true_scale_ppm * 1852 * 60 );  // Degrees, approximately
-    
+
 ///
     // We start with Double Click processing. The first left click just starts a timer and
     // is remembered, then we actually do something if there is a LeftDClick.
@@ -8815,8 +8821,8 @@ void ChartCanvas::DrawAllTidesInBBox( ocpnDC& dc, LLBBox& BBox )
     wxBrush *pgreen_brush = wxTheBrushList->FindOrCreateBrush( GetGlobalColor( _T ( "GREEN1" ) ),
                             wxBRUSHSTYLE_SOLID );
 //        wxBrush *pblack_brush = wxTheBrushList->FindOrCreateBrush ( GetGlobalColor ( _T ( "UINFD" ) ), wxSOLID );
-    wxBrush *brc_1 = wxTheBrushList->FindOrCreateBrush( GetGlobalColor( _T ( "BLUE2" ) ), wxBRUSHSTYLE_SOLID );
-    wxBrush *brc_2 = wxTheBrushList->FindOrCreateBrush( GetGlobalColor( _T ( "YELO1" ) ), wxBRUSHSTYLE_SOLID );
+    wxBrush *pblue_brush = wxTheBrushList->FindOrCreateBrush( GetGlobalColor( _T ( "BLUE2" ) ), wxBRUSHSTYLE_SOLID );
+    wxBrush *pyelo_brush = wxTheBrushList->FindOrCreateBrush( GetGlobalColor( _T ( "YELO1" ) ), wxBRUSHSTYLE_SOLID );
 
     wxFont *dFont = FontMgr::Get().GetFont( _("ExtendedTideIcon") );
     dc.SetTextForeground( FontMgr::Get().GetFontColor( _("ExtendedTideIcon") ) );
@@ -8890,7 +8896,7 @@ void ChartCanvas::DrawAllTidesInBBox( ocpnDC& dc, LLBBox& BBox )
                                 time_t lttime = 0;
                                 time_t httime = 0;
                                 bool wt;
-                                //define if flood or edd in the last ten minutes and verify if data are useable
+                                //define if flood or ebb in the last ten minutes and verify if data are useable
                                 if( ptcmgr->GetTideFlowSens( t_this_now, BACKWARD_TEN_MINUTES_STEP,
                                                              pIDX->IDX_rec_num, nowlev, val, wt ) ) {
 
@@ -8925,61 +8931,78 @@ void ChartCanvas::DrawAllTidesInBBox( ocpnDC& dc, LLBBox& BBox )
                                         lttime = tctime;
                                         ltleve = val;
                                     }
+                
+				    // draw the tide rectangle:
+				    
+				    // tide icon rectangle has default pre-scaled width = 12 , height = 45
+				    // scale default size by tide_draw_scaler factor
+				    int width = (int) (12 * tide_draw_scaler + 0.5);
+				    int height = (int) (45 * tide_draw_scaler + 0.5);
+				    int linew = wxMax(1, (int) (tide_draw_scaler + 0.5));
+
+				    //std::cerr << "tide icon w=" << width << ", h=" << height;
+				    //std::cerr << ", linew=" << linew << ", scale=" << tide_draw_scaler << std::endl;
 
                                     //process tide state  ( %height and flow sens )
                                     float ts = 1 - ( ( nowlev - ltleve ) / ( htleve - ltleve ) );
                                     int hs = ( httime > lttime ) ? -5 : 5;
                                     if( ts > 0.995 || ts < 0.005 ) hs = 0;
-                                    int ht_y = (int) ( 45.0 * ts );
+                                    int ht_y = (int) ( height * ts );
 
-                                    //draw yellow rectangle as total amplitude (width = 12 , height = 45 )
+				    //draw yellow tide rectangle outlined in black
                                     dc.SetPen( *pblack_pen );
-                                    dc.SetBrush( *brc_2 );
-                                    dc.DrawRectangle( w, h, 12, 45 );
-                                    //draw blue rectangle as water height
+				    pblack_pen->SetWidth(linew);
+                                    dc.SetBrush( *pyelo_brush );
+                                    dc.DrawRectangle( w, h, width, height );
+
+                                    //draw blue rectangle as water height, smaller in width than yellow rectangle
                                     dc.SetPen( *pblue_pen );
-                                    dc.SetBrush( *brc_1 );
-                                    dc.DrawRectangle( w + 2, h + ht_y, 8, 45 - ht_y );
+                                    dc.SetBrush( *pblue_brush );
+                                    dc.DrawRectangle( (w + 2*linew), h + ht_y, 
+						      (width - (4*linew)), height - ht_y );
 
                                     //draw sens arrows (ensure they are not "under-drawn" by top line of blue rectangle )
-
                                     int hl;
                                     wxPoint arrow[3];
-                                    arrow[0].x = w + 1;
-                                    arrow[1].x = w + 5;
-                                    arrow[2].x = w + 11;
+                                    arrow[0].x = w + 2*linew;
+                                    arrow[1].x = w + width / 2;
+                                    arrow[2].x = w + width - 2*linew;
+				    pyelo_pen->SetWidth(linew);
+				    pblue_pen->SetWidth(linew);
                                     if( ts > 0.35 || ts < 0.15 )      // one arrow at 3/4 hight tide
                                     {
-                                        hl = (int) ( 45.0 * 0.25 ) + h;
+                                        hl = (int) ( height * 0.25 ) + h;
                                         arrow[0].y = hl;
                                         arrow[1].y = hl + hs;
                                         arrow[2].y = hl;
-                                        if( ts < 0.15 ) dc.SetPen( *pyelo_pen );
+                                        if( ts < 0.15 ) 
+					  dc.SetPen( *pyelo_pen );
                                         else
-                                            dc.SetPen( *pblue_pen );
-
+					  dc.SetPen( *pblue_pen );
                                         dc.DrawLines( 3, arrow );
                                     }
                                     if( ts > 0.60 || ts < 0.40 )       //one arrow at 1/2 hight tide
                                     {
-                                        hl = (int) ( 45.0 * 0.5 ) + h;
+                                        hl = (int) ( height * 0.5 ) + h;
                                         arrow[0].y = hl;
                                         arrow[1].y = hl + hs;
                                         arrow[2].y = hl;
-                                        if( ts < 0.40 ) dc.SetPen( *pyelo_pen );
+                                        if( ts < 0.40 ) 
+					  dc.SetPen( *pyelo_pen );
                                         else
-                                            dc.SetPen( *pblue_pen );
+					  dc.SetPen( *pblue_pen );
                                         dc.DrawLines( 3, arrow );
                                     }
                                     if( ts < 0.65 || ts > 0.85 )       //one arrow at 1/4 Hight tide
                                     {
-                                        hl = (int) ( 45.0 * 0.75 ) + h;
+                                        hl = (int) ( height * 0.75 ) + h;
                                         arrow[0].y = hl;
                                         arrow[1].y = hl + hs;
                                         arrow[2].y = hl;
-                                        if( ts < 0.65 ) dc.SetPen( *pyelo_pen );
+                                        if( ts < 0.65 ) 
+					  dc.SetPen( *pyelo_pen );
                                         else
-                                            dc.SetPen( *pblue_pen );
+					  dc.SetPen( *pblue_pen );
                                         dc.DrawLines( 3, arrow );
                                     }
                                     //draw tide level text
@@ -8990,7 +9013,7 @@ void ChartCanvas::DrawAllTidesInBBox( ocpnDC& dc, LLBBox& BBox )
                                             wxString( pmsd->units_abbrv, wxConvUTF8 ) );
                                     int wx1;
                                     dc.GetTextExtent( s, &wx1, NULL );
-                                    dc.DrawText( s, r.x - ( wx1 / 2 ), h + 45 );
+                                    dc.DrawText( s, r.x - ( wx1 / 2 ), h + height );
                                 }
                             }
                         }
@@ -9092,8 +9115,8 @@ void ChartCanvas::DrawAllCurrentsInBBox( ocpnDC& dc, LLBBox& BBox )
                     wxPoint r;
                     GetCanvasPointPix( lat, lon, &r );
 
-                    wxPoint d[4];
-                    int dd = 6;
+                    wxPoint d[4]; // points of a diamond at the current station location
+                    int dd = (int) (6.0 * current_draw_scaler);  
                     d[0].x = r.x;
                     d[0].y = r.y + dd;
                     d[1].x = r.x + dd;
@@ -9104,14 +9127,14 @@ void ChartCanvas::DrawAllCurrentsInBBox( ocpnDC& dc, LLBBox& BBox )
                     d[3].y = r.y;
 
                     if( ptcmgr->GetTideOrCurrent15( now, i, tcvalue, dir, bnew_val ) ) {
-                        porange_pen->SetWidth( 1 );
+                        pblack_pen->SetWidth( 1 );
                         dc.SetPen( *pblack_pen );
                         dc.SetBrush( *porange_brush );
                         dc.DrawPolygon( 4, d );
 
                         if( type == 'C' ) {
                             dc.SetBrush( *pblack_brush );
-                            dc.DrawCircle( r.x, r.y, 2 );
+                            dc.DrawCircle( r.x, r.y, (int)(2*current_draw_scaler) ); 
                         }
 
                         else if( ( type == 'c' ) && ( GetVP().chart_scale < 1000000 ) )
@@ -9121,22 +9144,24 @@ void ChartCanvas::DrawAllCurrentsInBBox( ocpnDC& dc, LLBBox& BBox )
 //    Get the display pixel location of the current station
                                 int pixxc, pixyc;
                                 wxPoint cpoint;
-                                GetCanvasPointPix( lat, lon, &cpoint );
+                                GetCanvasPointPix( lat, lon, &cpoint ); // called above; why do this again?
                                 pixxc = cpoint.x;
                                 pixyc = cpoint.y;
 
-//    Adjust drawing size using logarithmic scale
+//    Adjust drawing size using logarithmic scale. tcvalue is current in knots
                                 double a1 = fabs( tcvalue ) * 10.;
-                                a1 = wxMax(1.0, a1);      // Current values less than 0.1 knot
-                                // will be displayed as 0
+				// Current values <= 0.1 knot will have no arrow
+                                a1 = wxMax(1.0, a1);      
                                 double a2 = log10( a1 );
 
-                                double scale = current_draw_scaler * a2;
+				// scale to pass to DrawArrow. 0.4 is a reasonable factor here.
+				// adjust value of CurrentArrowScale in config file as needed
+                                float cscale = current_draw_scaler * a2 * 0.4;
 
                                 porange_pen->SetWidth( 2 );
                                 dc.SetPen( *porange_pen );
                                 DrawArrow( dc, pixxc, pixyc,
-                                           dir - 90 + ( skew_angle * 180. / PI ), scale / 100 );
+                                           dir - 90 + ( skew_angle * 180. / PI ), cscale );
 // Draw text, if enabled
 
                                 if( bDrawCurrentValues ) {

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -346,6 +346,7 @@ extern int              g_GroupIndex;
 
 extern bool             g_bDebugOGL;
 extern int              g_current_arrow_scale;
+extern int              g_tide_rectangle_scale;
 extern wxString         g_GPS_Ident;
 extern bool             g_bGarminHostUpload;
 extern wxString         g_uploadConnection;
@@ -1329,6 +1330,7 @@ int MyConfig::LoadMyConfig()
     Read( _T ( "RouteLineWidth" ), &g_route_line_width, 2 );
     Read( _T ( "TrackLineWidth" ), &g_track_line_width, 2 );
     Read( _T ( "CurrentArrowScale" ), &g_current_arrow_scale, 100 );
+    Read( _T ( "TideRectangleScale" ), &g_tide_rectangle_scale, 100 );
     Read( _T ( "DefaultWPIcon" ), &g_default_wp_icon, _T("triangle") );
 
     SetPath( _T ( "/MMSIProperties" ) );
@@ -2266,6 +2268,7 @@ void MyConfig::UpdateSettings()
     Write( _T ( "RouteLineWidth" ), g_route_line_width );
     Write( _T ( "TrackLineWidth" ), g_track_line_width );
     Write( _T ( "CurrentArrowScale" ), g_current_arrow_scale );
+    Write( _T ( "TideRectangleScale" ), g_tide_rectangle_scale );
     Write( _T ( "DefaultWPIcon" ), g_default_wp_icon );
 
     DeleteGroup(_T ( "/MMSIProperties" ));


### PR DESCRIPTION
The size of tide rectangles (the rectangular "icons" drawn on the
chart to show tide height at tide stations) was previously hard-coded
in terms of pixels, and so the rectangles become too small to be
readable on high-resolution displays. The changes in this commit make
the size of the tide rectangles depend on screen resolution, to be
readable on any display.

The changes also introduce a parameter TideRectangleScale, default
value 100, which can be set in the opencpn configuration file to allow
users to modify the scaling of the tide reactangles, by analogy with the
existing CurrentArrowScale parameter for adjusting displayed size of
current arrows.

The changes have been tested under Ubuntu 16.04 LTS and Windows 10, on
displays up to 3200x1800 resolution.

Cf. http://www.cruisersforum.com/forums/f134/opencpn-scaling-problems-with-high-resolution-displays-179462.html