### PR TITLE
Add new API call to return the format of the Lat/Lon shown

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -1234,4 +1234,14 @@ extern DECL_EXP wxFont* FindOrCreateFont_PlugIn( int point_size, wxFontFamily fa
                     const wxString &facename = wxEmptyString,
                     wxFontEncoding encoding = wxFONTENCODING_DEFAULT );
 
+enum SDDMFORMAT
+{
+    DEGREES_DECIMAL_MINUTES = 0,
+    DECIMAL_DEGREES,
+    DEGREES_MINUTES_SECONDS,
+    END_SDDMFORMATS
+};
+
+extern DECL_EXP int GetLatLonFormat(void);
+
 #endif //_PLUGIN_H_

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -133,6 +133,8 @@ extern ChartGroupArray  *g_pGroupArray;
 
 unsigned int      gs_plib_flags;
 
+extern int              g_iSDMMFormat;
+
 enum
 {
     CurlThreadId = wxID_HIGHEST+1
@@ -6410,3 +6412,7 @@ wxFont* FindOrCreateFont_PlugIn( int point_size, wxFontFamily family,
     return FontMgr::Get().FindOrCreateFont(point_size, family, style, weight, underline, facename, encoding);
 }
 
+int GetLatLonFormat()
+{
+    return g_iSDMMFormat;
+}


### PR DESCRIPTION
Added so that when copy/past of Lat/Lon is done between OCPN and plugins the plugins can determine the format of the Lat/Lon.