### PR TITLE
Fix issue #884 - AIS and route rollover popups never time out when refreshes are < 500 ms

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -8349,8 +8349,9 @@ void ChartCanvas::Refresh( bool eraseBackground, const wxRect *rect )
     //      This handles the case when the chart is moving in auto-follow mode, but no user mouse input is made.
     //      The timer handler may Hide() the popup if the chart moved enough
     //      n.b.  We use slightly longer oneshot value to allow this method's Refresh() to complete before
-    //      ptentially getting another Refresh() in the popup timer handler.
-    if( (m_pRouteRolloverWin && m_pRouteRolloverWin->IsActive()) || (m_pAISRolloverWin && m_pAISRolloverWin->IsActive()) )
+    //      potentially getting another Refresh() in the popup timer handler.
+    if( !m_RolloverPopupTimer.IsRunning() &&
+        ((m_pRouteRolloverWin && m_pRouteRolloverWin->IsActive()) || (m_pAISRolloverWin && m_pAISRolloverWin->IsActive())))
         m_RolloverPopupTimer.Start( 500, wxTIMER_ONE_SHOT );
 
 #ifdef ocpnUSE_GL


### PR DESCRIPTION
Only set the timer (to 500ms) if it is not running yet.