### PR TITLE
Compute AIS target range and bearing even if GPS data is not valid.

### DIFF
--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -2082,18 +2082,21 @@ void AIS_Decoder::UpdateOneCPA( AIS_Target_Data *ptarget )
     ptarget->Range_NM = -1.;            // Defaults
     ptarget->Brg = -1.;
 
-    if( !ptarget->b_positionOnceValid || !bGPSValid ) {
-        ptarget->bCPA_Valid = false;
-        return;
-    }
-
     //    Compute the current Range/Brg to the target
+    //    This should always be possible even if GPS data is not valid
+    //    because O must always have a position for own-ship. Plugins need
+    //    AIS target range and bearing from own-ship position even if GPS is not valid.
     double brg, dist;
     DistanceBearingMercator( ptarget->Lat, ptarget->Lon, gLat, gLon, &brg, &dist );
     ptarget->Range_NM = dist;
     ptarget->Brg = brg;
 
     if( dist <= 1e-5 ) ptarget->Brg = -1.0;             // Brg is undefined if Range == 0.
+
+    if( !ptarget->b_positionOnceValid || !bGPSValid ) {
+        ptarget->bCPA_Valid = false;
+        return;
+    }
 
     //    There can be no collision between ownship and itself....
     //    This can happen if AIVDO messages are received, and there is another source of ownship position, like NMEA GLL


### PR DESCRIPTION
Plugins like AIS radar need this data.