### PR TITLE
Optionally allow space bar to drop mark at own ship position

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -709,6 +709,8 @@ int              g_maxWPNameLength;
 
 bool             g_bAdvanceRouteWaypointOnArrivalOnly;
 
+bool             g_bSpaceDropMark;
+
 wxArrayString    g_locale_catalog_array;
 bool             b_reloadForPlugins;
 

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -304,6 +304,8 @@ extern bool              g_bShowFPS;
 extern double            g_gl_ms_per_frame;
 extern bool              g_benable_rotate;
 
+extern bool              g_bSpaceDropMark;
+
 //  TODO why are these static?
 static int mouse_x;
 static int mouse_y;
@@ -1698,9 +1700,15 @@ void ChartCanvas::OnKeyDown( wxKeyEvent &event )
         }
 
         case 15:             // Ctrl O - Drop Marker at boat's position
-        case 32:            // Special needs use space bar
         {
             DropMarker(true);
+            break;
+        }
+
+        case 32:            // Special needs use space bar
+        {
+            if ( g_bSpaceDropMark )
+                DropMarker( true );
             break;
         }
 

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -1698,7 +1698,7 @@ void ChartCanvas::OnKeyDown( wxKeyEvent &event )
         }
 
         case 15:             // Ctrl O - Drop Marker at boat's position
-        case 32:
+        case 32:            // Special needs use space bar
         {
             DropMarker(true);
             break;

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -1698,6 +1698,7 @@ void ChartCanvas::OnKeyDown( wxKeyEvent &event )
         }
 
         case 15:             // Ctrl O - Drop Marker at boat's position
+        case 32:
         {
             DropMarker(true);
             break;

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -396,6 +396,7 @@ extern bool             g_bInlandEcdis;
 extern int              g_iENCToolbarPosX;
 extern int              g_iENCToolbarPosY;
 
+extern bool             g_bSpaceDropMark;
 
 extern wxString         g_uiStyle;
 
@@ -529,6 +530,7 @@ int MyConfig::LoadMyConfig()
      
     Read( _T ( "InlandEcdis" ), &g_bInlandEcdis, 0 );// First read if in iENC mode as this will override some config settings
 
+    Read( _T( "SpaceDropMark" ), &g_bSpaceDropMark, 0 );
     int mem_limit;
     Read( _T ( "MEMCacheLimit" ), &mem_limit, 0 );
     
@@ -1864,7 +1866,7 @@ void MyConfig::UpdateSettings()
     Write( _T ( "NavMessageShown" ), n_NavMessageShown );
     Write( _T ( "InlandEcdis" ), g_bInlandEcdis );
     Write( _T ( "UIexpert" ), g_bUIexpert );
-    
+    Write( _T( "SpaceDropMark" ), g_bSpaceDropMark );
     Write( _T ( "UIStyle" ), g_StyleManager->GetStyleNextInvocation() );
     Write( _T ( "ChartNotRenderScaleFactor" ), g_ChartNotRenderScaleFactor );
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -273,6 +273,7 @@ extern float g_ChartScaleFactorExp;
 extern double g_config_display_size_mm;
 extern bool g_config_display_size_manual;
 extern bool g_bInlandEcdis;
+extern bool g_bSpaceDropMark;
 
 extern "C" bool CheckSerialAccess(void);
 


### PR DESCRIPTION
Add "hidden" option to opencpn.conf (opencpn.ini) named SpaceDropMark that if set to 1 enables space bar to drop mark at own ship position.