### PR TITLE
This adds US ACE "Inland ENC Buoy Overlay" and "Inland ENC SW Pass Ov…

### DIFF
--- a/plugins/chartdldr_pi/data/chart_sources.xml
+++ b/plugins/chartdldr_pi/data/chart_sources.xml
@@ -839,6 +839,16 @@
               <location>http://www.ienccloud.us/ienc/products/catalog/IENCU37ProductsCatalog.xml</location>
               <dir>{USERDATA}/ENC/US_INLAND</dir>
             </catalog>
+            <catalog>
+              <name>US ACE Inland ENC Buoy Overlay</name>
+              <location>http://www.ienccloud.us/ienc/products/catalog/IENCBuoyProductsCatalog.xml</location>
+              <dir>{USERDATA}/ENC/US_INLAND_BUOYS</dir>
+            </catalog>
+            <catalog>
+              <name>US ACE Inland ENC SW Pass Overlay</name>
+              <location>http://www.ienccloud.us/ienc/products/catalog/IENCSWPassProductsCatalog.xml</location>
+              <dir>{USERDATA}/ENC/US_INLAND_OVERLAYS</dir>
+            </catalog>
           </catalogs>
         </section>
       </sections>

--- a/plugins/chartdldr_pi/src/chartcatalog.h
+++ b/plugins/chartdldr_pi/src/chartcatalog.h
@@ -90,7 +90,7 @@ public:
     virtual wxDateTime GetUpdateDatetime() { return zipfile_datetime_iso8601; }
 
     // public properties
-    wxString number;
+    wxString number; // chart number used for zip file name, BSB name, cell number  .Paul. 
     wxString title; //RNC: <title>, ENC:<lname>
     wxArrayString *coast_guard_districts;
     wxArrayString *states;
@@ -132,7 +132,7 @@ public:
     // public methods
 
     //public properties
-    wxString name;
+    //wxString name;  use wxString number in class Chart .Paul.
     wxString src_chart;
     int cscale;
     wxString status;
@@ -153,7 +153,7 @@ public:
     wxDateTime GetUpdateDatetime();
 
     //public properties
-    wxString name;
+    //wxString name;  use wxString number in class Chart .Paul.
     Location *location;
     wxString river_name;
     RiverMiles *river_miles;


### PR DESCRIPTION
…erlay"

This adds two catalogs,  "Inland ENC Buoy Overlay" and "Inland ENC SW Pass Overlay", to chart_sources.xml in chartdldr_pi. The catalogs are maintained by the US Army Corps of Engineers. There is one IENC overlay in each catalog.

The Buoy Overlay shows the navigation buoys that are maintained and repositioned by the US Coast Guard. The buoys are relocated for changing river stages, shoaling, etc. These buoys are not shown the many river charts produced by the Corps. The existing chart downloader plugin can download these river charts. The chart downloader should be able to download the Buoy Overlay. This pull request (PR) adds the Buoy Overlay to the chart downloader.

The SW Pass Overlay contains newer sounding data for the Southwest Pass of the Mississippi
River than is on the NOAA ENC. This overlay is of interest mostly for operators of deep draft vessels.

The chartcatalog.cpp and chartcatalog.h are revised to parse and display the new catalogs. Also, a minor bug in the generation of records (lines) within chartdldr_pi.dat is fixed for IENC and ENC charts. It was "minor" in that the chartdldr_pi corrected the records for chart names that begin with a letter, but failed write correct records for chart names beginning with a digit. So, it failed for the 3UABUOYS and 3UASW000 overlay chart names. This was not a bug for RNC file names.

Submitted by .Paul. (Paul Wood)