### PR TITLE
fixed dragging issue with touch-enabled pcs

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -6888,10 +6888,14 @@ bool ChartCanvas::MouseEventProcessCanvas( wxMouseEvent& event )
              * always to the very first drag start (since there is not reset of last_drag).
              *
              * Besides, should not left down and dragging be enough of a situation to start a drag procedure?
+             *
+             * Anyways, guarded it to be active in touch situations only.
              */
-            if(false == m_bChartDragging) {
-                last_drag.x = x, last_drag.y = y;
-                m_bChartDragging = true;
+            if( g_btouch ) {
+                if(false == m_bChartDragging) {
+                    last_drag.x = x, last_drag.y = y;
+                    m_bChartDragging = true;
+                }
             }
 
 

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -6879,6 +6879,22 @@ bool ChartCanvas::MouseEventProcessCanvas( wxMouseEvent& event )
     }
     
     if( event.Dragging() && event.LeftIsDown()){
+            /*
+             * fixed dragging.
+             * On my Surface Pro 3 running Arch Linux there is no mouse down event before the drag event.
+             * Hence, as there is no mouse down event, last_drag is not reset before the drag.
+             * And that results in one single drag session, meaning you cannot drag the map a few miles
+             * north, lift your finger, and the go even further north. Instead, the map resets itself
+             * always to the very first drag start (since there is not reset of last_drag).
+             *
+             * Besides, should not left down and dragging be enough of a situation to start a drag procedure?
+             */
+            if(false == m_bChartDragging) {
+                last_drag.x = x, last_drag.y = y;
+                m_bChartDragging = true;
+            }
+
+
             if( ( last_drag.x != x ) || ( last_drag.y != y ) ) {
                 m_bChartDragging = true;
                 StartTimedMovement();


### PR DESCRIPTION
had this issue with my surface pro 3 running arch linux that dragging around the visible part of the map was not usable at all when using touch. Fixed it in this small patch. Thoroughly tested. Might be worth a shot!

keep up the good work!