### PR TITLE
don't use reduced region when drawing charts

### DIFF
--- a/src/Quilt.cpp
+++ b/src/Quilt.cpp
@@ -1779,8 +1779,10 @@ bool Quilt::Compose( const ViewPort &vp_in )
                 QuiltPatch *pqp = new QuiltPatch;
                 pqp->dbIndex = pqc->dbIndex;
                 pqp->ProjType = m.GetChartProjectionType();
-                //pqp->quilt_region = pqc->GetCandidateRegion();
-                pqp->quilt_region = pqc->GetReducedCandidateRegion(factor);
+                // this is the region used for drawing, don't reduce it
+                // it's visible
+                pqp->quilt_region = pqc->GetCandidateRegion();
+                //pqp->quilt_region = pqc->GetReducedCandidateRegion(factor);
                 
                 pqp->b_Valid = true;
 


### PR DESCRIPTION
Hi,
reduced regions  introduce visible artifacts if used for drawing quilt. 
unpatched with gray area:
![capture du 2017-03-30 22 06 00 bad](https://cloud.githubusercontent.com/assets/12138026/24524413/b8b40ff8-1596-11e7-8ff5-e055fdf6fa3a.png)

patched
![capture du 2017-03-30 22 05 20 good](https://cloud.githubusercontent.com/assets/12138026/24524424/bf60aac8-1596-11e7-9b8b-941bbab274e2.png)

Regards
Didier