### PR TITLE
Optimize history graphs by avoiding thousands of calls to OS TZ func

### DIFF
--- a/plugins/dashboard_pi/src/baro_history.cpp
+++ b/plugins/dashboard_pi/src/baro_history.cpp
@@ -67,8 +67,8 @@ DashboardInstrument_BaroHistory::DashboardInstrument_BaroHistory( wxWindow *pare
       for (int idx = 0; idx < BARO_RECORD_COUNT; idx++) {
         m_ArrayPressHistory[idx] = -1;
         m_ExpSmoothArrayPressure[idx] = -1;
-        m_ArrayRecTime[idx]=wxDateTime::Now();
-        m_ArrayRecTime[idx].SetYear(999);
+        m_ArrayRecTime[idx]=wxDateTime::Now().GetTm();
+        m_ArrayRecTime[idx].year=999;
       }
       alpha=0.01;  //smoothing constant
       m_WindowRect=GetClientRect();
@@ -119,7 +119,7 @@ void DashboardInstrument_BaroHistory::SetData(int st, double data, wxString unit
 
       }
       m_ExpSmoothArrayPressure[BARO_RECORD_COUNT-1]=alpha*m_ArrayPressHistory[BARO_RECORD_COUNT-2]+(1-alpha)*m_ExpSmoothArrayPressure[BARO_RECORD_COUNT-2];
-      m_ArrayRecTime[BARO_RECORD_COUNT-1]=wxDateTime::Now();
+      m_ArrayRecTime[BARO_RECORD_COUNT-1]=wxDateTime::Now().GetTm();
       m_MaxPress   = wxMax(m_Press,m_MaxPress);
 
       m_MinPress   = wxMin(m_MinPress,m_Press);
@@ -254,7 +254,7 @@ void DashboardInstrument_BaroHistory::DrawForeground(wxGCDC* dc)
   wxColour col;
   double ratioH;
   int degw,degh;
-  int width,height,min,hour;
+  int width,height,sec,min,hour;
   wxString WindAngle,WindSpeed;
   wxPen pen;
   wxString label;
@@ -272,14 +272,14 @@ void DashboardInstrument_BaroHistory::DrawForeground(wxGCDC* dc)
   dc->SetFont(*g_pFontLabel);
   //determine the time range of the available data (=oldest data value)
   int i=0;
-  while(m_ArrayRecTime[i].GetYear()== 999 && i<BARO_RECORD_COUNT-1) i++;
+  while(m_ArrayRecTime[i].year == 999 && i<BARO_RECORD_COUNT-1) i++;
   if (i == BARO_RECORD_COUNT -1) {  min=0;
     hour=0;
 
   }
   else {
-    min=m_ArrayRecTime[i].GetMinute();
-    hour=m_ArrayRecTime[i].GetHour();
+    min=m_ArrayRecTime[i].min;
+    hour=m_ArrayRecTime[i].hour;
   }
   m_ratioW = double(m_DrawAreaRect.width) / (BARO_RECORD_COUNT-1);
  // dc->DrawText(wxString::Format(_(" Max %.1f Min %.1f since %02d:%02d  Overall Max %.1f Min %.1f "),m_MaxPress,m_MinPress,hour,min,m_TotalMaxPress,m_TotalMinPress), m_LeftLegend+3+2+degw, m_TopLineHeight-degh+5);
@@ -347,10 +347,11 @@ void DashboardInstrument_BaroHistory::DrawForeground(wxGCDC* dc)
   int done=-1;
   wxPoint pointTime;
   for (int idx = 0; idx < BARO_RECORD_COUNT; idx++) {
-    min=m_ArrayRecTime[idx].GetMinute();
-    hour=m_ArrayRecTime[idx].GetHour();
-    if(m_ArrayRecTime[idx].GetYear()!= 999) {
-      if ( (hour*100+min) != done && (min % 5 == 0 ) && (m_ArrayRecTime[idx].GetSecond() == 0 || m_ArrayRecTime[idx].GetSecond() == 1) ) {
+    sec = m_ArrayRecTime[idx].sec;
+    min=m_ArrayRecTime[idx].min;
+    hour=m_ArrayRecTime[idx].hour;
+    if(m_ArrayRecTime[idx].year!= 999) {
+      if ( (hour*100+min) != done && ( min % 5 == 0 ) && (sec == 0 || sec == 1) ) {
         pointTime.x = idx * m_ratioW + 3 + m_LeftLegend;
         dc->DrawLine( pointTime.x, m_TopLineHeight+1, pointTime.x,(m_TopLineHeight+m_DrawAreaRect.height+1) );
         label.Printf(_T("%02d:%02d"), hour,min);

--- a/plugins/dashboard_pi/src/baro_history.h
+++ b/plugins/dashboard_pi/src/baro_history.h
@@ -72,7 +72,7 @@ class DashboardInstrument_BaroHistory: public DashboardInstrument
             double m_ArrayPressHistory[BARO_RECORD_COUNT];
             double m_ExpSmoothArrayPressure[BARO_RECORD_COUNT];
 
-   wxDateTime m_ArrayRecTime[BARO_RECORD_COUNT];
+            wxDateTime::Tm m_ArrayRecTime[BARO_RECORD_COUNT];
 
 
 

--- a/plugins/dashboard_pi/src/wind_history.cpp
+++ b/plugins/dashboard_pi/src/wind_history.cpp
@@ -70,8 +70,8 @@ DashboardInstrument_WindDirHistory::DashboardInstrument_WindDirHistory( wxWindow
         m_ArrayWindSpdHistory[idx] = -1;
         m_ExpSmoothArrayWindSpd[idx] = -1;
         m_ExpSmoothArrayWindDir[idx] = -1;
-        m_ArrayRecTime[idx]=wxDateTime::Now();
-        m_ArrayRecTime[idx].SetYear(999);
+        m_ArrayRecTime[idx]=wxDateTime::Now().GetTm();
+        m_ArrayRecTime[idx].year=999;
       }
       alpha=0.01;  //smoothing constant
       m_WindowRect=GetClientRect();
@@ -124,8 +124,8 @@ void DashboardInstrument_WindDirHistory::SetData(int st, double data, wxString u
 			  m_ArrayWindSpdHistory[idx] = -1;
 			  m_ExpSmoothArrayWindSpd[idx] = -1;
 			  m_ExpSmoothArrayWindDir[idx] = -1;
-			  m_ArrayRecTime[idx] = wxDateTime::Now();
-			  m_ArrayRecTime[idx].SetYear(999);
+			  m_ArrayRecTime[idx] = wxDateTime::Now().GetTm();
+			  m_ArrayRecTime[idx].year = 999;
 		  }
 	  }
 	  m_WindSpeedUnit = unit;
@@ -176,7 +176,7 @@ void DashboardInstrument_WindDirHistory::SetData(int st, double data, wxString u
       }
       m_ExpSmoothArrayWindSpd[WIND_RECORD_COUNT-1]=alpha*m_ArrayWindSpdHistory[WIND_RECORD_COUNT-2]+(1-alpha)*m_ExpSmoothArrayWindSpd[WIND_RECORD_COUNT-2];
       m_ExpSmoothArrayWindDir[WIND_RECORD_COUNT-1]=alpha*m_ArrayWindDirHistory[WIND_RECORD_COUNT-2]+(1-alpha)*m_ExpSmoothArrayWindDir[WIND_RECORD_COUNT-2];
-      m_ArrayRecTime[WIND_RECORD_COUNT-1]=wxDateTime::Now();
+      m_ArrayRecTime[WIND_RECORD_COUNT-1]=wxDateTime::Now().GetTm();
       m_oldDirVal=m_ExpSmoothArrayWindDir[WIND_RECORD_COUNT-1];
       //include the new/latest value in the max/min value test too
       m_MaxWindDir = wxMax(m_WindDir,m_MaxWindDir);
@@ -488,7 +488,7 @@ void DashboardInstrument_WindDirHistory::DrawForeground(wxGCDC* dc)
   wxColour col;
   double ratioH;
   int degw,degh;
-  int width,height,min,hour;
+  int width,height,sec,min,hour;
   double dir;
   wxString WindAngle,WindSpeed;
   wxPen pen;
@@ -563,14 +563,14 @@ void DashboardInstrument_WindDirHistory::DrawForeground(wxGCDC* dc)
   dc->SetFont(*g_pFontLabel);
   //determine the time range of the available data (=oldest data value)
   int i=0;
-  while(m_ArrayRecTime[i].GetYear()== 999 && i<WIND_RECORD_COUNT-1) i++;
+  while(m_ArrayRecTime[i].year == 999 && i<WIND_RECORD_COUNT-1) i++;
   if (i == WIND_RECORD_COUNT -1) {
     min=0;
     hour=0;
   }
   else {
-    min=m_ArrayRecTime[i].GetMinute();
-    hour=m_ArrayRecTime[i].GetHour();
+    min=m_ArrayRecTime[i].min;
+    hour=m_ArrayRecTime[i].hour;
   }
   dc->DrawText(wxString::Format(_("Max %.1f %s since %02d:%02d  Overall %.1f %s"), m_MaxWindSpd, m_WindSpeedUnit.c_str(), hour, min, m_TotalMaxWindSpd, m_WindSpeedUnit.c_str()), m_LeftLegend + 3 + 2 + degw, m_TopLineHeight - degh + 5);
   pen.SetStyle(wxPENSTYLE_SOLID);
@@ -624,10 +624,11 @@ void DashboardInstrument_WindDirHistory::DrawForeground(wxGCDC* dc)
   int done=-1;
   wxPoint pointTime;
   for (int idx = 0; idx < WIND_RECORD_COUNT; idx++) {
-    min=m_ArrayRecTime[idx].GetMinute();
-    hour=m_ArrayRecTime[idx].GetHour();
-    if(m_ArrayRecTime[idx].GetYear()!= 999) {
-      if ( (hour*100+min) != done && (min % 5 == 0 ) && (m_ArrayRecTime[idx].GetSecond() == 0 || m_ArrayRecTime[idx].GetSecond() == 1) ) {
+    sec = m_ArrayRecTime[idx].sec;
+    min=m_ArrayRecTime[idx].min;
+    hour=m_ArrayRecTime[idx].hour;
+    if(m_ArrayRecTime[idx].year!= 999) {
+      if ( (hour*100+min) != done && (min % 5 == 0 ) && (sec == 0 || sec == 1) ) {
         pointTime.x = idx * m_ratioW + 3 + m_LeftLegend;
         dc->DrawLine( pointTime.x, m_TopLineHeight+1, pointTime.x,(m_TopLineHeight+m_DrawAreaRect.height+1) );
         label.Printf(_T("%02d:%02d"), hour,min);

--- a/plugins/dashboard_pi/src/wind_history.h
+++ b/plugins/dashboard_pi/src/wind_history.h
@@ -69,7 +69,7 @@ class DashboardInstrument_WindDirHistory: public DashboardInstrument
         double m_ArrayWindSpdHistory[WIND_RECORD_COUNT];
         double m_ExpSmoothArrayWindSpd[WIND_RECORD_COUNT];
         double m_ExpSmoothArrayWindDir[WIND_RECORD_COUNT];
-        wxDateTime m_ArrayRecTime[WIND_RECORD_COUNT];
+        wxDateTime::Tm m_ArrayRecTime[WIND_RECORD_COUNT];
             
         double m_MaxWindDir;
         double m_MinWindDir;


### PR DESCRIPTION
Addresses #808. On Windows calling the local timezone function is expensive. This optimization eliminates thousands of such calls for every Draw() event. Should improve performance under any other OS as well.