### PR TITLE
Make line and polygon smoothing optional in OpenGL mode.

### DIFF
--- a/include/glChartCanvas.h
+++ b/include/glChartCanvas.h
@@ -53,6 +53,9 @@ public:
 
     int m_iTextureDimension;
     int m_iTextureMemorySize;
+    
+    bool m_GLPolygonSmoothing;
+    bool m_GLLineSmoothing;
 };
 
 class ocpnDC;

--- a/include/options.h
+++ b/include/options.h
@@ -787,6 +787,8 @@ class OpenGLOptionsDlg : private Uncopyable, public wxDialog {
   explicit OpenGLOptionsDlg(wxWindow *parent);
   const bool GetAcceleratedPanning(void) const;
   const bool GetTextureCompression(void) const;
+  const bool GetPolygonSmoothing(void) const;
+  const bool GetLineSmoothing(void) const;
   const bool GetShowFPS(void) const;
   const bool GetSoftwareGL(void) const;
   const bool GetTextureCompressionCaching(void) const;
@@ -800,7 +802,8 @@ class OpenGLOptionsDlg : private Uncopyable, public wxDialog {
   const wxString GetTextureCacheSize(void);
 
   wxCheckBox *m_cbUseAcceleratedPanning, *m_cbTextureCompression;
-  wxCheckBox *m_cbTextureCompressionCaching, *m_cbShowFPS, *m_cbSoftwareGL;
+  wxCheckBox *m_cbTextureCompressionCaching, *m_cbShowFPS, *m_cbSoftwareGL,
+      *m_cbPolygonSmoothing, *m_cbLineSmoothing;
   wxSpinCtrl *m_sTextureDimension, *m_sTextureMemorySize;
   wxStaticText *m_cacheSize, *m_memorySize;
 

--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -85,6 +85,11 @@ millions of points.
 #include "navutil.h"
 #include "Select.h"
 
+#ifdef ocpnUSE_GL
+#include "glChartCanvas.h"
+extern ocpnGLOptions g_GLOptions;
+#endif
+
 extern ChartCanvas      *cc1;
 extern WayPointman *pWayPointMan;
 extern Routeman *g_pRouteMan;
@@ -691,7 +696,8 @@ void Track::Draw( ocpnDC& dc, ViewPort &VP, const LLBBox &box )
     else { // opengl version
         glColor3ub(col.Red(), col.Green(), col.Blue());
         glLineWidth( wxMax( g_GLMinSymbolLineWidth, width ) );
-        glEnable( GL_LINE_SMOOTH );
+        if( g_GLOptions.m_GLLineSmoothing )
+            glEnable( GL_LINE_SMOOTH );
         glEnable( GL_BLEND );
         
         int size = 0;

--- a/src/cm93.cpp
+++ b/src/cm93.cpp
@@ -56,6 +56,7 @@
 
 #ifdef ocpnUSE_GL
 #include "glChartCanvas.h"
+extern ocpnGLOptions g_GLOptions;
 #endif
 
 
@@ -6039,8 +6040,10 @@ bool cm93compchart::RenderNextSmallerCellOutlines ( ocpnDC &dc, ViewPort& vp )
           wxPen pen = dc.GetPen();
           wxColour col = pen.GetColour();
           
-          glEnable( GL_LINE_SMOOTH );
-          glHint( GL_LINE_SMOOTH_HINT, GL_NICEST );
+          if( g_GLOptions.m_GLLineSmoothing ) {
+              glEnable( GL_LINE_SMOOTH );
+              glHint( GL_LINE_SMOOTH_HINT, GL_NICEST );
+          }
           glEnable( GL_BLEND );
           glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
           

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -1387,8 +1387,8 @@ void glChartCanvas::RenderChartOutline( int dbIndex, ViewPort &vp )
     else
         color = GetGlobalColor( _T ( "UINFR" ) );
 
-//    glEnable( GL_BLEND );
-    glEnable( GL_LINE_SMOOTH );
+    if( g_GLOptions.m_GLLineSmoothing )
+        glEnable( GL_LINE_SMOOTH );
 
     glColor3ub(color.Red(), color.Green(), color.Blue());
     glLineWidth( g_GLMinSymbolLineWidth );
@@ -1838,8 +1838,10 @@ void glChartCanvas::ShipDraw(ocpnDC& dc)
     int img_height = 0;
     
     if( bb_screen.PointInBox( lShipMidPoint, 20 ) ) {
-        glEnable( GL_LINE_SMOOTH );
-        glEnable( GL_POLYGON_SMOOTH );
+        if( g_GLOptions.m_GLLineSmoothing )
+            glEnable( GL_LINE_SMOOTH );
+        if( g_GLOptions.m_GLPolygonSmoothing )
+            glEnable( GL_POLYGON_SMOOTH );
         glEnableClientState(GL_VERTEX_ARRAY);
     
         if( cc1->GetVP().chart_scale > 300000 )             // According to S52, this should be 50,000
@@ -3414,8 +3416,10 @@ void glChartCanvas::Render()
     // set opengl settings that don't normally change
     // this should be able to go in SetupOpenGL, but it's
     // safer here incase a plugin mangles these
-    glHint( GL_LINE_SMOOTH_HINT, GL_NICEST );
-    glHint( GL_POLYGON_SMOOTH_HINT, GL_NICEST );
+    if( g_GLOptions.m_GLLineSmoothing )
+        glHint( GL_LINE_SMOOTH_HINT, GL_NICEST );
+    if( g_GLOptions.m_GLPolygonSmoothing )
+        glHint( GL_POLYGON_SMOOTH_HINT, GL_NICEST );
     glBlendFunc( GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA );
 
     //  Delete any textures known to the GPU that

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -658,6 +658,8 @@ int MyConfig::LoadMyConfig()
 
     Read( _T ( "GPUTextureCompression" ), &g_GLOptions.m_bTextureCompression, 0);
     Read( _T ( "GPUTextureCompressionCaching" ), &g_GLOptions.m_bTextureCompressionCaching, 0);
+    Read( _T ( "PolygonSmoothing" ), &g_GLOptions.m_GLPolygonSmoothing, true);
+    Read( _T ( "LineSmoothing" ), &g_GLOptions.m_GLLineSmoothing, true);
 
     Read( _T ( "GPUTextureDimension" ), &g_GLOptions.m_iTextureDimension, 512 );
     Read( _T ( "GPUTextureMemSize" ), &g_GLOptions.m_iTextureMemorySize, 128 );
@@ -1968,6 +1970,8 @@ void MyConfig::UpdateSettings()
     Write( _T ( "GPUTextureCompressionCaching" ), g_GLOptions.m_bTextureCompressionCaching);
     Write( _T ( "GPUTextureDimension" ), g_GLOptions.m_iTextureDimension );
     Write( _T ( "GPUTextureMemSize" ), g_GLOptions.m_iTextureMemorySize );
+    Write( _T ( "PolygonSmoothing" ), g_GLOptions.m_GLPolygonSmoothing);
+    Write( _T ( "LineSmoothing" ), g_GLOptions.m_GLLineSmoothing);
 #endif
     Write( _T ( "SmoothPanZoom" ), g_bsmoothpanzoom );
 

--- a/src/ocpndc.cpp
+++ b/src/ocpndc.cpp
@@ -51,6 +51,11 @@
 #include "wx28compat.h"
 #include "cutil.h"
 
+#ifdef ocpnUSE_GL
+#include "glChartCanvas.h"
+extern ocpnGLOptions g_GLOptions;
+#endif
+
 extern float g_GLMinSymbolLineWidth;
 wxArrayPtrVoid gTesselatorVertices;
 
@@ -192,8 +197,10 @@ void ocpnDC::SetGLAttrs( bool highQuality )
 
  // Enable anti-aliased polys, at best quality
     if( highQuality ) {
-        glEnable( GL_LINE_SMOOTH );
-        glEnable( GL_POLYGON_SMOOTH );
+        if( g_GLOptions.m_GLLineSmoothing )
+            glEnable( GL_LINE_SMOOTH );
+        if( g_GLOptions.m_GLPolygonSmoothing )
+            glEnable( GL_POLYGON_SMOOTH );
         glEnable( GL_BLEND );
     } else {
         glDisable(GL_LINE_SMOOTH);
@@ -355,7 +362,8 @@ void ocpnDC::DrawLine( wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2, bool b_hi
 
 #ifndef __WXQT__
             glEnable( GL_BLEND );
-            glEnable( GL_LINE_SMOOTH );
+            if( g_GLOptions.m_GLLineSmoothing )
+                glEnable( GL_LINE_SMOOTH );
 #endif            
 
             if( pen_width > 1.0 ) {
@@ -578,8 +586,9 @@ void ocpnDC::DrawLines( int n, wxPoint points[], wxCoord xoffset, wxCoord yoffse
         } else {
 
             if( b_hiqual ) {
-                glEnable( GL_LINE_SMOOTH );
-                ;//                SetGLStipple(m_pen.GetStyle());
+                if( g_GLOptions.m_GLLineSmoothing )
+                    glEnable( GL_LINE_SMOOTH );
+                //                SetGLStipple(m_pen.GetStyle());
             }
 
             glBegin( GL_LINE_STRIP );
@@ -784,7 +793,8 @@ void ocpnDC::DrawPolygon( int n, wxPoint points[], wxCoord xoffset, wxCoord yoff
 #endif        
 
         if( ConfigureBrush() ) {
-            glEnable( GL_POLYGON_SMOOTH );
+            if( g_GLOptions.m_GLPolygonSmoothing )
+                glEnable( GL_POLYGON_SMOOTH );
             glBegin( GL_POLYGON );
             for( int i = 0; i < n; i++ )
                 glVertex2f( (points[i].x * scale) + xoffset, (points[i].y * scale) + yoffset );
@@ -793,7 +803,8 @@ void ocpnDC::DrawPolygon( int n, wxPoint points[], wxCoord xoffset, wxCoord yoff
         }
 
         if( ConfigurePen() ) {
-            glEnable( GL_LINE_SMOOTH );
+            if( g_GLOptions.m_GLLineSmoothing )
+                glEnable( GL_LINE_SMOOTH );
             glBegin( GL_LINE_LOOP );
             for( int i = 0; i < n; i++ )
                 glVertex2f( (points[i].x * scale) + xoffset, (points[i].y * scale) + yoffset );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -5583,6 +5583,9 @@ void options::OnOpenGLOptions(wxCommandEvent& event) {
     g_bShowFPS = dlg.GetShowFPS();
     g_bSoftwareGL = dlg.GetSoftwareGL();
 
+    g_GLOptions.m_GLPolygonSmoothing = dlg.GetPolygonSmoothing();
+    g_GLOptions.m_GLLineSmoothing = dlg.GetLineSmoothing();
+
     if (g_bGLexpert) {
       // user defined
       g_GLOptions.m_bTextureCompressionCaching =
@@ -8593,6 +8596,8 @@ OpenGLOptionsDlg::OpenGLOptionsDlg(wxWindow* parent)
   if (!g_bopengl || g_raster_format == GL_RGB) btnRebuild->Disable();
   btnClear->Enable(g_GLOptions.m_bTextureCompressionCaching);
   m_cbShowFPS = new wxCheckBox(this, wxID_ANY, _("Show FPS"));
+  m_cbPolygonSmoothing = new wxCheckBox(this, wxID_ANY, _("Polygon Smoothing"));
+  m_cbLineSmoothing = new wxCheckBox(this, wxID_ANY, _("Line Smoothing"));
   m_cbSoftwareGL =
       new wxCheckBox(this, wxID_ANY, _("Software OpenGL (restart OpenCPN)"));
   m_cbUseAcceleratedPanning =
@@ -8614,6 +8619,10 @@ OpenGLOptionsDlg::OpenGLOptionsDlg(wxWindow* parent)
   flexSizer->Add(btnClear, 0, wxALL | wxEXPAND, 5);
   flexSizer->Add(new wxStaticText(this, wxID_ANY, _("Miscellaneous")), 0,
                  wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL, 5);
+  flexSizer->Add(m_cbPolygonSmoothing, 0, wxALL | wxEXPAND, 5);
+  flexSizer->AddSpacer(0);
+  flexSizer->Add(m_cbLineSmoothing, 0, wxALL | wxEXPAND, 5);
+  flexSizer->AddSpacer(0);
   flexSizer->Add(m_cbShowFPS, 0, wxALL | wxEXPAND, 5);
   flexSizer->AddSpacer(0);
   flexSizer->Add(m_cbSoftwareGL, 0, wxALL | wxEXPAND, 5);
@@ -8643,6 +8652,14 @@ const bool OpenGLOptionsDlg::GetAcceleratedPanning(void) const {
 
 const bool OpenGLOptionsDlg::GetTextureCompression(void) const {
   return m_cbTextureCompression->GetValue();
+}
+
+const bool OpenGLOptionsDlg::GetPolygonSmoothing(void) const {
+    return m_cbPolygonSmoothing->GetValue();
+}
+
+const bool OpenGLOptionsDlg::GetLineSmoothing(void) const {
+    return m_cbLineSmoothing->GetValue();
 }
 
 const bool OpenGLOptionsDlg::GetShowFPS(void) const {
@@ -8686,6 +8703,8 @@ void OpenGLOptionsDlg::Populate(void) {
     m_sTextureMemorySize->SetValue(g_GLOptions.m_iTextureMemorySize);
   }
   m_cbShowFPS->SetValue(g_bShowFPS);
+  m_cbPolygonSmoothing->SetValue(g_GLOptions.m_GLPolygonSmoothing);
+  m_cbLineSmoothing->SetValue(g_GLOptions.m_GLLineSmoothing);
 
 #if defined(__UNIX__) && !defined(__OCPN__ANDROID__) && !defined(__WXOSX__)
   if (cc1->GetglCanvas()->GetVersionString().Upper().Find(_T( "MESA" )) !=

--- a/src/s52plib.cpp
+++ b/src/s52plib.cpp
@@ -52,13 +52,17 @@
 #include <wx/tokenzr.h>
 #include <wx/fileconf.h>
 
-
 extern float g_GLMinCartographicLineWidth;
 extern float g_GLMinSymbolLineWidth;
 extern double  g_overzoom_emphasis_base;
 extern bool    g_oz_vector_scale;
 extern float g_ChartScaleFactorExp;
 extern int g_chart_zoom_modifier_vector;
+
+#ifdef ocpnUSE_GL
+#include "glChartCanvas.h"
+extern ocpnGLOptions g_GLOptions;
+#endif
 
 float g_scaminScale;
 
@@ -3444,7 +3448,7 @@ int s52plib::RenderGLLS( ObjRazRules *rzRules, Rules *rules, ViewPort *vp )
     
 #else    
     glLineWidth(lineWidth);
-    if(lineWidth > 4.0){
+    if(lineWidth > 4.0 && g_GLOptions.m_GLLineSmoothing){
         glEnable( GL_LINE_SMOOTH );
         glEnable( GL_BLEND );
     }
@@ -3657,7 +3661,7 @@ int s52plib::RenderLS( ObjRazRules *rzRules, Rules *rules, ViewPort *vp )
             else
                 glDisable( GL_LINE_STIPPLE );
 #endif
-            if(w >= 2){    
+            if(w >= 2 && g_GLOptions.m_GLLineSmoothing){    
                 glEnable( GL_LINE_SMOOTH );
                 glEnable( GL_BLEND );
             }
@@ -3862,7 +3866,7 @@ int s52plib::RenderLSLegacy( ObjRazRules *rzRules, Rules *rules, ViewPort *vp )
         else
             glDisable( GL_LINE_STIPPLE );
 #endif
-        if(w >= 2){    
+        if(w >= 2 && g_GLOptions.m_GLLineSmoothing){
             glEnable( GL_LINE_SMOOTH );
             glEnable( GL_BLEND );
         }
@@ -4907,8 +4911,11 @@ next_seg_dc:
                     glBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
                     glEnable (GL_BLEND);
                     
-                    glEnable (GL_LINE_SMOOTH);
-                    glHint (GL_LINE_SMOOTH_HINT, GL_NICEST);
+                    if( g_GLOptions.m_GLLineSmoothing )
+                    {
+                        glEnable (GL_LINE_SMOOTH);
+                        glHint (GL_LINE_SMOOTH_HINT, GL_NICEST);
+                    }
 #endif
                     {
                         glBegin( GL_LINES );
@@ -4944,8 +4951,10 @@ next_seg_dc:
                     glBlendFunc (GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
                     glEnable (GL_BLEND);
 
-                    glEnable (GL_LINE_SMOOTH);
-                    glHint (GL_LINE_SMOOTH_HINT, GL_NICEST);
+                    if( g_GLOptions.m_GLLineSmoothing ) {
+                        glEnable (GL_LINE_SMOOTH);
+                        glHint (GL_LINE_SMOOTH_HINT, GL_NICEST);
+                    }
 
 #endif
                     {
@@ -5496,7 +5505,8 @@ int s52plib::RenderCARC_VBO( ObjRazRules *rzRules, Rules *rules, ViewPort *vp )
 
 #ifndef __OCPN__ANDROID__
         glEnable( GL_BLEND );
-        glEnable( GL_LINE_SMOOTH );
+        if( g_GLOptions.m_GLLineSmoothing )
+            glEnable( GL_LINE_SMOOTH );
 #endif        
         glEnableClientState(GL_VERTEX_ARRAY);             // activate vertex coords array
 
@@ -9249,8 +9259,8 @@ void RenderFromHPGL::SetPen()
     }
 #ifdef ocpnUSE_GL
     if( renderToOpenGl ) {
-    //    glEnable( GL_LINE_SMOOTH );
-        glEnable( GL_POLYGON_SMOOTH );
+        if( g_GLOptions.m_GLPolygonSmoothing )
+            glEnable( GL_POLYGON_SMOOTH );
         
         glColor4ub( penColor.Red(), penColor.Green(), penColor.Blue(), transparency );
         int line_width = wxMax(g_GLMinSymbolLineWidth, (float) penWidth * 0.7);
@@ -9265,7 +9275,7 @@ void RenderFromHPGL::SetPen()
 #endif
         
 #ifndef __OCPN__ANDROID__
-        if(line_width >= 2)
+        if( line_width >= 2 && g_GLOptions.m_GLLineSmoothing )
             glEnable( GL_LINE_SMOOTH );
         else
             glDisable( GL_LINE_SMOOTH );


### PR DESCRIPTION
Based on the points raised in https://github.com/OpenCPN/OpenCPN/issues/889 makes the polygon and line smoothing optional.
Of course I am no GL expert so have no idea whether or not we should also disable blending in case smoothing is off, but let's take this as a start...