### PR TITLE
Plugin API 1.14 - Externalize AIS drawing

### DIFF
--- a/include/FontMgr.h
+++ b/include/FontMgr.h
@@ -46,6 +46,7 @@ class FontMgr
         void SetLocale( wxString &newLocale );
         wxFont *GetFont(const wxString &TextElement, int default_size = 0);
         wxColour GetFontColor( const wxString &TextElement ) const;
+        bool SetFontColor( const wxString &TextElement, const wxColour color ) const;
     
         int GetNumFonts(void) const;
         const wxString & GetConfigString(int i) const;

--- a/include/ais.h
+++ b/include/ais.h
@@ -228,8 +228,8 @@ wxString ais_get_status(int index);
 wxString ais_get_type(int index);
 wxString ais_get_short_type(int index);
 
-void AISDrawAreaNotices (ocpnDC& dc );
-void AISDraw(ocpnDC& dc);
+void AISDrawAreaNotices (ocpnDC& dc, ViewPort &vp, ChartCanvas *cp );
+void AISDraw(ocpnDC& dc, ViewPort &vp, ChartCanvas *cp );
 bool AnyAISTargetsOnscreen( ViewPort &vp );
 
 

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -50,7 +50,7 @@ class wxGLContext;
 //    PlugIns conforming to API Version less then the most modern will also
 //    be correctly supported.
 #define API_VERSION_MAJOR           1
-#define API_VERSION_MINOR           13
+#define API_VERSION_MINOR           14
 
 //    Fwd Definitions
 class       wxFileConfig;
@@ -58,6 +58,7 @@ class       wxNotebook;
 class       wxFont;
 class       wxAuiManager;
 class       wxScrolledWindow;
+class       wxGLCanvas;
 
 //---------------------------------------------------------------------------------------------------------
 //
@@ -513,6 +514,14 @@ public:
     virtual bool KeyboardEventHook( wxKeyEvent &event );
     virtual void OnToolbarToolDownCallback(int id);
     virtual void OnToolbarToolUpCallback(int id);
+};
+
+class DECL_EXP opencpn_plugin_114 : public opencpn_plugin_113
+{
+public:
+  opencpn_plugin_114(void *pmgr);
+  virtual ~opencpn_plugin_114();
+
 };
 
 //------------------------------------------------------------------
@@ -1200,5 +1209,12 @@ private:
 //extern const wxEventType DECL_EXP wxEVT_DOWNLOAD_EVENT;
 
 extern WXDLLIMPEXP_CORE const wxEventType wxEVT_DOWNLOAD_EVENT;
+
+// API 1.14 Extra canvas Support
+
+/* Allow drawing of objects onto other OpenGL canvases */
+extern void PlugInAISDrawGL( wxGLCanvas* glcanvas, const PlugIn_ViewPort& vp );
+extern wxColour PlugInGetFontColor(const wxString TextElement);
+extern bool PlugInSetFontColor(const wxString TextElement, const wxColour color);
 
 #endif //_PLUGIN_H_

--- a/src/FontMgr.cpp
+++ b/src/FontMgr.cpp
@@ -122,6 +122,25 @@ wxColour FontMgr::GetFontColor( const wxString &TextElement ) const
     return wxColour( 0, 0, 0 );
 }
 
+bool FontMgr::SetFontColor( const wxString &TextElement, const wxColour color ) const
+{
+  //    Look thru the font list for a match
+  MyFontDesc *pmfd;
+  wxNode *node = (wxNode *) ( m_fontlist->GetFirst() );
+  while( node ) {
+    pmfd = (MyFontDesc *) node->GetData();
+    if( pmfd->m_dialogstring == TextElement ) {
+      if(pmfd->m_configstring.BeforeFirst('-') == s_locale) {
+        pmfd->m_color = color;
+        return true;
+      }
+    }
+    node = node->GetNext();
+  }
+
+  return false;
+}
+
 wxString FontMgr::GetFontConfigKey( const wxString &description )
 {
     // Create the configstring by combining the locale with

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -4468,8 +4468,8 @@ void ChartCanvas::UpdateAIS()
 
         // Draw the AIS Targets on the temp_dc
         ocpnDC ocpndc = ocpnDC( temp_dc );
-        AISDraw( ocpndc );
-        AISDrawAreaNotices( ocpndc );
+        AISDraw( ocpndc, GetVP(), this );
+        AISDrawAreaNotices( ocpndc, GetVP(), this );
 
         //  Retrieve the drawing extents
         ais_rect = wxRect( temp_dc.MinX(), temp_dc.MinY(), temp_dc.MaxX() - temp_dc.MinX(),
@@ -8441,7 +8441,7 @@ void ChartCanvas::DrawOverlayObjects( ocpnDC &dc, const wxRegion& ru )
         g_pi_manager->RenderAllCanvasOverlayPlugIns( dc, GetVP() );
     }
 
-    AISDrawAreaNotices( dc );
+    AISDrawAreaNotices( dc, GetVP(), this);
     DrawEmboss( dc, EmbossDepthScale( ) );
     DrawEmboss( dc, EmbossOverzoomIndicator( dc ) );
 
@@ -8456,7 +8456,7 @@ void ChartCanvas::DrawOverlayObjects( ocpnDC &dc, const wxRegion& ru )
     DrawAllWaypointsInBBox( dc, GetVP().GetBBox() );
     DrawAnchorWatchPoints( dc );
 
-    AISDraw( dc );
+    AISDraw( dc, GetVP(), this );
     ShipDraw( dc );
     AlertDraw( dc );
 

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -2139,10 +2139,10 @@ void glChartCanvas::DrawFloatingOverlayObjects( ocpnDC &dc )
     }
 
     // all functions called with cc1-> are still slow because they go through ocpndc
-    AISDrawAreaNotices( dc );
+    AISDrawAreaNotices( dc, cc1->GetVP(), cc1 );
 
     cc1->DrawAnchorWatchPoints( dc );
-    AISDraw( dc );
+    AISDraw( dc, cc1->GetVP(), cc1 );
     ShipDraw( dc );
     cc1->AlertDraw( dc );
 

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -505,6 +505,7 @@ bool PlugInManager::CallLateInit(void)
             case 111:
             case 112:
             case 113:
+            case 114:
                 if(pic->m_cap_flag & WANTS_LATE_INIT) {
                     wxString msg(_T("PlugInManager: Calling LateInit PlugIn: "));
                     msg += pic->m_plugin_file;
@@ -536,6 +537,7 @@ void PlugInManager::SendVectorChartObjectInfo(const wxString &chart, const wxStr
                 {
                 case 112:
                 case 113:
+                case 114:
                 {
                     opencpn_plugin_112 *ppi = dynamic_cast<opencpn_plugin_112 *>(pic->m_pplugin);
                     if(ppi)
@@ -1295,6 +1297,10 @@ PlugInContainer *PlugInManager::LoadPlugIn(wxString plugin_file)
     case 113:
         pic->m_pplugin = dynamic_cast<opencpn_plugin_113*>(plug_in);
         break;
+
+    case 114:
+        pic->m_pplugin = dynamic_cast<opencpn_plugin_114*>(plug_in);
+        break;
         
     default:
         break;
@@ -1359,6 +1365,7 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &v
                     case 111:
                     case 112:
                     case 113:
+                    case 114:
                     {
                         opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                         if(ppi)
@@ -1411,6 +1418,7 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &v
                     case 111:
                     case 112:
                     case 113:
+                    case 114:
                     {
                         opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                         if(ppi)
@@ -1473,6 +1481,7 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, cons
                 case 111:
                 case 112:
                 case 113:
+                case 114:
                 {
                     opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                     if(ppi)
@@ -1503,6 +1512,7 @@ bool PlugInManager::SendMouseEventToPlugins( wxMouseEvent &event)
                 {
                     case 112:
                     case 113:
+                    case 114:
                     {
                         opencpn_plugin_112 *ppi = dynamic_cast<opencpn_plugin_112*>(pic->m_pplugin);
                             if(ppi)
@@ -1535,6 +1545,7 @@ bool PlugInManager::SendKeyEventToPlugins( wxKeyEvent &event)
                     switch(pic->m_api_version)
                     {
                         case 113:
+                        case 114:
                         {
                             opencpn_plugin_113 *ppi = dynamic_cast<opencpn_plugin_113*>(pic->m_pplugin);
                             if(ppi && ppi->KeyboardEventHook( event ))
@@ -1596,6 +1607,7 @@ void NotifySetupOptionsPlugin( PlugInContainer *pic )
             case 111:
             case 112:
             case 113:
+            case 114:
             {
                 opencpn_plugin_19 *ppi = dynamic_cast<opencpn_plugin_19 *>(pic->m_pplugin);
                 if(ppi) {
@@ -1771,6 +1783,7 @@ void PlugInManager::SendMessageToAllPlugins(const wxString &message_id, const wx
                 case 111:
                 case 112:
                 case 113:
+                case 114:
                 {
                     opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                     if(ppi)
@@ -1849,6 +1862,7 @@ void PlugInManager::SendPositionFixToAllPlugIns(GenericPosDatEx *ppos)
                 case 111:
                 case 112:
                 case 113:
+                case 114:
                 {
                     opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                     if(ppi)
@@ -3712,6 +3726,18 @@ bool opencpn_plugin_113::KeyboardEventHook( wxKeyEvent &event )
 
 void opencpn_plugin_113::OnToolbarToolDownCallback(int id) {}
 void opencpn_plugin_113::OnToolbarToolUpCallback(int id) {}
+
+
+//    Opencpn_Plugin_114 Implementation
+opencpn_plugin_114::opencpn_plugin_114(void *pmgr)
+: opencpn_plugin_113(pmgr)
+{
+}
+
+opencpn_plugin_114::~opencpn_plugin_114(void)
+{
+}
+
 
 //          Helper and interface classes
 
@@ -6309,3 +6335,25 @@ bool PlugInManager::HandleCurlThreadError(wxCurlThreadError err, wxCurlBaseThrea
 }
 #endif
 #endif
+
+/* API 1.14 */
+
+void PlugInAISDrawGL( wxGLCanvas* glcanvas, const PlugIn_ViewPort &vp )
+{
+  ViewPort ocpn_vp = CreateCompatibleViewport(vp);
+
+  ocpnDC dc(*glcanvas);
+
+  AISDraw(dc, ocpn_vp, NULL);
+}
+
+wxColour PlugInGetFontColor(const wxString TextElement)
+{
+  return FontMgr::Get().GetFontColor(TextElement);
+}
+
+bool PlugInSetFontColor(const wxString TextElement, const wxColour color)
+{
+  return FontMgr::Get().SetFontColor(TextElement, color);
+}
+


### PR DESCRIPTION
The BR24radar_pi group is adding (M)ARPA support for which we are sending ARPA targets to OpenCPN.

We would like to be able to draw these on the radar-only PPI windows, with the added bonus that we also see the AIS targets on the PPI display. This is also what the Navico plotters do.

This commit refactors ais.cpp in as minimal a fashion as possible so that it allows sharing of the AIS drawing code with the plugin(s).