### PR TITLE
Change the AIS MOB logic

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -9925,7 +9925,8 @@ void MyFrame::ActivateAISMOBRoute( AIS_Target_Data *ptarget )
     pConfig->AddNewWayPoint( pWP_MOB, -1 );       // use auto next num
 
 
-    if( bGPSValid && !wxIsNaN(gCog) && !wxIsNaN(gSog) ) {
+    /* We want to start tracking any MOB in range (Which will trigger false alarms with messages received over the network etc., but will a) not discard nearby event even in case our GPS is momentarily unavailable and b) work even when the boat is stationary, in which case some GPS units do not provide COG)
+    if( bGPSValid && !wxIsNaN(gCog) && !wxIsNaN(gSog) ) { */
         RoutePoint *pWP_src = new RoutePoint( gLat, gLon, g_default_wp_icon,
                                               wxString( _( "Own ship" ) ), GPX_EMPTY_STRING );
         pSelect->AddSelectableRoutePoint( gLat, gLon, pWP_src );
@@ -9954,7 +9955,7 @@ void MyFrame::ActivateAISMOBRoute( AIS_Target_Data *ptarget )
         v[_T("GUID")] = pAISMOBRoute->m_GUID;
         wxString msg_id( _T("OCPN_MAN_OVERBOARD") );
         g_pi_manager->SendJSONMessageToAllPlugins( msg_id, v );
-    }
+    //}
 
     if( pRouteManagerDialog && pRouteManagerDialog->IsShown() ) {
         pRouteManagerDialog->UpdateRouteListCtrl();


### PR DESCRIPTION
The current implementation requires the GPS to work and provide both SOG and COG to establish an MOB route.
There is a clear problem leading to creation of a new MOB waypoint on every timer tick (every second) when any of the 3 forementioned conditions is not met.
There is an increasing number of GPS units not providing COG at close to zero speed as it is impossible to calculate reliably, so the problem would appear even on eg. an anchored boat with otherwise perfectly operational system and ready for a rescue operation.

The solution provided in this PR sure allows for false positives even when undesired, especially with external data feeds, but should make the operation under real world conditions safer and always fix the problem with repeated creation of the MOB waypoints.