### PR TITLE
Remove sha1 from ENC thumbnail bitmap file name.

### DIFF
--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -3633,7 +3633,7 @@ InitReturn s57chart::PostInit( ChartInitFlag flags, ColorScheme cs )
         SENCdir.Append( wxFileName::GetPathSeparator() );
     
     wxFileName s57File(m_SENCFileName);
-    wxFileName ThumbFileName( SENCdir, s57File.GetName(), _T("BMP") );
+    wxFileName ThumbFileName( SENCdir, s57File.GetName().Mid( 13 ), _T("BMP") );
 
     if( !ThumbFileName.FileExists() || m_bneed_new_thumbnail )
         BuildThumbnail( ThumbFileName.GetFullPath() );


### PR DESCRIPTION
This allows the ENC thumbnail to be shown after a restart without first displaying the ENC.