### PR TITLE
Show Zero XTE in active route context menu

### DIFF
--- a/src/canvasMenu.cpp
+++ b/src/canvasMenu.cpp
@@ -635,6 +635,7 @@ void CanvasMenuHandler::CanvasPopupMenu( int x, int y, int seltype )
                         MenuAppend1( menuRoute, ID_RT_MENU_ACTNXTPOINT, _( "Activate Next Waypoint" ) );
                     }
                     MenuAppend1( menuRoute, ID_RT_MENU_DEACTIVATE, _( "Deactivate" ) );
+                    MenuAppend1( menuRoute, ID_DEF_ZERO_XTE, _( "Zero XTE" ) );
                 }
                 else {
                     MenuAppend1( menuRoute, ID_RT_MENU_ACTIVATE, _( "Activate" ) );
@@ -650,6 +651,7 @@ void CanvasMenuHandler::CanvasPopupMenu( int x, int y, int seltype )
                         MenuAppend1( menuRoute, ID_RT_MENU_ACTNXTPOINT, _( "Activate Next Waypoint" ) );
                     }
                     MenuAppend1( menuRoute, ID_RT_MENU_DEACTIVATE, _( "Deactivate" ) );
+                    MenuAppend1( menuRoute, ID_DEF_ZERO_XTE, _( "Zero XTE" ) );
                 }
                 else {
                     MenuAppend1( menuRoute, ID_RT_MENU_ACTIVATE, _( "Activate" ) );


### PR DESCRIPTION
When a route is active users naturally right clicking on that route. But the context menu does not show the option to zero cross track error even though that could be why they clicked on it. This change adds the option to the route context menu.