### PR TITLE
Drop a MOB marker on Pause/Break key press

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -1508,6 +1508,10 @@ void ChartCanvas::OnKeyDown( wxKeyEvent &event )
         break;
     }
 
+    case WXK_PAUSE:                   // Drop MOB
+         parent_frame->ActivateMOB();
+         break;
+
     //NUMERIC PAD
     case WXK_NUMPAD_ADD:              // '+' on NUM PAD
     case WXK_PAGEUP:{


### PR DESCRIPTION
Adding an alternative shortcut to drop a Man-Over-Board
(MOB) marker on the map when the Pause/Break key is
pressed. The existing shortcut (Ctrl-Space) remains untouched.
A single key shortcut is required to allow the straight forward 
use of the Linux device tree overlay feature in order to support
a MOB switch (e.g. connected to the GPIO pins of the Raspberry 
PI). This way allows to efficiently handle and emit MOB key 
events at kernel level and guarantees high reliability.