### PR TITLE
Allow transparent toolbar in OpenGL mode on macOS

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -1914,6 +1914,9 @@ bool MyApp::OnInit()
         XCloseDisplay(disp);
     }
 #endif
+#ifdef __WXOSX__
+    g_bTransparentToolbarInOpenGLOK = true;
+#endif
 #endif
 
 


### PR DESCRIPTION
@bdbcat - Do you have memory why it was never enabled? Seems to be working just fine here.