### PR TITLE
correct name for track colour setting on Ships options page

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2589,7 +2589,7 @@ void options::CreatePanel_Ownship(size_t parent, int border_size,
       new wxCheckBox(itemPanelShip, ID_TRACKHILITE, _("Highlight Tracks"));
   hTrackGrid->Add(pTrackHighlite, 1, wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL, border_size);
   wxStaticText* trackColourText =
-      new wxStaticText( itemPanelShip, wxID_STATIC, _("Highlight Colour"));
+      new wxStaticText( itemPanelShip, wxID_STATIC, _("Track Colour"));
   hTrackGrid->Add(trackColourText, 1, wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL, border_size);
   m_colourTrackLineColour = new wxColourPickerCtrl(
       itemPanelShip, wxID_STATIC, *wxRED, wxDefaultPosition, wxDefaultSize, 0,


### PR DESCRIPTION
Original mod only set track highlight colour. (though variable name is TrackLineColour)
 
Recent commit correctly combined track colour and track highlight colour when displaying.
https://github.com/OpenCPN/OpenCPN/commit/dbefaf95dc8b7be1dc086902c822c4148e6f48cd

This pull request just clears up naming on Options -> Ships window.  Setting now titled 'Track Colour'