### PR TITLE
Grib interpolate

### DIFF
--- a/plugins/grib_pi/src/GribRecord.cpp
+++ b/plugins/grib_pi/src/GribRecord.cpp
@@ -240,6 +240,8 @@ GribRecord *GribRecord::Interpolated2DRecord(GribRecord *&rety,
     double La1, Lo1, La2, Lo2, Di, Dj;
     int im1, jm1, im2, jm2;
     int Ni, Nj, rec1offi, rec1offj, rec2offi, rec2offj;
+
+    rety = 0;
     if(!GetInterpolatedParameters(rec1x, rec2x, La1, Lo1, La2, Lo2, Di, Dj,
                                   im1, jm1, im2, jm2,
                                   Ni, Nj, rec1offi, rec1offj, rec2offi, rec2offj))

--- a/plugins/grib_pi/src/GribRecord.cpp
+++ b/plugins/grib_pi/src/GribRecord.cpp
@@ -251,9 +251,13 @@ GribRecord *GribRecord::Interpolated2DRecord(GribRecord *&rety,
        rec2x.Di != rec2y.Di ||rec2x.Dj != rec2y.Dj ||
        rec1x.Ni != rec1y.Ni ||rec1x.Nj != rec1y.Nj ||
        rec2x.Ni != rec2y.Ni ||rec2x.Nj != rec2y.Nj)
+    {
         // could also make sure lat and lon min/max are the same...
-        return NULL;
+        // copy first 
+        rety = new GribRecord(rec1y);
 
+        return new GribRecord(rec1x);
+    }
     // recopie les champs de bits
     int size = Ni*Nj;
     double *datax = new double[size], *datay = new double[size];


### PR DESCRIPTION
Hi,
Copy first grib rather than returning null if we can't interpolate.

I'm not sure it's the proper solution put IMO returning empty record is worse. 

eg if you download a grib from
http://195.154.231.142/IFREMER/
there's 15 mn current but if interpolated every .5 mn it returns empty grib.

U/V aren't exactly as the same position. As i'm producing these gribs from IFREMER NCFD curvilinear grids I could re map them but in my understanding these kind of grids are rather common for current (IIRC German current).

It's an issue with weather routing, more with IFREMER hourly current though. With a lot of exclusion zones hourly step is too big (Think Needles and Solent) but with 30 mn step interpolation is returning 0 current speed and routing is wrong.

Regards
Didier
