### PR TITLE
don't Quilt invisible chart

### DIFF
--- a/src/Quilt.cpp
+++ b/src/Quilt.cpp
@@ -1198,39 +1198,19 @@ bool Quilt::BuildExtendedChartStackAndCandidateArray(bool b_fullscreen, int ref_
             //    Now  add the candidate if its scale is smaller than the reference scale, or is not excessively underzoomed.
 
             if( ( candidate_chart_scale >= reference_scale ) || ( zoom_factor > .2 ) ) {
-                bool b_add = true;
-
                 //    Special case for S57 ENC
                 //    Add the chart only if the chart's fractional area exceeds n%
-                if( CHART_TYPE_S57 == reference_type ) {
-                    //Get the fractional area of this chart
-                    //                    double chart_fractional_area = 0.;
-//                    double quilt_area = vp_local.pix_width * vp_local.pix_height;
+                /* if( CHART_TYPE_S57 == reference_type ) { 
+                //Get the fractional area of this chart
+                    double chart_fractional_area = 0.;
+                    double quilt_area = vp_local.pix_width * vp_local.pix_height;
+                */
+                LLRegion cell_region = GetChartQuiltRegion( cte, vp_local );
 
-                    //                  LLRegion cell_region = GetChartQuiltRegion( cte, vp_local );
-
-//                    if( !cell_region.Empty() ) {
-//                        chart_fractional_area = ( cell_rect.GetWidth() * cell_rect.GetHeight() )
-                        //                                                / quilt_area;
-//                    } else
-//                        b_add = false;  // this chart has no actual overlap on screen
-                    // probably because it has a concave outline
-                    // or lots of NoCovr regions.  US3EC04.000 is a good example
-                    // i.e the full bboxes overlap, but the actual vp intersect is null.
-
-//                    if( chart_fractional_area < .05 ) {
- //                       b_add = false;
- //                   }
-
-                    //  Allow S57 charts that are near normal zoom, no matter what their fractional area coverage
-                    if(( zoom_factor > 0.1)/* && ( chart_fractional_area > .001 )*/ )
-                        b_add = true;
-                }
-
-                if( ref_db_index == i)
-                    b_add = true;
-
-                if( b_add ) {
+                // this is false if the chart has no actual overlap on screen
+                // or lots of NoCovr regions.  US3EC04.000 is a good example
+                // i.e the full bboxes overlap, but the actual vp intersect is null.
+                if( ! cell_region.Empty() ) {
                     // Check to see if this chart is already in the stack array
                     // by virtue of being under the Viewport center point....
                     bool b_exists = false;

--- a/src/Quilt.cpp
+++ b/src/Quilt.cpp
@@ -1083,52 +1083,49 @@ bool Quilt::BuildExtendedChartStackAndCandidateArray(bool b_fullscreen, int ref_
         ChartData->BuildChartStack( pCurrentStack, vp_local.clat, vp_local.clon );
     }
 
-    
-    int n_charts = 0;
-    if( pCurrentStack ) {
-        n_charts = pCurrentStack->nEntry;
+    int n_charts = pCurrentStack->nEntry;
 
-        //    Walk the current ChartStack...
-        //    Building the quilt candidate array
-        for( int ics = 0; ics < n_charts; ics++ ) {
-            int i = pCurrentStack->GetDBIndex( ics );
-            m_extended_stack_array.Add( i );
+    //    Walk the current ChartStack...
+    //    Building the quilt candidate array
+    for( int ics = 0; ics < n_charts; ics++ ) {
+        int i = pCurrentStack->GetDBIndex( ics );
+        m_extended_stack_array.Add( i );
 
-            //  If the reference chart is cm93, we need not add any charts to the candidate array from the vp center.
-            //  All required charts will be added (by family) as we consider the entire database (group) and full screen later
-            if(reference_type == CHART_TYPE_CM93COMP)
+        //  If the reference chart is cm93, we need not add any charts to the candidate array from the vp center.
+        //  All required charts will be added (by family) as we consider the entire database (group) and full screen later
+        if(reference_type == CHART_TYPE_CM93COMP)
                continue;
             
-            const ChartTableEntry &cte = ChartData->GetChartTableEntry( i );
+        const ChartTableEntry &cte = ChartData->GetChartTableEntry( i );
 
-            // only charts of the proper projection and type may be quilted....
-            // Also, only unskewed charts if so directed
-            // and we avoid adding CM93 Composite until later
+        // only charts of the proper projection and type may be quilted....
+        // Also, only unskewed charts if so directed
+        // and we avoid adding CM93 Composite until later
          
-            // If any PlugIn charts are involved, we make the inclusion test on chart family, instead of chart type.
-            if( (cte.GetChartType() == CHART_TYPE_PLUGIN ) || (reference_type == CHART_TYPE_PLUGIN )){
-                if( reference_family != cte.GetChartFamily() ){
-                    continue;
-                }
+        // If any PlugIn charts are involved, we make the inclusion test on chart family, instead of chart type.
+        if( (cte.GetChartType() == CHART_TYPE_PLUGIN ) || (reference_type == CHART_TYPE_PLUGIN )){
+            if( reference_family != cte.GetChartFamily() ){
+                continue;
             }
-            else{
-                if( reference_type != cte.GetChartType() ){
-                    continue;
-                }
+        }
+        else{
+            if( reference_type != cte.GetChartType() ){
+                continue;
             }
-            
-            if( cte.GetChartType() == CHART_TYPE_CM93COMP ) continue;
+        }
+        
+        if( cte.GetChartType() == CHART_TYPE_CM93COMP ) continue;
 
-            double skew_norm = cte.GetChartSkew();
-            if( skew_norm > 180. ) skew_norm -= 360.;
+        double skew_norm = cte.GetChartSkew();
+        if( skew_norm > 180. ) skew_norm -= 360.;
             
-            if( ( m_bquiltskew ? 1: fabs( skew_norm ) < 1.0 )
+        if( ( m_bquiltskew ? 1: fabs( skew_norm ) < 1.0 )
                 && ( m_bquiltanyproj || cte.GetChartProjectionType() == quilt_proj ) ) {
                     QuiltCandidate *qcnew = new QuiltCandidate;
                     qcnew->dbIndex = i;
                     qcnew->ChartScale = cte.GetScale();
                     m_pcandidate_array->Add( qcnew );               // auto-sorted on scale
-            }
+        }
             
 
 //             if( ( reference_type == cte.GetChartType() ) ||
@@ -1145,7 +1142,6 @@ bool Quilt::BuildExtendedChartStackAndCandidateArray(bool b_fullscreen, int ref_
 //                         m_pcandidate_array->Add( qcnew );               // auto-sorted on scale
 //                 }
 //             }
-        }
     }
 
     if( b_fullscreen ) {


### PR DESCRIPTION
Hi,

Test was removed by 1019bb51 but for charts with only nocvr areas visible you get:


![quilt error](https://cloud.githubusercontent.com/assets/12138026/24022518/4710651c-0aa7-11e7-8430-5f76d4dea8c6.png)
 
Eclipsed chart is not visible and displayed charts are dark green.

Regards
Didier
