### PR TITLE
Correct and clean up portable file savings

### DIFF
--- a/include/OCPNPlatform.h
+++ b/include/OCPNPlatform.h
@@ -132,6 +132,7 @@ public:
     wxString &GetLogFileName(){ return mlog_file; }
     MyConfig *GetConfigObject();
     wxString GetSupplementalLicenseString();
+    wxString NormalizePath(const wxString &full_path); //Adapt for portable use
     
     int DoFileSelectorDialog( wxWindow *parent, wxString *file_spec, wxString Title, wxString initDir,
                                 wxString suggestedName, wxString wildcard);

--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -1173,6 +1173,19 @@ wxString &OCPNPlatform::GetPluginDir()
     return m_PluginsDir;
 }
 
+wxString OCPNPlatform::NormalizePath(const wxString &full_path) {
+  if (!g_bportable) {
+    return full_path;
+  } else {
+    wxString path(full_path);
+    wxFileName f(path);
+    // If not on another voulme etc. make the portable relative path
+    if (f.MakeRelativeTo(g_Platform->GetPrivateDataDir())) {
+      path = f.GetFullPath();
+    }
+    return path;
+  }
+}
 
 wxString &OCPNPlatform::GetConfigFileName()
 {

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -1976,22 +1976,16 @@ bool MyApp::OnInit()
     //  If empty, preset one default (US) Ascii data source
     wxString default_tcdata =  ( g_Platform->GetSharedDataDir() + _T("tcdata") +
              wxFileName::GetPathSeparator() + _T("HARMONIC.IDX"));
-    wxFileName fdefault( default_tcdata );
-
+    
     if(!TideCurrentDataSet.GetCount()) {
-        if( g_bportable ) {
-            fdefault.MakeRelativeTo( g_Platform->GetPrivateDataDir() );
-            TideCurrentDataSet.Add( fdefault.GetFullPath() );
-        }
-        else
-            TideCurrentDataSet.Add( default_tcdata );
+        TideCurrentDataSet.Add(g_Platform->NormalizePath(default_tcdata) );
     }
     else {
         wxString first_tide = TideCurrentDataSet.Item(0);
         wxFileName ft(first_tide);
         if(!ft.FileExists()){
             TideCurrentDataSet.RemoveAt(0);
-            TideCurrentDataSet.Insert( default_tcdata, 0 );
+            TideCurrentDataSet.Insert(g_Platform->NormalizePath(default_tcdata), 0 );
         }
     }
 
@@ -2002,14 +1996,7 @@ bool MyApp::OnInit()
         wxString default_sound =  ( g_Platform->GetSharedDataDir() + _T("sounds") +
         wxFileName::GetPathSeparator() +
         _T("2bells.wav"));
-
-        if( g_bportable ) {
-            wxFileName f( default_sound );
-            f.MakeRelativeTo( g_Platform->GetPrivateDataDir() );
-            g_sAIS_Alert_Sound_File = f.GetFullPath();
-        }
-        else
-            g_sAIS_Alert_Sound_File = default_sound ;
+        g_sAIS_Alert_Sound_File = g_Platform->NormalizePath(default_sound);
     }
 
 

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -2250,8 +2250,8 @@ void MyConfig::UpdateSettings()
     Write( _T ( "InitChartDir" ), *pInit_Chart_Dir );
     Write( _T ( "GPXIODir" ), m_gpx_path );
     Write( _T ( "TCDataDir" ), g_TCData_Dir );
-    Write( _T ( "BasemapDir" ), gWorldMapLocation );
-
+    Write( _T ( "BasemapDir" ), g_Platform->NormalizePath(gWorldMapLocation) );
+    
     SetPath( _T ( "/Settings/NMEADataSource" ) );
     wxString connectionconfigs;
     for (size_t i = 0; i < g_pConnectionParams->Count(); i++)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -7262,12 +7262,7 @@ void options::OnButtonSelectSound(wxCommandEvent& event) {
 #endif
 
   if (response == wxID_OK) {
-    if (g_bportable) {
-      wxFileName f(sel_file);
-      f.MakeRelativeTo(g_Platform->GetHomeDir());
-      g_sAIS_Alert_Sound_File = f.GetFullPath();
-    } else
-      g_sAIS_Alert_Sound_File = sel_file;
+    g_sAIS_Alert_Sound_File = g_Platform->NormalizePath(sel_file);
 
     g_anchorwatch_sound.UnLoad();
   }
@@ -7862,22 +7857,12 @@ void options::OnInsertTideDataLocation(wxCommandEvent& event) {
 #endif
 
   if (response == wxID_OK) {
-    if (g_bportable) {
-      wxFileName f(sel_file);
-      f.MakeRelativeTo(g_Platform->GetHomeDir());
-      tcDataSelected->Append(f.GetFullPath());
-    } else
-      tcDataSelected->Append(sel_file);
+    tcDataSelected->Append(g_Platform->NormalizePath(sel_file));
 
     //    Record the currently selected directory for later use
     wxFileName fn(sel_file);
     wxString data_dir = fn.GetPath();
-    if (g_bportable) {
-      wxFileName f(data_dir);
-      f.MakeRelativeTo(g_Platform->GetHomeDir());
-      g_TCData_Dir = f.GetFullPath();
-    } else
-      g_TCData_Dir = data_dir;
+     g_TCData_Dir = g_Platform->NormalizePath(data_dir);
   }
 }
 


### PR DESCRIPTION
Fix issues in portable mode like:
BasemapDir=F:\PortOCPN\gshhs\ 

Don't fix the same issue in WMM: I think we need plugin API change 
WMMDataLocation=F:\PortOCPN\plugins\wmm_pi\data\
 I think we need a plugin API change so portable mode is detectable?
