### PR TITLE
keyboard shortcut for data quality FS #2294

### DIFF
--- a/include/chart1.h
+++ b/include/chart1.h
@@ -173,6 +173,7 @@ enum
     ID_MENU_ENC_LIGHTS,
     ID_MENU_ENC_SOUNDINGS,
     ID_MENU_ENC_ANCHOR,
+    ID_MENU_ENC_DATA_QUALITY,
 
     ID_MENU_SHOW_TIDES,
     ID_MENU_SHOW_CURRENTS,
@@ -383,6 +384,7 @@ class MyFrame: public wxFrame
     void DoPrint(void);
     void StopSockets(void);
     void ResumeSockets(void);
+    void ToggleDataQuality();
     void TogglebFollow(void);
     void ToggleFullScreen();
     void ToggleChartBar();

--- a/include/s52plib.h
+++ b/include/s52plib.h
@@ -179,6 +179,9 @@ public:
     
     void SetAnchorOn(bool val){ m_anchorOn = val; }
     bool GetAnchorOn();
+
+    void SetQualityOfDataOn(bool val){ m_qualityOfDataOn = val; }
+    bool GetQualityOfDataOn();
     
     int GetMajorVersion( void ) { return m_VersionMajor; }
     int GetMinorVersion( void ) { return m_VersionMinor; }
@@ -393,7 +396,8 @@ private:
 
     bool m_lightsOff;
     bool m_anchorOn;
-    
+    bool m_qualityOfDataOn;
+
     long m_state_hash;
 
     bool m_txf_ready;

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -4241,6 +4241,10 @@ void MyFrame::OnToolLeftClick( wxCommandEvent& event )
             ToggleAnchor();
             break;
         }
+        case ID_MENU_ENC_DATA_QUALITY: {
+            ToggleDataQuality();
+            break;
+        }
 #endif
 
         case ID_MENU_AIS_TARGETS: {
@@ -5106,7 +5110,7 @@ void MyFrame::ToggleAnchor( void )
 {
 #ifdef USE_S57
     if( ps52plib ) {
-        int old_vis =  0;
+        int old_vis;
 
         const char * categories[] = { "ACHBRT", "ACHARE", "CBLSUB", "PIPARE", "PIPSOL", "TUNNEL", "SBDARE" };
         unsigned int num = sizeof(categories) / sizeof(categories[0]);
@@ -5149,6 +5153,42 @@ void MyFrame::ToggleAnchor( void )
         cc1->ReloadVP();
 
     }
+#endif
+}
+
+void MyFrame::ToggleDataQuality( )
+{
+#ifdef USE_S57
+    if( ps52plib == 0) 
+        return;
+
+    int old_vis;
+
+    old_vis = ps52plib->GetQualityOfDataOn();
+    if(old_vis){                            // On, going off
+        ps52plib->SetQualityOfDataOn(false);
+        ps52plib->AddObjNoshow("M_QUAL");
+    }
+    else{                                   // Off, going on
+        ps52plib->SetQualityOfDataOn(true);
+        ps52plib->RemoveObjNoshow("M_QUAL");
+
+        for( unsigned int iPtr = 0; iPtr < ps52plib->pOBJLArray->GetCount(); iPtr++ ) {
+            OBJLElement *pOLE = (OBJLElement *) ( ps52plib->pOBJLArray->Item( iPtr ) );
+            if( !strncmp( pOLE->OBJLName, "M_QUAL", 6 ) ) {
+                pOLE->nViz = 1;         // force on
+                break;
+            }
+        }
+    }
+
+    SetMenubarItemState( ID_MENU_ENC_DATA_QUALITY, !old_vis );
+
+    if(g_pi_manager)
+        g_pi_manager->SendConfigToAllPlugIns();
+
+    ps52plib->GenerateStateHash();
+    cc1->ReloadVP();
 #endif
 }
 
@@ -5370,12 +5410,14 @@ void MyFrame::RegisterGlobalMenuItems()
     view_menu->AppendCheckItem( ID_MENU_ENC_LIGHTS, _menuText(_("Show ENC Lights"), _T("L")) );
     view_menu->AppendCheckItem( ID_MENU_ENC_SOUNDINGS, _menuText(_("Show ENC Soundings"), _T("S")) );
     view_menu->AppendCheckItem( ID_MENU_ENC_ANCHOR, _menuText(_("Show ENC Anchoring Info"), _T("A")) );
+    view_menu->AppendCheckItem( ID_MENU_ENC_DATA_QUALITY, _menuText(_("Show ENC Data Quality"), _T("U")) );
 #else
     view_menu->AppendCheckItem( ID_MENU_ENC_TEXT, _menuText(_("Show ENC text"), _T("Alt-T")) );
     view_menu->AppendCheckItem( ID_MENU_ENC_LIGHTS, _menuText(_("Show ENC Lights"), _T("Alt-L")) );
     view_menu->AppendCheckItem( ID_MENU_ENC_SOUNDINGS, _menuText(_("Show ENC Soundings"), _T("Alt-S")) );
     view_menu->AppendCheckItem( ID_MENU_ENC_ANCHOR, _menuText(_("Show ENC Anchoring Info"), _T("Alt-A")) );
-    #endif
+    view_menu->AppendCheckItem( ID_MENU_ENC_DATA_QUALITY, _menuText(_("Show ENC Data Quality"), _T("Alt-U")) );
+#endif
 #endif
     view_menu->AppendSeparator();
     view_menu->AppendCheckItem( ID_MENU_SHOW_TIDES, _("Show Tides") );
@@ -5482,10 +5524,13 @@ void MyFrame::UpdateGlobalMenuItems()
         if((nset == MARINERS_STANDARD) || (nset == OTHER) ){
             m_pMenuBar->FindItem( ID_MENU_ENC_ANCHOR )->Check( !ps52plib->IsObjNoshow("SBDARE") );
             m_pMenuBar->Enable( ID_MENU_ENC_ANCHOR, true);
+            m_pMenuBar->FindItem( ID_MENU_ENC_DATA_QUALITY )->Check( !ps52plib->IsObjNoshow("M_QUAL")  );
+            m_pMenuBar->Enable( ID_MENU_ENC_DATA_QUALITY, true);
         }
         else{
             m_pMenuBar->FindItem( ID_MENU_ENC_ANCHOR )->Check( false );
             m_pMenuBar->Enable( ID_MENU_ENC_ANCHOR, false);
+            m_pMenuBar->Enable( ID_MENU_ENC_DATA_QUALITY, false);
         }            
             
     }

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -1697,6 +1697,10 @@ void ChartCanvas::OnKeyDown( wxKeyEvent &event )
             parent_frame->ToggleENCText();
             break;
 
+        case 'U':
+            parent_frame->ToggleDataQuality();
+            break;
+
         case 1:                      // Ctrl A
             parent_frame->TogglebFollow();
             break;

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -1931,6 +1931,7 @@ void PlugInManager::SendConfigToAllPlugIns()
         v[_T("OpenCPN S52PLIB ShowSoundings")] = ps52plib->GetShowSoundings();
         v[_T("OpenCPN S52PLIB ShowLights")] = !ps52plib->GetLightsOff();
         v[_T("OpenCPN S52PLIB ShowAnchorConditions")] = ps52plib->GetAnchorOn();
+        v[_T("OpenCPN S52PLIB ShowQualityOfData")] = ps52plib->GetQualityOfDataOn();
         v[_T("OpenCPN S52PLIB DisplayCategory")] = ps52plib->GetDisplayCategory();
     }
 

--- a/src/s52plib.cpp
+++ b/src/s52plib.cpp
@@ -395,7 +395,8 @@ s52plib::s52plib( const wxString& PLib, bool b_forceLegacy )
 
     m_lightsOff = false;
     m_anchorOn = false;
-    
+    m_qualityOfDataOn = false;
+
     GenerateStateHash();
 
     HPGL = new RenderFromHPGL( this );
@@ -598,17 +599,40 @@ bool s52plib::GetAnchorOn()
                     old_vis = pOLE->nViz;
                     break;
                 }
-                pOLE = NULL;
             }
     }
     else if(OTHER == GetDisplayCategory())
         old_vis = true;
-        
-    const char * categories[] = { "ACHBRT", "ACHARE", "CBLSUB", "PIPARE", "PIPSOL", "TUNNEL", "SBDARE" };
-    unsigned int num = sizeof(categories) / sizeof(categories[0]);
-        
+
+    //other cat  
+    //const char * categories[] = { "ACHBRT", "ACHARE", "CBLSUB", "PIPARE", "PIPSOL", "TUNNEL", "SBDARE" };
+
     old_vis &= !IsObjNoshow("SBDARE");
+
+    return (old_vis != 0);
+}
+
+bool s52plib::GetQualityOfDataOn()
+{
+    //  Investigate and report the logical condition that "Quality of Data Condition" is shown
     
+    int old_vis =  0;
+    OBJLElement *pOLE = NULL;
+        
+    if(  MARINERS_STANDARD == GetDisplayCategory()){
+            for( unsigned int iPtr = 0; iPtr < pOBJLArray->GetCount(); iPtr++ ) {
+                OBJLElement *pOLE = (OBJLElement *) ( pOBJLArray->Item( iPtr ) );
+                if( !strncmp( pOLE->OBJLName, "M_QUAL", 6 ) ) {
+                    old_vis = pOLE->nViz;
+                    break;
+                }
+            }
+    }
+    else if(OTHER == GetDisplayCategory())
+        old_vis = true;
+
+    old_vis &= !IsObjNoshow("M_QUAL");
+
     return (old_vis != 0);
 }
         
@@ -8005,7 +8029,7 @@ void s52plib::RenderPolytessGL(ObjRazRules *rzRules, ViewPort *vp, double z_clip
 
 int s52plib::RenderAreaToGL( const wxGLContext &glcc, ObjRazRules *rzRules, ViewPort *vp )
 {
-    if( !ObjectRenderCheckRules( rzRules, vp ) )
+    if( !ObjectRenderCheckRules( rzRules, vp, true ) )
         return 0;
 
     Rules *rules = rzRules->LUP->ruleList;
@@ -8399,7 +8423,7 @@ int s52plib::RenderAreaToDC( wxDC *pdcin, ObjRazRules *rzRules, ViewPort *vp,
         render_canvas_parms *pb_spec )
 {
 
-    if( !ObjectRenderCheckRules( rzRules, vp ) )
+    if( !ObjectRenderCheckRules( rzRules, vp, true ) )
         return 0;
 
     m_pdc = pdcin; // use this DC
@@ -8596,7 +8620,7 @@ bool s52plib::ObjectRenderCheckCat( ObjRazRules *rzRules, ViewPort *vp )
     if( m_nDisplayCategory == OTHER ){
         if(OTHER == obj_cat){
             if( !strncmp( rzRules->LUP->OBCL, "M_", 2 ) )
-                if( !m_bShowMeta ) return false;
+                if( !m_bShowMeta &&  strncmp( rzRules->LUP->OBCL, "M_QUAL", 6 )) return false;
         }
     }
 
@@ -8979,6 +9003,21 @@ void s52plib::PrepareForRender()
                         }
                     }
                     if( cnt == num ) break;
+                }
+            }
+            // Handle Quality of data toggle
+            bool bQuality = m_qualityOfDataOn;
+            if(!bQuality){
+                AddObjNoshow("M_QUAL");
+            }
+            else{
+                RemoveObjNoshow("M_QUAL");
+                for( unsigned int iPtr = 0; iPtr < pOBJLArray->GetCount(); iPtr++ ) {
+                    OBJLElement *pOLE = (OBJLElement *) ( pOBJLArray->Item( iPtr ) );
+                    if( !strncmp( pOLE->OBJLName, "M_QUAL", 6 ) ) {
+                        pOLE->nViz = 1;         // force on
+                        break;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Hi,
Reuse anchor logic, which has slightly since 4.8.0: now by default it's off. IMO Objects  affected by anchor and data quality should be grayed in mariner standard option.
 
Need oesenc changes 

line 8032 modification in s52plip.cpp
-    if( !ObjectRenderCheckRules( rzRules, vp ) )
+    if( !ObjectRenderCheckRules( rzRules, vp, true ) )
         
May have unwelcome side effects.

Regards
Didier
