### PR TITLE
Handle both true and magnetic heading/bearing cases in route property list.

### DIFF
--- a/src/routeprop.cpp
+++ b/src/routeprop.cpp
@@ -1994,26 +1994,32 @@ bool RouteProp::UpdateProperties()
             // Course (bearing of next )
             if (_next_prp){
                 if( g_bShowMag ){
-                    double next_lat = prp->m_lat;
-                    double next_lon = prp->m_lon;
-                    if (_next_prp ){
-                        next_lat = _next_prp->m_lat;
-                        next_lon = _next_prp->m_lon;
+                    if ( arrival ) {
+                        double next_lat = prp->m_lat;
+                        double next_lon = prp->m_lon;
+                        if (_next_prp ){
+                            next_lat = _next_prp->m_lat;
+                            next_lon = _next_prp->m_lon;
+                        }
+
+                        double latAverage = (prp->m_lat + next_lat)/2;
+                        double lonAverage = (prp->m_lon + next_lon)/2;
+                        double varCourse = gFrame->GetMag( course, latAverage, lonAverage);
+
+                        t.Printf( _T("%03.0f Deg. M"), varCourse );
+                        m_wpList->SetItem( item_line_index, cols[COURSE_MAGNETIC], t );
                     }
-
-                    double latAverage = (prp->m_lat + next_lat)/2;
-                    double lonAverage = (prp->m_lon + next_lon)/2;
-                    double varCourse = gFrame->GetMag( course, latAverage, lonAverage);
-
-                    t.Printf( _T("%03.0f Deg. M"), varCourse );
+                    else
+                        m_wpList->SetItem( item_line_index, cols[COURSE_MAGNETIC], nullify );
                 }
-                else
-                    t.Printf( _T("%03.0f Deg. T"), course );
-                if( arrival )
-                    m_wpList->SetItem( item_line_index, cols[COURSE], t );
+                if ( g_bShowTrue ) {
+                    if ( arrival ) {
+                        t.Printf( _T("%03.0f Deg. T"), course );
+                        m_wpList->SetItem( item_line_index, cols[COURSE], t );
+                    } else
+                        m_wpList->SetItem( item_line_index, cols[COURSE], nullify );
+                }
             }
-            else
-                m_wpList->SetItem( item_line_index, cols[COURSE], nullify );
 
             //  Lat/Lon
             wxString tlat = toSDMM( 1, prp->m_lat, false );  // low precision for routes


### PR DESCRIPTION
There is still a bug in route properties. The object RouteProp is
created only once and reused each time the user views a route's
property sheet. However, if the user changes the compass heading
variation (true/magnetic) then the cached RouteProp object is
stale and may not have columns for the variation selected by the
user. This can cause a crash. The workaround is to close OpenCPN
anytime the user changes the variation options.