### PR TITLE
chart info window: set client size, help xfce window manager

### DIFF
--- a/src/ChInfoWin.cpp
+++ b/src/ChInfoWin.cpp
@@ -113,14 +113,19 @@ void ChInfoWin::SetBitmap()
 
     wxPoint top_position = GetParent()->ClientToScreen( m_position);
     SetSize( top_position.x, top_position.y, m_size.x, m_size.y );
+    SetClientSize( m_size.x, m_size.y );
 }
 
 void ChInfoWin::FitToChars( int char_width, int char_height )
 {
     wxSize size;
 
-    int adjust = 2;
-   
+    int adjust = 1;
+
+#ifdef __WXOSX__
+    adjust = 2;
+#endif
+
 #ifdef __OCPN__ANDROID__
     adjust = 4;
 #endif


### PR DESCRIPTION
Hi
Use 1 again for adjust on linux, but set clientsize.
It fixes my issue with xfce and wrong window size.

Notes:
- With unpatched version, sometime the size is right, ie with a lot of bottom white lines, sometimes it's displayed centered on screen. Unable to reproduce with this patch applied. 

- because it's a full dialog in night mode there's a nasty white flash. In my understanding the window is first rendered by the windows manager with the default background then redraw with dark background by the application. I tried to not delete this info window in chcanv.cp only hide/show it, did nothing. I also tried to set background color in CTOR , again no change. Changing the windows manager default background color could be the only option (I didn't test it).

Regards
Didier

