### PR TITLE
fix CMakeList.txt logic, after 549eb238ca7  'cmake: Enable option for…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1951,10 +1951,11 @@ TARGET_LINK_LIBRARIES( gorp ${wxWidgets_LIBRARIES} )
 ENDIF()
 
 # Sanitizers, part 2/2
-if (NOT "${ENABLE_SANITIZER}" MATCHES "none")
-    target_link_libraries(${PACKAGE_NAME} -fsanitize=${ENABLE_SANITIZER})
+if ( CMAKE_VERSION VERSION_GREATER 3.4 )
+  if (NOT "${ENABLE_SANITIZER}" MATCHES "none")
+     target_link_libraries(${PACKAGE_NAME} -fsanitize=${ENABLE_SANITIZER})
+  endif()
 endif()
-
 
 If(NOT APPLE AND NOT QT_ANDROID)
 TARGET_LINK_LIBRARIES(${PACKAGE_NAME}


### PR DESCRIPTION
… sanitizers'

Hi,
after 549eb23 cmake < 3.4 generates bogus Makefile with a not working linker parameters list:
.. -rdynamic -fsanitize= libNMEA0183.a -lportaudio libWXCURL.a ...

Regards
Didier
