### PR TITLE
ChartDatabase set bValid to false in CTOR

### DIFF
--- a/src/chartdbs.cpp
+++ b/src/chartdbs.cpp
@@ -906,6 +906,7 @@ WX_DEFINE_OBJARRAY(ArrayOfChartClassDescriptor);
 
 ChartDatabase::ChartDatabase()
 {
+      bValid = false;
       m_ChartTableEntryDummy.Clear();
 
       UpdateChartClassDescriptorArray();


### PR DESCRIPTION
On slow computer BuildChartStack can be called from Init before reading
the DB.

Leading to a crash:
`````
*** opencpn (wxWidgets 3.0.2) crashed ***, see backtrace!
0x841a96c in wxCrashPrint::Report() at ??:0
0x4a7f293 in  at ??:0
0x511c1a8 in  at ??:0
0x81a7ee1 in ChartDB::BuildChartStack(ChartStack*, float, float) at ??:0
0x82482b3 in Quilt::BuildExtendedChartStackAndCandidateArray(bool, int, ViewPort&) at ??:0
0x82484fe in Quilt::AdjustRefOnZoomIn(double) at ??:0
0x81e26c8 in ChartCanvas::DoZoomCanvas(double, bool) at ??:0
0x81e2d72 in ChartCanvas::DoMovement(long) at ??:0
0x81e316a in ChartCanvas::DoTimedMovement() at ??:0
0x491a2f6 in wxAppConsoleBase::HandleEvent(wxEvtHandler*, void (wxEvtHandler::*)(wxEvent&), wxEvent&) const at ??:0
0x491a71b in wxAppConsoleBase::CallEventHandler(wxEvtHandler*, wxEventFunctor&, wxEvent&) const at ??:0
0x4aa2c2a in wxEvtHandler::ProcessEventIfMatchesId(wxEventTableEntryBase const&, wxEvtHandler*, wxEvent&) at ??:0
0x4aa2cea in wxEventHashTable::HandleEvent(wxEvent&, wxEvtHandler*) at ??:0
0x4aa30b3 in wxEvtHandler::TryHereOnly(wxEvent&) at ??:0
0x4aa3134 in wxEvtHandler::ProcessEventLocally(wxEvent&) at ??:0
0x4aa3195 in wxEvtHandler::ProcessEvent(wxEvent&) at ??:0
0x4aa2ef4 in wxEvtHandler::SafelyProcessEvent(wxEvent&) at ??:0
0x4a0bab9 in wxTimerImpl::SendEvent() at ??:0
0x4a0b55b in wxTimer::Notify() at ??:0
0x4591012 in  at ??:0
0x4590e5f in  at ??:0
0x5b31be1 in  at ??:0
0x5b310a7 in g_main_context_dispatch at ??:0
0x5b31468 in  at ??:0
0x5b31528 in g_main_context_iteration at ??:0
0x57816a1 in gtk_main_iteration at ??:0
0x457e9fd in wxGUIEventLoop::YieldFor(long) at ??:0
0x4961118 in wxEventLoopBase::Yield(bool) at ??:0
0x491e03d in wxAppConsoleBase::Yield(bool) at ??:0
0x818cced in MyApp::OnInit() at ??:0
```