### PR TITLE
GetVPRegionIntersect on error only delete points array if it was allo…

### DIFF
--- a/src/viewport.cpp
+++ b/src/viewport.cpp
@@ -561,7 +561,7 @@ OCPNRegion ViewPort::GetVPRegionIntersect( const OCPNRegion &Region, size_t nPoi
 
     if(!valid)
     {
-        delete[] pp;
+        if ( ppoints == NULL ) delete[] pp;
         return OCPNRegion(); //empty;
     }
  


### PR DESCRIPTION
…cated by us

This test is done every where but here. Trigger a core dump with cm93 in
orthographic projection.