### PR TITLE
When zoom in a quilt don't change the reference chart to a chart

### DIFF
--- a/src/Quilt.cpp
+++ b/src/Quilt.cpp
@@ -984,6 +984,19 @@ int Quilt::AdjustRefOnZoomIn( double proposed_scale_onscreen )
 
     int proposed_ref_index = AdjustRefOnZoom( true, (ChartFamilyEnum)current_family, current_type, proposed_scale_onscreen );
 
+    if (current_db_index == -1) {
+        SetReferenceChart( proposed_ref_index );
+        return proposed_ref_index;
+    }
+
+    if (proposed_ref_index != -1) {
+        if (ChartData->GetDBChartScale(current_db_index) >= ChartData->GetDBChartScale(proposed_ref_index)) {
+            SetReferenceChart( proposed_ref_index );
+            return proposed_ref_index;
+        }
+    }
+    proposed_ref_index = current_db_index;
+
     SetReferenceChart( proposed_ref_index );
 
     return proposed_ref_index;


### PR DESCRIPTION
with a greater scale

it made charts 'flashing' ie:

With the option 'preserve scale when switching charts' set
click on a small scale chart in the piano
chart is displayed
zoom in
chart is not displayed with the new quilt

Ex before applying patch:
french Bretagne Belle-Île VMH charts after selecting 7142-1.kap chart:

![before_zoomin](https://cloud.githubusercontent.com/assets/12138026/23593945/c185b6ac-0215-11e7-8002-218adcc99092.png)

but after pressing pgup key the chart wasn't displayed anymore and I had to zoom an click again for seeing it!

![after_pgup_key](https://cloud.githubusercontent.com/assets/12138026/23593985/476ab3da-0216-11e7-8c18-8c62c83edc78.png)

