### PR TITLE
Reduce the yield time while downloading charts from 1 second to 10 milliseconds.

### DIFF
--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -1044,7 +1044,7 @@ After downloading the charts, please extract them to %s"), pPlugIn->m_pChartCata
                     m_stCatalogInfo->SetLabel( wxString::Format( _("Downloading chart %u of %u, %u downloads failed (%s / %s)"),
                                                                  downloading, to_download, failed_downloads,
                                                                  m_transferredsize.c_str(), m_totalsize.c_str() ) );
-                    wxMilliSleep(1000);
+                    wxMilliSleep(10);
                     wxYield();
 //                    if( !IsShownOnScreen() )
 //                        cancelled = true;

--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -1044,7 +1044,7 @@ After downloading the charts, please extract them to %s"), pPlugIn->m_pChartCata
                     m_stCatalogInfo->SetLabel( wxString::Format( _("Downloading chart %u of %u, %u downloads failed (%s / %s)"),
                                                                  downloading, to_download, failed_downloads,
                                                                  m_transferredsize.c_str(), m_totalsize.c_str() ) );
-                    wxMilliSleep(10);
+                    wxMilliSleep(30);
                     wxYield();
 //                    if( !IsShownOnScreen() )
 //                        cancelled = true;


### PR DESCRIPTION
When downloading many small charts (typically vector charts), the 1 second yield
could actually become the limiting factoring on total download time, since the
next chart would not start downloading until the yield ended.  Reducing it to
100 milliseconds ameliorates that problem, but it still feels a bit laggy because
the progress indicator is still updating fairly infrequently.  10 milliseconds
is fast enough that the progress indicator shouldn't feel laggy, but still enough
to avoid over burdening the system.