### PR TITLE
Only free row attributes once.

### DIFF
--- a/plugins/grib_pi/src/GribTable.cpp
+++ b/plugins/grib_pi/src/GribTable.cpp
@@ -216,6 +216,8 @@ void GRIBTable::InitGribTable( int zone, ArrayOfGribRecordSets *rsa )
 
     this->Fit();
     this->Refresh();
+    singledatarow->DecRef();    // Give up pointer control to Grid
+    doubledatarow->DecRef();
 }
 
 void GRIBTable::OnClose( wxCloseEvent& event )
@@ -263,6 +265,7 @@ void GRIBTable::AddDataRow( int num_rows, int num_cols, wxString label, wxGridCe
     if(m_pGribTable->GetNumberRows() == num_rows) {
         m_pGribTable->AppendRows(1);
         m_pGribTable->SetRowLabelValue(num_rows, label);
+        row_attr->IncRef();
         m_pGribTable->SetRowAttr(num_rows, row_attr);
     }
     m_pDataCellsColour = m_pGribTable->GetCellBackgroundColour(num_rows, num_cols);  //set default colour


### PR DESCRIPTION
When using an attribute pointer the wxGridTable object becomes the owner of the pointer. So if the same pointer is used multiple times to set the attributes for multiple rows or cells then wx will try to destroy it multiple times. To avoid this the ref counter needs to be incremented each usage after the first usage. This error caused multiple wxAsserts when the weather table is closed.