### PR TITLE
Fix API 1.14 for Microsoft Windows

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -1213,8 +1213,7 @@ extern WXDLLIMPEXP_CORE const wxEventType wxEVT_DOWNLOAD_EVENT;
 // API 1.14 Extra canvas Support
 
 /* Allow drawing of objects onto other OpenGL canvases */
-extern void PlugInAISDrawGL( wxGLCanvas* glcanvas, const PlugIn_ViewPort& vp );
-extern wxColour PlugInGetFontColor(const wxString TextElement);
-extern bool PlugInSetFontColor(const wxString TextElement, const wxColour color);
+extern DECL_EXP void PlugInAISDrawGL( wxGLCanvas* glcanvas, const PlugIn_ViewPort& vp );
+extern DECL_EXP bool PlugInSetFontColor(const wxString TextElement, const wxColour color);
 
 #endif //_PLUGIN_H_

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -6349,11 +6349,6 @@ void PlugInAISDrawGL( wxGLCanvas* glcanvas, const PlugIn_ViewPort &vp )
   AISDraw(dc, ocpn_vp, NULL);
 }
 
-wxColour PlugInGetFontColor(const wxString TextElement)
-{
-  return FontMgr::Get().GetFontColor(TextElement);
-}
-
 bool PlugInSetFontColor(const wxString TextElement, const wxColour color)
 {
   return FontMgr::Get().SetFontColor(TextElement, color);


### PR DESCRIPTION
Previous work on this had incorrectly omitted the DECL_EXP specification, so the API 1.14 changes did not work on Microsoft Windows.

Also, the new PluginGetFontColor() function was duplicate since there was already a GetFontColour_PlugIn(), so this is removed again.