### PR TITLE
Compile in C++11 mode.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,9 @@ IF(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include/version.h")
     MESSAGE(FATAL_ERROR "There exists a relic 'include/version.h' in the source tree! Remove it.")
 ENDIF(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include/version.h")
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 
 #Red Hat:   /etc/redhat-release
 #Slackware: /etc/slackware-version


### PR DESCRIPTION
C++11 was released in 2011, and has been well supported by all major
compilers (GCC, Clang, MSVC) for several releases at this point.
Switching it on enables use of some very convenient features like
std::atomic and std::thread.

NOTE: The particular method used to check for this requires CMake 3.1 or later, which was released in December 2014.  If that's not far enough back, I can probably make a workaround to support older CMake versions.