### PR TITLE
Added option to disable IsolatedDanger symbol

### DIFF
--- a/include/options.h
+++ b/include/options.h
@@ -180,7 +180,8 @@ enum {
   ID_TRACKROTATECOMPUTER,
   ID_SETSTDLIST,
   ID_VECZOOM,
-  ID_INLANDECDISBOX
+  ID_INLANDECDISBOX,
+  ID_ISODGR
 };
 
 /* Define an int bit field for dialog return value
@@ -435,7 +436,7 @@ class options : private Uncopyable,
   wxCheckBox *pCheck_SOUNDG, *pCheck_META, *pCheck_SHOWIMPTEXT;
   wxCheckBox *pCheck_SCAMIN, *pCheck_ATONTEXT, *pCheck_LDISTEXT;
   wxCheckBox *pCheck_XLSECTTEXT, *pCheck_DECLTEXT, *pCheck_NATIONALTEXT;
-  wxCheckBox *pSEnableCM93Offset;
+  wxCheckBox *pSEnableCM93Offset, *pCheck_ISODGR;
   wxTextCtrl *m_ShallowCtl, *m_SafetyCtl, *m_DeepCtl;
   wxStaticText *m_depthUnitsShal, *m_depthUnitsSafe, *m_depthUnitsDeep;
   wxSlider *m_pSlider_CM93_Zoom;

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -279,6 +279,7 @@ wxPrintData               *g_printData = (wxPrintData*) NULL ;
 // Global page setup data
 wxPageSetupData*          g_pageSetupData = (wxPageSetupData*) NULL;
 
+bool                      g_bShowISODGR;
 bool                      g_bShowOutlines;
 bool                      g_bShowDepthUnits;
 bool                      g_bDisplayGrid;  // Flag indicating weather the lat/lon grid should be displayed

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -147,6 +147,7 @@ extern bool             g_fog_overzoom;
 extern double           g_overzoom_emphasis_base;
 extern bool             g_oz_vector_scale;
 
+extern bool             g_bShowISODGR;
 extern bool             g_bShowOutlines;
 extern bool             g_bShowActiveRouteHighway;
 extern bool             g_bShowRouteTotal;
@@ -722,6 +723,7 @@ int MyConfig::LoadMyConfig()
     Read( _T ( "ShowLayers" ), &g_bShowLayers, 1 );
     Read( _T ( "ShowDepthUnits" ), &g_bShowDepthUnits, 1 );
     Read( _T ( "AutoAnchorDrop" ), &g_bAutoAnchorMark, 0 );
+    Read( _T ( "ShowISODGR" ), &g_bShowISODGR, 1 );
     Read( _T ( "ShowChartOutlines" ), &g_bShowOutlines, 0 );
     Read( _T ( "ShowActiveRouteHighway" ), &g_bShowActiveRouteHighway, 1 );
     Read( _T ( "ShowActiveRouteTotal" ), &g_bShowRouteTotal, 0 );
@@ -1891,6 +1893,7 @@ void MyConfig::UpdateSettings()
     Write( _T ( "PermanentMOBIcon" ), g_bPermanentMOBIcon );
     Write( _T ( "ShowLayers" ), g_bShowLayers );
     Write( _T ( "AutoAnchorDrop" ), g_bAutoAnchorMark );
+    Write( _T ( "ShowISODGR" ), g_bShowISODGR );
     Write( _T ( "ShowChartOutlines" ), g_bShowOutlines );
     Write( _T ( "ShowActiveRouteTotal" ), g_bShowRouteTotal );
     Write( _T ( "ShowActiveRouteHighway" ), g_bShowActiveRouteHighway );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -103,6 +103,7 @@ extern wxString g_PrivateDataDir;
 extern bool g_bSoftwareGL;
 extern bool g_bShowFPS;
 
+extern bool g_bShowISODGR;
 extern bool g_bShowOutlines;
 extern bool g_bShowChartBar;
 extern bool g_bShowDepthUnits;
@@ -3128,6 +3129,13 @@ void options::CreatePanel_VectorCharts(size_t parent, int border_size,
     pCheck_META->SetValue(FALSE);
     miscSizer->Add(pCheck_META, verticleInputFlags);
 
+    // ECDIS portrays wrecks, rocks and other obstructions with the
+    // "isolated danger" symbol if they are shoaler than the safety depth.
+    pCheck_ISODGR = new wxCheckBox(ps57Ctl, ID_ISODGR,
+                                 _("Isolated Danger Above Safety Contour"));
+    pCheck_ISODGR->SetValue(FALSE);
+    miscSizer->Add(pCheck_ISODGR, verticleInputFlags);
+    
     optionsColumn->Add(new wxStaticText(ps57Ctl, wxID_ANY, _("Buoys/Lights")),
                        groupLabelFlags);
 
@@ -3339,6 +3347,13 @@ void options::CreatePanel_VectorCharts(size_t parent, int border_size,
     pCheck_META->SetValue(FALSE);
     miscSizer->Add(pCheck_META, inputFlags);
 
+    // ECDIS portrays wrecks, rocks and other obstructions with the
+    // "isolated danger" symbol if they are shoaler than the safety depth.
+    pCheck_ISODGR = new wxCheckBox(ps57Ctl, ID_ISODGR,
+                                 _("Isolated Danger Above Safety Contour"));
+    pCheck_ISODGR->SetValue(FALSE);
+    miscSizer->Add(pCheck_ISODGR, inputFlags);
+    
     wxBoxSizer* lightSizer = new wxBoxSizer(wxVERTICAL);
     optionsColumn->Add(lightSizer, groupInputFlags);
 
@@ -5275,6 +5290,7 @@ void options::SetInitialVectorSettings(void)
         //  Other Display Filters
         pCheck_SOUNDG->SetValue(ps52plib->m_bShowSoundg);
         pCheck_META->SetValue(ps52plib->m_bShowMeta);
+	pCheck_ISODGR->SetValue(g_bShowISODGR);
         pCheck_SHOWIMPTEXT->SetValue(ps52plib->m_bShowS57ImportantTextOnly);
         pCheck_SCAMIN->SetValue(ps52plib->m_bUseSCAMIN);
         pCheck_ATONTEXT->SetValue(ps52plib->m_bShowAtonText);
@@ -6184,6 +6200,7 @@ void options::OnApplyClick(wxCommandEvent& event) {
 
     ps52plib->m_bShowSoundg = pCheck_SOUNDG->GetValue();
     ps52plib->m_bShowMeta = pCheck_META->GetValue();
+    g_bShowISODGR = pCheck_ISODGR->GetValue();
     ps52plib->m_bShowS57ImportantTextOnly = pCheck_SHOWIMPTEXT->GetValue();
     ps52plib->m_bUseSCAMIN = pCheck_SCAMIN->GetValue();
     ps52plib->m_bShowAtonText = pCheck_ATONTEXT->GetValue();

--- a/src/s52cnsy.cpp
+++ b/src/s52cnsy.cpp
@@ -54,6 +54,8 @@ WX_DEFINE_ARRAY_DOUBLE(double, ArrayOfSortedDoubles);
 
 extern s52plib  *ps52plib;
 
+extern bool g_bShowISODGR;
+
 wxString *CSQUAPNT01(S57Obj *obj);
 wxString *CSQUALIN01(S57Obj *obj);
 
@@ -638,8 +640,11 @@ static wxString *_UDWHAZ03(S57Obj *obj, double depth_value, ObjRazRules *rzRules
               }
               else
               {
+		if(g_bShowISODGR==TRUE)
+		  {
                     udwhaz03str = _T(";SY(ISODGR51)");     //_T(";OP(8OD14010);SY(ISODGR51)");
 //                  S57_setAtt(geo, "SCAMIN", "INFINITE");
+		  }
               }
 
               //  Move this object to DisplayBase category


### PR DESCRIPTION
ECDIS portrays wrecks, rocks and other obstructions with the "isolated danger" symbol if they are shoaler than the safety depth. This is not always practical for recreational boaters as they are more likely to travel i shoal water, e.g. taking a calculated risk based on the tidal water, the isolated danger symbol then hides useful information.

**I would therefore like an option to disable this use of the "isolated danger" symbol.**
This code is an example of how it could be done.

![screenshot from 2017-10-22 08-55-33](https://user-images.githubusercontent.com/32543111/31859096-dcf477b0-b706-11e7-9b33-98c594d38e89.png)

![screenshot from 2017-10-22 08-41-25](https://user-images.githubusercontent.com/32543111/31859099-e5aeeb06-b706-11e7-8579-e8e0fda47981.png)

![screenshot from 2017-10-22 08-55-52](https://user-images.githubusercontent.com/32543111/31859101-f057d8ba-b706-11e7-99ea-1db6be09dc00.png)
