### PR TITLE
Scale tide and current graph windows depending on screen resolution

### DIFF
--- a/include/TCWin.h
+++ b/include/TCWin.h
@@ -75,6 +75,7 @@ private:
     bool          m_created;
     int           m_tsx;      // test button width
     int           m_tsy;      // test button height
+    float         m_tcwin_scaler; // factor to scale TCWin and contents by
     
       IDX_entry   *pIDX;
       wxButton    *OK_button;

--- a/src/TCWin.cpp
+++ b/src/TCWin.cpp
@@ -196,13 +196,13 @@ TCWin::TCWin( ChartCanvas *parent, int x, int y, void *pvIDX )
     pLFont = FontMgr::Get().FindOrCreateFont( dlg_font_size+1, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_BOLD,
                                                       FALSE, wxString( _T ( "Arial" ) ) );
 
-    pblack_1 = wxThePenList->FindOrCreatePen( GetGlobalColor( _T ( "UINFD" ) ), 1,
+    pblack_1 = wxThePenList->FindOrCreatePen( GetGlobalColor( _T ( "UINFD" ) ), wxMax(1,(int)(m_tcwin_scaler+0.5)),
+					      wxPENSTYLE_SOLID );
+    pblack_2 = wxThePenList->FindOrCreatePen( GetGlobalColor( _T ( "UINFD" ) ), wxMax(2,(int)(2*m_tcwin_scaler+0.5)),
+					      wxPENSTYLE_SOLID );
+    pblack_3 = wxThePenList->FindOrCreatePen( GetGlobalColor( _T ( "UWHIT" ) ), wxMax(1,(int)(m_tcwin_scaler+0.5)),
                                                                           wxPENSTYLE_SOLID );
-    pblack_2 = wxThePenList->FindOrCreatePen( GetGlobalColor( _T ( "UINFD" ) ), 2,
-                                                                          wxPENSTYLE_SOLID );
-    pblack_3 = wxThePenList->FindOrCreatePen( GetGlobalColor( _T ( "UWHIT" ) ), 1,
-                                                                          wxPENSTYLE_SOLID );
-    pred_2 = wxThePenList->FindOrCreatePen( GetGlobalColor( _T ( "UINFR" ) ), 4,
+    pred_2 = wxThePenList->FindOrCreatePen( GetGlobalColor( _T ( "UINFR" ) ), wxMax(4,(int)(4*m_tcwin_scaler+0.5)),
                                                                         wxPENSTYLE_SOLID );
     pltgray = wxTheBrushList->FindOrCreateBrush( GetGlobalColor( _T ( "UIBCK" ) ),
                                                                                wxBRUSHSTYLE_SOLID );
@@ -284,14 +284,14 @@ void TCWin::RecalculateSize()
     int unscaledheight = 600;
     int unscaledwidth  = 650;
 
-    // value of tcwin_scaler should be about unity on a 100 dpi display,
+    // value of m_tcwin_scaler should be about unity on a 100 dpi display,
     // when scale parameter g_tcwin_scale is 100
     // parameter g_tcwin_scale is set in config file as value of TideCurrentWindowScale
     g_tcwin_scale = wxMax(g_tcwin_scale,10); // sanity check on g_tcwin_scale
-    float tcwin_scaler = g_Platform->GetDisplayDPmm() * 0.254 * g_tcwin_scale / 100.0;
+    m_tcwin_scaler = g_Platform->GetDisplayDPmm() * 0.254 * g_tcwin_scale / 100.0;
 
-    m_tc_size.x = (int) (unscaledwidth * tcwin_scaler + 0.5);
-    m_tc_size.y = (int) (unscaledheight * tcwin_scaler + 0.5);
+    m_tc_size.x = (int) (unscaledwidth * m_tcwin_scaler + 0.5);
+    m_tc_size.y = (int) (unscaledheight * m_tcwin_scaler + 0.5);
     
     m_tc_size.x = wxMin(m_tc_size.x, parent_size.x);
     m_tc_size.y = wxMin(m_tc_size.y, parent_size.y);
@@ -471,12 +471,12 @@ void TCWin::OnPaint( wxPaintEvent& event )
                     int x_shim = -20;
                     dc.DrawText( wxString( sbuf, wxConvUTF8 ), xd + x_shim + ( m_graph_rect.width / 25 ) / 2, m_graph_rect.y + m_graph_rect.height + 8 );
                 }
-                else{
+                else {
                     dc.SetPen( *pblack_1 );
                     dc.DrawLine( xd, m_graph_rect.y, xd, m_graph_rect.y + m_graph_rect.height + 5 );
                 }
             }
-            else{
+            else {
                 dc.SetPen( *pblack_1 );
                 dc.DrawLine( xd, m_graph_rect.y, xd, m_graph_rect.y + m_graph_rect.height + 5 );
                 wxString sst;
@@ -622,9 +622,10 @@ void TCWin::OnPaint( wxPaintEvent& event )
         while( i < it + 1 ) {
             int yd = m_graph_rect.y + ( m_plot_y_offset ) - ( ( i - val_off ) * m_graph_rect.height / im );
 
-            if( ( m_plot_y_offset + m_graph_rect.y ) == yd ) dc.SetPen( *pblack_2 );
+            if( ( m_plot_y_offset + m_graph_rect.y ) == yd ) 
+	      dc.SetPen( *pblack_2 );
             else
-                dc.SetPen( *pblack_1 );
+	      dc.SetPen( *pblack_1 );
 
             dc.DrawLine( m_graph_rect.x, yd, m_graph_rect.x + m_graph_rect.width, yd );
             snprintf( sbuf, 99, "%d", i );

--- a/src/TCWin.cpp
+++ b/src/TCWin.cpp
@@ -19,6 +19,8 @@ extern TCMgr *ptcmgr;
 extern wxString g_locale;
 extern OCPNPlatform *g_Platform;
 
+int g_tcwin_scale;
+
 enum
 {
       ID_TCWIN_NX,
@@ -279,16 +281,20 @@ void TCWin::RecalculateSize()
     if( pParent )
         parent_size = pParent->GetClientSize();
     
-    if(m_created)
-        m_tc_size.x = GetCharWidth() * 50;
-    else
-        m_tc_size.x = 650;
-        
+    int unscaledheight = 600;
+    int unscaledwidth  = 650;
+
+    // value of tcwin_scaler should be about unity on a 100 dpi display,
+    // when scale parameter g_tcwin_scale is 100
+    // parameter g_tcwin_scale is set in config file as value of TideCurrentWindowScale
+    g_tcwin_scale = wxMax(g_tcwin_scale,10); // sanity check on g_tcwin_scale
+    float tcwin_scaler = g_Platform->GetDisplayDPmm() * 0.254 * g_tcwin_scale / 100.0;
+
+    m_tc_size.x = (int) (unscaledwidth * tcwin_scaler + 0.5);
+    m_tc_size.y = (int) (unscaledheight * tcwin_scaler + 0.5);
     
     m_tc_size.x = wxMin(m_tc_size.x, parent_size.x);
-    m_tc_size.y = wxMin(600, parent_size.y);
-    
-
+    m_tc_size.y = wxMin(m_tc_size.y, parent_size.y);
    
     int xc = m_x + 8;
     int yc = m_y;

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -9015,20 +9015,21 @@ void ChartCanvas::DrawAllTidesInBBox( ocpnDC& dc, LLBBox& BBox )
 				    // scale default size by tide_draw_scaler factor
 				    int width = (int) (12 * tide_draw_scaler + 0.5);
 				    int height = (int) (45 * tide_draw_scaler + 0.5);
-				    int linew = wxMax(1, (int) (tide_draw_scaler + 0.5));
+				    int linew = wxMax(1, (int) (tide_draw_scaler));
 
 				    //std::cerr << "tide icon w=" << width << ", h=" << height;
 				    //std::cerr << ", linew=" << linew << ", scale=" << tide_draw_scaler << std::endl;
 
                                     //process tide state  ( %height and flow sens )
                                     float ts = 1 - ( ( nowlev - ltleve ) / ( htleve - ltleve ) );
-                                    int hs = ( httime > lttime ) ? -5 : 5;
+                                    int hs = ( httime > lttime ) ? -4 : 4;
+				    hs *= (int) (tide_draw_scaler + 0.5); 
                                     if( ts > 0.995 || ts < 0.005 ) hs = 0;
                                     int ht_y = (int) ( height * ts );
 
 				    //draw yellow tide rectangle outlined in black
-                                    dc.SetPen( *pblack_pen );
 				    pblack_pen->SetWidth(linew);
+                                    dc.SetPen( *pblack_pen );
                                     dc.SetBrush( *pyelo_brush );
                                     dc.DrawRectangle( w, h, width, height );
 
@@ -9193,7 +9194,7 @@ void ChartCanvas::DrawAllCurrentsInBBox( ocpnDC& dc, LLBBox& BBox )
                     GetCanvasPointPix( lat, lon, &r );
 
                     wxPoint d[4]; // points of a diamond at the current station location
-                    int dd = (int) (6.0 * current_draw_scaler);  
+                    int dd = (int) (5.0 * current_draw_scaler + 0.5);  
                     d[0].x = r.x;
                     d[0].y = r.y + dd;
                     d[1].x = r.x + dd;
@@ -9204,7 +9205,7 @@ void ChartCanvas::DrawAllCurrentsInBBox( ocpnDC& dc, LLBBox& BBox )
                     d[3].y = r.y;
 
                     if( ptcmgr->GetTideOrCurrent15( now, i, tcvalue, dir, bnew_val ) ) {
-                        pblack_pen->SetWidth( 1 );
+		      pblack_pen->SetWidth( wxMax(1, (int) (current_draw_scaler + 0.5)) );
                         dc.SetPen( *pblack_pen );
                         dc.SetBrush( *porange_brush );
                         dc.DrawPolygon( 4, d );
@@ -9232,10 +9233,10 @@ void ChartCanvas::DrawAllCurrentsInBBox( ocpnDC& dc, LLBBox& BBox )
                                 double a2 = log10( a1 );
 
 				// scale to pass to DrawArrow. 0.4 is a reasonable factor here.
-				// adjust value of CurrentArrowScale in config file as needed
+				// users can adjust value of CurrentArrowScale in config file as needed
                                 float cscale = current_draw_scaler * a2 * 0.4;
 
-                                porange_pen->SetWidth( 2 );
+                                porange_pen->SetWidth( wxMax(1, (int) (current_draw_scaler + 0.5)) );
                                 dc.SetPen( *porange_pen );
                                 DrawArrow( dc, pixxc, pixyc,
                                            dir - 90 + ( skew_angle * 180. / PI ), cscale );

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -348,6 +348,7 @@ extern int              g_GroupIndex;
 extern bool             g_bDebugOGL;
 extern int              g_current_arrow_scale;
 extern int              g_tide_rectangle_scale;
+extern int              g_tcwin_scale;
 extern wxString         g_GPS_Ident;
 extern bool             g_bGarminHostUpload;
 extern wxString         g_uploadConnection;
@@ -1338,6 +1339,7 @@ int MyConfig::LoadMyConfig()
     Read( _T ( "TrackLineWidth" ), &g_track_line_width, 2 );
     Read( _T ( "CurrentArrowScale" ), &g_current_arrow_scale, 100 );
     Read( _T ( "TideRectangleScale" ), &g_tide_rectangle_scale, 100 );
+    Read( _T ( "TideCurrentWindowScale" ), &g_tcwin_scale, 100 );
     Read( _T ( "DefaultWPIcon" ), &g_default_wp_icon, _T("triangle") );
 
     SetPath( _T ( "/MMSIProperties" ) );
@@ -2281,6 +2283,7 @@ void MyConfig::UpdateSettings()
     Write( _T ( "TrackLineWidth" ), g_track_line_width );
     Write( _T ( "CurrentArrowScale" ), g_current_arrow_scale );
     Write( _T ( "TideRectangleScale" ), g_tide_rectangle_scale );
+    Write( _T ( "TideCurrentWindowScale" ), g_tcwin_scale );
     Write( _T ( "DefaultWPIcon" ), g_default_wp_icon );
 
     DeleteGroup(_T ( "/MMSIProperties" ));


### PR DESCRIPTION
Even in Beta 4.5.213, tide and current graph windows (instances of TCWin)
do not render well on high-resolution displays because the window size
is too small. This commit addresses this problem by scaling each TCWin by
a factor that depends on the screen resolution.

This commit also introduces a configuration file parameter
TideCurrentWindowScale, default value 100, which allows the user to
modify the scaling, along the lines of the existing parameters
CurrentArrowScale and TideRectangleScale.

Cf. http://www.cruisersforum.com/forums/f134/opencpn-scaling-problems-with-high-resolution-displays-179462.html#post2316692