### PR TITLE
Implement information about waypoints ignored during GPX import.

### DIFF
--- a/include/NavObjectCollection.h
+++ b/include/NavObjectCollection.h
@@ -94,7 +94,7 @@ public:
     bool AddGPXWaypoint(RoutePoint *pWP );
     
     bool CreateAllGPXObjects();
-    bool LoadAllGPXObjects( bool b_full_viz = false);
+    bool LoadAllGPXObjects( bool b_full_viz, int &wpt_duplicates );
     int LoadAllGPXObjectsAsLayer(int layer_id, bool b_layerviz);
     
     bool SaveFile( const wxString filename );

--- a/src/NavObjectCollection.cpp
+++ b/src/NavObjectCollection.cpp
@@ -1297,8 +1297,9 @@ bool NavObjectCollection1::SaveFile( const wxString filename )
     return true;
 }
 
-bool NavObjectCollection1::LoadAllGPXObjects( bool b_full_viz )
+bool NavObjectCollection1::LoadAllGPXObjects( bool b_full_viz, int &wpt_duplicates )
 {
+    wpt_duplicates = 0;
     pugi::xml_node objects = this->child("gpx");
     
     for (pugi::xml_node object = objects.first_child(); object; object = object.next_sibling())
@@ -1313,8 +1314,10 @@ bool NavObjectCollection1::LoadAllGPXObjects( bool b_full_viz )
                         pWayPointMan->AddRoutePoint( pWp );
                      pSelect->AddSelectableRoutePoint( pWp->m_lat, pWp->m_lon, pWp );
             }
-            else
+            else {
                 delete pWp;
+                wpt_duplicates++;
+            }
         }
         else
             if( !strcmp(object.name(), "trk") ) {

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -1538,11 +1538,12 @@ void MyConfig::LoadNavObjects()
     if( NULL == m_pNavObjectInputSet )
         m_pNavObjectInputSet = new NavObjectCollection1();
 
+    int wpt_dups;
     if( ::wxFileExists( m_sNavObjSetFile ) &&
         m_pNavObjectInputSet->load_file( m_sNavObjSetFile.fn_str() ) )
-        m_pNavObjectInputSet->LoadAllGPXObjects();
+        m_pNavObjectInputSet->LoadAllGPXObjects(false, wpt_dups);
 
-    wxLogMessage( _T("Done loading navobjects") );
+    wxLogMessage( _T("Done loading navobjects, %d duplicate waypoints ignored"), wpt_dups );
     delete m_pNavObjectInputSet;
 
     if( ::wxFileExists( m_sNavObjSetChangesFile ) ) {
@@ -2712,9 +2713,13 @@ void MyConfig::UI_ImportGPX( wxWindow* parent, bool islayer, wxString dirpath, b
                 if(islayer){
                     l->m_NoOfItems = pSet->LoadAllGPXObjectsAsLayer(l->m_LayerID, l->m_bIsVisibleOnChart);
                 }
-                else
-                    pSet->LoadAllGPXObjects( !pSet->IsOpenCPN() ); // Import with full vizibility of names and objects
-
+                else {
+                    int wpt_dups;
+                    pSet->LoadAllGPXObjects( !pSet->IsOpenCPN(), wpt_dups ); // Import with full visibility of names and objects
+                    if(wpt_dups > 0) {
+                        OCPNMessageBox(parent, wxString::Format(_("%d duplicate waypoints detected during import and ignored."), wpt_dups), _("OpenCPN Info"), wxICON_INFORMATION|wxOK, 10);
+                    }
+                }
                 delete pSet;
             }
         }


### PR DESCRIPTION
Implements an information dialog displayed in case some waypoints were ignored during the import of a GPX file, which is usually the case when they already exist in a layer and turned out to be confusing for the users when done silently.