### PR TITLE
Travis for O5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,16 @@ before_install:
 install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libwxgtk3.0-dev libwxgtk3.0-0 libgps-dev libglu1-mesa-dev libgtk2.0-dev libbz2-dev libtinyxml-dev; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libportaudio2 portaudio19-dev libcurl4-openssl-dev libexpat1-dev libcairo2-dev; fi
-    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libarchive-dev liblzma-dev libexif-dev libsqlite3-dev; fi
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cairo libexif libarchive wxmac; export PATH="/usr/local/opt/gettext/bin:$PATH";  echo 'export PATH="/usr/local/opt/gettext/bin:$PATH"' >> ~/.bash_profile; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libarchive-dev liblzma-dev libexif-dev libsqlite3-dev gettext; fi
+#    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install wxmac --devel; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cairo libexif libarchive;  wget http://opencpn.navnux.org/build_deps/cairo_macos107.tar.xz; tar xJf cairo_macos107.tar.xz -C /tmp; wget http://opencpn.navnux.org/build_deps/wx_opencpn_macos107.tar.xz; tar xJf wx_opencpn_macos107.tar.xz -C /tmp; wget http://opencpn.navnux.org/build_deps/libarchive_macos107.tar.xz; tar xJf libarchive_macos107.tar.xz -C /tmp; export PATH="/usr/local/opt/gettext/bin:$PATH";  echo 'export PATH="/usr/local/opt/gettext/bin:$PATH"' >> ~/.bash_profile; fi
 
 script:
     - mkdir build && cd build
-    - cmake -DCMAKE_BUILD_TYPE=Debug ../
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then cmake -DCMAKE_BUILD_TYPE=Debug ..; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then cmake -DOCPN_USE_LIBCPP=ON -DwxWidgets_CONFIG_EXECUTABLE=/tmp/wx_opencpn_macos107/bin/wx-config -DwxWidgets_CONFIG_OPTIONS="--prefix=/tmp/wx_opencpn_macos107" -DLibArchive_INCLUDE_DIR=/tmp/libarchive_macos107/include -DLibArchive_LIBRARY=/tmp/libarchive_macos107/lib/libarchive.dylib -DCAIRO_INCLUDE_DIR=/tmp/cairo_macos107/include -DCAIRO_LIBRARY=/tmp/cairo_macos107/lib/libcairo.dylib -DCMAKE_INSTALL_PREFIX=/tmp/opencpn ..; fi
     - make -s
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then mkdir -p /tmp/opencpn/bin/OpenCPN.app/Contents/MacOS/; chmod 644 /usr/local/lib/lib*.dylib; cp /tmp/libarchive_macos107/lib/libarchive.16.dylib /tmp/opencpn/bin/OpenCPN.app/Contents/MacOS/; cp /tmp/cairo_macos107/lib/libcairo.2.dylib /tmp/opencpn/bin/OpenCPN.app/Contents/MacOS/; make install; make create-dmg; fi
 
 notifications:
     email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,18 +8,20 @@ matrix:
       compiler: gcc
     - os: osx
       compiler: clang
-      #We currently build against wxmac from Homebrew here for simplicity and to save time and resources, this is not exactly the same as the official builds backward compatible all the way to OS X 10.7 Lion, but should be "good enough" to find bugs affecting the clang toolchain
 
 before_install:                                                                                               
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade; fi
+#  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew upgrade; fi
+# Homebrew upgrade disabled to save time
 
 install:
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libwxgtk3.0-dev libwxgtk3.0-0 libgps-dev libglu1-mesa-dev libgtk2.0-dev libbz2-dev libtinyxml-dev; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libportaudio2 portaudio19-dev libcurl4-openssl-dev libexpat1-dev libcairo2-dev; fi
     - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install libarchive-dev liblzma-dev libexif-dev libsqlite3-dev gettext; fi
 #    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install wxmac --devel; fi
+# We do not use wxmac, everything comes in the prebuilt tarball downloaded bellow
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cairo libexif libarchive;  wget http://opencpn.navnux.org/build_deps/cairo_macos107.tar.xz; tar xJf cairo_macos107.tar.xz -C /tmp; wget http://opencpn.navnux.org/build_deps/wx_opencpn_macos107.tar.xz; tar xJf wx_opencpn_macos107.tar.xz -C /tmp; wget http://opencpn.navnux.org/build_deps/libarchive_macos107.tar.xz; tar xJf libarchive_macos107.tar.xz -C /tmp; export PATH="/usr/local/opt/gettext/bin:$PATH";  echo 'export PATH="/usr/local/opt/gettext/bin:$PATH"' >> ~/.bash_profile; fi
+# We install cairo and libarchive from Homebrew to pull in the dependencies, but use the custom Lion compatible build later.
 
 script:
     - mkdir build && cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,14 @@
 language: cpp
 
-os:                                                                                                           
-  - linux
-  - osx
-  #We currently build against wxmac from Homebrew here for simplicity and to save time and resources, this is not exactly the same as the official builds backward compatible all the way to OS X 10.7 Lion, but should be "good enough" to find bugs affecting the clang toolchain
+matrix:
+  include:
+    - dist: precise
+      compiler: gcc
+    - dist: trusty
+      compiler: gcc
+    - os: osx
+      compiler: clang
+      #We currently build against wxmac from Homebrew here for simplicity and to save time and resources, this is not exactly the same as the official builds backward compatible all the way to OS X 10.7 Lion, but should be "good enough" to find bugs affecting the clang toolchain
 
 before_install:                                                                                               
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi


### PR DESCRIPTION
Update travis build for O5 and produce a fully usable installer for macOS instead of building against stock wxmac