### PR TITLE
Fix Grib plugin to use same screen size as main application

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -50,7 +50,7 @@ class wxGLContext;
 //    PlugIns conforming to API Version less then the most modern will also
 //    be correctly supported.
 #define API_VERSION_MAJOR           1
-#define API_VERSION_MINOR           14
+#define API_VERSION_MINOR           15
 
 //    Fwd Definitions
 class       wxFileConfig;
@@ -521,6 +521,14 @@ class DECL_EXP opencpn_plugin_114 : public opencpn_plugin_113
 public:
   opencpn_plugin_114(void *pmgr);
   virtual ~opencpn_plugin_114();
+
+};
+
+class DECL_EXP opencpn_plugin_115 : public opencpn_plugin_114
+{
+public:
+    opencpn_plugin_115(void *pmgr);
+    virtual ~opencpn_plugin_115();
 
 };
 
@@ -1215,5 +1223,9 @@ extern WXDLLIMPEXP_CORE const wxEventType wxEVT_DOWNLOAD_EVENT;
 /* Allow drawing of objects onto other OpenGL canvases */
 extern DECL_EXP void PlugInAISDrawGL( wxGLCanvas* glcanvas, const PlugIn_ViewPort& vp );
 extern DECL_EXP bool PlugInSetFontColor(const wxString TextElement, const wxColour color);
+
+// API 1.15
+extern DECL_EXP double PlugInGetDisplaySizeMM();
+
 
 #endif //_PLUGIN_H_

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -238,16 +238,11 @@ GRIBOverlayFactory::GRIBOverlayFactory( GRIBUICtrlBar &dlg )
 #endif    
 
     if(wxGetDisplaySize().x > 0){
-#ifdef __WXGTK__
-        GdkScreen *screen = gdk_screen_get_default();
-        m_pixelMM = (double)gdk_screen_get_monitor_width_mm(screen, 0) / wxGetDisplaySize().x;
-#else
-        m_pixelMM = (double)wxGetDisplaySizeMM().x / wxGetDisplaySize().x;
-#endif
-        m_pixelMM = wxMax(.02, m_pixelMM);          // protect against bad data
+         m_pixelMM = PlugInGetDisplaySizeMM() / wxGetDisplaySize().x;
+         m_pixelMM = wxMax(.02, m_pixelMM);          // protect against bad data
     }
     else
-        m_pixelMM = 0.27;               // semi-standard number...
+          m_pixelMM = 0.27;               // semi-standard number...
 
     m_pGribTimelineRecordSet = NULL;
     m_last_vp_scale = 0.;

--- a/plugins/grib_pi/src/IsoLine.cpp
+++ b/plugins/grib_pi/src/IsoLine.cpp
@@ -171,19 +171,12 @@ double      round_msvc (double x)
 IsoLine::IsoLine(double val, double coeff, double offset, const GribRecord *rec_)
 {
     if(wxGetDisplaySize().x > 0){
-
-#ifdef __WXGTK__
-        GdkScreen *screen = gdk_screen_get_default();
-        m_pixelMM = (double)gdk_screen_get_monitor_width_mm(screen, 0) / wxGetDisplaySize().x;
-#else
-        m_pixelMM = (double)wxGetDisplaySizeMM().x / wxGetDisplaySize().x;
-#endif
-        
+        m_pixelMM = PlugInGetDisplaySizeMM() / wxGetDisplaySize().x;
         m_pixelMM = wxMax(.02, m_pixelMM);          // protect against bad data
     }
     else
         m_pixelMM = 0.27;               // semi-standard number...
-    
+
     value = val/coeff-offset;
 
     rec = rec_;

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -73,7 +73,7 @@ extern int   m_DialogStyle;
 //---------------------------------------------------------------------------------------------------------
 
 grib_pi::grib_pi(void *ppimgr)
-    :opencpn_plugin_112(ppimgr)
+    :opencpn_plugin_115(ppimgr)
 {
       // Create the PlugIn icons
       initialize_images();

--- a/plugins/grib_pi/src/grib_pi.h
+++ b/plugins/grib_pi/src/grib_pi.h
@@ -38,7 +38,7 @@
 #define     PLUGIN_VERSION_MINOR    1
 
 #define     MY_API_VERSION_MAJOR    1
-#define     MY_API_VERSION_MINOR    12
+#define     MY_API_VERSION_MINOR    15
 
 #include "../../../include/ocpn_plugin.h"
 
@@ -62,7 +62,7 @@
 #define SEPARATED_HORIZONTAL   2          // dialog separated shown honrizontaly
 #define SEPARATED_VERTICAL     3          // dialog separated shown vaerticaly
 
-class grib_pi : public opencpn_plugin_112
+class grib_pi : public opencpn_plugin_115
 {
 public:
       grib_pi(void *ppimgr);

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -507,6 +507,7 @@ bool PlugInManager::CallLateInit(void)
             case 112:
             case 113:
             case 114:
+            case 115:
                 if(pic->m_cap_flag & WANTS_LATE_INIT) {
                     wxString msg(_T("PlugInManager: Calling LateInit PlugIn: "));
                     msg += pic->m_plugin_file;
@@ -539,6 +540,7 @@ void PlugInManager::SendVectorChartObjectInfo(const wxString &chart, const wxStr
                 case 112:
                 case 113:
                 case 114:
+		case 115:
                 {
                     opencpn_plugin_112 *ppi = dynamic_cast<opencpn_plugin_112 *>(pic->m_pplugin);
                     if(ppi)
@@ -1302,6 +1304,9 @@ PlugInContainer *PlugInManager::LoadPlugIn(wxString plugin_file)
     case 114:
         pic->m_pplugin = dynamic_cast<opencpn_plugin_114*>(plug_in);
         break;
+    case 115:
+        pic->m_pplugin = dynamic_cast<opencpn_plugin_115*>(plug_in);
+        break;
         
     default:
         break;
@@ -1367,13 +1372,13 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &v
                     case 112:
                     case 113:
                     case 114:
+		    case 115:
                     {
                         opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                         if(ppi)
                             ppi->RenderOverlay(*pdc, &pivp);
                         break;
                     }
-
                     default:
                         break;
                     }
@@ -1420,13 +1425,13 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &v
                     case 112:
                     case 113:
                     case 114:
+                    case 115:
                     {
                         opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                         if(ppi)
                             b_rendered = ppi->RenderOverlay(mdc, &pivp);
                         break;
                     }
-
                     default:
                     {
                         b_rendered = pic->m_pplugin->RenderOverlay(&mdc, &pivp);
@@ -1483,6 +1488,7 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, cons
                 case 112:
                 case 113:
                 case 114:
+                case 115:
                 {
                     opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                     if(ppi)
@@ -1507,24 +1513,23 @@ bool PlugInManager::SendMouseEventToPlugins( wxMouseEvent &event)
         PlugInContainer *pic = plugin_array.Item(i);
         if(pic->m_bEnabled && pic->m_bInitState)
         {
-            if(pic->m_cap_flag & WANTS_MOUSE_EVENTS){
+            if(pic->m_cap_flag & WANTS_MOUSE_EVENTS)
             {
                 switch(pic->m_api_version)
                 {
                     case 112:
                     case 113:
                     case 114:
+                    case 115:
                     {
                         opencpn_plugin_112 *ppi = dynamic_cast<opencpn_plugin_112*>(pic->m_pplugin);
-                            if(ppi)
-                                if(ppi->MouseEventHook( event ))
-                                    bret = true;
-                            break;
-                        }
-                        
-                        default:
-                            break;
+                        if(ppi)
+                            if(ppi->MouseEventHook( event ))
+                                bret = true;
+                        break;
                     }
+                    default:
+                        break;
                 }
             }
         }
@@ -1547,13 +1552,13 @@ bool PlugInManager::SendKeyEventToPlugins( wxKeyEvent &event)
                     {
                         case 113:
                         case 114:
+                        case 115:
                         {
                             opencpn_plugin_113 *ppi = dynamic_cast<opencpn_plugin_113*>(pic->m_pplugin);
                             if(ppi && ppi->KeyboardEventHook( event ))
                                 bret = true;
                             break;
                         }
-                        
                         default:
                             break;
                     }
@@ -1609,6 +1614,7 @@ void NotifySetupOptionsPlugin( PlugInContainer *pic )
             case 112:
             case 113:
             case 114:
+            case 115:
             {
                 opencpn_plugin_19 *ppi = dynamic_cast<opencpn_plugin_19 *>(pic->m_pplugin);
                 if(ppi) {
@@ -1785,6 +1791,7 @@ void PlugInManager::SendMessageToAllPlugins(const wxString &message_id, const wx
                 case 112:
                 case 113:
                 case 114:
+                case 115:
                 {
                     opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                     if(ppi)
@@ -1864,13 +1871,13 @@ void PlugInManager::SendPositionFixToAllPlugIns(GenericPosDatEx *ppos)
                 case 112:
                 case 113:
                 case 114:
+                case 115:
                 {
                     opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                     if(ppi)
                         ppi->SetPositionFixEx(pfix_ex);
                     break;
                 }
-
                 default:
                     break;
                 }
@@ -3740,6 +3747,15 @@ opencpn_plugin_114::~opencpn_plugin_114(void)
 {
 }
 
+//    Opencpn_Plugin_115 Implementation
+opencpn_plugin_115::opencpn_plugin_115(void *pmgr)
+: opencpn_plugin_114(pmgr)
+{
+}
+
+opencpn_plugin_115::~opencpn_plugin_115(void)
+{
+}
 
 //          Helper and interface classes
 
@@ -6354,3 +6370,9 @@ bool PlugInSetFontColor(const wxString TextElement, const wxColour color)
   return FontMgr::Get().SetFontColor(TextElement, color);
 }
 
+/* API 1.15 */
+
+double PlugInGetDisplaySizeMM()
+{
+    return g_Platform->GetDisplaySizeMM();
+}


### PR DESCRIPTION
Fixes #892 
I have started API 1.15 with added support for this functionality instead of implementing a workaround by reading the ini file from the plug-in, seems cleaner to me.