### PR TITLE
Handle iterators going off the end of the list in a portable way.

### DIFF
--- a/src/LLRegion.cpp
+++ b/src/LLRegion.cpp
@@ -612,8 +612,8 @@ void LLRegion::Optimize()
         int s = i->size();
         for(int c=0; c<s; c++) {
             poly_contour::iterator l = j, k = j;
-            l--; if(l == i->end()) l--;
-            k++; if(k == i->end()) k++;
+            if (l == i->begin()) l = i->end(); l--;
+            k++; if(k == i->end()) k = i->begin();
             if(l == k)
                 break;
             if(fabs(cross(vector(*j, *l), vector(*j, *k))) < 1e-12) {

--- a/src/LLRegion.cpp
+++ b/src/LLRegion.cpp
@@ -612,8 +612,15 @@ void LLRegion::Optimize()
         int s = i->size();
         for(int c=0; c<s; c++) {
             poly_contour::iterator l = j, k = j;
-            if (l == i->begin()) l = i->end(); l--;
-            k++; if(k == i->end()) k = i->begin();
+            
+            if (l == i->begin())
+                l = i->end();
+            l--;
+            
+            k++;
+            if(k == i->end())
+                k = i->begin();
+            
             if(l == k)
                 break;
             if(fabs(cross(vector(*j, *l), vector(*j, *k))) < 1e-12) {


### PR DESCRIPTION
This PR fixes a portability issue. Not all STL implementations use a circular list implementation. The behavior of decrementing past the head or incrementing past the tail is undefined. MSVC never implemented the list object as a circular linked list.