### PR TITLE
Implement simple safeguards to maintain quilting performance acceptable

### DIFF
--- a/src/Quilt.cpp
+++ b/src/Quilt.cpp
@@ -60,6 +60,13 @@ extern bool g_bopengl;
 
 #define GetChartTableEntry(i) GetChartTable()[i]
 
+//  Calculating the chart coverage region with extremely complicated shape is very expensive,
+//  put a limit on the complefity of "not covered" areas to prevent the application from slowing
+//  down to total unusability.
+//  On US ENC charts, the number of NOCOVR PLYs seems to always be under 300, but on the SCS ENCs it
+//  can get as high as 10000 and make the application totally unusable with chart quilting enabled
+//  while bringing little real effect.
+#define NOCOVR_PLY_PERF_LIMIT 500
 
 static int CompareScales( int *i1, int *i2 )
 {
@@ -523,8 +530,12 @@ LLRegion Quilt::GetChartQuiltRegion( const ChartTableEntry &cte, ViewPort &vp )
     int nNoCovrPlyEntries = cte.GetnNoCovrPlyEntries();
     if( nNoCovrPlyEntries ) {
         for( int ip = 0; ip < nNoCovrPlyEntries; ip++ ) {
-            float *pfp = cte.GetpNoCovrPlyTableEntry( ip );
             int nNoCovrPly = cte.GetNoCovrCntTableEntry( ip );
+            if( nNoCovrPly > NOCOVR_PLY_PERF_LIMIT ) {
+                //wxLogMessage("NOCOVR calculation skipped for %s, nNoCovrPly: %d", cte.GetpFullPath(), nNoCovrPly);
+                continue;
+            }
+            float *pfp = cte.GetpNoCovrPlyTableEntry( ip );
 
             LLRegion t_region(nNoCovrPly, pfp);
             t_region.Intersect(screen_region);


### PR DESCRIPTION
Protects against:
- Overly complicated NOCOVR areas used while building the chart quilt. This helps to limit the performance impact of some badly designed ENC chart cells.
On the SCS ENC cells, the NOCOVR areas have up to 10000 PLYs, together with the similar complexity of the cell PLYs, combining the regions has disastrous performance impacts with little real effect.
- Overly complicated PLYs. Again seen only on some of the SCS ENC cells. When a shape too complicated is detected, it is skipped and the full chart extents are added to the region.

This is still just a partial improvement, the cells still are causing significant slowdown, but on decent HW, the application stays usable.

As far as I can tell, areas covered by sane chartmakers are completely unaffected.