### PR TITLE
CompressImageRGBpow2_Flatten_Throttle_Abort: deal with image smaller …

### DIFF
--- a/src/texcmp/squish/squish.cpp
+++ b/src/texcmp/squish/squish.cpp
@@ -307,6 +307,10 @@ void CompressImageRGBpow2_Flatten_Throttle_Abort( u8 const* rgb, int width, int 
     
     // loop over blocks
     double tt = 0;
+
+    int bw = std::min(width, 4);
+    int bh = std::min(height, 4);
+                
     for( int y = 0; y < height; y += 4 )
     {
         for( int x = 0; x < width; x += 4 )
@@ -320,8 +324,8 @@ void CompressImageRGBpow2_Flatten_Throttle_Abort( u8 const* rgb, int width, int 
                 for( int px = 0; px < 4; ++px )
                 {
                     // get the source pixel in the image
-                    int sx = x + px;
-                    int sy = y + py;
+                    int sx = x + (px % bw);
+                    int sy = y + (py % bh);
                     
                     // copy the rgba value
                     u8 const* sourcePixel = rgb + 3*( width*sy + sx );


### PR DESCRIPTION
…than 4x4 pixels

Hi,
Before mipmaps were on only up to level 4 thus bigger than 4x4 for common texture sizes.  

Copied from Nvidia NvidiaTextureTools squish.

Regards
Didier

NB.
There's still races in gl textures handling, this patch solves some core dumps but not all.



