### PR TITLE
Don't try to trim/compare with an empty string.

### DIFF
--- a/plugins/dashboard_pi/src/nmea0183/lat.cpp
+++ b/plugins/dashboard_pi/src/nmea0183/lat.cpp
@@ -81,11 +81,11 @@ void LATITUDE::Set( double position, const wxString& north_or_south )
    Latitude = position;
    wxString ts = north_or_south;
 
-   if ( ts.Trim(false)[ 0 ] == _T('N') )
+   if ( !ts.IsEmpty( ) && ts.Trim(false)[ 0 ] == _T('N') )
    {
       Northing = North;
    }
-   else if (ts.Trim(false)[ 0 ] == _T('S') )
+   else if ( !ts.IsEmpty( ) && ts.Trim(false)[ 0 ] == _T('S') )
    {
       Northing = South;
    }

--- a/plugins/dashboard_pi/src/nmea0183/long.cpp
+++ b/plugins/dashboard_pi/src/nmea0183/long.cpp
@@ -81,11 +81,11 @@ void LONGITUDE::Set( double position, const wxString& east_or_west )
    Longitude = position;
    wxString ts = east_or_west;
 
-   if ( ts.Trim(false)[ 0 ] == 'E' )
+   if ( !ts.IsEmpty( ) && ts.Trim(false)[ 0 ] == 'E' )
    {
       Easting = East;
    }
-   else if ( ts.Trim(false)[ 0 ] == 'W' )
+   else if ( !ts.IsEmpty( ) && ts.Trim(false)[ 0 ] == 'W' )
    {
       Easting = West;
    }

--- a/src/nmea0183/lat.cpp
+++ b/src/nmea0183/lat.cpp
@@ -81,11 +81,11 @@ void LATITUDE::Set( double position, const wxString& north_or_south )
    Latitude = position;
    wxString ts = north_or_south;
 
-   if ( ts.Trim(false)[ 0 ] == _T('N') )
+   if ( !ts.IsEmpty() && ts.Trim(false)[ 0 ] == _T('N') )
    {
       Northing = North;
    }
-   else if (ts.Trim(false)[ 0 ] == _T('S') )
+   else if ( !ts.IsEmpty( ) && ts.Trim(false)[ 0 ] == _T('S') )
    {
       Northing = South;
    }

--- a/src/nmea0183/long.cpp
+++ b/src/nmea0183/long.cpp
@@ -81,11 +81,11 @@ void LONGITUDE::Set( double position, const wxString& east_or_west )
    Longitude = position;
    wxString ts = east_or_west;
 
-   if ( ts.Trim(false)[ 0 ] == 'E' )
+   if ( !ts.IsEmpty( ) && ts.Trim(false)[ 0 ] == 'E' )
    {
       Easting = East;
    }
-   else if ( ts.Trim(false)[ 0 ] == 'W' )
+   else if ( !ts.IsEmpty( ) && ts.Trim(false)[ 0 ] == 'W' )
    {
       Easting = West;
    }


### PR DESCRIPTION
Trying to trim or compare an empty wxString causes an assert. Sometimes the lat/long fields are empty with certain Garmin GPS units and possibly others when signal strength from satellites is low.