### PR TITLE
Change one Port string to Data Port

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1724,7 +1724,7 @@ void options::CreatePanel_NMEA_Compact(size_t parent, int border_size,
                        NULL, this);
 #endif
 
-  wxString columns[] = {_("On"),   _("Type"), _("Port"),   _("Prio"),
+  wxString columns[] = {_("On"),   _("Type"), _("Data Port"),   _("Prio"),
                         _("Parm"), _("I/O"),  _("Filters")};
   for (int i = 0; i < 7; ++i) {
     wxListItem col;


### PR DESCRIPTION
The "Port" string in options.cpp is about a Data port. The "Port" string in ais.cpp is about port as opposite to starboard. That's confusing translation to Swedish and may be the same for other languages? 
I know this is an old issue but this change may solve this one?
