### PR TITLE
make wxLogTrace a noop in wxJSON always

### DIFF
--- a/src/wxJSON/jsonreader.cpp
+++ b/src/wxJSON/jsonreader.cpp
@@ -12,11 +12,9 @@
 //    #pragma implementation "jsonreader.cpp"
 //#endif
 
-#ifdef NDEBUG
-// make wxLogTrace a noop if no debug set, it's really slow
+// make wxLogTrace a noop, it's really slow
 // must be defined before including debug.h
 #define wxDEBUG_LEVEL 0
-#endif
 
 #include <wx/jsonreader.h>
 

--- a/src/wxJSON/jsonval.cpp
+++ b/src/wxJSON/jsonval.cpp
@@ -12,11 +12,9 @@
 //    #pragma implementation "jsonval.cpp"
 //#endif
 
-#ifdef NDEBUG
-// make wxLogTrace a noop if no debug set, it's really slow
-// must be defined before including wx/debug.h (also included by wx/wxprec.h)
+// make wxLogTrace a noop, it's really slow
+// must be defined before including debug.h
 #define wxDEBUG_LEVEL 0
-#endif
 
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"

--- a/src/wxJSON/jsonwriter.cpp
+++ b/src/wxJSON/jsonwriter.cpp
@@ -12,11 +12,9 @@
 //    #pragma implementation "jsonwriter.cpp"
 //#endif
 
-#ifdef NDEBUG
-// make wxLogTrace a noop if no debug set, it's really slow
+// make wxLogTrace a noop, it's really slow
 // must be defined before including debug.h
 #define wxDEBUG_LEVEL 0
-#endif
 
 #include <wx/jsonwriter.h>
 


### PR DESCRIPTION
I am using wxJSON for signalk parsing for my pypilot (signalk autopilot) plugin.   As you know, on linux (unlike windows), the plugins will use the wxJSON symbols in opencpn rather than their own wxJSON.

wxLogTrace is unbearably slow.

So slow that it makes the plugin hiccup while it parses the signalk streams.

This is currently guarded in #ifdef NDEBUG.   The NDEBUG macro is never defined by linux builds, only windows ones.

I propose to just disable wxLogTrace in wxJSON.   It is for debugging wxJSON itself, not invalid json data.