### PR TITLE
Implement support for Mail.app to send grib requests

### DIFF
--- a/plugins/grib_pi/src/email.cpp
+++ b/plugins/grib_pi/src/email.cpp
@@ -73,7 +73,18 @@ bool wxEmail::Send(wxMailMessage& message,  int sendMethod, const wxString& prof
     wxString msg,sendmail;
 
     if(sendMethod == 0) {                    //with xdg-email via local mail system (MUA)
-
+#ifdef __WXMAC__
+    wxString addr;
+    for (size_t rcpt = 0; rcpt < message.m_to.GetCount(); rcpt++)
+    {
+        if ( rcpt > 0)
+            addr << ",";
+        addr << message.m_to[rcpt];
+    }
+    wxString msg = wxString::Format("sh -c \"open 'mailto:%s?subject=%s&body=%s'\"", addr.c_str(), message.m_subject.c_str(), message.m_body.c_str());
+    long ret = wxExecute(msg.c_str());
+    return ret != 0; // 0 means the execution failed
+#else
     if(wxFileExists(sendMail0))
         sendmail << sendMail0;
     else if(wxFileExists(sendMail1))
@@ -125,7 +136,9 @@ bool wxEmail::Send(wxMailMessage& message,  int sendMethod, const wxString& prof
         wxRemoveFile(filename);
 
         return TRUE;
+#endif
     }
+    return FALSE;
 }
 #else
     wxLogMessage(_T("Send eMail not yet implemented for this platform") );


### PR DESCRIPTION
On macOS, open the default MUA application with the grib request e-mail.
Tested only with the default Mail.app client on macOS Sierra.