### PR TITLE
various Cleanup

### DIFF
--- a/include/glTextureManager.h
+++ b/include/glTextureManager.h
@@ -167,7 +167,5 @@ class glTextureDescriptor;
 void GetFullMap( glTextureDescriptor *ptd,  const wxRect &rect, wxString chart_path, int level);
 int TextureDim(int level);
 int TextureTileSize(int level, bool compressed);
-bool CompressUsingGPU(const unsigned char *data, int dim, int size,
-                      unsigned char *tex_data, int level, bool inplace);
 
 #endif

--- a/include/glTextureManager.h
+++ b/include/glTextureManager.h
@@ -92,7 +92,7 @@ public:
     bool DoJob(const wxRect &rect);
     
     glTexFactory *pFact;
-    wxRect       rect;
+    wxRect      m_rect;
     int         level_min_request;
     int         ident;
     bool        b_throttle;

--- a/include/s52plib.h
+++ b/include/s52plib.h
@@ -128,6 +128,7 @@ public:
     void SetGLRendererString(const wxString &renderer);
 
     bool ObjectRenderCheck( ObjRazRules *rzRules, ViewPort *vp );
+    bool ObjectRenderCheckRules( ObjRazRules *rzRules, ViewPort *vp, bool check_noshow = false );
     bool ObjectRenderCheckPos( ObjRazRules *rzRules, ViewPort *vp );
     bool ObjectRenderCheckCat( ObjRazRules *rzRules, ViewPort *vp );
     bool ObjectRenderCheckCS( ObjRazRules *rzRules, ViewPort *vp );

--- a/src/glTextureManager.cpp
+++ b/src/glTextureManager.cpp
@@ -384,8 +384,8 @@ int TextureTileSize(int level, bool compressed)
 
 bool JobTicket::DoJob()
 {
-    if(!rect.IsEmpty())
-        return DoJob(rect);
+    if(!m_rect.IsEmpty())
+        return DoJob(m_rect);
 
     // otherwise this ticket covers all the rects in the chart
     ChartBase *pchart = ChartData->OpenChartFromDB( m_ChartPath, FULL_INIT );
@@ -892,7 +892,7 @@ void glTextureManager::OnEvtThread( OCPN_CompressionThreadEvent & event )
                     ticket->ident, GetRunningJobCount(), (unsigned long)todo_list.GetCount());
     } else if(!b_inCompressAllCharts) {
         //   Normal completion from here
-        glTextureDescriptor *ptd = ticket->pFact->GetpTD( ticket->rect );
+        glTextureDescriptor *ptd = ticket->pFact->GetpTD( ticket->m_rect );
         if(ptd) {
             for(int i=0 ; i < g_mipmap_max_level+1 ; i++)
                 ptd->comp_array[i] = ticket->comp_bits_array[i];
@@ -1006,7 +1006,7 @@ bool glTextureManager::ScheduleJob(glTexFactory* client, const wxRect &rect, int
         wxJobListNode *node = todo_list.GetFirst();
         while(node){
             JobTicket *ticket = node->GetData();
-            if( (ticket->m_ChartPath == chart_path) && (ticket->rect == rect)) {
+            if( (ticket->m_ChartPath == chart_path) && (ticket->m_rect == rect)) {
                 // bump to front
                 todo_list.DeleteNode(node);
                 todo_list.Insert(ticket);
@@ -1021,7 +1021,7 @@ bool glTextureManager::ScheduleJob(glTexFactory* client, const wxRect &rect, int
         wxJobListNode *tnode = running_list.GetFirst();
         while(tnode){
             JobTicket *ticket = tnode->GetData();
-            if(ticket->rect == rect &&
+            if(ticket->m_rect == rect &&
                ticket->m_ChartPath == chart_path) {
                 return false;
             }
@@ -1031,9 +1031,9 @@ bool glTextureManager::ScheduleJob(glTexFactory* client, const wxRect &rect, int
     
     JobTicket *pt = new JobTicket;
     pt->pFact = client;
-    pt->rect = rect;
+    pt->m_rect = rect;
     pt->level_min_request = level;
-    glTextureDescriptor *ptd = client->GetOrCreateTD( pt->rect );
+    glTextureDescriptor *ptd = client->GetOrCreateTD( pt->m_rect );
     pt->ident = (ptd->tex_name << 16) + level;
     pt->b_throttle = b_throttle_thread;
     pt->m_ChartPath = chart_path;
@@ -1094,7 +1094,7 @@ bool glTextureManager::StartTopJob()
 
     todo_list.DeleteNode(node);
 
-    glTextureDescriptor *ptd = ticket->pFact->GetpTD( ticket->rect );
+    glTextureDescriptor *ptd = ticket->pFact->GetpTD( ticket->m_rect );
     // don't need the job if we already have the compressed data
     if(ptd->comp_array[0]) {
         delete ticket;

--- a/src/glTextureManager.cpp
+++ b/src/glTextureManager.cpp
@@ -176,7 +176,7 @@ int CompareInts(int n1, int n2)
     return (int)(d1 - d2);
 }
 
-MySortedArrayInt idx_sorted_by_distance(CompareInts);
+static MySortedArrayInt idx_sorted_by_distance(CompareInts);
 
 class compress_target
 {
@@ -204,6 +204,7 @@ JobTicket::JobTicket()
  *   when compressed anyway, and this way the compression algorithm will use
  *   the exact same color in  adjacent 4x4 tiles and the result is nicer for our purpose.
  *   the lz4 compressed texture is smaller as well. */
+static 
 void FlattenColorsForCompression(unsigned char *data, int dim, bool swap_colors=true)
 {
     #ifdef __WXMSW__ /* undo BGR flip from ocpn_pixel (if ocpnUSE_ocpnBitmap is defined) */
@@ -226,6 +227,7 @@ void FlattenColorsForCompression(unsigned char *data, int dim, bool swap_colors=
 }
 
 /* return malloced data which is the etc compressed texture of the source */
+static 
 void CompressDataETC(const unsigned char *data, int dim, int size,
                      unsigned char *tex_data, volatile bool &b_abort)
 {
@@ -249,6 +251,7 @@ void CompressDataETC(const unsigned char *data, int dim, int size,
     }
 }
 
+static
 bool CompressUsingGPU(const unsigned char *data, int dim, int size,
                       unsigned char *tex_data, int level, bool inplace)
 {
@@ -290,6 +293,7 @@ bool CompressUsingGPU(const unsigned char *data, int dim, int size,
     return true;
 }
 
+static 
 void GetLevel0Map( glTextureDescriptor *ptd,  const wxRect &rect, wxString &chart_path )
 {
     // Load level 0 uncompressed data

--- a/src/glTextureManager.cpp
+++ b/src/glTextureManager.cpp
@@ -909,7 +909,6 @@ void glTextureManager::OnEvtThread( OCPN_CompressionThreadEvent & event )
             // We need to force a refresh to replace the uncompressed texture
             // This frees video memory and is also really required if we had
             // gone up a mipmap level
-            extern ChartCanvas *cc1;
             if(cc1) {
                 glChartCanvas::Invalidate(); // ensure we refresh
                 cc1->Refresh();

--- a/src/s52plib.cpp
+++ b/src/s52plib.cpp
@@ -5901,45 +5901,8 @@ int s52plib::DoRenderObject( wxDC *pdcin, ObjRazRules *rzRules, ViewPort *vp )
 //        if(!strncmp(rzRules->obj->FeatureName, "berths", 6))
 //            int yyp = 0;
 
-    if( !ObjectRenderCheckPos( rzRules, vp ) )
+    if( !ObjectRenderCheckRules( rzRules, vp, true ) )
         return 0;
-    
-    if( IsObjNoshow( rzRules->LUP->OBCL) )
-        return 0;
-        
-    if( !ObjectRenderCheckCat( rzRules, vp ) ) {
-
-        //  If this object cannot be moved to a higher category by CS procedures,
-        //  then we are done here
-        if(!rzRules->obj->m_bcategory_mutable)
-            return 0;
-
-        // already added, nothing below can change its display category        
-        if(rzRules->obj->bCS_Added ) 
-            return 0;
-
-        //  Otherwise, make sure the CS, if present, has been evaluated,
-        //  and then check the category again    
-        //  no rules 
-        if( !ObjectRenderCheckCS( rzRules, vp ) )
-            return 0;
-
-
-        rzRules->obj->CSrules = NULL;
-        Rules *rules = rzRules->LUP->ruleList;
-        while( rules != NULL ) {
-            if( RUL_CND_SY ==  rules->ruleType ){
-                GetAndAddCSRules( rzRules, rules );
-                rzRules->obj->bCS_Added = 1; // mark the object
-                break;
-            }
-            rules = rules->next;
-        }
-        
-        // still not displayable    
-        if( !ObjectRenderCheckCat( rzRules, vp ) ) 
-            return 0;
-    }
 
     m_pdc = pdcin; // use this DC
     Rules *rules = rzRules->LUP->ruleList;
@@ -6039,46 +6002,9 @@ int s52plib::DoRenderObjectTextOnly( wxDC *pdcin, ObjRazRules *rzRules, ViewPort
 //    if(rzRules->obj->Index != 636)
 //        return 0;
     
-    if( !ObjectRenderCheckPos( rzRules, vp ) )
+    if( !ObjectRenderCheckRules( rzRules, vp, true ) )
         return 0;
-    
-    if( IsObjNoshow( rzRules->LUP->OBCL) )
-        return 0;
-    
-    if( !ObjectRenderCheckCat( rzRules, vp ) ) {
-        
-        //  If this object cannot be moved to a higher category by CS procedures,
-        //  then we are done here
-        if(!rzRules->obj->m_bcategory_mutable)
-            return 0;
-        
-        // already added, nothing below can change its display category        
-        if(rzRules->obj->bCS_Added ) 
-            return 0;
-        
-        //  Otherwise, make sure the CS, if present, has been evaluated,
-        //  and then check the category again    
-        //  no rules 
-        if( !ObjectRenderCheckCS( rzRules, vp ) )
-            return 0;
-        
-        
-        rzRules->obj->CSrules = NULL;
-        Rules *rules = rzRules->LUP->ruleList;
-        while( rules != NULL ) {
-            if( RUL_CND_SY ==  rules->ruleType ){
-                GetAndAddCSRules( rzRules, rules );
-                rzRules->obj->bCS_Added = 1; // mark the object
-                break;
-            }
-            rules = rules->next;
-        }
-        
-        // still not displayable    
-        if( !ObjectRenderCheckCat( rzRules, vp ) ) 
-            return 0;
-    }
-    
+
     m_pdc = pdcin; // use this DC
     Rules *rules = rzRules->LUP->ruleList;
     
@@ -8173,42 +8099,8 @@ void s52plib::RenderPolytessGL(ObjRazRules *rzRules, ViewPort *vp, double z_clip
 
 int s52plib::RenderAreaToGL( const wxGLContext &glcc, ObjRazRules *rzRules, ViewPort *vp )
 {
-    if( !ObjectRenderCheckPos( rzRules, vp ) )
+    if( !ObjectRenderCheckRules( rzRules, vp ) )
         return 0;
-
-    if( !ObjectRenderCheckCat( rzRules, vp ) ) {
-
-        //  If this object cannot be moved to a higher category by CS procedures,
-        //  then we are done here
-        if(!rzRules->obj->m_bcategory_mutable)
-            return 0;
-
-        // already added, nothing below can change its display category        
-        if(rzRules->obj->bCS_Added ) 
-            return 0;
-
-        //  Otherwise, make sure the CS, if present, has been evaluated,
-        //  and then check the category again    
-        //  no rules 
-        if( !ObjectRenderCheckCS( rzRules, vp ) )
-            return 0;
-
-
-        rzRules->obj->CSrules = NULL;
-        Rules *rules = rzRules->LUP->ruleList;
-        while( rules != NULL ) {
-            if( RUL_CND_SY ==  rules->ruleType ){
-                GetAndAddCSRules( rzRules, rules );
-                rzRules->obj->bCS_Added = 1; // mark the object
-                break;
-            }
-            rules = rules->next;
-        }
-        
-        // still not displayable    
-        if( !ObjectRenderCheckCat( rzRules, vp ) ) 
-            return 0;
-    }
 
     Rules *rules = rzRules->LUP->ruleList;
 
@@ -8542,41 +8434,8 @@ int s52plib::RenderAreaToDC( wxDC *pdcin, ObjRazRules *rzRules, ViewPort *vp,
         render_canvas_parms *pb_spec )
 {
 
-    if( !ObjectRenderCheckPos( rzRules, vp ) )
+    if( !ObjectRenderCheckRules( rzRules, vp ) )
         return 0;
-
-    if( !ObjectRenderCheckCat( rzRules, vp ) ) {
-
-        //  If this object cannot be moved to a higher category by CS procedures,
-        //  then we are done here
-        if(!rzRules->obj->m_bcategory_mutable)
-            return 0;
-
-        // already added, nothing below can change its display category        
-        if(rzRules->obj->bCS_Added ) 
-            return 0;
-
-        //  Otherwise, make sure the CS, if present, has been evaluated,
-        //  and then check the category again    
-        //  no rules 
-        if( !ObjectRenderCheckCS( rzRules, vp ) )
-            return 0;
-
-        rzRules->obj->CSrules = NULL;
-        Rules *rules = rzRules->LUP->ruleList;
-        while( rules != NULL ) {
-            if( RUL_CND_SY ==  rules->ruleType ){
-                GetAndAddCSRules( rzRules, rules );
-                rzRules->obj->bCS_Added = 1; // mark the object
-                break;
-            }
-            rules = rules->next;
-        }
-        
-        // still not displayable    
-        if( !ObjectRenderCheckCat( rzRules, vp ) ) 
-            return 0;
-    }
 
     m_pdc = pdcin; // use this DC
     Rules *rules = rzRules->LUP->ruleList;
@@ -8872,6 +8731,51 @@ bool s52plib::ObjectRenderCheckCat( ObjRazRules *rzRules, ViewPort *vp )
 
     return b_visible;
 }
+
+bool s52plib::ObjectRenderCheckRules( ObjRazRules *rzRules, ViewPort *vp, bool check_noshow )
+{
+    if( !ObjectRenderCheckPos( rzRules, vp ) ) 
+        return false;
+
+    if( check_noshow && IsObjNoshow( rzRules->LUP->OBCL) )
+        return false;
+
+    if( ObjectRenderCheckCat( rzRules, vp ) ) 
+        return true;
+
+    //  If this object cannot be moved to a higher category by CS procedures,
+    //  then we are done here
+    if(!rzRules->obj->m_bcategory_mutable)
+        return false;
+
+    // already added, nothing below can change its display category        
+    if(rzRules->obj->bCS_Added ) 
+        return false;
+
+    //  Otherwise, make sure the CS, if present, has been evaluated,
+    //  and then check the category again    
+    //  no rules 
+    if( !ObjectRenderCheckCS( rzRules, vp ) )
+        return false;
+
+    rzRules->obj->CSrules = NULL;
+    Rules *rules = rzRules->LUP->ruleList;
+    while( rules != NULL ) {
+        if( RUL_CND_SY ==  rules->ruleType ){
+            GetAndAddCSRules( rzRules, rules );
+            rzRules->obj->bCS_Added = 1; // mark the object
+            break;
+        }
+        rules = rules->next;
+    }
+    
+    // still not displayable    
+    if( !ObjectRenderCheckCat( rzRules, vp ) ) 
+        return false;
+
+    return true;
+}
+
 
 void s52plib::SetDisplayCategory(enum _DisCat cat)
 {

--- a/src/s52plib.cpp
+++ b/src/s52plib.cpp
@@ -6053,30 +6053,30 @@ int s52plib::DoRenderObjectTextOnly( wxDC *pdcin, ObjRazRules *rzRules, ViewPort
             return 0;
         
         // already added, nothing below can change its display category        
-            if(rzRules->obj->bCS_Added ) 
-                return 0;
-            
-            //  Otherwise, make sure the CS, if present, has been evaluated,
-                //  and then check the category again    
-                //  no rules 
-                if( !ObjectRenderCheckCS( rzRules, vp ) )
-                    return 0;
-                
-                
-                rzRules->obj->CSrules = NULL;
-                Rules *rules = rzRules->LUP->ruleList;
-                while( rules != NULL ) {
-                    if( RUL_CND_SY ==  rules->ruleType ){
-                        GetAndAddCSRules( rzRules, rules );
-                        rzRules->obj->bCS_Added = 1; // mark the object
-                        break;
-                    }
-                    rules = rules->next;
-                }
-                
-                // still not displayable    
-                if( !ObjectRenderCheckCat( rzRules, vp ) ) 
-                    return 0;
+        if(rzRules->obj->bCS_Added ) 
+            return 0;
+        
+        //  Otherwise, make sure the CS, if present, has been evaluated,
+        //  and then check the category again    
+        //  no rules 
+        if( !ObjectRenderCheckCS( rzRules, vp ) )
+            return 0;
+        
+        
+        rzRules->obj->CSrules = NULL;
+        Rules *rules = rzRules->LUP->ruleList;
+        while( rules != NULL ) {
+            if( RUL_CND_SY ==  rules->ruleType ){
+                GetAndAddCSRules( rzRules, rules );
+                rzRules->obj->bCS_Added = 1; // mark the object
+                break;
+            }
+            rules = rules->next;
+        }
+        
+        // still not displayable    
+        if( !ObjectRenderCheckCat( rzRules, vp ) ) 
+            return 0;
     }
     
     m_pdc = pdcin; // use this DC
@@ -8733,7 +8733,8 @@ bool s52plib::ObjectRenderCheckCS( ObjRazRules *rzRules, ViewPort *vp )
 
 bool s52plib::ObjectRenderCheckPos( ObjRazRules *rzRules, ViewPort *vp )
 {
-    if( rzRules->obj == NULL ) return false;
+    if( rzRules->obj == NULL ) 
+        return false;
 
     // Of course, the object must be at least partly visible in the viewport
     const LLBBox &vpBox = vp->GetBBox(), &testBox = rzRules->obj->BBObj;

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -2579,9 +2579,10 @@ bool s57chart::DoRenderOnGL( const wxGLContext &glc, const ViewPort& VPoint )
 
     //      Render the areas quickly
     for( i = 0; i < PRIO_NUM; ++i ) {
-        if( ps52plib->m_nBoundaryStyle == SYMBOLIZED_BOUNDARIES ) top = razRules[i][4]; // Area Symbolized Boundaries
+        if( ps52plib->m_nBoundaryStyle == SYMBOLIZED_BOUNDARIES ) 
+            top = razRules[i][4]; // Area Symbolized Boundaries
         else
-            top = razRules[i][3];           // Area Plain Boundaries
+            top = razRules[i][3]; // Area Plain Boundaries
 
         while( top != NULL ) {
             crnt = top;
@@ -2593,9 +2594,10 @@ bool s57chart::DoRenderOnGL( const wxGLContext &glc, const ViewPort& VPoint )
 
     //    Render the lines and points
     for( i = 0; i < PRIO_NUM; ++i ) {
-        if( ps52plib->m_nBoundaryStyle == SYMBOLIZED_BOUNDARIES ) top = razRules[i][4]; // Area Symbolized Boundaries
+        if( ps52plib->m_nBoundaryStyle == SYMBOLIZED_BOUNDARIES ) 
+            top = razRules[i][4]; // Area Symbolized Boundaries
         else
-            top = razRules[i][3];           // Area Plain Boundaries
+            top = razRules[i][3]; // Area Plain Boundaries
         while( top != NULL ) {
             crnt = top;
             top = top->next;               // next object
@@ -2605,13 +2607,14 @@ bool s57chart::DoRenderOnGL( const wxGLContext &glc, const ViewPort& VPoint )
 
         top = razRules[i][2];           //LINES
         while( top != NULL ) {
-            ObjRazRules *crnt = top;
+            crnt = top;
             top = top->next;
             crnt->sm_transform_parms = &vp_transform;
             ps52plib->RenderObjectToGL( glc, crnt, &tvp );
         }
 
-        if( ps52plib->m_nSymbolStyle == SIMPLIFIED ) top = razRules[i][0];       //SIMPLIFIED Points
+        if( ps52plib->m_nSymbolStyle == SIMPLIFIED ) 
+            top = razRules[i][0];       //SIMPLIFIED Points
         else
             top = razRules[i][1];           //Paper Chart Points Points
 
@@ -2637,7 +2640,8 @@ bool s57chart::DoRenderOnGLText( const wxGLContext &glc, const ViewPort& VPoint 
     ObjRazRules *top;
     ObjRazRules *crnt;
     ViewPort tvp = VPoint;                    // undo const  TODO fix this in PLIB
-    
+
+#if 0    
     //      Render the areas quickly
     for( i = 0; i < PRIO_NUM; ++i ) {
         if( ps52plib->m_nBoundaryStyle == SYMBOLIZED_BOUNDARIES )
@@ -2652,37 +2656,41 @@ bool s57chart::DoRenderOnGLText( const wxGLContext &glc, const ViewPort& VPoint 
 ///                ps52plib->RenderAreaToGL( glc, crnt, &tvp );
             }
     }
+#endif
     
     //    Render the lines and points
     for( i = 0; i < PRIO_NUM; ++i ) {
-        if( ps52plib->m_nBoundaryStyle == SYMBOLIZED_BOUNDARIES ) top = razRules[i][4]; // Area Symbolized Boundaries
+        if( ps52plib->m_nBoundaryStyle == SYMBOLIZED_BOUNDARIES ) 
+            top = razRules[i][4]; // Area Symbolized Boundaries
         else
-            top = razRules[i][3];           // Area Plain Boundaries
-            while( top != NULL ) {
+            top = razRules[i][3]; // Area Plain Boundaries
+
+        while( top != NULL ) {
                 crnt = top;
                 top = top->next;               // next object
                 crnt->sm_transform_parms = &vp_transform;
                 ps52plib->RenderObjectToGLText( glc, crnt, &tvp );
-            }
+        }
             
-            top = razRules[i][2];           //LINES
-            while( top != NULL ) {
-                ObjRazRules *crnt = top;
-                top = top->next;
-                crnt->sm_transform_parms = &vp_transform;
-                ps52plib->RenderObjectToGLText( glc, crnt, &tvp );
-            }
-            
-            if( ps52plib->m_nSymbolStyle == SIMPLIFIED ) top = razRules[i][0];       //SIMPLIFIED Points
-        else
-            top = razRules[i][1];           //Paper Chart Points Points
-            
-            while( top != NULL ) {
+        top = razRules[i][2];           //LINES
+        while( top != NULL ) {
                 crnt = top;
                 top = top->next;
                 crnt->sm_transform_parms = &vp_transform;
                 ps52plib->RenderObjectToGLText( glc, crnt, &tvp );
-            }
+        }
+            
+        if( ps52plib->m_nSymbolStyle == SIMPLIFIED ) 
+            top = razRules[i][0];       //SIMPLIFIED Points
+        else
+            top = razRules[i][1];           //Paper Chart Points Points
+            
+        while( top != NULL ) {
+                crnt = top;
+                top = top->next;
+                crnt->sm_transform_parms = &vp_transform;
+                ps52plib->RenderObjectToGLText( glc, crnt, &tvp );
+        }
             
     }
     
@@ -3116,9 +3124,10 @@ int s57chart::DCRenderRect( wxMemoryDC& dcinput, const ViewPort& vp, wxRect* rec
 
 //      Render the areas quickly
     for( i = 0; i < PRIO_NUM; ++i ) {
-        if( ps52plib->m_nBoundaryStyle == SYMBOLIZED_BOUNDARIES ) top = razRules[i][4]; // Area Symbolized Boundaries
+        if( ps52plib->m_nBoundaryStyle == SYMBOLIZED_BOUNDARIES ) 
+            top = razRules[i][4]; // Area Symbolized Boundaries
         else
-            top = razRules[i][3];           // Area Plain Boundaries
+            top = razRules[i][3]; // Area Plain Boundaries
 
         while( top != NULL ) {
             crnt = top;
@@ -3179,7 +3188,8 @@ bool s57chart::DCRenderLPB( wxMemoryDC& dcinput, const ViewPort& vp, wxRect* rec
 //         pdcc = new wxDCClipper(dcinput, nr);
         }
 
-        if( ps52plib->m_nBoundaryStyle == SYMBOLIZED_BOUNDARIES ) top = razRules[i][4]; // Area Symbolized Boundaries
+        if( ps52plib->m_nBoundaryStyle == SYMBOLIZED_BOUNDARIES ) 
+            top = razRules[i][4]; // Area Symbolized Boundaries
         else
             top = razRules[i][3];           // Area Plain Boundaries
         while( top != NULL ) {
@@ -3191,13 +3201,14 @@ bool s57chart::DCRenderLPB( wxMemoryDC& dcinput, const ViewPort& vp, wxRect* rec
 
         top = razRules[i][2];           //LINES
         while( top != NULL ) {
-            ObjRazRules *crnt = top;
+            crnt = top;
             top = top->next;
             crnt->sm_transform_parms = &vp_transform;
             ps52plib->RenderObjectToDC( &dcinput, crnt, &tvp );
         }
 
-        if( ps52plib->m_nSymbolStyle == SIMPLIFIED ) top = razRules[i][0];       //SIMPLIFIED Points
+        if( ps52plib->m_nSymbolStyle == SIMPLIFIED ) 
+            top = razRules[i][0];       //SIMPLIFIED Points
         else
             top = razRules[i][1];           //Paper Chart Points Points
 
@@ -3231,34 +3242,37 @@ bool s57chart::DCRenderText( wxMemoryDC& dcinput, const ViewPort& vp )
     
     for( i = 0; i < PRIO_NUM; ++i ) {
         
-        if( ps52plib->m_nBoundaryStyle == SYMBOLIZED_BOUNDARIES ) top = razRules[i][4]; // Area Symbolized Boundaries
+        if( ps52plib->m_nBoundaryStyle == SYMBOLIZED_BOUNDARIES ) 
+            top = razRules[i][4]; // Area Symbolized Boundaries
         else
-            top = razRules[i][3];           // Area Plain Boundaries
-            while( top != NULL ) {
+            top = razRules[i][3]; // Area Plain Boundaries
+
+        while( top != NULL ) {
                 crnt = top;
                 top = top->next;               // next object
                 crnt->sm_transform_parms = &vp_transform;
                 ps52plib->RenderObjectToDCText( &dcinput, crnt, &tvp );
-            }
+        }
             
-            top = razRules[i][2];           //LINES
-            while( top != NULL ) {
-                ObjRazRules *crnt = top;
-                top = top->next;
-                crnt->sm_transform_parms = &vp_transform;
-                ps52plib->RenderObjectToDCText( &dcinput, crnt, &tvp );
-            }
-            
-            if( ps52plib->m_nSymbolStyle == SIMPLIFIED ) top = razRules[i][0];       //SIMPLIFIED Points
-        else
-            top = razRules[i][1];           //Paper Chart Points Points
-            
-            while( top != NULL ) {
+        top = razRules[i][2];           //LINES
+        while( top != NULL ) {
                 crnt = top;
                 top = top->next;
                 crnt->sm_transform_parms = &vp_transform;
                 ps52plib->RenderObjectToDCText( &dcinput, crnt, &tvp );
-            }
+        }
+            
+        if( ps52plib->m_nSymbolStyle == SIMPLIFIED ) 
+            top = razRules[i][0];       //SIMPLIFIED Points
+        else
+            top = razRules[i][1];           //Paper Chart Points Points
+            
+        while( top != NULL ) {
+                crnt = top;
+                top = top->next;
+                crnt->sm_transform_parms = &vp_transform;
+                ps52plib->RenderObjectToDCText( &dcinput, crnt, &tvp );
+        }
     }
             
     return true;

--- a/src/texcmp/squish/alpha.h
+++ b/src/texcmp/squish/alpha.h
@@ -26,7 +26,7 @@
 #ifndef SQUISH_ALPHA_H
 #define SQUISH_ALPHA_H
 
-#include <squish.h>
+#include "squish.h"
 
 namespace squish {
 

--- a/src/texcmp/squish/clusterfit.h
+++ b/src/texcmp/squish/clusterfit.h
@@ -27,7 +27,7 @@
 #ifndef SQUISH_CLUSTERFIT_H
 #define SQUISH_CLUSTERFIT_H
 
-#include <squish.h>
+#include "squish.h"
 #include "maths.h"
 #include "simd.h"
 #include "colourfit.h"

--- a/src/texcmp/squish/colourblock.h
+++ b/src/texcmp/squish/colourblock.h
@@ -26,7 +26,7 @@
 #ifndef SQUISH_COLOURBLOCK_H
 #define SQUISH_COLOURBLOCK_H
 
-#include <squish.h>
+#include "squish.h"
 #include "maths.h"
 
 namespace squish {

--- a/src/texcmp/squish/colourfit.h
+++ b/src/texcmp/squish/colourfit.h
@@ -26,7 +26,7 @@
 #ifndef SQUISH_COLOURFIT_H
 #define SQUISH_COLOURFIT_H
 
-#include <squish.h>
+#include "squish.h"
 #include "maths.h"
 
 namespace squish {

--- a/src/texcmp/squish/colourset.h
+++ b/src/texcmp/squish/colourset.h
@@ -26,7 +26,7 @@
 #ifndef SQUISH_COLOURSET_H
 #define SQUISH_COLOURSET_H
 
-#include <squish.h>
+#include "squish.h"
 #include "maths.h"
 
 namespace squish {

--- a/src/texcmp/squish/rangefit.h
+++ b/src/texcmp/squish/rangefit.h
@@ -26,7 +26,7 @@
 #ifndef SQUISH_RANGEFIT_H
 #define SQUISH_RANGEFIT_H
 
-#include <squish.h>
+#include "squish.h"
 #include "colourfit.h"
 #include "maths.h"
 

--- a/src/texcmp/squish/singlecolourfit.h
+++ b/src/texcmp/squish/singlecolourfit.h
@@ -27,7 +27,7 @@
 #define SQUISH_SINGLECOLOURFIT_H
 
 #include <limits.h>
-#include <squish.h>
+#include "squish.h"
 #include "colourfit.h"
 
 namespace squish {

--- a/src/texcmp/squish/singlecolourfitfast.h
+++ b/src/texcmp/squish/singlecolourfitfast.h
@@ -27,7 +27,7 @@
 #define SQUISH_SINGLECOLOURFITFAST_H
 
 #include <limits.h>
-#include <squish.h>
+#include "squish.h"
 #include "colourfit.h"
 
 namespace squish {

--- a/src/texcmp/squish/squish.cpp
+++ b/src/texcmp/squish/squish.cpp
@@ -26,7 +26,7 @@
 #include <stdio.h>
 #include <stdint.h>
    
-#include <squish.h>
+#include "squish.h"
 #include "colourset.h"
 #include "maths.h"
 #include "rangefit.h"

--- a/src/texcmp/squish/twocolourfitfast.h
+++ b/src/texcmp/squish/twocolourfitfast.h
@@ -27,7 +27,7 @@
 #define SQUISH_TWOCOLOURFITFAST_H
 
 #include <limits.h>
-#include <squish.h>
+#include "squish.h"
 #include "colourfit.h"
 
 namespace squish {


### PR DESCRIPTION
Hi,

stuff I changed when looking for bugs

JobTicket: rename rect member m_rect
     there's a lot of variable rect shadowing JobTicket rect member, make code harder to read.

replace include <squish.h> with "squish.h"
We really don't want to use a squish.h from system directories but the one in our source treee.

Regards
Didier
