### PR TITLE
Use the actual sqlite3 headers to get the correct defines.

### DIFF
--- a/src/SQLiteCpp/include/SQLiteCpp/Database.h
+++ b/src/SQLiteCpp/include/SQLiteCpp/Database.h
@@ -19,13 +19,14 @@
 struct sqlite3;
 struct sqlite3_context;
 
+#ifndef _SQLITE3_H_ //This forward define may be problematic so let's try it only if needed
 #ifndef SQLITE_USE_LEGACY_STRUCT // Since SQLITE 3.19 (used by default since SQLiteCpp 2.1.0)
 typedef struct sqlite3_value sqlite3_value;
 #else // Before SQLite 3.19 (legacy struct forward declaration can be activated with CMake SQLITECPP_LEGACY_STRUCT var)
 struct Mem;
 typedef struct Mem sqlite3_value;
 #endif
-
+#endif //_SQLITE3_H_
 
 namespace SQLite
 {

--- a/src/mbtiles.cpp
+++ b/src/mbtiles.cpp
@@ -59,8 +59,8 @@
 #include "ocpn_pixel.h"
 #include "ChartDataInputStream.h"
 
+#include <sqlite3.h> //We need some defines
 #include <SQLiteCpp/SQLiteCpp.h>
-#define SQLITE_DONE        101  /* sqlite3_step() has finished executing */
 
 //  Missing from MSW include files
 #ifdef _MSC_VER


### PR DESCRIPTION
This should fix compilation on modern Linux distros.
Currently we depend on https://github.com/OpenCPN/OpenCPN/blob/master/CMakeLists.txt#L941 to decide which version of `sqlite3_value` to forward declare. It does not work at least on Ubuntu 17.10+

Let's see where it breaks it...