### PR TITLE
Continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: cpp
 install:
-    - sudo apt-get install libwxgtk3.0-dev libwxgtk3.0-0
-
+    - sudo apt-get -qq update
+    - sudo apt-get install libwxgtk3.0-dev libwxgtk3.0-0 libgps-dev libglu1-mesa-dev libgtk2.0-dev libbz2-dev libtinyxml-dev 
+    - sudo apt-get install libportaudio2 portaudio19-dev libcurl4-openssl-dev libexpat1-dev libcairo2-dev
 script:
     - mkdir build && cd build
-    - cmake ../
-    - make
+    - cmake -DCMAKE_BUILD_TYPE=Debug ../
+    - make -s
 
 notifications:
     email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,13 @@
 clone_folder: c:\project\opencpn
 shallow_clone: true
+image:
+- Visual Studio 2015
 
-platform: x64
+platform: 
+# - x64
+- Win32
+
 configuration: Release
-deploy: OFF
 test: OFF
 
 install:
@@ -35,11 +39,30 @@ before_build:
   - cd c:\project\opencpn
   - mkdir build
   - cd build
-  - cmake -T v120_xp ..
   - ps: Start-FileDownload http://downloads.sourceforge.net/project/opencpnplugins/opencpn_packaging_data/OpenCPN_buildwin.7z
-  - cmd: 7z x OpenCPN_buildwin.7z -oc:\project\opencpn
+  - cmd: 7z x -y OpenCPN_buildwin.7z -oc:\project\opencpn
+  - cmake -T v120_xp ..
 
 build_script:
-  - cmake --build . --config debug
-  - cmake --build . --config release
+  # - cmake --build . --config debug
+  - cmake --build . --target opencpn --config release
+  - cmake --build . --target package --config release
   # --target package doesn't work because of nsis not correctly installed
+
+artifacts:
+  - path: 'build\*.exe'
+    name: installer
+
+  - path: 'build\Release\opencpn.lib'
+    name: lib
+
+deploy:
+  description: 'release created by AppVeyor CI'
+  provider: GitHub
+  auth_token: '%GitHub_auth_token%'
+  artifact: installer,lib
+  draft: true
+  prerelease: true
+  on:
+    appveyor_repo_tag: true # deploy on tag push only
+    configuration: Release  # Debug contains non-redist MS DLLs


### PR DESCRIPTION
Hi,
Update appveyor and travis config files.

Appveyor build release installer + opencpn.lib for windows 32 bits.
travis build Unbuntu 14.04 gcc 4.8 

We could add windows 64, gcc 6/7, clang and OSX

Regards
Didier
