### PR TITLE
Do not use wxGCDC on Linux/GTK. The problem with this is:

### DIFF
--- a/plugins/dashboard_pi/src/baro_history.cpp
+++ b/plugins/dashboard_pi/src/baro_history.cpp
@@ -133,7 +133,7 @@ void DashboardInstrument_BaroHistory::SetData(int st, double data, wxString unit
   }
 
 
-void DashboardInstrument_BaroHistory::Draw(wxGCDC* dc)
+void DashboardInstrument_BaroHistory::Draw(myDC* dc)
 {
    m_WindowRect = GetClientRect();
    m_DrawAreaRect=GetClientRect();
@@ -148,7 +148,7 @@ void DashboardInstrument_BaroHistory::Draw(wxGCDC* dc)
 //*********************************************************************************
 // draw pressure scale
 //*********************************************************************************
-void  DashboardInstrument_BaroHistory::DrawWindSpeedScale(wxGCDC* dc)
+void  DashboardInstrument_BaroHistory::DrawWindSpeedScale(myDC* dc)
 {
   wxString label1,label2,label3,label4,label5;
   wxColour cl;
@@ -215,7 +215,7 @@ void  DashboardInstrument_BaroHistory::DrawWindSpeedScale(wxGCDC* dc)
 //*********************************************************************************
 //draw background
 //*********************************************************************************
-void DashboardInstrument_BaroHistory::DrawBackground(wxGCDC* dc)
+void DashboardInstrument_BaroHistory::DrawBackground(myDC* dc)
 {
   wxString label,label1,label2,label3,label4,label5;
   wxColour cl;
@@ -249,7 +249,7 @@ void DashboardInstrument_BaroHistory::DrawBackground(wxGCDC* dc)
 //*********************************************************************************
 //draw foreground
 //*********************************************************************************
-void DashboardInstrument_BaroHistory::DrawForeground(wxGCDC* dc)
+void DashboardInstrument_BaroHistory::DrawForeground(myDC* dc)
 {
   wxColour col;
   double ratioH;

--- a/plugins/dashboard_pi/src/baro_history.h
+++ b/plugins/dashboard_pi/src/baro_history.h
@@ -95,12 +95,12 @@ class DashboardInstrument_BaroHistory: public DashboardInstrument
             int m_currSec,m_lastSec,m_SpdCntperSec;
             double m_cntSpd,m_cntDir,m_avgSpd,m_avgDir;
 
-            void Draw(wxGCDC* dc);
-            void DrawBackground(wxGCDC* dc);
-            void DrawForeground(wxGCDC* dc);
+            void Draw(myDC* dc);
+            void DrawBackground(myDC* dc);
+            void DrawForeground(myDC* dc);
             void SetMinMaxWindScale();
 
-   void DrawWindSpeedScale(wxGCDC* dc);
+   void DrawWindSpeedScale(myDC* dc);
    //wxString GetWindDirStr(wxString WindDir);
 };
 

--- a/plugins/dashboard_pi/src/clock.cpp
+++ b/plugins/dashboard_pi/src/clock.cpp
@@ -138,7 +138,7 @@ void DashboardInstrument_Moon::SetData( int st, double value, wxString format )
     }
 }
 
-void DashboardInstrument_Moon::Draw(wxGCDC* dc)
+void DashboardInstrument_Moon::Draw(myDC* dc)
 {
     if ( m_phase == -1 || m_hemisphere == _T("") ) return;
 
@@ -296,7 +296,7 @@ wxSize DashboardInstrument_Sun::GetSize( int orient, wxSize hint )
       }
 }
 
-void DashboardInstrument_Sun::Draw(wxGCDC* dc)
+void DashboardInstrument_Sun::Draw(myDC* dc)
 {
       wxColour cl;
 

--- a/plugins/dashboard_pi/src/clock.h
+++ b/plugins/dashboard_pi/src/clock.h
@@ -70,7 +70,7 @@ public:
 
     wxSize GetSize( int orient, wxSize hint );
     void SetData( int, double, wxString );
-    void Draw(wxGCDC* dc);
+    void Draw(myDC* dc);
     void SetUtcTime(wxDateTime value);
 
 private:
@@ -88,7 +88,7 @@ public:
     ~DashboardInstrument_Sun(){}
 
     wxSize GetSize( int orient, wxSize hint );
-    void Draw(wxGCDC* dc);
+    void Draw(myDC* dc);
     void SetData( int st, double data, wxString unit );
     void SetUtcTime( wxDateTime value );
 

--- a/plugins/dashboard_pi/src/compass.cpp
+++ b/plugins/dashboard_pi/src/compass.cpp
@@ -66,13 +66,13 @@ void DashboardInstrument_Compass::SetData(int st, double data, wxString unit)
       }
 }
 
-void DashboardInstrument_Compass::DrawBackground(wxGCDC* dc)
+void DashboardInstrument_Compass::DrawBackground(myDC* dc)
 {
     DrawBoat( dc, m_cx, m_cy, m_radius );
     DrawCompassRose( dc, m_cx, m_cy, 0.7 * m_radius, m_AngleStart, true );
 }
 
-void DashboardInstrument_Compass::DrawForeground(wxGCDC* dc)
+void DashboardInstrument_Compass::DrawForeground(myDC* dc)
 {
       // We dont want the default foreground (arrow) drawn
 }

--- a/plugins/dashboard_pi/src/compass.h
+++ b/plugins/dashboard_pi/src/compass.h
@@ -65,8 +65,8 @@ class DashboardInstrument_Compass: public DashboardInstrument_Dial
       private:
 
       protected:
-            void DrawBackground(wxGCDC* dc);
-            void DrawForeground(wxGCDC* dc);
+            void DrawBackground(myDC* dc);
+            void DrawForeground(myDC* dc);
 };
 
 #endif // __Compass_H__

--- a/plugins/dashboard_pi/src/depth.cpp
+++ b/plugins/dashboard_pi/src/depth.cpp
@@ -87,13 +87,13 @@ void DashboardInstrument_Depth::SetData(int st, double data, wxString unit)
       }
 }
 
-void DashboardInstrument_Depth::Draw(wxGCDC* dc)
+void DashboardInstrument_Depth::Draw(myDC* dc)
 {
       DrawBackground(dc);
       DrawForeground(dc);
 }
 
-void DashboardInstrument_Depth::DrawBackground(wxGCDC* dc)
+void DashboardInstrument_Depth::DrawBackground(myDC* dc)
 {
       wxSize size = GetClientSize();
       wxColour cl;
@@ -145,7 +145,7 @@ void DashboardInstrument_Depth::DrawBackground(wxGCDC* dc)
       dc->DrawText(label, size.x-width-1, size.y-height);
 }
 
-void DashboardInstrument_Depth::DrawForeground(wxGCDC* dc)
+void DashboardInstrument_Depth::DrawForeground(myDC* dc)
 {
       wxSize size = GetClientSize();
       wxColour cl;

--- a/plugins/dashboard_pi/src/depth.h
+++ b/plugins/dashboard_pi/src/depth.h
@@ -65,9 +65,9 @@ class DashboardInstrument_Depth: public DashboardInstrument
             wxString m_DepthUnit;
             wxString m_Temp;
 
-            void Draw(wxGCDC* dc);
-            void DrawBackground(wxGCDC* dc);
-            void DrawForeground(wxGCDC* dc);
+            void Draw(myDC* dc);
+            void DrawBackground(myDC* dc);
+            void DrawForeground(myDC* dc);
 };
 
 #endif // __DEPTH_H__

--- a/plugins/dashboard_pi/src/dial.cpp
+++ b/plugins/dashboard_pi/src/dial.cpp
@@ -108,7 +108,7 @@ void DashboardInstrument_Dial::SetData(int st, double data, wxString unit)
       }
 }
 
-void DashboardInstrument_Dial::Draw(wxGCDC* bdc)
+void DashboardInstrument_Dial::Draw(myDC* bdc)
 {
     wxColour c1;
     GetGlobalColor(_T("DASHB"), &c1);
@@ -135,7 +135,7 @@ void DashboardInstrument_Dial::Draw(wxGCDC* bdc)
     DrawForeground(bdc);
 }
 
-void DashboardInstrument_Dial::DrawFrame( wxGCDC* dc )
+void DashboardInstrument_Dial::DrawFrame( myDC* dc )
 {
     wxSize size = GetClientSize();
     wxColour cl;
@@ -197,7 +197,7 @@ void DashboardInstrument_Dial::DrawFrame( wxGCDC* dc )
     }
 }
 
-void DashboardInstrument_Dial::DrawMarkers(wxGCDC* dc)
+void DashboardInstrument_Dial::DrawMarkers(myDC* dc)
 {
     if( m_MarkerOption == DIAL_MARKER_NONE ) return;
 
@@ -246,7 +246,7 @@ void DashboardInstrument_Dial::DrawMarkers(wxGCDC* dc)
     }
 }
 
-void DashboardInstrument_Dial::DrawLabels(wxGCDC* dc)
+void DashboardInstrument_Dial::DrawLabels(myDC* dc)
 {
       if (m_LabelOption == DIAL_LABEL_NONE)
             return;
@@ -341,13 +341,13 @@ void DashboardInstrument_Dial::DrawLabels(wxGCDC* dc)
 
 }
 
-void DashboardInstrument_Dial::DrawBackground(wxGCDC* dc)
+void DashboardInstrument_Dial::DrawBackground(myDC* dc)
 {
       // Nothing to do here right now, will be overwritten
       // by child classes if required
 }
 
-void DashboardInstrument_Dial::DrawData(wxGCDC* dc, double value,
+void DashboardInstrument_Dial::DrawData(myDC* dc, double value,
             wxString unit, wxString format, DialPositionOption position)
 {
       if (position == DIAL_POSITION_NONE)
@@ -463,7 +463,7 @@ void DashboardInstrument_Dial::DrawData(wxGCDC* dc, double value,
       }
 }
 
-void DashboardInstrument_Dial::DrawForeground(wxGCDC* dc)
+void DashboardInstrument_Dial::DrawForeground(myDC* dc)
 {
       // The default foreground is the arrow used in most dials
       wxColour cl;
@@ -517,7 +517,7 @@ void DashboardInstrument_Dial::DrawForeground(wxGCDC* dc)
 }
 
 /* Shared functions */
-void DrawCompassRose(wxGCDC* dc, int cx, int cy, int radius, int startangle, bool showlabels)
+void DrawCompassRose(myDC* dc, int cx, int cy, int radius, int startangle, bool showlabels)
 {
       wxPoint pt, points[3];
       wxString Value;
@@ -584,7 +584,7 @@ void DrawCompassRose(wxGCDC* dc, int cx, int cy, int radius, int startangle, boo
       }
 }
 
-void DrawBoat( wxGCDC* dc, int cx, int cy, int radius )
+void DrawBoat( myDC* dc, int cx, int cy, int radius )
 {
     // Now draw the boat
     wxColour cl;

--- a/plugins/dashboard_pi/src/dial.h
+++ b/plugins/dashboard_pi/src/dial.h
@@ -122,18 +122,18 @@ class DashboardInstrument_Dial: public DashboardInstrument
             DialLabelOption m_LabelOption;
             wxArrayString m_LabelArray;
 
-            virtual void Draw(wxGCDC* dc);
-            virtual void DrawFrame(wxGCDC* dc);
-            virtual void DrawMarkers(wxGCDC* dc);
-            virtual void DrawLabels(wxGCDC* dc);
-            virtual void DrawBackground(wxGCDC* dc);
-            virtual void DrawData(wxGCDC* dc, double value, wxString unit, wxString format, DialPositionOption position);
-            virtual void DrawForeground(wxGCDC* dc);
+            virtual void Draw(myDC* dc);
+            virtual void DrawFrame(myDC* dc);
+            virtual void DrawMarkers(myDC* dc);
+            virtual void DrawLabels(myDC* dc);
+            virtual void DrawBackground(myDC* dc);
+            virtual void DrawData(myDC* dc, double value, wxString unit, wxString format, DialPositionOption position);
+            virtual void DrawForeground(myDC* dc);
 };
 
 /* Shared functions */
-void DrawCompassRose( wxGCDC* dc, int cx, int cy, int radius, int startangle, bool showlabels );
-void DrawBoat( wxGCDC* dc, int cx, int cy, int radius );
+void DrawCompassRose( myDC* dc, int cx, int cy, int radius, int startangle, bool showlabels );
+void DrawBoat( myDC* dc, int cx, int cy, int radius );
 
 #endif // __Dial_H__
 

--- a/plugins/dashboard_pi/src/from_ownship.cpp
+++ b/plugins/dashboard_pi/src/from_ownship.cpp
@@ -47,7 +47,7 @@ DashboardInstrument_FromOwnship::DashboardInstrument_FromOwnship(wxWindow *ppare
     s_lon = 99999999;
 }
 
-void DashboardInstrument_FromOwnship::Draw(wxGCDC* dc)
+void DashboardInstrument_FromOwnship::Draw(myDC* dc)
 {
     wxColour cl;
 

--- a/plugins/dashboard_pi/src/from_ownship.h
+++ b/plugins/dashboard_pi/src/from_ownship.h
@@ -65,7 +65,7 @@ protected:
     int               m_cap_flag4;
     int               m_DataHeight;
 
-    void Draw(wxGCDC* dc);
+    void Draw(myDC* dc);
 };
 
 #endif

--- a/plugins/dashboard_pi/src/gps.cpp
+++ b/plugins/dashboard_pi/src/gps.cpp
@@ -93,14 +93,14 @@ void DashboardInstrument_GPS::SetSatInfo(int cnt, int seq, SAT_INFO sats[4])
       }
 }
 
-void DashboardInstrument_GPS::Draw(wxGCDC* dc)
+void DashboardInstrument_GPS::Draw(myDC* dc)
 {
       DrawFrame(dc);
       DrawBackground(dc);
       DrawForeground(dc);
 }
 
-void DashboardInstrument_GPS::DrawFrame(wxGCDC* dc)
+void DashboardInstrument_GPS::DrawFrame(myDC* dc)
 {
       wxSize size = GetClientSize();
       wxColour cb;
@@ -177,7 +177,7 @@ void DashboardInstrument_GPS::DrawFrame(wxGCDC* dc)
       dc->DrawLine(3, 130, size.x-3, 130);
 }
 
-void DashboardInstrument_GPS::DrawBackground(wxGCDC* dc)
+void DashboardInstrument_GPS::DrawBackground(myDC* dc)
 {
       // Draw SatID
 
@@ -208,7 +208,7 @@ void DashboardInstrument_GPS::DrawBackground(wxGCDC* dc)
 
 }
 
-void DashboardInstrument_GPS::DrawForeground( wxGCDC* dc )
+void DashboardInstrument_GPS::DrawForeground( myDC* dc )
 {
     wxColour cl;
     GetGlobalColor( _T("DASHL"), &cl );

--- a/plugins/dashboard_pi/src/gps.h
+++ b/plugins/dashboard_pi/src/gps.h
@@ -64,10 +64,10 @@ class DashboardInstrument_GPS: public DashboardInstrument
             int m_SatCount;
             SAT_INFO m_SatInfo[12];
 
-            void Draw(wxGCDC* dc);
-            void DrawFrame(wxGCDC* dc);
-            void DrawBackground(wxGCDC* dc);
-            void DrawForeground(wxGCDC* dc);
+            void Draw(myDC* dc);
+            void DrawFrame(myDC* dc);
+            void DrawBackground(myDC* dc);
+            void DrawForeground(myDC* dc);
 };
 
 #endif // __GPS_H__

--- a/plugins/dashboard_pi/src/instrument.cpp
+++ b/plugins/dashboard_pi/src/instrument.cpp
@@ -107,7 +107,7 @@ void DashboardInstrument::OnPaint( wxPaintEvent& WXUNUSED(event) )
         return;
     }
 
-#if wxUSE_GRAPHICS_CONTEXT
+#if !defined(__WXGTK__) && (wxUSE_GRAPHICS_CONTEXT == 1)
     wxGCDC dc( pdc );
 #else
     wxDC &dc( pdc );
@@ -193,7 +193,7 @@ wxSize DashboardInstrument_Single::GetSize( int orient, wxSize hint )
       }
 }
 
-void DashboardInstrument_Single::Draw(wxGCDC* dc)
+void DashboardInstrument_Single::Draw(myDC* dc)
 {
       wxColour cl;
 #ifdef __WXMSW__
@@ -287,7 +287,7 @@ wxSize DashboardInstrument_Position::GetSize( int orient, wxSize hint )
       }
 }
 
-void DashboardInstrument_Position::Draw(wxGCDC* dc)
+void DashboardInstrument_Position::Draw(myDC* dc)
 {
       wxColour cl;
 

--- a/plugins/dashboard_pi/src/instrument.h
+++ b/plugins/dashboard_pi/src/instrument.h
@@ -34,8 +34,10 @@
   #include "wx/wx.h"
 #endif //precompiled headers
 
-#if !wxUSE_GRAPHICS_CONTEXT
-#define wxGCDC wxDC
+#if !defined(__WXGTK__) && (wxUSE_GRAPHICS_CONTEXT == 1)
+#define myDC wxGCDC
+#else
+#define myDC wxDC
 #endif
 
 // Required GetGlobalColor
@@ -115,7 +117,7 @@ protected:
       int               m_TitleHeight;
       wxString          m_title;
 
-      virtual void Draw(wxGCDC* dc) = 0;
+      virtual void Draw(myDC* dc) = 0;
 private:
     bool m_drawSoloInPane;
 };
@@ -134,7 +136,7 @@ protected:
       wxString          m_format;
       int               m_DataHeight;
 
-      void Draw(wxGCDC* dc);
+      void Draw(myDC* dc);
 };
 
 class DashboardInstrument_Position : public DashboardInstrument
@@ -153,7 +155,7 @@ protected:
       int               m_cap_flag2;
       int               m_DataHeight;
 
-      void Draw(wxGCDC* dc);
+      void Draw(myDC* dc);
 };
 
 #endif

--- a/plugins/dashboard_pi/src/rudder_angle.cpp
+++ b/plugins/dashboard_pi/src/rudder_angle.cpp
@@ -89,7 +89,7 @@ void DashboardInstrument_RudderAngle::SetData(int st, double data, wxString unit
       else return;
 }
 
-void DashboardInstrument_RudderAngle::DrawFrame(wxGCDC* dc)
+void DashboardInstrument_RudderAngle::DrawFrame(myDC* dc)
 {
       // We don't need the upper part
       // Move center up
@@ -119,7 +119,7 @@ void DashboardInstrument_RudderAngle::DrawFrame(wxGCDC* dc)
       dc->DrawLine(x1, y1, x2, y2);
 }
 
-void DashboardInstrument_RudderAngle::DrawBackground(wxGCDC* dc)
+void DashboardInstrument_RudderAngle::DrawBackground(myDC* dc)
 {
       wxCoord x = m_cx - (m_radius * 0.3);
       wxCoord y = m_cy - (m_radius * 0.5);

--- a/plugins/dashboard_pi/src/rudder_angle.h
+++ b/plugins/dashboard_pi/src/rudder_angle.h
@@ -55,8 +55,8 @@ class DashboardInstrument_RudderAngle: public DashboardInstrument_Dial
       private:
 
       protected:
-            void DrawFrame(wxGCDC* dc);
-            void DrawBackground(wxGCDC* dc);
+            void DrawFrame(myDC* dc);
+            void DrawBackground(myDC* dc);
 };
 
 #endif // __RudderAngle_H__

--- a/plugins/dashboard_pi/src/wind.cpp
+++ b/plugins/dashboard_pi/src/wind.cpp
@@ -53,7 +53,7 @@ DashboardInstrument_Wind::DashboardInstrument_Wind( wxWindow *parent, wxWindowID
       SetOptionLabel(30, DIAL_LABEL_HORIZONTAL, wxArrayString(12, labels));
 }
 
-void DashboardInstrument_Wind::DrawBackground(wxGCDC* dc)
+void DashboardInstrument_Wind::DrawBackground(myDC* dc)
 {
     DrawBoat( dc, m_cx, m_cy, m_radius );
 }
@@ -66,7 +66,7 @@ DashboardInstrument_WindCompass::DashboardInstrument_WindCompass( wxWindow *pare
       SetOptionLabel(45, DIAL_LABEL_HORIZONTAL, wxArrayString(8, labels));
 }
 
-void DashboardInstrument_WindCompass::DrawBackground(wxGCDC* dc)
+void DashboardInstrument_WindCompass::DrawBackground(myDC* dc)
 {
       DrawCompassRose(dc, m_cx, m_cy, m_radius * 0.85, m_AngleStart, false);
 }
@@ -83,7 +83,7 @@ DashboardInstrument_TrueWindAngle::DashboardInstrument_TrueWindAngle( wxWindow *
       SetOptionLabel(30, DIAL_LABEL_HORIZONTAL, wxArrayString(12, labels));
 }
 
-void DashboardInstrument_TrueWindAngle::DrawBackground(wxGCDC* dc)
+void DashboardInstrument_TrueWindAngle::DrawBackground(myDC* dc)
 {
     DrawBoat( dc, m_cx, m_cy, m_radius );
 }
@@ -101,7 +101,7 @@ DashboardInstrument_Dial(parent, id, title, cap_flag, 0, 360, 0, 360)
 	SetOptionLabel(30, DIAL_LABEL_HORIZONTAL, wxArrayString(12, labels));
 }
 
-void DashboardInstrument_AppTrueWindAngle::DrawBackground(wxGCDC* dc)
+void DashboardInstrument_AppTrueWindAngle::DrawBackground(myDC* dc)
 {
 	DrawBoat(dc, m_cx, m_cy, m_radius);
 }
@@ -130,7 +130,7 @@ void DashboardInstrument_AppTrueWindAngle::SetData(int st, double data, wxString
 	}
 	Refresh();
 }
-void DashboardInstrument_AppTrueWindAngle::Draw(wxGCDC* bdc)
+void DashboardInstrument_AppTrueWindAngle::Draw(myDC* bdc)
 {
 	wxColour c1;
 	GetGlobalColor(_T("DASHB"), &c1);
@@ -158,7 +158,7 @@ void DashboardInstrument_AppTrueWindAngle::Draw(wxGCDC* bdc)
 	DrawData(bdc, m_ExtraValueTrue, m_ExtraValueTrueUnit, m_ExtraValueFormat, m_ExtraValueOption2);
 	DrawForeground(bdc);
 }
-void DashboardInstrument_AppTrueWindAngle::DrawForeground(wxGCDC* dc)
+void DashboardInstrument_AppTrueWindAngle::DrawForeground(myDC* dc)
 {
 	wxPoint points[4];
 	double data;
@@ -245,7 +245,7 @@ void DashboardInstrument_AppTrueWindAngle::DrawForeground(wxGCDC* dc)
 	points[3].y = m_cy + (m_radius * 0.22 * sin(value - 2.8));
 	dc->DrawPolygon(4, points, 0, 0);
 }
-void DashboardInstrument_AppTrueWindAngle::DrawData(wxGCDC* dc, double value,
+void DashboardInstrument_AppTrueWindAngle::DrawData(myDC* dc, double value,
 	wxString unit, wxString format, DialPositionOption position)
 {
 	if (position == DIAL_POSITION_NONE)

--- a/plugins/dashboard_pi/src/wind.h
+++ b/plugins/dashboard_pi/src/wind.h
@@ -62,7 +62,7 @@ class DashboardInstrument_Wind: public DashboardInstrument_Dial
       private:
 
       protected:
-            void DrawBackground(wxGCDC* dc);
+            void DrawBackground(myDC* dc);
 };
 
 class DashboardInstrument_WindCompass: public DashboardInstrument_Dial
@@ -75,7 +75,7 @@ class DashboardInstrument_WindCompass: public DashboardInstrument_Dial
       private:
 
       protected:
-            void DrawBackground(wxGCDC* dc);
+            void DrawBackground(myDC* dc);
 };
 
 class DashboardInstrument_TrueWindAngle: public DashboardInstrument_Dial
@@ -89,7 +89,7 @@ class DashboardInstrument_TrueWindAngle: public DashboardInstrument_Dial
 
       protected:
 
-            void DrawBackground(wxGCDC* dc);
+            void DrawBackground(myDC* dc);
 };
 /*****************************************************************************
 Apparent & True wind angle combined in one dial instrument
@@ -112,10 +112,10 @@ protected:
 
 	wxString m_ExtraValueAppUnit, m_ExtraValueTrueUnit, m_MainValueAppUnit, m_MainValueTrueUnit;
 	DialPositionOption m_MainValueOption1, m_MainValueOption2, m_ExtraValueOption1, m_ExtraValueOption2;
-	void DrawBackground(wxGCDC* dc);
-	virtual void Draw(wxGCDC* dc);
-	virtual void DrawForeground(wxGCDC* dc);
-	virtual void DrawData(wxGCDC* dc, double value, wxString unit, wxString format, DialPositionOption position);
+	void DrawBackground(myDC* dc);
+	virtual void Draw(myDC* dc);
+	virtual void DrawForeground(myDC* dc);
+	virtual void DrawData(myDC* dc, double value, wxString unit, wxString format, DialPositionOption position);
 
 
 };

--- a/plugins/dashboard_pi/src/wind_history.cpp
+++ b/plugins/dashboard_pi/src/wind_history.cpp
@@ -191,7 +191,7 @@ void DashboardInstrument_WindDirHistory::SetData(int st, double data, wxString u
   }
 }
 
-void DashboardInstrument_WindDirHistory::Draw(wxGCDC* dc)
+void DashboardInstrument_WindDirHistory::Draw(myDC* dc)
 {
    m_WindowRect = GetClientRect();
    m_DrawAreaRect=GetClientRect();
@@ -246,7 +246,7 @@ void DashboardInstrument_WindDirHistory::SetMinMaxWindScale()
 //*********************************************************************************
 // wind direction legend
 //*********************************************************************************
-void  DashboardInstrument_WindDirHistory::DrawWindDirScale(wxGCDC* dc)
+void  DashboardInstrument_WindDirHistory::DrawWindDirScale(myDC* dc)
 {
   wxString label1,label2,label3,label4,label5;
   wxColour cl;
@@ -314,7 +314,7 @@ void  DashboardInstrument_WindDirHistory::DrawWindDirScale(wxGCDC* dc)
 //*********************************************************************************
 // draw wind speed scale
 //*********************************************************************************
-void  DashboardInstrument_WindDirHistory::DrawWindSpeedScale(wxGCDC* dc)
+void  DashboardInstrument_WindDirHistory::DrawWindSpeedScale(myDC* dc)
 {
   wxString label1,label2,label3,label4,label5;
   wxColour cl;
@@ -394,7 +394,7 @@ void  DashboardInstrument_WindDirHistory::DrawWindSpeedScale(wxGCDC* dc)
 //*********************************************************************************
 //draw background
 //*********************************************************************************
-void DashboardInstrument_WindDirHistory::DrawBackground(wxGCDC* dc)
+void DashboardInstrument_WindDirHistory::DrawBackground(myDC* dc)
 {
   wxString label,label1,label2,label3,label4,label5;
   wxColour cl;
@@ -483,7 +483,7 @@ wxString DashboardInstrument_WindDirHistory::GetWindDirStr(wxString WindDir)
 //*********************************************************************************
 //draw foreground
 //*********************************************************************************
-void DashboardInstrument_WindDirHistory::DrawForeground(wxGCDC* dc)
+void DashboardInstrument_WindDirHistory::DrawForeground(myDC* dc)
 {
   wxColour col;
   double ratioH;

--- a/plugins/dashboard_pi/src/wind_history.h
+++ b/plugins/dashboard_pi/src/wind_history.h
@@ -93,12 +93,12 @@ class DashboardInstrument_WindDirHistory: public DashboardInstrument
         int m_currSec,m_lastSec,m_SpdCntperSec,m_DirCntperSec;
         double m_cntSpd,m_cntDir,m_avgSpd,m_avgDir;
 
-        void Draw(wxGCDC* dc);
-        void DrawBackground(wxGCDC* dc);
-        void DrawForeground(wxGCDC* dc);
+        void Draw(myDC* dc);
+        void DrawBackground(myDC* dc);
+        void DrawForeground(myDC* dc);
         void SetMinMaxWindScale();
-        void DrawWindDirScale(wxGCDC* dc);
-        void DrawWindSpeedScale(wxGCDC* dc);
+        void DrawWindDirScale(myDC* dc);
+        void DrawWindSpeedScale(myDC* dc);
         wxString GetWindDirStr(wxString WindDir);
 };
 


### PR DESCRIPTION
- Inside OnPaint we get a wxBufferedPaintDC(this) and create a wxGCDC from it.
  The wxGCDC has a constructor from wxMemoryDC, which is used in this case.
  The constructor does not set m_window inside the underlaying wxDCImpl.

- Inside GetSize methods we use a wxClientDC(this) to do dc.GetTextExtent().
  The wxClientDC has a window associated to itself.

- When running on a GTK display with high PPI configured to use a custom
  DPI setting for fonts, the above leads to large sizes returned from GetSize(),
  but only small text drawn from the actual Draw() routines.

Using wxDC instead of wxGCDC preserves the associated window in the
wxBufferedPaintDC, so GetSize() and Draw() use the same font sizes.