### PR TITLE
json , disable wxLogTrace in release mode, it's slow

### DIFF
--- a/plugins/dashboard_pi/src/wxJSON/jsonreader.cpp
+++ b/plugins/dashboard_pi/src/wxJSON/jsonreader.cpp
@@ -8,6 +8,12 @@
 // Licence:     wxWidgets licence
 /////////////////////////////////////////////////////////////////////////////
 
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including debug.h
+#define wxDEBUG_LEVEL 0
+#endif
+
 #include <wx/jsonreader.h>
 
 #include <wx/mstream.h>
@@ -167,9 +173,10 @@
 // trace messages by setting the:
 // WXTRACE=traceReader StoreComment
 // environment variable
+#if wxDEBUG_LEVEL > 0
 static const wxChar* traceMask = _T("traceReader");
 static const wxChar* storeTraceMask = _T("StoreComment");
-
+#endif
 
 //! Ctor
 /*!

--- a/plugins/dashboard_pi/src/wxJSON/jsonval.cpp
+++ b/plugins/dashboard_pi/src/wxJSON/jsonval.cpp
@@ -8,6 +8,11 @@
 // Licence:     wxWidgets licence
 /////////////////////////////////////////////////////////////////////////////
 
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including debug.h
+#define wxDEBUG_LEVEL 0
+#endif
 
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
@@ -34,10 +39,11 @@ WX_DEFINE_OBJARRAY( wxJSONInternalArray );
 
 // the trace mask used in wxLogTrace() function
 // static const wxChar* traceMask = _T("jsonval");
+#if wxDEBUG_LEVEL > 0
 static const wxChar* traceMask = _T("jsonval");
 static const wxChar* compareTraceMask = _T("sameas");
 static const wxChar* cowTraceMask = _T("traceCOW" );
-
+#endif
 
 
 /*******************************************************************

--- a/plugins/dashboard_pi/src/wxJSON/jsonwriter.cpp
+++ b/plugins/dashboard_pi/src/wxJSON/jsonwriter.cpp
@@ -8,6 +8,11 @@
 // Licence:     wxWidgets licence
 /////////////////////////////////////////////////////////////////////////////
 
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including debug.h
+#define wxDEBUG_LEVEL 0
+#endif
 
 #include <wx/jsonwriter.h>
 
@@ -16,7 +21,9 @@
 #include <wx/debug.h>
 #include <wx/log.h>
 
+#if wxDEBUG_LEVEL > 0
 static const wxChar* writerTraceMask = _T("traceWriter");
+#endif
 
 /*! \class wxJSONWriter
  \brief The JSON document writer

--- a/plugins/grib_pi/src/jsonreader.cpp
+++ b/plugins/grib_pi/src/jsonreader.cpp
@@ -8,6 +8,12 @@
 // Licence:     wxWidgets licence
 /////////////////////////////////////////////////////////////////////////////
 
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including debug.h
+#define wxDEBUG_LEVEL 0
+#endif
+
 #include <wx/jsonreader.h>
 
 #include <wx/mstream.h>
@@ -167,9 +173,10 @@
 // trace messages by setting the:
 // WXTRACE=traceReader StoreComment
 // environment variable
+#if wxDEBUG_LEVEL > 0
 static const wxChar* traceMask = _T("traceReader");
 static const wxChar* storeTraceMask = _T("StoreComment");
-
+#endif
 
 //! Ctor
 /*!

--- a/plugins/grib_pi/src/jsonval.cpp
+++ b/plugins/grib_pi/src/jsonval.cpp
@@ -8,6 +8,11 @@
 // Licence:     wxWidgets licence
 /////////////////////////////////////////////////////////////////////////////
 
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including debug.h
+#define wxDEBUG_LEVEL 0
+#endif
 
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
@@ -34,10 +39,11 @@ WX_DEFINE_OBJARRAY( wxJSONInternalArray );
 
 // the trace mask used in wxLogTrace() function
 // static const wxChar* traceMask = _T("jsonval");
+#if wxDEBUG_LEVEL > 0
 static const wxChar* traceMask = _T("jsonval");
 static const wxChar* compareTraceMask = _T("sameas");
 static const wxChar* cowTraceMask = _T("traceCOW" );
-
+#endif
 
 
 /*******************************************************************

--- a/plugins/grib_pi/src/jsonwriter.cpp
+++ b/plugins/grib_pi/src/jsonwriter.cpp
@@ -8,6 +8,11 @@
 // Licence:     wxWidgets licence
 /////////////////////////////////////////////////////////////////////////////
 
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including debug.h
+#define wxDEBUG_LEVEL 0
+#endif
 
 #include <wx/jsonwriter.h>
 
@@ -16,7 +21,9 @@
 #include <wx/debug.h>
 #include <wx/log.h>
 
+#if wxDEBUG_LEVEL > 0
 static const wxChar* writerTraceMask = _T("traceWriter");
+#endif
 
 /*! \class wxJSONWriter
  \brief The JSON document writer

--- a/plugins/wmm_pi/src/jsonreader.cpp
+++ b/plugins/wmm_pi/src/jsonreader.cpp
@@ -12,13 +12,18 @@
     #pragma implementation "jsonreader.cpp"
 #endif
 
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including wx/debug.h (also included by wx/wxprec.h)
+#define wxDEBUG_LEVEL 0
+#endif
+
 #include "jsonreader.h"
 
 #include <wx/mstream.h>
 #include <wx/sstream.h>
 #include <wx/debug.h>
 #include <wx/log.h>
-
 
 
 /*! \class wxJSONReader
@@ -171,9 +176,10 @@
 // trace messages by setting the:
 // WXTRACE=traceReader StoreComment
 // environment variable
+#if wxDEBUG_LEVEL > 0
 static const wxChar* traceMask = _T("traceReader");
 static const wxChar* storeTraceMask = _T("StoreComment");
-
+#endif
 
 //! Ctor
 /*!

--- a/plugins/wmm_pi/src/jsonval.cpp
+++ b/plugins/wmm_pi/src/jsonval.cpp
@@ -12,6 +12,11 @@
 //    #pragma implementation "jsonval.cpp"
 //#endif
 
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including wx/debug.h (also included by wx/wxprec.h)
+#define wxDEBUG_LEVEL 0
+#endif
 
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
@@ -20,8 +25,8 @@
 #pragma hdrstop
 #endif
 
+
 #include <wx/log.h>
-#include <wx/debug.h>
 #include <wx/arrimpl.cpp>
 
 #include <wx/jsonval.h>
@@ -35,12 +40,13 @@ WX_DEFINE_OBJARRAY( wxJSONInternalArray );
 #define compatibleLongLongFmtSpec wxLongLongFmtSpec
 #endif
 
+#if wxDEBUG_LEVEL > 0
 // the trace mask used in wxLogTrace() function
 // static const wxChar* traceMask = _T("jsonval");
 static const wxChar* traceMask = _T("jsonval");
 static const wxChar* compareTraceMask = _T("sameas");
 static const wxChar* cowTraceMask = _T("traceCOW" );
-
+#endif
 
 
 /*******************************************************************

--- a/plugins/wmm_pi/src/jsonwriter.cpp
+++ b/plugins/wmm_pi/src/jsonwriter.cpp
@@ -12,6 +12,11 @@
     #pragma implementation "jsonwriter.cpp"
 #endif
 
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including wx/debug.h (also included by wx/wxprec.h)
+#define wxDEBUG_LEVEL 0
+#endif
 
 #include "jsonwriter.h"
 
@@ -20,7 +25,9 @@
 #include <wx/debug.h>
 #include <wx/log.h>
 
+#if wxDEBUG_LEVEL > 0
 static const wxChar* writerTraceMask = _T("traceWriter");
+#endif
 
 /*! \class wxJSONWriter
  \brief The JSON document writer

--- a/src/wxJSON/jsonreader.cpp
+++ b/src/wxJSON/jsonreader.cpp
@@ -12,13 +12,18 @@
 //    #pragma implementation "jsonreader.cpp"
 //#endif
 
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including debug.h
+#define wxDEBUG_LEVEL 0
+#endif
+
 #include <wx/jsonreader.h>
 
 #include <wx/mstream.h>
 #include <wx/sstream.h>
 #include <wx/debug.h>
 #include <wx/log.h>
-
 
 
 /*! \class wxJSONReader
@@ -171,9 +176,10 @@
 // trace messages by setting the:
 // WXTRACE=traceReader StoreComment
 // environment variable
+#if wxDEBUG_LEVEL > 0
 static const wxChar* traceMask = _T("traceReader");
 static const wxChar* storeTraceMask = _T("StoreComment");
-
+#endif
 
 //! Ctor
 /*!

--- a/src/wxJSON/jsonval.cpp
+++ b/src/wxJSON/jsonval.cpp
@@ -12,6 +12,11 @@
 //    #pragma implementation "jsonval.cpp"
 //#endif
 
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including wx/debug.h (also included by wx/wxprec.h)
+#define wxDEBUG_LEVEL 0
+#endif
 
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
@@ -20,8 +25,8 @@
 #pragma hdrstop
 #endif
 
+
 #include <wx/log.h>
-#include <wx/debug.h>
 #include <wx/arrimpl.cpp>
 
 #include <wx/jsonval.h>
@@ -35,12 +40,13 @@ WX_DEFINE_OBJARRAY( wxJSONInternalArray );
 #define compatibleLongLongFmtSpec wxLongLongFmtSpec
 #endif
 
+#if wxDEBUG_LEVEL > 0
 // the trace mask used in wxLogTrace() function
 // static const wxChar* traceMask = _T("jsonval");
 static const wxChar* traceMask = _T("jsonval");
 static const wxChar* compareTraceMask = _T("sameas");
 static const wxChar* cowTraceMask = _T("traceCOW" );
-
+#endif
 
 
 /*******************************************************************

--- a/src/wxJSON/jsonwriter.cpp
+++ b/src/wxJSON/jsonwriter.cpp
@@ -12,6 +12,11 @@
 //    #pragma implementation "jsonwriter.cpp"
 //#endif
 
+#ifdef NDEBUG
+// make wxLogTrace a noop if no debug set, it's really slow
+// must be defined before including debug.h
+#define wxDEBUG_LEVEL 0
+#endif
 
 #include <wx/jsonwriter.h>
 
@@ -20,7 +25,9 @@
 #include <wx/debug.h>
 #include <wx/log.h>
 
+#if wxDEBUG_LEVEL > 0
 static const wxChar* writerTraceMask = _T("traceWriter");
+#endif
 
 /*! \class wxJSONWriter
  \brief The JSON document writer


### PR DESCRIPTION
hi,

There's a lot of stuff like:
    wxLogTrace( traceMask, _T("(%s) searched key=\'%s\'"), __PRETTY_FUNCTION__, key.c_str());

in json code, by default it does nothing but it's still slow, building the function parameters is slow enough to show up in perf traces, up to 5% with a lot of plugins enable.

With wxDEBUG_LEVEL defined as 0 wxLogTrace is empty and there's no slow down.
Of course plugins outside OCPN tree have to be modified too.

An other option would be to put json and font stuff in OCPN plugin ABI.

By default wxDEBUG_LEVEL is defined as 1 in debug.h which is included by wx/wxprec.h in most (all?) OCPN source files. Thus using -DwxDEBUG_LEVEL=0 argument would remove a lot of ASSERTs.


Regards
Didier
