### PR TITLE
SetViewPoint merge conflict resolution error

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -3114,7 +3114,7 @@ bool ChartCanvas::SetViewPoint( double lat, double lon, double scale_ppm, double
 
     //  Any sensible change?
     if (VPoint.IsValid()) {
-        if( ( fabs( VPoint.view_scale_ppm - scale_ppm ) < 1e-5 )
+        if( ( fabs( VPoint.view_scale_ppm - scale_ppm )/ scale_ppm < 1e-5 )
             && ( fabs( VPoint.skew - skew ) < 1e-9 )
             && ( fabs( VPoint.rotation - rotation ) < 1e-9 )
             && ( fabs( VPoint.clat - lat ) < 1e-9 )


### PR DESCRIPTION
Hi,
fix improper merge conflict between f55bae
"Improve zoom logic to skip micro-zooms."

and 23c383
" in ChartsRefresh init Current_ch with a Dummy chart if not set"

Symptom: 
Unable to zoom in CM93 chart with the mouse after zooming it out to 1/70 000 000.
(kbd still working).

Regards
Didier
