### PR TITLE
Fix crash in grib_pi when data is requested but no grib file is loaded

### DIFF
--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -1322,6 +1322,8 @@ wxDateTime GRIBUICtrlBar::MinTime()
 
 GribTimelineRecordSet* GRIBUICtrlBar::GetTimeLineRecordSet(wxDateTime time)
 {
+    if (m_bGRIBActiveFile == NULL)
+        return NULL;
     ArrayOfGribRecordSets *rsa = m_bGRIBActiveFile->GetRecordSetArrayPtr();
 
     if(rsa->GetCount() == 0)


### PR DESCRIPTION
This can be reproduced for example using the weather_routing plugin: just define a route and click on "Calculate", OpenCPN will crash if no grib file is available.

Some discussion here: http://www.cruisersforum.com/forums/showthread.php?p=2535010
