### PR TITLE
Fix track length calc

### DIFF
--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -959,12 +959,16 @@ void Track::DouglasPeuckerReducer( std::vector<TrackPoint*>& list,
 double Track::Length()
 {
     TrackPoint *l = NULL;
-    double total = 0;
+    double total = 0.0;
     for(size_t i = 0; i < TrackPoints.size(); i++) {
         TrackPoint *t = TrackPoints[i];
         if(l) {
-            double dd = DistGreatCircle( l->m_lat, l->m_lon, t->m_lat, t->m_lon );
-            total += dd;
+            const double offsetLat = 1e-6;
+            const double deltaLat = l->m_lat - t->m_lat;
+            if ( fabs( deltaLat ) > offsetLat )
+                total += DistGreatCircle( l->m_lat, l->m_lon, t->m_lat, t->m_lon );
+            else
+                total += DistGreatCircle( l->m_lat + copysign( offsetLat, deltaLat ), l->m_lon, t->m_lat, t->m_lon );
         }
         l = t;
     }

--- a/src/TrackPropDlg.cpp
+++ b/src/TrackPropDlg.cpp
@@ -968,9 +968,9 @@ bool TrackPropDlg::UpdateProperties()
         }
 ///        m_scrolledWindowLinks->DestroyChildren();
         int NbrOfLinks = m_pTrack->m_HyperlinkList->GetCount();
-            HyperlinkList *hyperlinklist = m_pTrack->m_HyperlinkList;
+        HyperlinkList *hyperlinklist = m_pTrack->m_HyperlinkList;
     //            int len = 0;
-            if( NbrOfLinks > 0 ) {
+        if( NbrOfLinks > 0 ) {
             wxHyperlinkListNode *linknode = hyperlinklist->GetFirst();
             while( linknode ) {
                 Hyperlink *link = linknode->GetData();
@@ -1015,7 +1015,7 @@ bool TrackPropDlg::UpdateProperties()
             total_seconds =
                     last_point->GetCreateTime().Subtract( first_point->GetCreateTime() ).GetSeconds().ToDouble();
             if( total_seconds != 0. ) {
-                m_avgspeed = m_pTrack->Length() / total_seconds * 3600;
+                m_avgspeed = m_pTrack->trackLength / total_seconds * 3600;
             } else {
                 m_avgspeed = 0;
             }
@@ -1027,7 +1027,7 @@ bool TrackPropDlg::UpdateProperties()
 
     //  Total length
     wxString slen;
-    slen.Printf( wxT("%5.2f ") + getUsrDistanceUnit(), toUsrDistance( m_pTrack->Length() ) );
+    slen.Printf( wxT("%5.2f ") + getUsrDistanceUnit(), toUsrDistance( m_pTrack->trackLength ) );
 
     m_tTotDistance->SetValue( slen );
 

--- a/src/TrackPropDlg.cpp
+++ b/src/TrackPropDlg.cpp
@@ -1006,6 +1006,7 @@ bool TrackPropDlg::UpdateProperties()
     // Calculate AVG speed if we are showing a track and total time
     TrackPoint *last_point = m_pTrack->GetLastPoint();
     TrackPoint *first_point = m_pTrack->GetPoint( 0 );
+    double trackLength = m_pTrack->Length( );
     double total_seconds = 0.;
 
     wxString speed( _T("--") );
@@ -1015,7 +1016,7 @@ bool TrackPropDlg::UpdateProperties()
             total_seconds =
                     last_point->GetCreateTime().Subtract( first_point->GetCreateTime() ).GetSeconds().ToDouble();
             if( total_seconds != 0. ) {
-                m_avgspeed = m_pTrack->trackLength / total_seconds * 3600;
+                m_avgspeed = trackLength / total_seconds * 3600;
             } else {
                 m_avgspeed = 0;
             }
@@ -1027,7 +1028,7 @@ bool TrackPropDlg::UpdateProperties()
 
     //  Total length
     wxString slen;
-    slen.Printf( wxT("%5.2f ") + getUsrDistanceUnit(), toUsrDistance( m_pTrack->trackLength ) );
+    slen.Printf( wxT("%5.2f ") + getUsrDistanceUnit(), toUsrDistance( trackLength ) );
 
     m_tTotDistance->SetValue( slen );
 

--- a/src/georef.cpp
+++ b/src/georef.cpp
@@ -1358,6 +1358,7 @@ double DistGreatCircle(double slat, double slon, double dlat, double dlon)
         L = sindthm * sindthm + (cosdthm * cosdthm - sinthm * sinthm)
             * sindlamm * sindlamm;
         d = acos(cosd = 1 - L - L);
+        wxASSERT( d != 0.0 );
         if (ellipse) {
               E = cosd + cosd;
               sind = sin( d );


### PR DESCRIPTION
Added latitude offset in case latitudes of adjacent track points are too close together else the great circle distance calculator will divide by zero. Minimize the error thus introduced by minimizing the amount of offset. For tracks with thousand of points close together the error can add up to as much as 0.05NM.

Also, cached track length in the property dialog to avoid multiple calls to Track::Length().

Added wxASSERT in the great circle calculator to alert debuggers when a divide by zero is about to happen.