### PR TITLE
Misc fixes

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -905,12 +905,6 @@ public:
 class DECL_EXP PI_S57Obj
 {
 public:
-
-      //  Public Methods
-      PI_S57Obj();
-      ~PI_S57Obj();
-
-public:
       // Instance Data
       char                    FeatureName[8];
       int                     Primitive_type;

--- a/src/cm93.cpp
+++ b/src/cm93.cpp
@@ -4592,7 +4592,7 @@ int cm93chart::loadsubcell ( int cellindex, wxChar sub_char )
       
       if ( g_bDebugCM93 )
       {
-          printf("noFind count: %d\n", m_noFindArray.GetCount());
+          printf("noFind count: %d\n", (int)m_noFindArray.GetCount());
       }
                 
       if(!bfound && !compfile.Length())

--- a/src/mygdal/ogr_attrind.h
+++ b/src/mygdal/ogr_attrind.h
@@ -91,7 +91,7 @@ protected:
                 OGRLayerAttrIndex();
 
 public:
-    virtual     ~OGRLayerAttrIndex();
+    virtual     ~OGRLayerAttrIndex() = 0;
 
     virtual OGRErr Initialize( const char *pszIndexPath, OGRLayer * ) = 0;
 

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -141,7 +141,7 @@ enum
 #include <wx/listimpl.cpp>
 WX_DEFINE_LIST(Plugin_WaypointList);
 WX_DEFINE_LIST(Plugin_HyperlinkList);
-
+WX_DEFINE_LIST(ListOfPI_S57Obj);
 
 //    Some static helper funtions
 //    Scope is local to this module


### PR DESCRIPTION
These fix compiling with -fsanitize=... with recent g++. The bits causing linker errors are normally dropped away and thus no error in normal builds.

Have a PR with cmake support for -fsanitize=... later.

Also kill a warning in cm93.
