### PR TITLE
support all conic projections

### DIFF
--- a/src/chartimg.cpp
+++ b/src/chartimg.cpp
@@ -1064,7 +1064,7 @@ InitReturn ChartKAP::Init( const wxString& name, ChartInitFlag init_flags )
                                     bp_set = true;
                               }
 
-                              if(stru.Matches(_T("*POLYCONIC*")))
+                              if(stru.Matches(_T("*CONIC*")))
                               {
                                     m_projection = PROJECTION_POLYCONIC;
                                     bp_set = true;


### PR DESCRIPTION
conic projections rely on internal reference points
or coefficients anyway so we already support all types
of conic projections.

We should remove the code that computes conformal conic
projection coordinates because it should never be used anyway.

I realize that conic charts (even of same type of conic)
cannot be quilted without opengl.  Currently allowed, it is technically
incorrect.   This is true of transverse mercator as well.

In many cases the error is less than a pixel so
could be allowed for that case.  It currently doesn't (and never did)
compute the error to verify that it is ok to quilt these charts.
We can quilt different projections without opengl as long as the max
error is below a pixel, but would be tricky to compute optimal quilts.