### PR TITLE
Gribv1 without DiDj 

### DIFF
--- a/plugins/grib_pi/src/GribV1Record.cpp
+++ b/plugins/grib_pi/src/GribV1Record.cpp
@@ -574,12 +574,19 @@ bool GribV1Record::readGribSection4_BDS(ZUFILE* file) {
     if (isAdjacentI) {
         for (j=0; j<Nj; j++) {
             for (i=0; i<Ni; i++) {
+#if 0
+                // XXX
+                // not need because we do it in XY after recomputing Di and Dj?
                 if (!hasDiDj && !isScanJpositive) {
                     ind = (Nj-1 -j)*Ni+i;
                 }
                 else {
                     ind = j*Ni+i;
                 }
+#else
+                ind = j*Ni+i;
+#endif
+
                 if (hasValue(i,j)) {
                     x = readPackedBits(buf, startbit, nbBitsInPack);
                     data[ind] = (refValue + x*scaleFactorEpow2)/decimalFactorD;
@@ -595,12 +602,17 @@ bool GribV1Record::readGribSection4_BDS(ZUFILE* file) {
     else {
         for (i=0; i<Ni; i++) {
             for (j=0; j<Nj; j++) {
+#if 0
                 if (!hasDiDj && !isScanJpositive) {
                     ind = (Nj-1 -j)*Ni+i;
                 }
                 else {
                     ind = j*Ni+i;
                 }
+#else
+                ind = j*Ni+i;
+#endif
+
                 if (hasValue(i,j)) {
                     x = readPackedBits(buf, startbit, nbBitsInPack);
                     startbit += nbBitsInPack;

--- a/plugins/grib_pi/src/GribV1Record.cpp
+++ b/plugins/grib_pi/src/GribV1Record.cpp
@@ -53,6 +53,16 @@ void  GribV1Record::translateDataType()
         }
                                                                                 
 	}
+	//------------------------
+	// EMCF masquaraded as NOAA ?
+	//------------------------
+	else if ( idCenter==7 && idModel==64 && idGrid==4)
+	{
+        dataCenterModel = NOAA_GFS;
+        if (dataType == GRB_PRECIP_RATE) {	// mm/s -> mm/h
+            multiplyAllData( 3600.0 );
+        }
+    }
     //------------------------
 	//DNMI-NEurope.grb
 	//------------------------


### PR DESCRIPTION
Hi,
fix for http://www.cruisersforum.com/forums/f134/inverted-grib-display-193517.html and missing rain.

The issue is with !hasDiDj being true, I'm not sure where is coming from in zyGrib but it' s not needed.
I have double checked with degrib and I get the same output lat,long, value. Moreover ECMF grib tools are able to convert this file  in readable for us grib V2 so I don't think is a badly generated file.

I don't have other files with !hasDiDj true.

Untested are files with a !hasDiDi and a BMS.

Regards
Didier