### PR TITLE
fix for plugins GL textures slowliness

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,10 @@ install:
   - cmd: SET PATH=%PATH%;%WXWIN%;%wxWidgets_LIB_DIR%;C:\Program Files (x86)\Poedit\Gettexttools\bin;
 
   # install dependencies:
-  - choco install poedit nsis -x86
+  - choco install poedit -x86
+
+  - ps: Start-FileDownload http://opencpn.navnux.org/build_deps/nsis-3.03-setup.exe
+  - cmd: nsis-3.03-setup.exe /S
 
   # Download and unzip wxwidgets
   - ps: Start-FileDownload http://downloads.sourceforge.net/project/wxwindows/3.0.2/wxWidgets-3.0.2.zip

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -2497,7 +2497,6 @@ void glChartCanvas::RenderRasterChartRegionGL( ChartBase *chart, ViewPort &vp, L
 
     if(b_inCompressAllCharts) return; // don't want multiple texfactories to exist
     
-    double scalefactor = pBSBChart->GetRasterScaleFactor(vp);
 
     //    Look for the texture factory for this chart
     wxString key = chart->GetHashKey();
@@ -2526,6 +2525,36 @@ void glChartCanvas::RenderRasterChartRegionGL( ChartBase *chart, ViewPort &vp, L
     int base_level;
     if(vp.m_projection_type == PROJECTION_MERCATOR &&
        chart->GetChartProjectionType() == PROJECTION_MERCATOR) {
+        double scalefactor = pBSBChart->GetRasterScaleFactor(vp);
+        ///// XXX HACK ////////////////////
+        //////////////////////////////////
+        /// missing GetRasterScaleFactor in plugin
+        /// partial revert of 026f7d371
+        ChartPlugInWrapper *pPlugInWrapper = dynamic_cast<ChartPlugInWrapper*>( chart );
+        if( pPlugInWrapper ) {
+               wxRect R;
+
+               double skew_norm = chart->GetChartSkew();
+               if( skew_norm > 180. ) skew_norm -= 360.;
+
+               ViewPort svp = vp;
+               svp.pix_width = svp.rv_rect.width;
+               svp.pix_height = svp.rv_rect.height;
+
+               if(vp.b_quilt && (fabs(skew_norm) > 1.0)){
+                  //  make a larger viewport to ensure getting all of the chart tiles
+                  ViewPort xvp = svp;
+                  xvp.pix_width *= 2;
+                  xvp.pix_height *= 2;
+                  pPlugInWrapper->ComputeSourceRectangle( xvp, &R );
+              }
+              else {
+                  pPlugInWrapper->ComputeSourceRectangle( svp, &R );
+              }
+              // hopefully ComputeSourceRectangle had computed the right value
+              scalefactor = pBSBChart->GetRasterScaleFactor(vp);
+        }
+        //////////////////////////////////
         base_level = log(scalefactor) / log(2.0);
 
         if(base_level < 0) /* for overzoom */

--- a/src/glTextureManager.cpp
+++ b/src/glTextureManager.cpp
@@ -1269,10 +1269,10 @@ bool glTextureManager::TextureCrunch(double factor)
     
     ChartPathHashTexfactType::iterator it0;
     for( it0 = m_chart_texfactory_hash.begin(); it0 != m_chart_texfactory_hash.end(); ++it0 ) {
-        wxString chart_full_path = it0->first;
         glTexFactory *ptf = it0->second;
         if(!ptf)
             continue;
+        wxString chart_full_path = ptf->GetChartPath();
         
         bGLMemCrunch = g_tex_mem_used > (double)(g_GLOptions.m_iTextureMemorySize * 1024 * 1024) * factor *hysteresis;
         if(!bGLMemCrunch)

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -4884,8 +4884,13 @@ void ChartPlugInWrapper::GetValidCanvasRegion(const ViewPort& VPoint, OCPNRegion
 
 void ChartPlugInWrapper::SetColorScheme(ColorScheme cs, bool bApplyImmediate)
 {
-    if(m_ppicb)
+    if(m_ppicb) {
         m_ppicb->SetColorScheme(cs, bApplyImmediate);
+    }
+    m_global_color_scheme = cs;
+    //      Force a new thumbnail
+    if(pThumbData)
+        pThumbData->pDIBThumb = NULL;
 }
 
 
@@ -5898,6 +5903,7 @@ PI_DLEvtHandler::~PI_DLEvtHandler()
 void PI_DLEvtHandler::onDLEvent( OCPN_downloadEvent &event)
 {
 //    qDebug() << "Got Event " << (int)event.getDLEventStatus() << (int)event.getDLEventCondition();
+
     g_download_status = event.getDLEventStatus();
     g_download_condition = event.getDLEventCondition();
 


### PR DESCRIPTION
Hi,

- plugins were using the wrong color scheme for thumbnail. (cf TD-BR-MAR-2010/1900201.BAP charts)

- where purging textures O always  thought charts were not active so it was always purging and reloading textures, it's a bigger issue with raster plugins because they load the whole mipmap set , for  example kap 1900201.kap chart most of the time  8MB, .bap 43MB

- workaround: plugins don't compute the right value for GetRasterScaleFactor , used for selecting first mipmap level (ie loading fewer textures). Likely unfixable without breaking plugins ABI.

- appveyor backport from master (was failing in make package).
 
Regards
Didier
