### PR TITLE
wxSVG and pugixml update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -738,6 +738,7 @@ IF(OCPN_USE_SVG)
       #set(VIDEO_FFMPEG_LIBRARIES ${FFMPEG_LIBRARIES} ${SWSCALE_LIBRARIES})
 
        FIND_PACKAGE(EXPAT REQUIRED)
+       INCLUDE(FindEXIF.cmake)
     ELSE(NOT WIN32)
       #On Windows, we have our own expat
       SET(EXPAT_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/buildwin/expat-2.1.0/include)
@@ -771,6 +772,7 @@ IF(OCPN_USE_SVG)
         ${CAIRO_EXTRA_LIBRARIES}
 #        ${FFMPEG_LIBRARIES}
         ${EXPAT_LIBRARIES}
+        ${EXIF_LIBRARIES}
         ${GTK_LIBRARIES}
       )
     ENDIF(WIN32)
@@ -783,7 +785,6 @@ IF(OCPN_USE_SVG)
       src/wxsvg/src/Elements_GetAttributes.cpp
       src/wxsvg/src/Elements_HasAttribute.cpp
       src/wxsvg/src/Elements_SetAttribute.cpp
-      src/wxsvg/src/ExifHandler.cpp
       src/wxsvg/src/GetSVGDocument.cpp
       src/wxsvg/src/NodeList.cpp
       src/wxsvg/src/SVGAngle.cpp
@@ -845,6 +846,12 @@ IF(OCPN_USE_SVG)
       src/wxsvg/src/svgxml/svgxml.cpp
       src/wxsvg/src/svgxml/svgxmlhelpr.cpp
     )
+    if(EXIF_FOUND)
+        SET(SRC_WXSVG ${SRC_WXSVG}
+            src/wxsvg/src/ExifHandler.cpp
+        )
+        ADD_DEFINITIONS(-DwxsvgUSE_EXIF) 
+    endif()
     ADD_LIBRARY(WXSVG ${SRC_WXSVG})
     TARGET_LINK_LIBRARIES(WXSVG ${SVG_LIBS})
     INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/src/wxsvg/include/wxSVG)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -783,6 +783,7 @@ IF(OCPN_USE_SVG)
       src/wxsvg/src/Elements_GetAttributes.cpp
       src/wxsvg/src/Elements_HasAttribute.cpp
       src/wxsvg/src/Elements_SetAttribute.cpp
+      src/wxsvg/src/ExifHandler.cpp
       src/wxsvg/src/GetSVGDocument.cpp
       src/wxsvg/src/NodeList.cpp
       src/wxsvg/src/SVGAngle.cpp

--- a/FindEXIF.cmake
+++ b/FindEXIF.cmake
@@ -1,0 +1,112 @@
+# - Find libexif
+# Find the native EXIF includes and library.
+# Once done this will define:
+#
+#  EXIF_ROOT_DIR       - The base directory of EXIF library.
+#  EXIF_INCLUDE_DIRS   - Where to find exif-*.h header files.
+#  EXIF_LIBRARIES      - Libraries to be linked with executable.
+#  EXIF_FOUND          - True if EXIF library is found.
+#
+#  EXIF_VERSION_STRING - The version of EXIF library found (x.y.z)
+#  EXIF_VERSION_MAJOR  - The major version of EXIF library
+#  EXIF_VERSION_MINOR  - The minor version of EXIF library
+#  EXIF_VERSION_PATCH  - The patch version of EXIF library
+#
+# Optional input variables:
+#
+#  EXIF_USE_STATIC_LIB - This can be set to ON to use the static version of
+#      the library. If it does not exist in the system, a warning is printed
+#      and the shared library is used.
+#
+# If libexif is installed in a custom folder (this usually happens on Windows)
+# the environment variable EXIF_ROOT_DIR can be set to the base folder of
+# the library.
+#
+#=============================================================================
+# Copyright (C) 2011 Simone Rossetto <simros85@gmail.com>
+# 
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#=============================================================================
+
+### FIND section ###
+find_path(EXIF_ROOT_DIR
+    NAMES "include/libexif/exif-data.h"
+    PATHS ENV EXIF_ROOT_DIR)
+
+find_path(EXIF_INCLUDE_DIR
+    NAMES "libexif/exif-data.h"
+    HINTS ${EXIF_ROOT_DIR}
+    PATHS ENV EXIF_ROOT_DIR
+    PATH_SUFFIXES "include")
+
+find_library(EXIF_LIBRARY
+    NAMES "exif"
+    HINTS ${EXIF_ROOT_DIR}
+    PATHS ENV EXIF_ROOT_DIR
+    PATH_SUFFIXES "lib")
+
+find_file(_exif_pkg_config_file
+    NAMES "libexif.pc"
+    HINTS ${EXIF_ROOT_DIR}
+    PATHS ENV EXIF_ROOT_DIR
+    PATH_SUFFIXES "lib/pkgconfig" "pkgconfig")
+
+if(EXISTS ${_exif_pkg_config_file})
+    file(STRINGS "${_exif_pkg_config_file}" _exif_version REGEX "^Version: .*$")
+    string(REGEX REPLACE "^.*Version: ([0-9]+).*$" "\\1" EXIF_VERSION_MAJOR "${_exif_version}")
+    string(REGEX REPLACE "^.*Version: [0-9]+\\.([0-9]+).*$" "\\1" EXIF_VERSION_MINOR  "${_exif_version}")
+    string(REGEX REPLACE "^.*Version: [0-9]+\\.[0-9]+\\.([0-9]+).*$" "\\1" EXIF_VERSION_PATCH "${_exif_version}")
+    set(EXIF_VERSION_STRING "${EXIF_VERSION_MAJOR}.${EXIF_VERSION_MINOR}.${EXIF_VERSION_PATCH}")
+else(EXISTS ${_exif_pkg_config_file})
+    set(EXIF_VERSION_STRING "")
+endif(EXISTS ${_exif_pkg_config_file})
+
+
+### OPTIONS and COMPONENTS section ###
+if(EXIF_USE_STATIC_LIB)
+    set(_exif_shared_lib ${EXIF_LIBRARY})
+    if(WIN32 AND NOT MSVC)
+        string(REPLACE ".dll.a" ".a" _exif_static_lib ${_exif_shared_lib})
+    elseif(APPLE)
+        string(REPLACE ".dylib" ".a" _exif_static_lib ${_exif_shared_lib})
+    elseif(UNIX)
+        string(REPLACE ".so" ".a" _exif_static_lib ${_exif_shared_lib})
+    endif()
+
+    if(EXISTS ${_exif_static_lib})
+        set(EXIF_LIBRARY ${_exif_static_lib})
+    else(EXISTS ${_exif_static_lib})
+        message(WARNING "EXIF static library does not exist, using the shared one.")
+        set(EXIF_LIBRARY ${_exif_shared_lib})
+    endif(EXISTS ${_exif_static_lib})
+endif(EXIF_USE_STATIC_LIB)
+
+mark_as_advanced(
+    EXIF_LIBRARY
+    EXIF_INCLUDE_DIR
+    _exif_pkg_config_file
+    _exif_shared_lib
+    _exif_static_lib)
+
+
+### final check ###
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(EXIF
+    REQUIRED_VARS EXIF_LIBRARY EXIF_INCLUDE_DIR
+    VERSION_VAR EXIF_VERSION_STRING)
+
+if(EXIF_FOUND)
+    set(EXIF_INCLUDE_DIRS ${EXIF_INCLUDE_DIR} "${EXIF_INCLUDE_DIR}/libexif")
+    set(EXIF_LIBRARIES ${EXIF_LIBRARY})
+endif(EXIF_FOUND)

--- a/include/pugiconfig.hpp
+++ b/include/pugiconfig.hpp
@@ -1,7 +1,7 @@
 /**
- * pugixml parser - version 1.7
+ * pugixml parser - version 1.8
  * --------------------------------------------------------
- * Copyright (C) 2006-2015, by Arseny Kapoulkine (arseny.kapoulkine@gmail.com)
+ * Copyright (C) 2006-2016, by Arseny Kapoulkine (arseny.kapoulkine@gmail.com)
  * Report bugs and download new versions at http://pugixml.org/
  *
  * This library is distributed under the MIT License. See notice at the end
@@ -49,7 +49,7 @@
 #endif
 
 /**
- * Copyright (c) 2006-2015 Arseny Kapoulkine
+ * Copyright (c) 2006-2016 Arseny Kapoulkine
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -62,7 +62,7 @@
  *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND

--- a/include/pugixml.hpp
+++ b/include/pugixml.hpp
@@ -1,7 +1,7 @@
 /**
- * pugixml parser - version 1.7
+ * pugixml parser - version 1.8
  * --------------------------------------------------------
- * Copyright (C) 2006-2015, by Arseny Kapoulkine (arseny.kapoulkine@gmail.com)
+ * Copyright (C) 2006-2016, by Arseny Kapoulkine (arseny.kapoulkine@gmail.com)
  * Report bugs and download new versions at http://pugixml.org/
  *
  * This library is distributed under the MIT License. See notice at the end
@@ -13,7 +13,7 @@
 
 #ifndef PUGIXML_VERSION
 // Define version macro; evaluates to major * 100 + minor so that it's safe to use in less-than comparisons
-#	define PUGIXML_VERSION 170
+#	define PUGIXML_VERSION 180
 #endif
 
 // Include user configuration file (this can define various configuration macros)
@@ -69,6 +69,24 @@
 #		define PUGIXML_HAS_LONG_LONG
 #	elif defined(_MSC_VER) && _MSC_VER >= 1400
 #		define PUGIXML_HAS_LONG_LONG
+#	endif
+#endif
+
+// If the platform is known to have move semantics support, compile move ctor/operator implementation
+#ifndef PUGIXML_HAS_MOVE
+#	if __cplusplus >= 201103
+#		define PUGIXML_HAS_MOVE
+#	elif defined(_MSC_VER) && _MSC_VER >= 1600
+#		define PUGIXML_HAS_MOVE
+#	endif
+#endif
+
+// If C++ is 2011 or higher, add 'override' qualifiers
+#ifndef PUGIXML_OVERRIDE
+#	if __cplusplus >= 201103
+#		define PUGIXML_OVERRIDE override
+#	else
+#		define PUGIXML_OVERRIDE
 #	endif
 #endif
 
@@ -133,13 +151,13 @@ namespace pugi
 
 	// This flag determines if EOL characters are normalized (converted to #xA) during parsing. This flag is on by default.
 	const unsigned int parse_eol = 0x0020;
-	
+
 	// This flag determines if attribute values are normalized using CDATA normalization rules during parsing. This flag is on by default.
 	const unsigned int parse_wconv_attribute = 0x0040;
 
 	// This flag determines if attribute values are normalized using NMTOKENS normalization rules during parsing. This flag is off by default.
 	const unsigned int parse_wnorm_attribute = 0x0080;
-	
+
 	// This flag determines if document declaration (node_declaration) is added to the DOM tree. This flag is off by default.
 	const unsigned int parse_declaration = 0x0100;
 
@@ -157,6 +175,11 @@ namespace pugi
 	// This flag determines if plain character data that does not have a parent node is added to the DOM tree, and if an empty document
 	// is a valid document. This flag is off by default.
 	const unsigned int parse_fragment = 0x1000;
+
+	// This flag determines if plain character data is be stored in the parent element's value. This significantly changes the structure of
+	// the document; this flag is only recommended for parsing documents with many PCDATA nodes in memory-constrained environments.
+	// This flag is off by default.
+	const unsigned int parse_embed_pcdata = 0x2000;
 
 	// The default parsing mode.
 	// Elements, PCDATA and CDATA sections are added to the DOM tree, character/reference entities are expanded,
@@ -184,16 +207,16 @@ namespace pugi
 	};
 
 	// Formatting flags
-	
+
 	// Indent the nodes that are written to output stream with as many indentation strings as deep the node is in DOM tree. This flag is on by default.
 	const unsigned int format_indent = 0x01;
-	
+
 	// Write encoding-specific BOM to the output stream. This flag is off by default.
 	const unsigned int format_write_bom = 0x02;
 
 	// Use raw output mode (no indentation and no line breaks are written). This flag is off by default.
 	const unsigned int format_raw = 0x04;
-	
+
 	// Omit default XML declaration even if there is no declaration in the document. This flag is off by default.
 	const unsigned int format_no_declaration = 0x08;
 
@@ -205,6 +228,9 @@ namespace pugi
 
 	// Write every attribute on a new line with appropriate indentation. This flag is off by default.
 	const unsigned int format_indent_attributes = 0x40;
+
+	// Don't output empty element tags, instead writing an explicit start and end tag even if there are no children. This flag is off by default.
+	const unsigned int format_no_empty_element_tags = 0x80;
 
 	// The default set of formatting flags.
 	// Nodes are indented depending on their depth in DOM tree, a default declaration is output if document has none.
@@ -225,7 +251,7 @@ namespace pugi
 	class xml_node;
 
 	class xml_text;
-	
+
 	#ifndef PUGIXML_NO_XPATH
 	class xpath_node;
 	class xpath_node_set;
@@ -268,7 +294,7 @@ namespace pugi
 		// Construct writer from a FILE* object; void* is used to avoid header dependencies on stdio
 		xml_writer_file(void* file);
 
-		virtual void write(const void* data, size_t size);
+		virtual void write(const void* data, size_t size) PUGIXML_OVERRIDE;
 
 	private:
 		void* file;
@@ -283,7 +309,7 @@ namespace pugi
 		xml_writer_stream(std::basic_ostream<char, std::char_traits<char> >& stream);
 		xml_writer_stream(std::basic_ostream<wchar_t, std::char_traits<wchar_t> >& stream);
 
-		virtual void write(const void* data, size_t size);
+		virtual void write(const void* data, size_t size) PUGIXML_OVERRIDE;
 
 	private:
 		std::basic_ostream<char, std::char_traits<char> >* narrow_stream;
@@ -299,13 +325,13 @@ namespace pugi
 
 	private:
 		xml_attribute_struct* _attr;
-	
+
 		typedef void (*unspecified_bool_type)(xml_attribute***);
 
 	public:
 		// Default constructor. Constructs an empty attribute.
 		xml_attribute();
-		
+
 		// Constructs attribute from internal pointer
 		explicit xml_attribute(xml_attribute_struct* attr);
 
@@ -354,6 +380,8 @@ namespace pugi
 		// Set attribute value with type conversion (numbers are converted to strings, boolean is converted to "true"/"false")
 		bool set_value(int rhs);
 		bool set_value(unsigned int rhs);
+		bool set_value(long rhs);
+		bool set_value(unsigned long rhs);
 		bool set_value(double rhs);
 		bool set_value(float rhs);
 		bool set_value(bool rhs);
@@ -367,6 +395,8 @@ namespace pugi
 		xml_attribute& operator=(const char_t* rhs);
 		xml_attribute& operator=(int rhs);
 		xml_attribute& operator=(unsigned int rhs);
+		xml_attribute& operator=(long rhs);
+		xml_attribute& operator=(unsigned long rhs);
 		xml_attribute& operator=(double rhs);
 		xml_attribute& operator=(float rhs);
 		xml_attribute& operator=(bool rhs);
@@ -417,7 +447,7 @@ namespace pugi
 
 		// Borland C++ workaround
 		bool operator!() const;
-	
+
 		// Comparison operators (compares wrapped node pointers)
 		bool operator==(const xml_node& r) const;
 		bool operator!=(const xml_node& r) const;
@@ -438,7 +468,7 @@ namespace pugi
 		// Get node value, or "" if node is empty or it has no value
 		// Note: For <node>text</node> node.value() does not return "text"! Use child_value() or text() methods to access text inside nodes.
 		const char_t* value() const;
-	
+
 		// Get attribute list
 		xml_attribute first_attribute() const;
 		xml_attribute last_attribute() const;
@@ -450,7 +480,7 @@ namespace pugi
 		// Get next/previous sibling in the children list of the parent node
 		xml_node next_sibling() const;
 		xml_node previous_sibling() const;
-		
+
 		// Get parent node
 		xml_node parent() const;
 
@@ -478,7 +508,7 @@ namespace pugi
 		// Set node name/value (returns false if node is empty, there is not enough memory, or node can not have name/value)
 		bool set_name(const char_t* rhs);
 		bool set_value(const char_t* rhs);
-		
+
 		// Add attribute with specified name. Returns added attribute, or empty attribute on errors.
 		xml_attribute append_attribute(const char_t* name);
 		xml_attribute prepend_attribute(const char_t* name);
@@ -532,11 +562,11 @@ namespace pugi
 		template <typename Predicate> xml_attribute find_attribute(Predicate pred) const
 		{
 			if (!_root) return xml_attribute();
-			
+
 			for (xml_attribute attrib = first_attribute(); attrib; attrib = attrib.next_attribute())
 				if (pred(attrib))
 					return attrib;
-		
+
 			return xml_attribute();
 		}
 
@@ -544,11 +574,11 @@ namespace pugi
 		template <typename Predicate> xml_node find_child(Predicate pred) const
 		{
 			if (!_root) return xml_node();
-	
+
 			for (xml_node node = first_child(); node; node = node.next_sibling())
 				if (pred(node))
 					return node;
-		
+
 			return xml_node();
 		}
 
@@ -558,7 +588,7 @@ namespace pugi
 			if (!_root) return xml_node();
 
 			xml_node cur = first_child();
-			
+
 			while (cur._root && cur._root != _root)
 			{
 				if (pred(cur)) return cur;
@@ -590,7 +620,7 @@ namespace pugi
 
 		// Recursively traverse subtree with xml_tree_walker
 		bool traverse(xml_tree_walker& walker);
-	
+
 	#ifndef PUGIXML_NO_XPATH
 		// Select single node by evaluating XPath query. Returns first node from the resulting node set.
 		xpath_node select_node(const char_t* query, xpath_variable_set* variables = 0) const;
@@ -605,7 +635,7 @@ namespace pugi
 		xpath_node select_single_node(const xpath_query& query) const;
 
 	#endif
-		
+
 		// Print subtree using a writer object
 		void print(xml_writer& writer, const char_t* indent = PUGIXML_TEXT("\t"), unsigned int flags = format_default, xml_encoding encoding = encoding_auto, unsigned int depth = 0) const;
 
@@ -701,6 +731,8 @@ namespace pugi
 		// Set text with type conversion (numbers are converted to strings, boolean is converted to "true"/"false")
 		bool set(int rhs);
 		bool set(unsigned int rhs);
+		bool set(long rhs);
+		bool set(unsigned long rhs);
 		bool set(double rhs);
 		bool set(float rhs);
 		bool set(bool rhs);
@@ -714,6 +746,8 @@ namespace pugi
 		xml_text& operator=(const char_t* rhs);
 		xml_text& operator=(int rhs);
 		xml_text& operator=(unsigned int rhs);
+		xml_text& operator=(long rhs);
+		xml_text& operator=(unsigned long rhs);
 		xml_text& operator=(double rhs);
 		xml_text& operator=(float rhs);
 		xml_text& operator=(bool rhs);
@@ -867,11 +901,11 @@ namespace pugi
 
 	private:
 		int _depth;
-	
+
 	protected:
 		// Get current traversal depth
 		int depth() const;
-	
+
 	public:
 		xml_tree_walker();
 		virtual ~xml_tree_walker();
@@ -942,13 +976,13 @@ namespace pugi
 		char_t* _buffer;
 
 		char _memory[192];
-		
+
 		// Non-copyable semantics
 		xml_document(const xml_document&);
 		xml_document& operator=(const xml_document&);
 
-		void create();
-		void destroy();
+		void _create();
+		void _destroy();
 
 	public:
 		// Default constructor, makes empty document
@@ -1051,7 +1085,7 @@ namespace pugi
 		// Non-copyable semantics
 		xpath_variable(const xpath_variable&);
 		xpath_variable& operator=(const xpath_variable&);
-		
+
 	public:
 		// Get variable name
 		const char_t* name() const;
@@ -1095,7 +1129,7 @@ namespace pugi
 		xpath_variable_set(const xpath_variable_set& rhs);
 		xpath_variable_set& operator=(const xpath_variable_set& rhs);
 
-	#if __cplusplus >= 201103
+	#ifdef PUGIXML_HAS_MOVE
 		// Move semantics support
 		xpath_variable_set(xpath_variable_set&& rhs);
 		xpath_variable_set& operator=(xpath_variable_set&& rhs);
@@ -1139,7 +1173,7 @@ namespace pugi
 		// Destructor
 		~xpath_query();
 
-	#if __cplusplus >= 201103
+	#ifdef PUGIXML_HAS_MOVE
 		// Move semantics support
 		xpath_query(xpath_query&& rhs);
 		xpath_query& operator=(xpath_query&& rhs);
@@ -1147,21 +1181,21 @@ namespace pugi
 
 		// Get query expression return type
 		xpath_value_type return_type() const;
-		
+
 		// Evaluate expression as boolean value in the specified context; performs type conversion if necessary.
 		// If PUGIXML_NO_EXCEPTIONS is not defined, throws std::bad_alloc on out of memory errors.
 		bool evaluate_boolean(const xpath_node& n) const;
-		
+
 		// Evaluate expression as double value in the specified context; performs type conversion if necessary.
 		// If PUGIXML_NO_EXCEPTIONS is not defined, throws std::bad_alloc on out of memory errors.
 		double evaluate_number(const xpath_node& n) const;
-		
+
 	#ifndef PUGIXML_NO_STL
 		// Evaluate expression as string value in the specified context; performs type conversion if necessary.
 		// If PUGIXML_NO_EXCEPTIONS is not defined, throws std::bad_alloc on out of memory errors.
 		string_t evaluate_string(const xpath_node& n) const;
 	#endif
-		
+
 		// Evaluate expression as string value in the specified context; performs type conversion if necessary.
 		// At most capacity characters are written to the destination buffer, full result size is returned (includes terminating zero).
 		// If PUGIXML_NO_EXCEPTIONS is not defined, throws std::bad_alloc on out of memory errors.
@@ -1188,7 +1222,7 @@ namespace pugi
 		// Borland C++ workaround
 		bool operator!() const;
 	};
-	
+
 	#ifndef PUGIXML_NO_EXCEPTIONS
 	// XPath exception class
 	class PUGIXML_CLASS xpath_exception: public std::exception
@@ -1201,26 +1235,26 @@ namespace pugi
 		explicit xpath_exception(const xpath_parse_result& result);
 
 		// Get error message
-		virtual const char* what() const throw();
+		virtual const char* what() const throw() PUGIXML_OVERRIDE;
 
 		// Get parse result
 		const xpath_parse_result& result() const;
 	};
 	#endif
-	
+
 	// XPath node class (either xml_node or xml_attribute)
 	class PUGIXML_CLASS xpath_node
 	{
 	private:
 		xml_node _node;
 		xml_attribute _attribute;
-	
+
 		typedef void (*unspecified_bool_type)(xpath_node***);
 
 	public:
 		// Default constructor; constructs empty XPath node
 		xpath_node();
-		
+
 		// Construct XPath node from XML node/attribute
 		xpath_node(const xml_node& node);
 		xpath_node(const xml_attribute& attribute, const xml_node& parent);
@@ -1228,13 +1262,13 @@ namespace pugi
 		// Get node/attribute, if any
 		xml_node node() const;
 		xml_attribute attribute() const;
-		
+
 		// Get parent of contained node/attribute
 		xml_node parent() const;
 
 		// Safe bool conversion operator
 		operator unspecified_bool_type() const;
-		
+
 		// Borland C++ workaround
 		bool operator!() const;
 
@@ -1260,13 +1294,13 @@ namespace pugi
 			type_sorted,			// Sorted by document order (ascending)
 			type_sorted_reverse		// Sorted by document order (descending)
 		};
-		
+
 		// Constant iterator type
 		typedef const xpath_node* const_iterator;
 
 		// We define non-constant iterator to be the same as constant iterator so that various generic algorithms (i.e. boost foreach) work
 		typedef const xpath_node* iterator;
-	
+
 		// Default constructor. Constructs empty set.
 		xpath_node_set();
 
@@ -1275,12 +1309,12 @@ namespace pugi
 
 		// Destructor
 		~xpath_node_set();
-		
+
 		// Copy constructor/assignment operator
 		xpath_node_set(const xpath_node_set& ns);
 		xpath_node_set& operator=(const xpath_node_set& ns);
 
-	#if __cplusplus >= 201103
+	#ifdef PUGIXML_HAS_MOVE
 		// Move semantics support
 		xpath_node_set(xpath_node_set&& rhs);
 		xpath_node_set& operator=(xpath_node_set&& rhs);
@@ -1288,31 +1322,31 @@ namespace pugi
 
 		// Get collection type
 		type_t type() const;
-		
+
 		// Get collection size
 		size_t size() const;
 
 		// Indexing operator
 		const xpath_node& operator[](size_t index) const;
-		
+
 		// Collection iterators
 		const_iterator begin() const;
 		const_iterator end() const;
 
 		// Sort the collection in ascending/descending order by document order
 		void sort(bool reverse = false);
-		
+
 		// Get first node in the collection by document order
 		xpath_node first() const;
-		
+
 		// Check if collection is empty
 		bool empty() const;
-	
+
 	private:
 		type_t _type;
-		
+
 		xpath_node _storage;
-		
+
 		xpath_node* _begin;
 		xpath_node* _end;
 
@@ -1325,7 +1359,7 @@ namespace pugi
 	// Convert wide string to UTF8
 	std::basic_string<char, std::char_traits<char>, std::allocator<char> > PUGIXML_FUNCTION as_utf8(const wchar_t* str);
 	std::basic_string<char, std::char_traits<char>, std::allocator<char> > PUGIXML_FUNCTION as_utf8(const std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> >& str);
-	
+
 	// Convert UTF8 to wide string
 	std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > PUGIXML_FUNCTION as_wide(const char* str);
 	std::basic_string<wchar_t, std::char_traits<wchar_t>, std::allocator<wchar_t> > PUGIXML_FUNCTION as_wide(const std::basic_string<char, std::char_traits<char>, std::allocator<char> >& str);
@@ -1333,13 +1367,13 @@ namespace pugi
 
 	// Memory allocation function interface; returns pointer to allocated memory or NULL on failure
 	typedef void* (*allocation_function)(size_t size);
-	
+
 	// Memory deallocation function interface
 	typedef void (*deallocation_function)(void* ptr);
 
 	// Override default memory management functions. All subsequent allocations/deallocations will be performed via supplied functions.
 	void PUGIXML_FUNCTION set_memory_management_functions(allocation_function allocate, deallocation_function deallocate);
-	
+
 	// Get current memory management functions
 	allocation_function PUGIXML_FUNCTION get_memory_allocation_function();
 	deallocation_function PUGIXML_FUNCTION get_memory_deallocation_function();
@@ -1375,7 +1409,7 @@ namespace std
 #endif
 
 /**
- * Copyright (c) 2006-2015 Arseny Kapoulkine
+ * Copyright (c) 2006-2016 Arseny Kapoulkine
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -1388,7 +1422,7 @@ namespace std
  *
  * The above copyright notice and this permission notice shall be
  * included in all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
  * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
  * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND

--- a/src/wxsvg/include/wxSVG/ExifHandler.h
+++ b/src/wxsvg/include/wxSVG/ExifHandler.h
@@ -1,0 +1,25 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        ExifHandler.h
+// Author:      Alex Thuering
+// Created:		30.12.2007
+// RCS-ID:      $Id: ExifHandler.h,v 1.1 2016/10/23 18:34:03 ntalex Exp $
+// Copyright:   (c) Alex Thuering
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#ifndef WXSVG_EXIFHANDLER_H
+#define WXSVG_EXIFHANDLER_H
+
+#include <wx/string.h>
+#include <wx/image.h>
+
+/** Reads EXIF metainformation from image files */
+class ExifHandler {
+  public:
+	/** Returns the orientation tag that indicates the orientation of the captured scene */
+	static int getOrient(const wxString& filename);
+	/** Rotates the image according to orientation tag  */
+	static void rotateImage(const wxString& filename, wxImage& image);
+};
+
+#endif // WXSVG_EXIFHANDLER_H

--- a/src/wxsvg/include/wxSVG/SVGCanvasItem.h
+++ b/src/wxsvg/include/wxSVG/SVGCanvasItem.h
@@ -3,7 +3,7 @@
 // Purpose:     Canvas items
 // Author:      Alex Thuering
 // Created:     2005/05/09
-// RCS-ID:      $Id: SVGCanvasItem.h,v 1.28 2016/01/09 23:31:15 ntalex Exp $
+// RCS-ID:      $Id: SVGCanvasItem.h,v 1.29 2016/07/27 08:54:21 ntalex Exp $
 // Copyright:   (c) 2005 Alex Thuering
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
@@ -44,9 +44,9 @@ class wxSVGCanvasItem {
 	wxSVGCanvasItemType GetType() { return m_type; }
 	
     /** returns the bounding box of the item */
-    virtual wxSVGRect GetBBox(const wxSVGMatrix& matrix = *(wxSVGMatrix*)NULL) { return wxSVGRect(); }
+    virtual wxSVGRect GetBBox(const wxSVGMatrix* matrix = NULL) { return wxSVGRect(); }
     virtual wxSVGRect GetResultBBox(const wxCSSStyleDeclaration& style,
-      const wxSVGMatrix& matrix = *(wxSVGMatrix*)NULL) { return GetBBox(); }
+      const wxSVGMatrix* matrix = NULL) { return GetBBox(matrix); }
 	
   protected:
 	wxSVGCanvasItemType m_type;
@@ -114,8 +114,8 @@ struct wxSVGCanvasTextChunk {
   wxSVGCanvasTextCharList chars;
   wxCSSStyleDeclaration style;
   wxSVGMatrix matrix;
-  wxSVGRect GetBBox(const wxSVGMatrix& matrix);
-  wxSVGRect GetBBox() { return GetBBox(*(wxSVGMatrix*)NULL); }
+  wxSVGRect GetBBox(const wxSVGMatrix* matrix);
+  wxSVGRect GetBBox() { return GetBBox(NULL); }
 };
 
 WX_DECLARE_OBJARRAY(wxSVGCanvasTextChunk, wxSVGCanvasTextChunkList);
@@ -128,7 +128,7 @@ class wxSVGCanvasText: public wxSVGCanvasItem
 	virtual ~wxSVGCanvasText();
 	
 	virtual void Init(wxSVGTextElement& element, const wxCSSStyleDeclaration& style, wxSVGMatrix* matrix);
-    virtual wxSVGRect GetBBox(const wxSVGMatrix& matrix = *(wxSVGMatrix*)NULL);
+    virtual wxSVGRect GetBBox(const wxSVGMatrix* matrix = NULL);
 	virtual long GetNumberOfChars();
     virtual double GetComputedTextLength();
     virtual double GetSubStringLength(unsigned long charnum, unsigned long nchars);

--- a/src/wxsvg/include/wxSVG/SVGDocument.h
+++ b/src/wxsvg/include/wxSVG/SVGDocument.h
@@ -91,7 +91,7 @@ class wxSVGDocument:
     wxImage Render(int width = -1, int height = -1, const wxSVGRect* rect = NULL, bool preserveAspectRatio = true,
 		bool alpha = false, wxProgressDialog* progressDlg = NULL);
     
-    static void ApplyAnimation(wxSVGElement* parent);
+    static void ApplyAnimation(wxSVGElement* parent, wxSVGSVGElement* ownerSVGElement);
   private:
       DECLARE_DYNAMIC_CLASS(wxSVGDocument)
 };

--- a/src/wxsvg/include/wxSVG/SVGStringList.h
+++ b/src/wxsvg/include/wxSVG/SVGStringList.h
@@ -14,13 +14,12 @@
 #include <wx/dynarray.h>
 WX_DECLARE_OBJARRAY(wxString, wxSVGStringListBase);
 
-class wxSVGStringList: public wxSVGStringListBase
-{
-  public:
-    wxSVGStringList() {}
-    
-    wxString GetValueAsString() const;
-    void SetValueAsString(const wxString& value, wxChar delimiter = wxT(','));
+class wxSVGStringList: public wxSVGStringListBase {
+public:
+	wxSVGStringList() {}
+
+	wxString GetValueAsString(wxChar delimiter = wxT(',')) const;
+	void SetValueAsString(const wxString& value, wxChar delimiter = wxT(','));
 };
 
 #endif // WX_SVG_STRING_LIST_H

--- a/src/wxsvg/include/wxSVG/mediadec_ffmpeg.h
+++ b/src/wxsvg/include/wxSVG/mediadec_ffmpeg.h
@@ -3,7 +3,7 @@
 // Purpose:     FFMPEG Media Decoder
 // Author:      Alex Thuering
 // Created:     21.07.2007
-// RCS-ID:      $Id: mediadec_ffmpeg.h,v 1.8 2015/09/21 13:23:51 ntalex Exp $
+// RCS-ID:      $Id: mediadec_ffmpeg.h,v 1.9 2016/05/03 19:44:46 ntalex Exp $
 // Copyright:   (c) Alex Thuering
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
@@ -13,6 +13,10 @@
 
 #include <wx/string.h>
 #include <wx/image.h>
+#include <vector>
+#include <map>
+using namespace std;
+
 struct AVFormatContext;
 struct AVCodecContext;
 struct AVFrame;
@@ -60,6 +64,12 @@ public:
 	wxString GetFormatName();
 	/** Returns time base for video codec (tbc). */
 	float GetCodecTimeBase();
+	/** Returns list of chapters */
+	vector<double> GetChapters();
+	/** Returns file metadata */
+	map<wxString, wxString> GetMetadata();
+	/** Returns stream metadata */
+	map<wxString, wxString> GetMetadata(unsigned int streamIndex);
 	
 private:
 	AVFormatContext* m_formatCtx;

--- a/src/wxsvg/src/ExifHandler.cpp
+++ b/src/wxsvg/src/ExifHandler.cpp
@@ -1,0 +1,61 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:        ExifHandler.cpp
+// Author:      Alex Thuering
+// Created:		30.12.2007
+// RCS-ID:      $Id: ExifHandler.cpp,v 1.2 2016/10/23 18:54:56 ntalex Exp $
+// Copyright:   (c) Alex Thuering
+// Licence:     wxWindows licence
+/////////////////////////////////////////////////////////////////////////////
+
+#include "ExifHandler.h"
+#include <libexif/exif-loader.h>
+#include <wx/log.h>
+
+/** Returns the orientation tag that indicates the orientation of the captured scene */
+int ExifHandler::getOrient(const wxString& filename) {
+	ExifData* exifData = exif_data_new_from_file(filename.mb_str());
+	if (!exifData)
+		return -1;
+	if (!exif_content_get_entry(exifData->ifd[EXIF_IFD_EXIF], EXIF_TAG_EXIF_VERSION))
+		return -1;
+	int orient = -1;
+	ExifEntry* entry = exif_content_get_entry(exifData->ifd[EXIF_IFD_0], EXIF_TAG_ORIENTATION);
+	if (entry) {
+		ExifByteOrder byteOrder = exif_data_get_byte_order(exifData);
+		orient = exif_get_short(entry->data, byteOrder);
+	}
+	exif_data_unref(exifData);
+	return (int) orient;
+}
+
+/** Rotates the image according to orientation tag  */
+void ExifHandler::rotateImage(const wxString& filename, wxImage& image) {
+	if (!image.Ok() || filename.length() < 5 || filename.Mid(filename.length() - 4).Lower() != wxT(".jpg"))
+		return;
+	int orient = getOrient(filename);
+	switch (orient) {
+	case 2: // horizontally mirror
+		image = image.Mirror();
+		break;
+	case 3: // rotated 180
+		image = image.Rotate90().Rotate90();
+		break;
+	case 4: // vertically mirror
+		image = image.Mirror(false);
+		break;
+	case 5: // 90 CW and horizontally mirror
+		image = image.Rotate90().Mirror();
+		break;
+	case 6: // 90 CW
+		image = image.Rotate90();
+		break;
+	case 7: // 90 CW and vertically mirror
+		image = image.Rotate90().Mirror(false);
+		break;
+	case 8: // 90 CCW
+		image = image.Rotate90(false);
+		break;
+	default:
+		break;
+	}
+}

--- a/src/wxsvg/src/SVGAnimationElement.cpp
+++ b/src/wxsvg/src/SVGAnimationElement.cpp
@@ -3,7 +3,7 @@
 // Purpose:     Implementation of wxSVGAnimationElement
 // Author:      Alex Thuering
 // Created:     2005/05/10
-// RCS-ID:      $Id: SVGAnimationElement.cpp,v 1.8 2016/01/29 16:40:01 ntalex Exp $
+// RCS-ID:      $Id: SVGAnimationElement.cpp,v 1.10 2016/05/16 21:08:52 ntalex Exp $
 // Copyright:   (c) 2005 Alex Thuering
 // Licence:     wxWindows licence
 //////////////////////////////////////////////////////////////////////////////
@@ -37,7 +37,7 @@ wxString wxSVGAnimationElement::GetCustomAttribute(const wxString& name) const {
 	if (name == wxT("repeatCount"))
 		return m_repeatCount < 0 ? wxT("indefinite") : wxString::Format(wxT("%d"), m_repeatCount);
 	else if (name == wxT("values"))
-		return m_values.GetValueAsString();
+		return m_values.GetValueAsString(wxT(';'));
 	return wxT("");
 }
 
@@ -66,8 +66,8 @@ wxSvgXmlAttrHash wxSVGAnimationElement::GetCustomAttributes() const {
 }
 
 wxSVGElement* wxSVGAnimationElement::GetTargetElement() const {
-	if (m_href.length() && GetOwnerSVGElement()) {
-		return (wxSVGElement*) GetOwnerSVGElement()->GetElementById(m_href);
+	if (m_href.length() && m_href.GetChar(0) == wxT('#') && GetOwnerSVGElement()) {
+		return (wxSVGElement*) GetOwnerSVGElement()->GetElementById(m_href.substr(1));
 	}
 	return (wxSVGElement*) GetParent();
 }

--- a/src/wxsvg/src/SVGCanvasItem.cpp
+++ b/src/wxsvg/src/SVGCanvasItem.cpp
@@ -1,10 +1,9 @@
 //////////////////////////////////////////////////////////////////////////////
 // Name:        SVGCanvasItem.cpp
-// Purpose:     
 // Author:      Alex Thuering
 // Created:     2005/05/09
-// RCS-ID:      $Id: SVGCanvasItem.cpp,v 1.52 2016/01/09 23:31:14 ntalex Exp $
-// Copyright:   (c) 2005 Alex Thuering
+// RCS-ID:      $Id: SVGCanvasItem.cpp,v 1.58 2016/12/28 17:59:30 ntalex Exp $
+// Copyright:   (c) Alex Thuering
 // Licence:     wxWindows licence
 //////////////////////////////////////////////////////////////////////////////
 
@@ -12,6 +11,7 @@
 #include <wx/tokenzr.h>
 #include "SVGCanvasItem.h"
 #include "SVGCanvas.h"
+#include "ExifHandler.h"
 #include <math.h>
 #include <wx/log.h>
 #include <wx/progdlg.h>
@@ -538,12 +538,12 @@ bool IsQuadraticType(wxPATHSEG segType) {
 }
 
 double AngleBisect(float a1, float a2) {
-	double delta = fmod((double)(a2 - a1), 2 * M_PI);
+    double delta = (double) fmod(a2 - a1, 2 * M_PI);
 	if (delta < 0) {
 		delta += 2 * M_PI;
 	}
 	/* delta is now the angle from a1 around to a2, in the range [0, 2*M_PI) */
-	float r = a1 + delta / 2;
+	double r = a1 + delta / 2;
 	if (delta >= M_PI) {
 		/* the arc from a2 to a1 is smaller, so use the ray on that side */
 		r += M_PI;
@@ -1164,12 +1164,12 @@ void wxSVGCanvasText::EndTextAnchor() {
 	}
 }
 
-wxSVGRect wxSVGCanvasTextChunk::GetBBox(const wxSVGMatrix& matrix) {
+wxSVGRect wxSVGCanvasTextChunk::GetBBox(const wxSVGMatrix* matrix) {
 	wxSVGRect bbox;
 	for (int i = 0; i < (int) chars.Count(); i++) {
 		wxSVGRect elemBBox = chars[i].path->GetBBox(matrix);
 		if (elemBBox.IsEmpty())
-			elemBBox = &matrix ? chars[i].bbox.MatrixTransform(matrix) : chars[i].bbox;
+			elemBBox = matrix ? chars[i].bbox.MatrixTransform(*matrix) : chars[i].bbox;
 		if (i == 0)
 			bbox = elemBBox;
 		else {
@@ -1190,15 +1190,15 @@ wxSVGRect wxSVGCanvasTextChunk::GetBBox(const wxSVGMatrix& matrix) {
 	return bbox;
 }
 
-wxSVGRect wxSVGCanvasText::GetBBox(const wxSVGMatrix& matrix)
+wxSVGRect wxSVGCanvasText::GetBBox(const wxSVGMatrix* matrix)
 {
   wxSVGRect bbox;
   for (int i=0; i<(int)m_chunks.Count(); i++)
   {
     wxSVGMatrix tmpMatrix = m_chunks[i].matrix;
-    if (&matrix)
-      tmpMatrix = ((wxSVGMatrix&) matrix).Multiply(m_chunks[i].matrix);
-    wxSVGRect elemBBox = m_chunks[i].GetBBox(tmpMatrix);
+    if (matrix)
+      tmpMatrix = (*matrix).Multiply(m_chunks[i].matrix);
+    wxSVGRect elemBBox = m_chunks[i].GetBBox(&tmpMatrix);
 	if (i == 0)
 	  bbox = elemBBox;
 	else
@@ -1406,7 +1406,7 @@ void wxSVGCanvasImage::Init(wxSVGImageElement& element, const wxCSSStyleDeclarat
 			m_svgImageData->IncRef();
 		}
 	} else if (m_href.length()) {
-		long pos = 0;
+		long pos = -1;
 		wxString filename = m_href;
 		if (filename.StartsWith(wxT("concat:"))) {
 			if (filename.Find(wxT('#')) != wxNOT_FOUND && filename.AfterLast(wxT('#')).ToLong(&pos))
@@ -1440,6 +1440,7 @@ void wxSVGCanvasImage::Init(wxSVGImageElement& element, const wxCSSStyleDeclarat
 #ifdef USE_LIBAV
 		bool log = wxLog::EnableLogging(false);
 		m_image.LoadFile(filename);
+		ExifHandler::rotateImage(filename, m_image);
 		wxLog::EnableLogging(log);
 		if (!m_image.Ok()) {
 			wxFfmpegMediaDecoder decoder;
@@ -1451,7 +1452,7 @@ void wxSVGCanvasImage::Init(wxSVGImageElement& element, const wxCSSStyleDeclarat
 				double duration = decoder.GetDuration();
 				if (duration > 0 || pos > 0) {
 					m_image = decoder.GetNextFrame();
-					double dpos = pos > 0 ? ((double)pos)/1000 : (duration < 6000 ? duration * 0.05 : 300);
+					double dpos = pos >= 0 ? ((double)pos)/1000 : (duration < 6000 ? duration * 0.05 : 300);
 					if (!decoder.SetPosition(dpos > 1.0 ? dpos - 1.0 : 0.0)) {
 						wxLog* oldLog = wxLog::SetActiveTarget(new wxLogStderr());
 						wxLogError(wxT("decoder.GetDuration(): %f"), duration);
@@ -1478,6 +1479,7 @@ void wxSVGCanvasImage::Init(wxSVGImageElement& element, const wxCSSStyleDeclarat
 			}
 		}
 #else
+		ExifHandler::rotateImage(filename, m_image);
 		m_image.LoadFile(filename);
 #endif
 	}
@@ -1504,7 +1506,6 @@ wxSVGSVGElement* wxSVGCanvasImage::GetSvgImage(wxSVGDocument* doc) {
 		} else if (m_svgImageData->GetSvgImage()->GetOwnerDocument() != doc) {
 			wxSVGCanvasSvgImageData* svgImageDataOld = m_svgImageData;
 			m_svgImageData = new wxSVGCanvasSvgImageData(m_svgImageData->GetSvgImage(), doc);
-			wxSVGDocument::ApplyAnimation(m_svgImageData->GetSvgImage());
 			if (svgImageDataOld->DecRef() == 0)
 				delete svgImageDataOld;
 		}

--- a/src/wxsvg/src/SVGCanvasItem.cpp
+++ b/src/wxsvg/src/SVGCanvasItem.cpp
@@ -11,7 +11,9 @@
 #include <wx/tokenzr.h>
 #include "SVGCanvasItem.h"
 #include "SVGCanvas.h"
+#ifdef wxsvgUSE_EXIF
 #include "ExifHandler.h"
+#endif
 #include <math.h>
 #include <wx/log.h>
 #include <wx/progdlg.h>
@@ -1440,7 +1442,9 @@ void wxSVGCanvasImage::Init(wxSVGImageElement& element, const wxCSSStyleDeclarat
 #ifdef USE_LIBAV
 		bool log = wxLog::EnableLogging(false);
 		m_image.LoadFile(filename);
+#ifdef wxsvgUSE_EXIF
 		ExifHandler::rotateImage(filename, m_image);
+#endif
 		wxLog::EnableLogging(log);
 		if (!m_image.Ok()) {
 			wxFfmpegMediaDecoder decoder;
@@ -1479,7 +1483,9 @@ void wxSVGCanvasImage::Init(wxSVGImageElement& element, const wxCSSStyleDeclarat
 			}
 		}
 #else
+#ifdef wxsvgUSE_EXIF
 		ExifHandler::rotateImage(filename, m_image);
+#endif
 		m_image.LoadFile(filename);
 #endif
 	}

--- a/src/wxsvg/src/SVGLineElement.cpp
+++ b/src/wxsvg/src/SVGLineElement.cpp
@@ -3,7 +3,7 @@
 // Purpose:     
 // Author:      Alex Thuering
 // Created:     2005/05/10
-// RCS-ID:      $Id: SVGLineElement.cpp,v 1.4 2006/01/08 12:44:30 ntalex Exp $
+// RCS-ID:      $Id: SVGLineElement.cpp,v 1.5 2016/07/28 09:05:28 ntalex Exp $
 // Copyright:   (c) 2005 Alex Thuering
 // Licence:     wxWindows licence
 //////////////////////////////////////////////////////////////////////////////
@@ -11,55 +11,53 @@
 #include "SVGLineElement.h"
 #include "SVGCanvas.h"
 
-wxSVGRect wxSVGLineElement::GetBBox(wxSVG_COORDINATES coordinates)
-{
-  wxSVGPoint p1 = wxSVGPoint(GetX1().GetAnimVal(), GetY1().GetAnimVal());
-  wxSVGPoint p2 = wxSVGPoint(GetX2().GetAnimVal(), GetY2().GetAnimVal());
-  if (coordinates != wxSVG_COORDINATES_USER)
-  {
-    wxSVGMatrix matrix = GetMatrix(coordinates);
-    p1 = p1.MatrixTransform(matrix);
-    p2 = p2.MatrixTransform(matrix);
-  }
-  
-  double x1 = p1.GetX();
-  double y1 = p1.GetY();
-  double x2 = p2.GetX();
-  double y2 = p2.GetY();
+wxSVGRect wxSVGLineElement::GetBBox(wxSVG_COORDINATES coordinates) {
+	wxSVGPoint p1 = wxSVGPoint(GetX1().GetAnimVal(), GetY1().GetAnimVal());
+	wxSVGPoint p2 = wxSVGPoint(GetX2().GetAnimVal(), GetY2().GetAnimVal());
+	if (coordinates != wxSVG_COORDINATES_USER) {
+		wxSVGMatrix matrix = GetMatrix(coordinates);
+		p1 = p1.MatrixTransform(matrix);
+		p2 = p2.MatrixTransform(matrix);
+	}
 
-  wxSVGRect bbox(x1, y1, x2 - x1, y2 - y1);
-  
-  if (x1 > x2)
-  {
-	bbox.SetX(x2);
-	bbox.SetWidth(x1 - x2);
-  }
-  
-  if (y1 > y2)
-  {
-	bbox.SetY(y2);
-	bbox.SetHeight(y1 - y2);
-  }
-  
-  return bbox;
+	double x1 = p1.GetX();
+	double y1 = p1.GetY();
+	double x2 = p2.GetX();
+	double y2 = p2.GetY();
+
+	wxSVGRect bbox(x1, y1, x2 - x1, y2 - y1);
+
+	if (x1 > x2) {
+		bbox.SetX(x2);
+		bbox.SetWidth(x1 - x2);
+	}
+
+	if (y1 > y2) {
+		bbox.SetY(y2);
+		bbox.SetHeight(y1 - y2);
+	}
+
+	return bbox;
 }
 
-wxSVGRect wxSVGLineElement::GetResultBBox(wxSVG_COORDINATES coordinates)
-{
-  wxCSSStyleDeclaration style = GetResultStyle(*this);
-  if (style.GetStroke().GetPaintType() == wxSVG_PAINTTYPE_NONE)
-    return GetBBox(coordinates);
-  WX_SVG_CREATE_M_CANVAS_ITEM
-  wxSVGRect bbox = coordinates == wxSVG_COORDINATES_USER ?
-    m_canvasItem->GetResultBBox(style) :
-    m_canvasItem->GetResultBBox(style, GetMatrix(coordinates));
-  WX_SVG_CLEAR_M_CANVAS_ITEM
-  return bbox; 
+wxSVGRect wxSVGLineElement::GetResultBBox(wxSVG_COORDINATES coordinates) {
+	wxCSSStyleDeclaration style = GetResultStyle(*this);
+	if (style.GetStroke().GetPaintType() == wxSVG_PAINTTYPE_NONE)
+		return GetBBox(coordinates);
+	WX_SVG_CREATE_M_CANVAS_ITEM
+	wxSVGRect bbox;
+	if (coordinates == wxSVG_COORDINATES_USER) {
+		bbox = m_canvasItem->GetResultBBox(style);
+	} else {
+		wxSVGMatrix m = GetMatrix(coordinates);
+		bbox = m_canvasItem->GetResultBBox(style, &m);
+	}
+	WX_SVG_CLEAR_M_CANVAS_ITEM
+	return bbox;
 }
 
-void wxSVGLineElement::SetCanvasItem(wxSVGCanvasItem* canvasItem)
-{
-  if (m_canvasItem)
-    delete m_canvasItem;
-  m_canvasItem = canvasItem;
+void wxSVGLineElement::SetCanvasItem(wxSVGCanvasItem* canvasItem) {
+	if (m_canvasItem)
+		delete m_canvasItem;
+	m_canvasItem = canvasItem;
 }

--- a/src/wxsvg/src/SVGPathElement.cpp
+++ b/src/wxsvg/src/SVGPathElement.cpp
@@ -3,7 +3,7 @@
 // Purpose:     Implementation of wxSVGPathElement
 // Author:      Alex Thuering
 // Created:     2005/05/10
-// RCS-ID:      $Id: SVGPathElement.cpp,v 1.7 2014/08/09 11:13:02 ntalex Exp $
+// RCS-ID:      $Id: SVGPathElement.cpp,v 1.8 2016/07/28 09:05:28 ntalex Exp $
 // Copyright:   (c) 2005 Alex Thuering
 // Licence:     wxWindows licence
 //////////////////////////////////////////////////////////////////////////////
@@ -14,8 +14,13 @@
 
 wxSVGRect wxSVGPathElement::GetBBox(wxSVG_COORDINATES coordinates) {
 	WX_SVG_CREATE_M_CANVAS_ITEM
-	wxSVGRect bbox = coordinates == wxSVG_COORDINATES_USER ? m_canvasItem->GetBBox() :
-			m_canvasItem->GetBBox(GetMatrix(coordinates));
+	wxSVGRect bbox;
+	if (coordinates == wxSVG_COORDINATES_USER) {
+		bbox = m_canvasItem->GetBBox();
+	} else {
+		wxSVGMatrix m = GetMatrix(coordinates);
+		bbox = m_canvasItem->GetBBox(&m);
+	}
 	WX_SVG_CLEAR_M_CANVAS_ITEM
 	return bbox;
 }
@@ -25,8 +30,13 @@ wxSVGRect wxSVGPathElement::GetResultBBox(wxSVG_COORDINATES coordinates) {
 	if (style.GetStroke().GetPaintType() == wxSVG_PAINTTYPE_NONE)
 		return GetBBox(coordinates);
 	WX_SVG_CREATE_M_CANVAS_ITEM
-	wxSVGRect bbox = coordinates == wxSVG_COORDINATES_USER ? m_canvasItem->GetResultBBox(style) :
-			m_canvasItem->GetResultBBox(style, GetMatrix(coordinates));
+	wxSVGRect bbox;
+	if (coordinates == wxSVG_COORDINATES_USER) {
+		bbox = m_canvasItem->GetResultBBox(style);
+	} else {
+		wxSVGMatrix m = GetMatrix(coordinates);
+		bbox = m_canvasItem->GetResultBBox(style, &m);
+	}
 	WX_SVG_CLEAR_M_CANVAS_ITEM
 	return bbox;
 }
@@ -77,38 +87,38 @@ wxSVGPathSegLinetoRel wxSVGPathElement::CreateSVGPathSegLinetoRel(double x, doub
 	return res;
 }
 
-wxSVGPathSegCurvetoCubicAbs wxSVGPathElement::CreateSVGPathSegCurvetoCubicAbs(
-		double x, double y, double x1, double y1, double x2, double y2) const {
+wxSVGPathSegCurvetoCubicAbs wxSVGPathElement::CreateSVGPathSegCurvetoCubicAbs(double x, double y, double x1, double y1,
+		double x2, double y2) const {
 	wxSVGPathSegCurvetoCubicAbs res;
 	return res;
 }
 
-wxSVGPathSegCurvetoCubicRel wxSVGPathElement::CreateSVGPathSegCurvetoCubicRel(
-		double x, double y, double x1, double y1, double x2, double y2) const {
+wxSVGPathSegCurvetoCubicRel wxSVGPathElement::CreateSVGPathSegCurvetoCubicRel(double x, double y, double x1, double y1,
+		double x2, double y2) const {
 	wxSVGPathSegCurvetoCubicRel res;
 	return res;
 }
 
-wxSVGPathSegCurvetoQuadraticAbs wxSVGPathElement::CreateSVGPathSegCurvetoQuadraticAbs(
-		double x, double y, double x1, double y1) const {
+wxSVGPathSegCurvetoQuadraticAbs wxSVGPathElement::CreateSVGPathSegCurvetoQuadraticAbs(double x, double y, double x1,
+		double y1) const {
 	wxSVGPathSegCurvetoQuadraticAbs res;
 	return res;
 }
 
-wxSVGPathSegCurvetoQuadraticRel wxSVGPathElement::CreateSVGPathSegCurvetoQuadraticRel(
-		double x, double y, double x1, double y1) const {
+wxSVGPathSegCurvetoQuadraticRel wxSVGPathElement::CreateSVGPathSegCurvetoQuadraticRel(double x, double y, double x1,
+		double y1) const {
 	wxSVGPathSegCurvetoQuadraticRel res;
 	return res;
 }
 
-wxSVGPathSegArcAbs wxSVGPathElement::CreateSVGPathSegArcAbs(double x, double y,
-		double r1, double r2, double angle, bool largeArcFlag, bool sweepFlag) const {
+wxSVGPathSegArcAbs wxSVGPathElement::CreateSVGPathSegArcAbs(double x, double y, double r1, double r2, double angle,
+		bool largeArcFlag, bool sweepFlag) const {
 	wxSVGPathSegArcAbs res;
 	return res;
 }
 
-wxSVGPathSegArcRel wxSVGPathElement::CreateSVGPathSegArcRel(double x, double y,
-		double r1, double r2, double angle, bool largeArcFlag, bool sweepFlag) const {
+wxSVGPathSegArcRel wxSVGPathElement::CreateSVGPathSegArcRel(double x, double y, double r1, double r2, double angle,
+		bool largeArcFlag, bool sweepFlag) const {
 	wxSVGPathSegArcRel res;
 	return res;
 }
@@ -133,26 +143,26 @@ wxSVGPathSegLinetoVerticalRel wxSVGPathElement::CreateSVGPathSegLinetoVerticalRe
 	return res;
 }
 
-wxSVGPathSegCurvetoCubicSmoothAbs wxSVGPathElement::CreateSVGPathSegCurvetoCubicSmoothAbs(
-		double x, double y, double x2, double y2) const {
+wxSVGPathSegCurvetoCubicSmoothAbs wxSVGPathElement::CreateSVGPathSegCurvetoCubicSmoothAbs(double x, double y, double x2,
+		double y2) const {
 	wxSVGPathSegCurvetoCubicSmoothAbs res;
 	return res;
 }
 
-wxSVGPathSegCurvetoCubicSmoothRel wxSVGPathElement::CreateSVGPathSegCurvetoCubicSmoothRel(
-		double x, double y, double x2, double y2) const {
+wxSVGPathSegCurvetoCubicSmoothRel wxSVGPathElement::CreateSVGPathSegCurvetoCubicSmoothRel(double x, double y, double x2,
+		double y2) const {
 	wxSVGPathSegCurvetoCubicSmoothRel res;
 	return res;
 }
 
-wxSVGPathSegCurvetoQuadraticSmoothAbs wxSVGPathElement::CreateSVGPathSegCurvetoQuadraticSmoothAbs(
-		double x, double y) const {
+wxSVGPathSegCurvetoQuadraticSmoothAbs wxSVGPathElement::CreateSVGPathSegCurvetoQuadraticSmoothAbs(double x,
+		double y) const {
 	wxSVGPathSegCurvetoQuadraticSmoothAbs res;
 	return res;
 }
 
-wxSVGPathSegCurvetoQuadraticSmoothRel wxSVGPathElement::CreateSVGPathSegCurvetoQuadraticSmoothRel(
-		double x, double y) const {
+wxSVGPathSegCurvetoQuadraticSmoothRel wxSVGPathElement::CreateSVGPathSegCurvetoQuadraticSmoothRel(double x,
+		double y) const {
 	wxSVGPathSegCurvetoQuadraticSmoothRel res;
 	return res;
 }

--- a/src/wxsvg/src/SVGPointList.cpp
+++ b/src/wxsvg/src/SVGPointList.cpp
@@ -11,34 +11,27 @@
 #include <wx/arrimpl.cpp>
 WX_DEFINE_OBJARRAY(wxSVGPointListBase);
 
-wxString wxSVGPointList::GetValueAsString() const
-{
-  wxString value;
-  for (int i=0; i<(int)GetCount(); i++)
-    value += (i==0 ? wxT("") : wxT(" ")) + 
-      wxString::Format(wxT("%g,%g"), Item(i).GetX(), Item(i).GetY());
-  return value;
+wxString wxSVGPointList::GetValueAsString() const {
+	wxString value;
+	for (int i = 0; i < (int) GetCount(); i++) {
+		if (i > 0) {
+			value += wxT(" ");
+		}
+		value += wxString::Format(wxT("%g,%g"), Item(i).GetX(), Item(i).GetY());
+	}
+	return value;
 }
 
-void wxSVGPointList::SetValueAsString(const wxString& value)
-{
-  int num = 0;
-  double numbers[2];
-  wxStringTokenizer tkz(value, wxT(", \t"));
-  while (tkz.HasMoreTokens()) 
-  { 
-    wxString token = tkz.GetNextToken(); 
-    if (token.length() && token.ToDouble(&numbers[num]))
-    {
-      num++;
-      if (num == 2)
-      {
-        wxSVGPoint point;
-        point.SetX(numbers[0]);
-        point.SetY(numbers[1]);
-        Add(point);
-        num = 0;
-      }
-    }
-  }
+void wxSVGPointList::SetValueAsString(const wxString& value) {
+	Clear();
+	double x, y;
+	wxStringTokenizer tkz(value, wxT(" \t\r\n"));
+	while (tkz.HasMoreTokens()) {
+		wxString token = tkz.GetNextToken().Strip(wxString::both);
+		if (token.length() && token.Find(wxT(',')) > 0
+				&& token.BeforeFirst(wxT(',')).ToDouble(&x)
+				&& token.AfterFirst(wxT(',')).ToDouble(&y)) {
+			Add(wxSVGPoint(x, y));
+		}
+	}
 }

--- a/src/wxsvg/src/SVGPolygonElement.cpp
+++ b/src/wxsvg/src/SVGPolygonElement.cpp
@@ -3,7 +3,7 @@
 // Purpose:     
 // Author:      Alex Thuering
 // Created:     2005/05/10
-// RCS-ID:      $Id: SVGPolygonElement.cpp,v 1.4 2006/01/08 12:44:30 ntalex Exp $
+// RCS-ID:      $Id: SVGPolygonElement.cpp,v 1.5 2016/07/28 09:05:28 ntalex Exp $
 // Copyright:   (c) 2005 Alex Thuering
 // Licence:     wxWindows licence
 //////////////////////////////////////////////////////////////////////////////
@@ -11,62 +11,58 @@
 #include "SVGPolygonElement.h"
 #include "SVGCanvas.h"
 
-wxSVGRect wxSVGPolygonElement::GetBBox(wxSVG_COORDINATES coordinates)
-{
-  const wxSVGPointList& points = GetPoints();
-  if (points.Count() == 0)
-	return wxSVGRect();
-  
-  wxSVGPoint p0 = points[0];
-  wxSVGMatrix matrix;
-  if (coordinates != wxSVG_COORDINATES_USER)
-  {
-    matrix = GetMatrix(coordinates);
-    p0 = p0.MatrixTransform(matrix);
-  }
-  wxSVGRect bbox(p0.GetX(), p0.GetY(), 0, 0);
-  
-  wxSVGPoint pi = wxSVGPoint();
-  for (int i = 1; i<(int)points.Count(); i++)
-  {
-  	pi = coordinates == wxSVG_COORDINATES_USER ?
-      points[i] : points[i].MatrixTransform(matrix);
-	if (bbox.GetX() > pi.GetX())
-	{
-	  bbox.SetWidth(bbox.GetWidth() + bbox.GetX() - pi.GetX());
-	  bbox.SetX(pi.GetX());
+wxSVGRect wxSVGPolygonElement::GetBBox(wxSVG_COORDINATES coordinates) {
+	const wxSVGPointList& points = GetPoints();
+	if (points.Count() == 0)
+		return wxSVGRect();
+
+	wxSVGPoint p0 = points[0];
+	wxSVGMatrix matrix;
+	if (coordinates != wxSVG_COORDINATES_USER) {
+		matrix = GetMatrix(coordinates);
+		p0 = p0.MatrixTransform(matrix);
 	}
-	if (bbox.GetY() > pi.GetY())
-	{
-	  bbox.SetHeight(bbox.GetHeight() + bbox.GetY() - pi.GetY());
-	  bbox.SetY(pi.GetY());
+	wxSVGRect bbox(p0.GetX(), p0.GetY(), 0, 0);
+
+	wxSVGPoint pi = wxSVGPoint();
+	for (int i = 1; i < (int) points.Count(); i++) {
+		pi = coordinates == wxSVG_COORDINATES_USER ? points[i] : points[i].MatrixTransform(matrix);
+		if (bbox.GetX() > pi.GetX()) {
+			bbox.SetWidth(bbox.GetWidth() + bbox.GetX() - pi.GetX());
+			bbox.SetX(pi.GetX());
+		}
+		if (bbox.GetY() > pi.GetY()) {
+			bbox.SetHeight(bbox.GetHeight() + bbox.GetY() - pi.GetY());
+			bbox.SetY(pi.GetY());
+		}
+
+		if (bbox.GetX() + bbox.GetWidth() < pi.GetX())
+			bbox.SetWidth(pi.GetX() - bbox.GetX());
+		if (bbox.GetY() + bbox.GetHeight() < pi.GetY())
+			bbox.SetHeight(pi.GetY() - bbox.GetY());
 	}
-	
-	if (bbox.GetX() + bbox.GetWidth() < pi.GetX())
-	  bbox.SetWidth(pi.GetX() - bbox.GetX());
-	if (bbox.GetY() + bbox.GetHeight() < pi.GetY())
-	  bbox.SetHeight(pi.GetY() - bbox.GetY());
-  }
-  
-  return bbox;
+
+	return bbox;
 }
 
-wxSVGRect wxSVGPolygonElement::GetResultBBox(wxSVG_COORDINATES coordinates)
-{
-  wxCSSStyleDeclaration style = GetResultStyle(*this);
-  if (style.GetStroke().GetPaintType() == wxSVG_PAINTTYPE_NONE)
-    return GetBBox(coordinates);
-  WX_SVG_CREATE_M_CANVAS_ITEM
-  wxSVGRect bbox = coordinates == wxSVG_COORDINATES_USER ?
-    m_canvasItem->GetResultBBox(style) :
-    m_canvasItem->GetResultBBox(style, GetMatrix(coordinates));
-  WX_SVG_CLEAR_M_CANVAS_ITEM
-  return bbox;
+wxSVGRect wxSVGPolygonElement::GetResultBBox(wxSVG_COORDINATES coordinates) {
+	wxCSSStyleDeclaration style = GetResultStyle(*this);
+	if (style.GetStroke().GetPaintType() == wxSVG_PAINTTYPE_NONE)
+		return GetBBox(coordinates);
+	WX_SVG_CREATE_M_CANVAS_ITEM
+	wxSVGRect bbox;
+	if (coordinates == wxSVG_COORDINATES_USER) {
+		bbox = m_canvasItem->GetResultBBox(style);
+	} else {
+		wxSVGMatrix m = GetMatrix(coordinates);
+		bbox = m_canvasItem->GetResultBBox(style, &m);
+	}
+	WX_SVG_CLEAR_M_CANVAS_ITEM
+	return bbox;
 }
 
-void wxSVGPolygonElement::SetCanvasItem(wxSVGCanvasItem* canvasItem)
-{
-  if (m_canvasItem)
-    delete m_canvasItem;
-  m_canvasItem = canvasItem;
+void wxSVGPolygonElement::SetCanvasItem(wxSVGCanvasItem* canvasItem) {
+	if (m_canvasItem)
+		delete m_canvasItem;
+	m_canvasItem = canvasItem;
 }

--- a/src/wxsvg/src/SVGPolylineElement.cpp
+++ b/src/wxsvg/src/SVGPolylineElement.cpp
@@ -3,7 +3,7 @@
 // Purpose:     
 // Author:      Alex Thuering
 // Created:     2005/05/10
-// RCS-ID:      $Id: SVGPolylineElement.cpp,v 1.4 2006/01/08 12:44:30 ntalex Exp $
+// RCS-ID:      $Id: SVGPolylineElement.cpp,v 1.5 2016/07/28 09:05:28 ntalex Exp $
 // Copyright:   (c) 2005 Alex Thuering
 // Licence:     wxWindows licence
 //////////////////////////////////////////////////////////////////////////////
@@ -11,62 +11,58 @@
 #include "SVGPolylineElement.h"
 #include "SVGCanvas.h"
 
-wxSVGRect wxSVGPolylineElement::GetBBox(wxSVG_COORDINATES coordinates)
-{
-  const wxSVGPointList& points = GetPoints();
-  if (points.Count() == 0)
-	return wxSVGRect();
-  
-  wxSVGPoint p0 = points[0];
-  wxSVGMatrix matrix;
-  if (coordinates != wxSVG_COORDINATES_USER)
-  {
-    matrix = GetMatrix(coordinates);
-    p0 = p0.MatrixTransform(matrix);
-  }
-  wxSVGRect bbox(p0.GetX(), p0.GetY(), 0, 0);
-  
-  wxSVGPoint pi;
-  for (int i = 1; i<(int)points.Count(); i++)
-  {
-    pi = coordinates == wxSVG_COORDINATES_USER ?
-      points[i] : points[i].MatrixTransform(matrix);
-	if (bbox.GetX() > pi.GetX())
-	{
-	  bbox.SetWidth(bbox.GetWidth() + bbox.GetX() - pi.GetX());
-	  bbox.SetX(pi.GetX());
+wxSVGRect wxSVGPolylineElement::GetBBox(wxSVG_COORDINATES coordinates) {
+	const wxSVGPointList& points = GetPoints();
+	if (points.Count() == 0)
+		return wxSVGRect();
+
+	wxSVGPoint p0 = points[0];
+	wxSVGMatrix matrix;
+	if (coordinates != wxSVG_COORDINATES_USER) {
+		matrix = GetMatrix(coordinates);
+		p0 = p0.MatrixTransform(matrix);
 	}
-	if (bbox.GetY() > pi.GetY())
-	{
-	  bbox.SetHeight(bbox.GetHeight() + bbox.GetY() - pi.GetY());
-	  bbox.SetY(pi.GetY());
+	wxSVGRect bbox(p0.GetX(), p0.GetY(), 0, 0);
+
+	wxSVGPoint pi;
+	for (int i = 1; i < (int) points.Count(); i++) {
+		pi = coordinates == wxSVG_COORDINATES_USER ? points[i] : points[i].MatrixTransform(matrix);
+		if (bbox.GetX() > pi.GetX()) {
+			bbox.SetWidth(bbox.GetWidth() + bbox.GetX() - pi.GetX());
+			bbox.SetX(pi.GetX());
+		}
+		if (bbox.GetY() > pi.GetY()) {
+			bbox.SetHeight(bbox.GetHeight() + bbox.GetY() - pi.GetY());
+			bbox.SetY(pi.GetY());
+		}
+
+		if (bbox.GetX() + bbox.GetWidth() < pi.GetX())
+			bbox.SetWidth(pi.GetX() - bbox.GetX());
+		if (bbox.GetY() + bbox.GetHeight() < pi.GetY())
+			bbox.SetHeight(pi.GetY() - bbox.GetY());
 	}
-	
-	if (bbox.GetX() + bbox.GetWidth() < pi.GetX())
-	  bbox.SetWidth(pi.GetX() - bbox.GetX());
-	if (bbox.GetY() + bbox.GetHeight() < pi.GetY())
-	  bbox.SetHeight(pi.GetY() - bbox.GetY());
-  }
-  
-  return bbox;
+
+	return bbox;
 }
 
-wxSVGRect wxSVGPolylineElement::GetResultBBox(wxSVG_COORDINATES coordinates)
-{
-  wxCSSStyleDeclaration style = GetResultStyle(*this);
-  if (style.GetStroke().GetPaintType() == wxSVG_PAINTTYPE_NONE)
-    return GetBBox(coordinates);
-  WX_SVG_CREATE_M_CANVAS_ITEM
-  wxSVGRect bbox = coordinates == wxSVG_COORDINATES_USER ?
-    m_canvasItem->GetResultBBox(style) :
-    m_canvasItem->GetResultBBox(style, GetMatrix(coordinates));
-  WX_SVG_CLEAR_M_CANVAS_ITEM
-  return bbox;
+wxSVGRect wxSVGPolylineElement::GetResultBBox(wxSVG_COORDINATES coordinates) {
+	wxCSSStyleDeclaration style = GetResultStyle(*this);
+	if (style.GetStroke().GetPaintType() == wxSVG_PAINTTYPE_NONE)
+		return GetBBox(coordinates);
+	WX_SVG_CREATE_M_CANVAS_ITEM
+	wxSVGRect bbox;
+	if (coordinates == wxSVG_COORDINATES_USER) {
+		bbox = m_canvasItem->GetResultBBox(style);
+	} else {
+		wxSVGMatrix m = GetMatrix(coordinates);
+		bbox = m_canvasItem->GetResultBBox(style, &m);
+	}
+	WX_SVG_CLEAR_M_CANVAS_ITEM
+	return bbox;
 }
 
-void wxSVGPolylineElement::SetCanvasItem(wxSVGCanvasItem* canvasItem)
-{
-  if (m_canvasItem)
-    delete m_canvasItem;
-  m_canvasItem = canvasItem;
+void wxSVGPolylineElement::SetCanvasItem(wxSVGCanvasItem* canvasItem) {
+	if (m_canvasItem)
+		delete m_canvasItem;
+	m_canvasItem = canvasItem;
 }

--- a/src/wxsvg/src/SVGRectElement.cpp
+++ b/src/wxsvg/src/SVGRectElement.cpp
@@ -3,7 +3,7 @@
 // Purpose:     Implementation of wxSVGRectElement
 // Author:      Alex Thuering
 // Created:     2005/05/10
-// RCS-ID:      $Id: SVGRectElement.cpp,v 1.6 2014/03/24 21:16:35 ntalex Exp $
+// RCS-ID:      $Id: SVGRectElement.cpp,v 1.7 2016/07/28 09:05:28 ntalex Exp $
 // Copyright:   (c) 2005 Alex Thuering
 // Licence:     wxWindows licence
 //////////////////////////////////////////////////////////////////////////////
@@ -18,8 +18,13 @@ const double pi = 3.1415926;
 
 wxSVGRect wxSVGRectElement::GetBBox(wxSVG_COORDINATES coordinates) {
 	WX_SVG_CREATE_M_CANVAS_ITEM
-	wxSVGRect bbox = coordinates == wxSVG_COORDINATES_USER ? m_canvasItem->GetBBox() :
-			m_canvasItem->GetBBox(GetMatrix(coordinates));
+	wxSVGRect bbox;
+	if (coordinates == wxSVG_COORDINATES_USER) {
+		bbox = m_canvasItem->GetBBox();
+	} else {
+		wxSVGMatrix m = GetMatrix(coordinates);
+		bbox = m_canvasItem->GetBBox(&m);
+	}
 	WX_SVG_CLEAR_M_CANVAS_ITEM
 	return bbox;
 }
@@ -29,8 +34,13 @@ wxSVGRect wxSVGRectElement::GetResultBBox(wxSVG_COORDINATES coordinates) {
 	if (style.GetStroke().GetPaintType() == wxSVG_PAINTTYPE_NONE)
 		return GetBBox(coordinates);
 	WX_SVG_CREATE_M_CANVAS_ITEM
-	wxSVGRect bbox = coordinates == wxSVG_COORDINATES_USER ? m_canvasItem->GetResultBBox(style) :
-			m_canvasItem->GetResultBBox(style, GetMatrix(coordinates));
+	wxSVGRect bbox;
+	if (coordinates == wxSVG_COORDINATES_USER) {
+		bbox = m_canvasItem->GetResultBBox(style);
+	} else {
+		wxSVGMatrix m = GetMatrix(coordinates);
+		bbox = m_canvasItem->GetResultBBox(style, &m);
+	}
 	WX_SVG_CLEAR_M_CANVAS_ITEM
 	return bbox;
 }

--- a/src/wxsvg/src/SVGSVGElement.cpp
+++ b/src/wxsvg/src/SVGSVGElement.cpp
@@ -3,7 +3,7 @@
 // Purpose:     
 // Author:      Alex Thuering
 // Created:     2005/05/10
-// RCS-ID:      $Id: SVGSVGElement.cpp,v 1.12 2014/08/09 11:13:02 ntalex Exp $
+// RCS-ID:      $Id: SVGSVGElement.cpp,v 1.13 2017/05/01 17:06:53 ntalex Exp $
 // Copyright:   (c) 2005 Alex Thuering
 // Licence:     wxWindows licence
 //////////////////////////////////////////////////////////////////////////////
@@ -52,8 +52,9 @@ void RecurseIntersectionList(const wxSVGSVGElement& root, const wxSVGElement& el
 	if (((wxSVGSVGElement*) &root)->CheckIntersection(element, rect)) {
 		res.Add((wxSVGElement*) &element);
 		wxSVGElement* n = (wxSVGElement*) element.GetChildren();
-		while (n && n->GetType() == wxSVGXML_ELEMENT_NODE) {
-			RecurseIntersectionList(root, *n, rect, res);
+		while (n) {
+			if (n->GetType() == wxSVGXML_ELEMENT_NODE)
+				RecurseIntersectionList(root, *n, rect, res);
 			n = (wxSVGElement*) n->GetNext();
 		}
 	}

--- a/src/wxsvg/src/SVGStringList.cpp
+++ b/src/wxsvg/src/SVGStringList.cpp
@@ -11,14 +11,19 @@
 #include <wx/arrimpl.cpp>
 WX_DEFINE_OBJARRAY(wxSVGStringListBase);
 
-wxString wxSVGStringList::GetValueAsString() const {
+wxString wxSVGStringList::GetValueAsString(wxChar delimiter) const {
 	wxString value;
-	for (int i = 0; i < (int) GetCount(); i++)
-		value += (i == 0 ? wxT("") : wxT(",")) + Item(i);
+	for (unsigned int i = 0; i < GetCount(); i++) {
+		if (i > 0) {
+			value += delimiter;
+		}
+		value += Item(i);
+	}
 	return value;
 }
 
 void wxSVGStringList::SetValueAsString(const wxString& value, wxChar delimiter) {
+	Clear();
 	wxStringTokenizer tkz(value, delimiter);
 	while (tkz.HasMoreTokens()) {
 		Add(tkz.GetNextToken().Strip(wxString::both));

--- a/src/wxsvg/src/SVGTextElement.cpp
+++ b/src/wxsvg/src/SVGTextElement.cpp
@@ -3,7 +3,7 @@
 // Purpose:     svg text element
 // Author:      Alex Thuering
 // Created:     2005/05/10
-// RCS-ID:      $Id: SVGTextElement.cpp,v 1.5 2008/04/14 15:44:55 etisserant Exp $
+// RCS-ID:      $Id: SVGTextElement.cpp,v 1.6 2016/07/28 09:05:28 ntalex Exp $
 // Copyright:   (c) 2005 Alex Thuering
 // Licence:     wxWindows licence
 //////////////////////////////////////////////////////////////////////////////
@@ -12,108 +12,106 @@
 #include "SVGCanvas.h"
 #include <math.h>
 
-wxSVGRect wxSVGTextElement::GetBBox(wxSVG_COORDINATES coordinates)
-{
-  wxSVGMatrix matrix = wxSVGLocatable::GetCTM(this);
-  WX_SVG_CREATE_M_CANVAS_ITEM
-  wxSVGRect bbox = coordinates == wxSVG_COORDINATES_USER ? 
-    m_canvasItem->GetBBox() : m_canvasItem->GetBBox(GetMatrix(coordinates));
-  WX_SVG_CLEAR_M_CANVAS_ITEM
-  return bbox.MatrixTransform(matrix);
-  //return bbox;
+wxSVGRect wxSVGTextElement::GetBBox(wxSVG_COORDINATES coordinates) {
+	wxSVGMatrix matrix = wxSVGLocatable::GetCTM(this);
+	WX_SVG_CREATE_M_CANVAS_ITEM
+	wxSVGRect bbox;
+	if (coordinates == wxSVG_COORDINATES_USER) {
+		bbox = m_canvasItem->GetBBox();
+	} else {
+		wxSVGMatrix m = GetMatrix(coordinates);
+		bbox = m_canvasItem->GetBBox(&m);
+	}
+	WX_SVG_CLEAR_M_CANVAS_ITEM
+	return bbox.MatrixTransform(matrix);
+	//return bbox;
 }
 
-wxSVGRect wxSVGTextElement::GetResultBBox(wxSVG_COORDINATES coordinates)
-{
-  wxCSSStyleDeclaration style = GetResultStyle(*this);
-  if (style.GetStroke().GetPaintType() == wxSVG_PAINTTYPE_NONE)
-    return GetBBox(coordinates);
-  WX_SVG_CREATE_M_CANVAS_ITEM
-  wxSVGRect bbox = coordinates == wxSVG_COORDINATES_USER ?
-    m_canvasItem->GetResultBBox(style) :
-    m_canvasItem->GetResultBBox(style, GetMatrix(coordinates));
-  WX_SVG_CLEAR_M_CANVAS_ITEM
-  return bbox;
+wxSVGRect wxSVGTextElement::GetResultBBox(wxSVG_COORDINATES coordinates) {
+	wxCSSStyleDeclaration style = GetResultStyle(*this);
+	if (style.GetStroke().GetPaintType() == wxSVG_PAINTTYPE_NONE)
+		return GetBBox(coordinates);
+	WX_SVG_CREATE_M_CANVAS_ITEM
+	wxSVGRect bbox;
+	if (coordinates == wxSVG_COORDINATES_USER) {
+		bbox = m_canvasItem->GetResultBBox(style);
+	} else {
+		wxSVGMatrix m = GetMatrix(coordinates);
+		bbox = m_canvasItem->GetResultBBox(style, &m);
+	}
+	WX_SVG_CLEAR_M_CANVAS_ITEM
+	return bbox;
 }
 
-void wxSVGTextElement::SetCanvasItem(wxSVGCanvasItem* canvasItem)
-{
-  if (m_canvasItem)
-    delete m_canvasItem;
-  m_canvasItem = canvasItem;
+void wxSVGTextElement::SetCanvasItem(wxSVGCanvasItem* canvasItem) {
+	if (m_canvasItem)
+		delete m_canvasItem;
+	m_canvasItem = canvasItem;
 }
 
-long wxSVGTextElement::GetNumberOfChars()
-{
-  WX_SVG_CREATE_M_CANVAS_ITEM
-  long number = ((wxSVGCanvasText*)m_canvasItem)->GetNumberOfChars();
-  WX_SVG_CLEAR_M_CANVAS_ITEM
-  return number;
+long wxSVGTextElement::GetNumberOfChars() {
+	WX_SVG_CREATE_M_CANVAS_ITEM
+	long number = ((wxSVGCanvasText*) m_canvasItem)->GetNumberOfChars();
+	WX_SVG_CLEAR_M_CANVAS_ITEM
+	return number;
 }
 
-double wxSVGTextElement::GetComputedTextLength()
-{
-  wxSVGMatrix matrix = wxSVGLocatable::GetCTM(this);
-  WX_SVG_CREATE_M_CANVAS_ITEM
-  double length = ((wxSVGCanvasText*)m_canvasItem)->GetComputedTextLength();
-  WX_SVG_CLEAR_M_CANVAS_ITEM
-  return length * sqrt(matrix.GetA() * matrix.GetA() + matrix.GetB() * matrix.GetB());
+double wxSVGTextElement::GetComputedTextLength() {
+	wxSVGMatrix matrix = wxSVGLocatable::GetCTM(this);
+	WX_SVG_CREATE_M_CANVAS_ITEM
+	double length = ((wxSVGCanvasText*) m_canvasItem)->GetComputedTextLength();
+	WX_SVG_CLEAR_M_CANVAS_ITEM
+	return length * sqrt(matrix.GetA() * matrix.GetA() + matrix.GetB() * matrix.GetB());
 }
 
-double wxSVGTextElement::GetSubStringLength(unsigned long charnum, unsigned long nchars)
-{
-  wxSVGMatrix matrix = wxSVGLocatable::GetCTM(this);
-  WX_SVG_CREATE_M_CANVAS_ITEM
-  double length = ((wxSVGCanvasText*)m_canvasItem)->GetSubStringLength(charnum, nchars);
-  WX_SVG_CLEAR_M_CANVAS_ITEM
-  return length * sqrt(matrix.GetA() * matrix.GetA() + matrix.GetB() * matrix.GetB());
+double wxSVGTextElement::GetSubStringLength(unsigned long charnum, unsigned long nchars) {
+	wxSVGMatrix matrix = wxSVGLocatable::GetCTM(this);
+	WX_SVG_CREATE_M_CANVAS_ITEM
+	double length = ((wxSVGCanvasText*) m_canvasItem)->GetSubStringLength(charnum, nchars);
+	WX_SVG_CLEAR_M_CANVAS_ITEM
+	return length * sqrt(matrix.GetA() * matrix.GetA() + matrix.GetB() * matrix.GetB());
 }
 
-wxSVGPoint wxSVGTextElement::GetStartPositionOfChar(unsigned long charnum)
-{
-  wxSVGPoint real_position;  
-  wxSVGMatrix matrix = wxSVGLocatable::GetCTM(this);
-  WX_SVG_CREATE_M_CANVAS_ITEM
-  wxSVGPoint position = ((wxSVGCanvasText*)m_canvasItem)->GetStartPositionOfChar(charnum);
-  WX_SVG_CLEAR_M_CANVAS_ITEM
-  real_position.SetX(matrix.GetA() * position.GetX() + matrix.GetB() * position.GetY() + matrix.GetE());
-  real_position.SetY(matrix.GetB() * position.GetX() + matrix.GetD() * position.GetY() + matrix.GetF());
-  return real_position;
+wxSVGPoint wxSVGTextElement::GetStartPositionOfChar(unsigned long charnum) {
+	wxSVGPoint real_position;
+	wxSVGMatrix matrix = wxSVGLocatable::GetCTM(this);
+	WX_SVG_CREATE_M_CANVAS_ITEM
+	wxSVGPoint position = ((wxSVGCanvasText*) m_canvasItem)->GetStartPositionOfChar(charnum);
+	WX_SVG_CLEAR_M_CANVAS_ITEM
+	real_position.SetX(matrix.GetA() * position.GetX() + matrix.GetB() * position.GetY() + matrix.GetE());
+	real_position.SetY(matrix.GetB() * position.GetX() + matrix.GetD() * position.GetY() + matrix.GetF());
+	return real_position;
 }
 
-wxSVGPoint wxSVGTextElement::GetEndPositionOfChar(unsigned long charnum)
-{
-  wxSVGPoint real_position;  
-  wxSVGMatrix matrix = wxSVGLocatable::GetCTM(this);
-  WX_SVG_CREATE_M_CANVAS_ITEM
-  wxSVGPoint position = ((wxSVGCanvasText*)m_canvasItem)->GetEndPositionOfChar(charnum);
-  WX_SVG_CLEAR_M_CANVAS_ITEM
-  real_position.SetX(matrix.GetA() * position.GetX() + matrix.GetB() * position.GetY() + matrix.GetE());
-  real_position.SetY(matrix.GetB() * position.GetX() + matrix.GetD() * position.GetY() + matrix.GetF());
-  return real_position;
+wxSVGPoint wxSVGTextElement::GetEndPositionOfChar(unsigned long charnum) {
+	wxSVGPoint real_position;
+	wxSVGMatrix matrix = wxSVGLocatable::GetCTM(this);
+	WX_SVG_CREATE_M_CANVAS_ITEM
+	wxSVGPoint position = ((wxSVGCanvasText*) m_canvasItem)->GetEndPositionOfChar(charnum);
+	WX_SVG_CLEAR_M_CANVAS_ITEM
+	real_position.SetX(matrix.GetA() * position.GetX() + matrix.GetB() * position.GetY() + matrix.GetE());
+	real_position.SetY(matrix.GetB() * position.GetX() + matrix.GetD() * position.GetY() + matrix.GetF());
+	return real_position;
 }
 
-wxSVGRect wxSVGTextElement::GetExtentOfChar(unsigned long charnum)
-{
-  wxSVGMatrix matrix = wxSVGLocatable::GetCTM(this);
-  WX_SVG_CREATE_M_CANVAS_ITEM
-  wxSVGRect extent = ((wxSVGCanvasText*)m_canvasItem)->GetExtentOfChar(charnum);
-  WX_SVG_CLEAR_M_CANVAS_ITEM
-  return extent.MatrixTransform(matrix);
+wxSVGRect wxSVGTextElement::GetExtentOfChar(unsigned long charnum) {
+	wxSVGMatrix matrix = wxSVGLocatable::GetCTM(this);
+	WX_SVG_CREATE_M_CANVAS_ITEM
+	wxSVGRect extent = ((wxSVGCanvasText*) m_canvasItem)->GetExtentOfChar(charnum);
+	WX_SVG_CLEAR_M_CANVAS_ITEM
+	return extent.MatrixTransform(matrix);
 }
 
-double wxSVGTextElement::GetRotationOfChar(unsigned long charnum)
-{
-  WX_SVG_CREATE_M_CANVAS_ITEM
-  double rotation = ((wxSVGCanvasText*)m_canvasItem)->GetRotationOfChar(charnum);
-  WX_SVG_CLEAR_M_CANVAS_ITEM
-  return rotation;
+double wxSVGTextElement::GetRotationOfChar(unsigned long charnum) {
+	WX_SVG_CREATE_M_CANVAS_ITEM
+	double rotation = ((wxSVGCanvasText*) m_canvasItem)->GetRotationOfChar(charnum);
+	WX_SVG_CLEAR_M_CANVAS_ITEM
+	return rotation;
 }
 
-long wxSVGTextElement::GetCharNumAtPosition(const wxSVGPoint& point)
-{
-  WX_SVG_CREATE_M_CANVAS_ITEM
-  long charnum = ((wxSVGCanvasText*)m_canvasItem)->GetCharNumAtPosition(point);
-  WX_SVG_CLEAR_M_CANVAS_ITEM
-  return charnum;
+long wxSVGTextElement::GetCharNumAtPosition(const wxSVGPoint& point) {
+	WX_SVG_CREATE_M_CANVAS_ITEM
+	long charnum = ((wxSVGCanvasText*) m_canvasItem)->GetCharNumAtPosition(point);
+	WX_SVG_CLEAR_M_CANVAS_ITEM
+	return charnum;
 }

--- a/src/wxsvg/src/cairo/SVGCanvasCairo.cpp
+++ b/src/wxsvg/src/cairo/SVGCanvasCairo.cpp
@@ -3,7 +3,7 @@
 // Purpose:     Cairo render
 // Author:      Alex Thuering
 // Created:     2005/05/12
-// RCS-ID:      $Id: SVGCanvasCairo.cpp,v 1.33 2015/09/19 17:18:23 ntalex Exp $
+// RCS-ID:      $Id: SVGCanvasCairo.cpp,v 1.34 2016/07/27 08:54:21 ntalex Exp $
 // Copyright:   (c) 2005 Alex Thuering
 // Licence:     wxWindows licence
 //////////////////////////////////////////////////////////////////////////////
@@ -457,7 +457,8 @@ void wxSVGCanvasCairo::DrawCanvasPath(wxSVGCanvasPathCairo& canvasPath, wxSVGMat
 			int dx = int(floor(stdX * 3 * sqrt(2 * M_PI) / 4 + 0.5));
 			int dy = int(floor(stdY * 3 * sqrt(2 * M_PI) / 4 + 0.5));
 			
-			wxSVGRect rect = canvasPath.GetResultBBox(style, matrix.Inverse());
+			wxSVGMatrix invMatrix = matrix.Inverse();
+			wxSVGRect rect = canvasPath.GetResultBBox(style, &invMatrix);
 			rect.SetX(rect.GetX() - 2*dx);
 			rect.SetY(rect.GetY() - 2*dy);
 			rect.SetWidth(rect.GetWidth() + 4*dx);

--- a/src/wxsvg/src/cairo/SVGCanvasPathCairo.cpp
+++ b/src/wxsvg/src/cairo/SVGCanvasPathCairo.cpp
@@ -3,7 +3,7 @@
 // Purpose:     Cairo canvas path
 // Author:      Alex Thuering
 // Created:     2005/05/12
-// RCS-ID:      $Id: SVGCanvasPathCairo.cpp,v 1.14 2014/11/23 11:36:16 ntalex Exp $
+// RCS-ID:      $Id: SVGCanvasPathCairo.cpp,v 1.15 2016/07/27 08:54:21 ntalex Exp $
 // Copyright:   (c) 2005 Alex Thuering
 // Licence:     wxWindows licence
 //////////////////////////////////////////////////////////////////////////////
@@ -35,15 +35,16 @@ cairo_path_t* wxSVGCanvasPathCairo::GetPath() {
 	return cairo_copy_path(m_cr);
 }
 
-wxSVGRect wxSVGCanvasPathCairo::GetBBox(const wxSVGMatrix& matrix) {
-	if (&matrix) {
+wxSVGRect wxSVGCanvasPathCairo::GetBBox(const wxSVGMatrix* matrix) {
+	if (matrix) {
 		cairo_matrix_t m;
-		cairo_matrix_init(&m, matrix.GetA(), matrix.GetB(), matrix.GetC(), matrix.GetD(), matrix.GetE(), matrix.GetF());
+		cairo_matrix_init(&m, matrix->GetA(), matrix->GetB(), matrix->GetC(), matrix->GetD(),
+				matrix->GetE(), matrix->GetF());
 		cairo_set_matrix(m_cr, &m);
 	}
 	double x1, y1, x2, y2;
 	cairo_fill_extents(m_cr, &x1, &y1, &x2, &y2);
-	if (&matrix) {
+	if (matrix) {
 		cairo_matrix_t mat;
 		cairo_matrix_init(&mat, 1, 0, 0, 1, 0, 0);
 		cairo_set_matrix(m_cr, &mat);
@@ -51,10 +52,11 @@ wxSVGRect wxSVGCanvasPathCairo::GetBBox(const wxSVGMatrix& matrix) {
 	return wxSVGRect(x1, y1, x2 - x1, y2 - y1);
 }
 
-wxSVGRect wxSVGCanvasPathCairo::GetResultBBox(const wxCSSStyleDeclaration& style, const wxSVGMatrix& matrix) {
-	if (&matrix) {
+wxSVGRect wxSVGCanvasPathCairo::GetResultBBox(const wxCSSStyleDeclaration& style, const wxSVGMatrix* matrix) {
+	if (matrix) {
 		cairo_matrix_t m;
-		cairo_matrix_init(&m, matrix.GetA(), matrix.GetB(), matrix.GetC(), matrix.GetD(), matrix.GetE(), matrix.GetF());
+		cairo_matrix_init(&m, matrix->GetA(), matrix->GetB(), matrix->GetC(), matrix->GetD(),
+				matrix->GetE(), matrix->GetF());
 		cairo_set_matrix(m_cr, &m);
 	}
 	ApplyStrokeStyle(m_cr, style);
@@ -63,7 +65,7 @@ wxSVGRect wxSVGCanvasPathCairo::GetResultBBox(const wxCSSStyleDeclaration& style
 		cairo_stroke_extents(m_cr, &x1, &y1, &x2, &y2);
 	else
 		cairo_fill_extents(m_cr, &x1, &y1, &x2, &y2);
-	if (&matrix) {
+	if (matrix) {
 		cairo_matrix_t mat;
 		cairo_matrix_init(&mat, 1, 0, 0, 1, 0, 0);
 		cairo_set_matrix(m_cr, &mat);

--- a/src/wxsvg/src/cairo/SVGCanvasPathCairo.h
+++ b/src/wxsvg/src/cairo/SVGCanvasPathCairo.h
@@ -3,7 +3,7 @@
 // Purpose:     Cairo canvas path
 // Author:      Alex Thuering
 // Created:     2005/05/12
-// RCS-ID:      $Id: SVGCanvasPathCairo.h,v 1.6 2013/01/19 18:26:28 ntalex Exp $
+// RCS-ID:      $Id: SVGCanvasPathCairo.h,v 1.7 2016/07/27 08:54:21 ntalex Exp $
 // Copyright:   (c) 2005 Alex Thuering
 // Licence:     wxWindows licence
 //////////////////////////////////////////////////////////////////////////////
@@ -24,8 +24,8 @@ public:
 	virtual ~wxSVGCanvasPathCairo();
 	
 	void End();
-	wxSVGRect GetBBox(const wxSVGMatrix& matrix = *(wxSVGMatrix*) NULL);
-	wxSVGRect GetResultBBox(const wxCSSStyleDeclaration& style, const wxSVGMatrix& matrix = *(wxSVGMatrix*) NULL);
+	wxSVGRect GetBBox(const wxSVGMatrix* matrix = NULL);
+	wxSVGRect GetResultBBox(const wxCSSStyleDeclaration& style, const wxSVGMatrix* matrix = NULL);
 	
 	cairo_t* GetCr() { return m_cr; }
 	cairo_path_t* GetPath();

--- a/src/wxsvg/src/mediadec_ffmpeg.cpp
+++ b/src/wxsvg/src/mediadec_ffmpeg.cpp
@@ -3,7 +3,7 @@
 // Purpose:     FFMPEG Media Decoder
 // Author:      Alex Thuering
 // Created:     21.07.2007
-// RCS-ID:      $Id: mediadec_ffmpeg.cpp,v 1.34 2016/02/29 13:09:59 ntalex Exp $
+// RCS-ID:      $Id: mediadec_ffmpeg.cpp,v 1.35 2016/05/03 19:44:45 ntalex Exp $
 // Copyright:   (c) Alex Thuering
 // Licence:     wxWindows licence
 /////////////////////////////////////////////////////////////////////////////
@@ -24,6 +24,8 @@ extern "C" {
 #include <libswscale/swscale.h>
 #include <libavutil/avutil.h>
 #include <libavutil/mathematics.h>
+#include <libavutil/dict.h>
+#include <libavutil/rational.h>
 }
 
 #if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(55, 28, 1)
@@ -320,4 +322,36 @@ float wxFfmpegMediaDecoder::GetCodecTimeBase() {
 	if (m_codecCtx == NULL || !m_codecCtx->time_base.den || !m_codecCtx->time_base.den)
 		return -1;
 	return 1 / av_q2d(m_codecCtx->time_base);
+}
+
+/** Returns list of chapters */
+vector<double> wxFfmpegMediaDecoder::GetChapters() {
+	vector<double> chapters;
+	for (unsigned int i = 0; i < m_formatCtx->nb_chapters; i++) {
+		AVChapter *chapter = m_formatCtx->chapters[i];
+		double d = chapter->start * av_q2d(chapter->time_base);
+		chapters.push_back(d);
+	}
+	return chapters;
+}
+
+/** Returns file metadata */
+map<wxString, wxString> wxFfmpegMediaDecoder::GetMetadata() {
+	map<wxString, wxString> metadata;
+	AVDictionaryEntry *tag = NULL;
+	while ((tag = av_dict_get(m_formatCtx->metadata, "", tag, AV_DICT_IGNORE_SUFFIX))) {
+		metadata[wxString(tag->key, wxConvUTF8)] = wxString(tag->value, wxConvUTF8);
+	}
+	return metadata;
+}
+
+
+/** Returns stream metadata */
+map<wxString, wxString> wxFfmpegMediaDecoder::GetMetadata(unsigned int streamIndex) {
+	map<wxString, wxString> metadata;
+	AVDictionaryEntry *tag = NULL;
+	while ((tag = av_dict_get(m_formatCtx->streams[streamIndex]->metadata, "", tag, AV_DICT_IGNORE_SUFFIX))) {
+		metadata[wxString(tag->key, wxConvUTF8)] = wxString(tag->value, wxConvUTF8);
+	}
+	return metadata;
 }

--- a/src/wxsvg/src/svgctrl.cpp
+++ b/src/wxsvg/src/svgctrl.cpp
@@ -3,7 +3,7 @@
 // Purpose:     svg control widget
 // Author:      Alex Thuering
 // Created:     2005/05/07
-// RCS-ID:      $Id: svgctrl.cpp,v 1.19 2012/04/09 11:29:36 ntalex Exp $
+// RCS-ID:      $Id: svgctrl.cpp,v 1.20 2016/05/07 10:18:27 ntalex Exp $
 // Copyright:   (c) 2005 Alex Thuering
 // Licence:     wxWindows licence
 //////////////////////////////////////////////////////////////////////////////
@@ -100,7 +100,7 @@ void wxSVGCtrlBase::OnPaint(wxPaintEvent& event) {
 #ifdef __WXMSW__
 	int w = GetClientSize().GetWidth();
 	int h = GetClientSize().GetHeight();
-	dc.SetPen(wxPen(wxColour(), 0, wxTRANSPARENT));
+	dc.SetPen(*wxTRANSPARENT_PEN);
 	dc.DrawRectangle(m_buffer.GetWidth(), 0, w - m_buffer.GetWidth(), h);
 	dc.DrawRectangle(0, m_buffer.GetHeight(), m_buffer.GetWidth(), h - m_buffer.GetHeight());
 #endif


### PR DESCRIPTION
To keep up to date with upstreams, not fixing any apparent problems and can wait for O5.

wxSVG introduced support for exif metadata via libexif in 1.5.10. We support building with it on Linux and macOS when libexif is found, turn off the support if not (unlike the upstream which always requires it now).
On Windows we do not even try - another update to the dependency bundle would be needed with libexif and there was enough for O4.8.2 already.