### PR TITLE
grib: memory leak on read error

### DIFF
--- a/plugins/grib_pi/src/GribV1Record.cpp
+++ b/plugins/grib_pi/src/GribV1Record.cpp
@@ -547,6 +547,7 @@ bool GribV1Record::readGribSection4_BDS(ZUFILE* file) {
         eof = true;
     }
     if (!ok) {
+        delete [] buf;
         return ok;
     }
 


### PR DESCRIPTION
Hi,

Was leaking memory when reading a bad file.

Regards
Didier