### PR TITLE
Fix portable save of CHRTLIST.DAT and MMSINAME.CSV

### DIFF
--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -1130,8 +1130,6 @@ wxString &OCPNPlatform::GetPrivateDataDir()
         
         if( g_bportable ){
             m_PrivateDataDir = GetHomeDir();
-            if(m_PrivateDataDir.Last() == wxFileName::GetPathSeparator())
-                m_PrivateDataDir.RemoveLast();
         }
         
 #ifdef __OCPN__ANDROID__

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -899,26 +899,17 @@ wxString newPrivateFileName(wxString home_locn, const char *name, const char *wi
     wxString fwname = wxString::FromUTF8(windowsName);
     wxString filePathAndName;
 
-#ifdef __WXMSW__
-    filePathAndName = fwname;
-    filePathAndName.Prepend( home_locn );
-
-#else
     filePathAndName = g_Platform->GetPrivateDataDir();
-    appendOSDirSlash(&filePathAndName);
-    filePathAndName.Append( fname );
+    if (filePathAndName.Last() != wxFileName::GetPathSeparator())
+       filePathAndName.Append(wxFileName::GetPathSeparator());
+
+#ifdef __WXMSW__
+     filePathAndName.Append( fwname );
+#else
+     filePathAndName.Append( fname );
 #endif
 
-    if( g_bportable ) {
-        filePathAndName.Clear();
-#ifdef __WXMSW__
-        filePathAndName.Append( fwname );
-#else
-        filePathAndName.Append( fname );
-#endif
-        filePathAndName.Prepend( home_locn );
-    }
-    return filePathAndName;
+     return filePathAndName;
 }
 
 


### PR DESCRIPTION
In Win portable mode the two files was saved wo path separator thus in wrong place and by wrong name.
This fix runs fine in Windows but neither tested on Linux nor Mac. Please check before merge.
Thanks