### PR TITLE
Always show zero line on current graphs

### DIFF
--- a/include/TCWin.h
+++ b/include/TCWin.h
@@ -62,29 +62,30 @@ public:
       void RecalculateSize();
 
 private:
-    wxTextCtrl  *m_ptextctrl;
+    wxTextCtrl   *m_ptextctrl;
     wxTimer	  m_TCWinPopupTimer;
-    RolloverWin *m_pTCRolloverWin;
+    RolloverWin  *m_pTCRolloverWin;
     int           curs_x;
     int           curs_y;
-    int          m_plot_type;
+    int           m_plot_type;
     wxSize        m_tc_size;
-    wxPoint       m_position;
-    int           m_x;
-    int           m_y;
+    wxPoint       m_position; // window ULC in screen coordinates
+    int           m_x;        // x coord of mouse click that launched window
+    int           m_y;        // y coord of mouse click that launched window
     bool          m_created;
-    int           m_tsx;
-    int           m_tsy;
+    int           m_tsx;      // test button width
+    int           m_tsy;      // test button height
     
       IDX_entry   *pIDX;
       wxButton    *OK_button;
       wxButton    *NX_button;
       wxButton    *PR_button;
 
-      int         im;
-      int         ib;
-      int         it;
-      int         val_off;
+      int         im;  // span of values to graph
+      int         ib;  // minimum value to graph
+      int         it;  // maximum value to graph
+      int         val_off; // offset
+      int         i_skip; // vertical stride in graph
       wxRect    m_graph_rect;
 
 

--- a/src/TCWin.cpp
+++ b/src/TCWin.cpp
@@ -577,6 +577,19 @@ void TCWin::OnPaint( wxPaintEvent& event )
                 val_off = ib;
             }
 
+	    // Arrange to skip some lines and legends if there are too many for the vertical space we have
+	    int height_stext;
+	    dc.GetTextExtent( _T("1"), NULL, &height_stext );
+	    float available_lines = (float) m_graph_rect.height / height_stext;
+	    i_skip = (int) ceil(im / available_lines); 
+	    
+	    if( CURRENT_PLOT == m_plot_type && i_skip != 1) {
+	      // Adjust steps so slack current "0" line is always drawn on graph
+	      ib -= it % i_skip;
+	      it = -ib;
+	      im = 2 * it;
+	    }
+
 //    Build spline list of points
 
             m_sList.DeleteContents( true );
@@ -598,12 +611,6 @@ void TCWin::OnPaint( wxPaintEvent& event )
 
         //    Vertical Axis
 
-        //      Maybe skip some lines and legends if the range is too high
-        int height_stext;
-         dc.GetTextExtent( _T("1"), NULL, &height_stext );
-
-        int i_skip = 1;
-        if( height_stext > m_graph_rect.height / im ) i_skip = 2;
 
         i = ib;
         while( i < it + 1 ) {


### PR DESCRIPTION
In some circumstances, current graphs would be displayed without an
explicit "0" line, which would make it difficult to see the precise
times of slack current. This commit arranges the graph's  vertical
coordinates so that the "0" line of slack current is always displayed.

This implements (my own) flyspray feature request FS#2119.