### PR TITLE
Grib not def values

### DIFF
--- a/plugins/grib_pi/src/CustomGrid.cpp
+++ b/plugins/grib_pi/src/CustomGrid.cpp
@@ -238,7 +238,7 @@ void CustomGrid::OnLabeClick( wxGridEvent& event)
             for( int c = 0; c < m_numCols; c++){
                 double value = m_NumRowVal[idx][c];
                 /*Current direction is generally reported as the "flow" direction, which is opposite from wind convention. So, adjust.*/
-                if( idx == R_CURRENT && m_IsDigit.GetChar(idx) == 'X' ){
+                if( idx == R_CURRENT && m_IsDigit.GetChar(idx) == 'X' && value != GRIB_NOTDEF){
                     value += 180;
                     if(value >= 360) value -= 360;
                     if( value < 0 ) value += 360;
@@ -265,7 +265,7 @@ void CustomGrid::SetNumericalRow( int row, int col, int datatype, double value )
     m_NumRow[datatype] = row;
     m_NumRowVal[datatype].push_back(value);
     /*Current direction is generally reported as the "flow" direction,which is opposite from wind convention. So, adjust.*/
-    if( datatype == R_CURRENT && m_IsDigit.GetChar(datatype) == 'X' ){
+    if( datatype == R_CURRENT && m_IsDigit.GetChar(datatype) == 'X' && value != GRIB_NOTDEF){
         value += 180;
         if(value >= 360) value -= 360;
         if( value < 0 ) value += 360;

--- a/plugins/grib_pi/src/GribRecord.cpp
+++ b/plugins/grib_pi/src/GribRecord.cpp
@@ -721,7 +721,7 @@ bool GribRecord::getInterpolatedValues(double &M, double &A,
 //         nbval ++;
 
      int nbval = 0;     // how many values in grid ?
-     if (GRX->getValue(i0, j0) != GRIB_NOTDEF)
+     if (GRY->getValue(i0, j0) != GRIB_NOTDEF)
          nbval ++;
      if (GRY->getValue(i1, j0) != GRIB_NOTDEF)
          nbval ++;
@@ -730,7 +730,20 @@ bool GribRecord::getInterpolatedValues(double &M, double &A,
      if (GRY->getValue(i1, j1) != GRIB_NOTDEF)
          nbval ++;
 
-    if (nbval < 3)
+    if (nbval <= 3)
+        return false;
+
+     nbval = 0;     // how many values in grid ?
+     if (GRX->getValue(i0, j0) != GRIB_NOTDEF)
+         nbval ++;
+     if (GRX->getValue(i1, j0) != GRIB_NOTDEF)
+         nbval ++;
+     if (GRX->getValue(i0, j1) != GRIB_NOTDEF)
+         nbval ++;
+     if (GRX->getValue(i1, j1) != GRIB_NOTDEF)
+         nbval ++;
+
+    if (nbval <= 3)
         return false;
 
     dx = (3.0 - 2.0*dx)*dx*dx;   // pseudo hermite interpolation


### PR DESCRIPTION
Hi,

Sometime undefined current value or UV vectors were used as if valid.

Attached a small grib showing the problem. If you move the cursor around you get bogus values, same when displaying a grib table.

Regards
Didier

NB
There's another bug, sometime it returns an overlay to big for this small file, I'm looking at it.

[test-grib.zip](https://github.com/OpenCPN/OpenCPN/files/1702303/test-grib.zip)
