### PR TITLE
Initialize m_DataHeight in constructors.

### DIFF
--- a/plugins/dashboard_pi/src/instrument.cpp
+++ b/plugins/dashboard_pi/src/instrument.cpp
@@ -177,6 +177,7 @@ DashboardInstrument_Single::DashboardInstrument_Single(wxWindow *pparent, wxWind
 {
       m_format = format;
       m_data = _T("---");
+      m_DataHeight = 0;
 }
 
 wxSize DashboardInstrument_Single::GetSize( int orient, wxSize hint )
@@ -271,6 +272,7 @@ DashboardInstrument_Position::DashboardInstrument_Position(wxWindow *pparent, wx
       m_data2 = _T("---");
       m_cap_flag1 = cap_flag1;
       m_cap_flag2 = cap_flag2;
+      m_DataHeight = 0;
 }
 
 wxSize DashboardInstrument_Position::GetSize( int orient, wxSize hint )


### PR DESCRIPTION
Critical members were not initialized in constructor. Sometimes instrument could be drawn before GetSize() was called thus causing an uninitialized variable trap.