### PR TITLE
Change "Declination" into "Variation" see FS#1065

### DIFF
--- a/plugins/wmm_pi/src/MagneticPlotMap.cpp
+++ b/plugins/wmm_pi/src/MagneticPlotMap.cpp
@@ -359,7 +359,7 @@ bool MagneticPlotMap::Recompute(wxDateTime date)
 
   wxGenericProgressDialog *progressdialog = new wxGenericProgressDialog(
       _("Building Magnetic Map"),
-      m_type==DECLINATION?_("Declination"):
+      m_type==DECLINATION?_("Variation"):
       m_type==INCLINATION?_("Inclination"):_("Field Strength"), 180, NULL,
       wxPD_SMOOTH | wxPD_ELAPSED_TIME | wxPD_REMAINING_TIME | wxPD_CAN_ABORT);
 

--- a/plugins/wmm_pi/src/WmmUIDialog.cpp
+++ b/plugins/wmm_pi/src/WmmUIDialog.cpp
@@ -326,7 +326,7 @@ WmmPlotSettingsDialogBase::WmmPlotSettingsDialogBase( wxWindow* parent, wxWindow
 	wxGridSizer* gSizer2;
 	gSizer2 = new wxGridSizer( 0, 3, 0, 0 );
 	
-	m_cbDeclination = new wxCheckBox( this, wxID_ANY, _("Declination"), wxDefaultPosition, wxDefaultSize, 0 );
+	m_cbDeclination = new wxCheckBox( this, wxID_ANY, _("Variation"), wxDefaultPosition, wxDefaultSize, 0 );
 	m_cbDeclination->SetValue(true); 
 	gSizer2->Add( m_cbDeclination, 0, wxALL, 5 );
 	

--- a/plugins/wmm_pi/src/wmm_pi.cpp
+++ b/plugins/wmm_pi/src/wmm_pi.cpp
@@ -85,9 +85,9 @@ void WmmPlotSettingsDialog::About( wxCommandEvent& event )
     wxString msg0(
         _("\n\
 World Magnetic Model Plotting allows users to cross reference the\
- magnetic declination values printed on many raster charts.\n\n\
-Declination is the angle between true and magnetic north.\n\
-Inclination is the vertical angle of the magnetic field.\n\
+ magnetic variation values printed on many raster charts.\n\n\
+Variation is the angle between true and magnetic north.\n\
+Inclination or dip, is the vertical angle of the magnetic field.\n\
 \t(+- 90 at the magnetic poles)\n\
 Field Strength is the magnetic field in nano tesla from\n\
 \t20000 to 66000\n\n\


### PR DESCRIPTION
In the wmm plugin dialogs there is on a view places the term declination used where variation is the correct one. In the code there are a lot of variables also named / marked as declination, but those are not changed, only the ones appear in the dialogs.