### PR TITLE
Implement optional dark window decorations on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1301,6 +1301,12 @@ SET(SRCS
                 src/iENCToolbar.cpp
                 src/mbtiles.cpp
     )
+IF(APPLE)
+    SET(SRCS ${SRCS}
+        src/DarkMode.mm
+        src/DarkMode.h
+    )
+ENDIF(APPLE)
 
 IF(NOT WIN32 AND NOT APPLE AND NOT QT_ANDROID)
   SET(HDRS ${HDRS} include/crashprint.h )

--- a/include/options.h
+++ b/include/options.h
@@ -185,7 +185,8 @@ enum {
   ID_SOGCOGDAMPINTTEXTCTRL,
   // LIVE ETA OPTION
   ID_CHECK_LIVEETA,
-  ID_DEFAULT_BOAT_SPEED
+  ID_DEFAULT_BOAT_SPEED,
+  ID_DARKDECORATIONSBOX
 };
 
 /* Define an int bit field for dialog return value
@@ -351,7 +352,7 @@ class options : private Uncopyable,
   wxCheckBox *pAutoAnchorMark, *pCDOQuilting, *pCBRaster, *pCBVector;
   wxCheckBox *pCBCM93, *pCBLookAhead, *pSkewComp, *pOpenGL, *pSmoothPanZoom;
   wxCheckBox *pFullScreenQuilt, *pMobile, *pResponsive, *pOverzoomEmphasis;
-  wxCheckBox *pOZScaleVector, *pToolbarAutoHideCB, *pInlandEcdis;
+  wxCheckBox *pOZScaleVector, *pToolbarAutoHideCB, *pInlandEcdis, *pDarkDecorations;
   wxTextCtrl *pCOGUPUpdateSecs, *m_pText_OSCOG_Predictor, *pScreenMM;
   wxTextCtrl *pToolbarHideSecs, *m_pText_OSHDT_Predictor;
   wxChoice *m_pShipIconType, *m_pcTCDatasets;

--- a/src/DarkMode.h
+++ b/src/DarkMode.h
@@ -1,0 +1,31 @@
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ *
+ ***************************************************************************
+ *   Copyright (C) 2018 by David S. Register                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ */
+
+#include "wx/wxprec.h"
+
+
+#include "wx/osx/private.h"
+
+void applyDarkAppearanceToWindow(NSWindow *window, bool vibrant = false, bool flat = false, bool subviews = false);
+

--- a/src/DarkMode.mm
+++ b/src/DarkMode.mm
@@ -1,0 +1,63 @@
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ *
+ ***************************************************************************
+ *   Copyright (C) 2018 by David S. Register                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ */
+
+#import "DarkMode.h"
+
+void updateDarkModeStateForTreeStartingAtView(__kindof NSView *rootView, bool vibrant = false)
+{
+    for (NSView *view in rootView.subviews) {
+        if( vibrant ) {
+            view.appearance = [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark];
+        }
+        if ([view isKindOfClass:[NSVisualEffectView class]]) {
+            [(NSVisualEffectView *)view setMaterial:NSVisualEffectMaterialDark];
+        }
+        
+        if ([view isKindOfClass:[NSClipView class]] ||
+            [view isKindOfClass:[NSScrollView class]] ||
+            [view isKindOfClass:[NSMatrix class]] ||
+            [view isKindOfClass:[NSTextView class]] ||
+            [view isKindOfClass:NSClassFromString(@"TBrowserTableView")] ||
+            [view isKindOfClass:NSClassFromString(@"TIconView")]) {
+            [view performSelector:@selector(setBackgroundColor:) withObject:[NSColor colorWithCalibratedWhite:0.1 alpha:1.0]];
+        }
+        
+        if (view.subviews.count > 0)
+            updateDarkModeStateForTreeStartingAtView(view, vibrant);
+    }
+}
+
+void applyDarkAppearanceToWindow (NSWindow *window, bool vibrant, bool flat, bool subviews)
+{
+    if( vibrant ) {
+        [window setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameVibrantDark]];
+    }
+    if( flat ) {
+        window.titlebarAppearsTransparent = true; // gives it "flat" look
+    }
+    [window setBackgroundColor:[NSColor blackColor]];
+    if( subviews ) {
+        updateDarkModeStateForTreeStartingAtView(window.contentView, vibrant);
+    }
+}

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -153,6 +153,10 @@
 #include "crashprint.h"
 #endif
 
+#ifdef __WXOSX__
+#include "DarkMode.h"
+#endif
+
 #include <wx/arrimpl.cpp>
 WX_DEFINE_OBJARRAY( ArrayOfCDI );
 
@@ -678,6 +682,8 @@ double                    g_UserVar;
 bool                      g_bMagneticAPB;
 
 bool                      g_bInlandEcdis;
+
+bool                      g_bDarkDecorations;
 
 //                        OpenGL Globals
 int                       g_GPU_MemSize;
@@ -2936,15 +2942,25 @@ void MyFrame::SetAndApplyColorScheme( ColorScheme cs )
     g_Piano->ResetRollover();
     g_Piano->SetColorScheme( cs );
 
-    if( g_options ) g_options->SetColorScheme( cs );
+    if( g_options ) {
+        g_options->SetColorScheme( cs );
+    }
 
-    if( console ) console->SetColorScheme( cs );
+    if( console ) {
+        console->SetColorScheme( cs );
+    }
 
-    if( g_pRouteMan ) g_pRouteMan->SetColorScheme( cs );
+    if( g_pRouteMan ) {
+        g_pRouteMan->SetColorScheme( cs );
+    }
 
-    if( pMarkPropDialog ) pMarkPropDialog->SetColorScheme( cs );
+    if( pMarkPropDialog ) {
+        pMarkPropDialog->SetColorScheme( cs );
+    }
     
-    if( pRoutePropDialog ) pRoutePropDialog->SetColorScheme( cs );
+    if( pRoutePropDialog ) {
+        pRoutePropDialog->SetColorScheme( cs );
+    }
     
     //    For the AIS target query dialog, we must rebuild it to incorporate the style desired for the colorscheme selected
     if( g_pais_query_dialog_active ) {
@@ -2973,6 +2989,11 @@ void MyFrame::SetAndApplyColorScheme( ColorScheme cs )
     UpdateToolbar( cs );
 
     if( g_pi_manager ) g_pi_manager->SetColorSchemeForAllPlugIns( cs );
+#ifdef __WXOSX__
+    if( g_bDarkDecorations ) {
+        applyDarkAppearanceToWindow(MacGetTopLevelWindowRef(), true);
+    }
+#endif
 }
 
 void MyFrame::ApplyGlobalColorSchemetoStatusBar( void )
@@ -5667,7 +5688,9 @@ int MyFrame::DoOptionsDialog()
     if(NULL == g_options) {
         g_Platform->ShowBusySpinner();
         g_options = new options( this, -1, _("Options") );
-        g_options->SetColorScheme(global_color_scheme);
+        //g_options->SetColorScheme(global_color_scheme);
+        //applyDarkAppearanceToWindow(g_options->MacGetTopLevelWindowRef());
+
         g_Platform->HideBusySpinner();
     }
 
@@ -6675,7 +6698,8 @@ void MyFrame::OnInitTimer(wxTimerEvent& event)
         case 4:
         {
             g_options = new options( this, -1, _("Options") );
-            g_options->SetColorScheme(global_color_scheme);
+            //g_options->SetColorScheme(global_color_scheme);
+            //applyDarkAppearanceToWindow(g_options->MacGetTopLevelWindowRef());
             
             if( g_MainToolbar )
                 g_MainToolbar->EnableTool( ID_SETTINGS, true );

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -38,6 +38,10 @@
 #include "dychart.h"
 #include "OCPNPlatform.h"
 
+#ifdef __WXOSX__
+#include "DarkMode.h"
+#endif
+
 #include <wx/listimpl.cpp>
 
 #include "chcanv.h"
@@ -220,6 +224,8 @@ extern bool             g_bWayPointPreventDragging;
 extern bool             g_bEnableZoomToCursor;
 extern bool             g_bShowChartBar;
 extern bool             g_bInlandEcdis;
+
+extern bool             g_bDarkDecorations;
 
 extern AISTargetAlertDialog    *g_pais_alert_dialog_active;
 extern AISTargetQueryDialog    *g_pais_query_dialog_active;
@@ -10381,14 +10387,18 @@ void DimeControl( wxWindow* ctrl, wxColour col, wxColour window_back_color, wxCo
         if( cs == GLOBAL_COLOR_SCHEME_DAY || cs == GLOBAL_COLOR_SCHEME_RGB ) {
 #ifdef __WXOSX__
             window_back_color = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWFRAME);
+            ctrl->SetBackgroundColour( window_back_color );
+            if( g_bDarkDecorations ) {
+                applyDarkAppearanceToWindow(ctrl->MacGetTopLevelWindowRef(), false, true, true);
+            }
 #else
             window_back_color = wxNullColour;
+            ctrl->SetBackgroundColour( window_back_color );
 #endif
 
             col = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOX);
         }
 
-        ctrl->SetBackgroundColour( window_back_color );
     }
 
     wxWindowList kids = ctrl->GetChildren();

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -418,6 +418,8 @@ extern wxString         g_uiStyle;
 
 int                     g_nCPUCount;
 
+extern bool             g_bDarkDecorations;
+
 #ifdef ocpnUSE_GL
 extern ocpnGLOptions g_GLOptions;
 #endif
@@ -545,6 +547,8 @@ int MyConfig::LoadMyConfig()
     Read( _T ( "NCacheLimit" ), &g_nCacheLimit, 0 );
      
     Read( _T ( "InlandEcdis" ), &g_bInlandEcdis, 0 );// First read if in iENC mode as this will override some config settings
+    
+    Read( _T ("DarkDecorations" ), &g_bDarkDecorations, 0 );
 
     Read( _T( "SpaceDropMark" ), &g_bSpaceDropMark, 0 );
     int mem_limit;
@@ -1912,6 +1916,9 @@ void MyConfig::UpdateSettings()
     Write( _T ( "ConfigVersionString" ), g_config_version_string );
     Write( _T ( "NavMessageShown" ), n_NavMessageShown );
     Write( _T ( "InlandEcdis" ), g_bInlandEcdis );
+    
+    Write( _T ( "DarkDecorations"), g_bDarkDecorations );
+    
     Write( _T ( "UIexpert" ), g_bUIexpert );
     Write( _T( "SpaceDropMark" ), g_bSpaceDropMark );
     Write( _T ( "UIStyle" ), g_StyleManager->GetStyleNextInvocation() );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -86,6 +86,9 @@ extern GLuint g_raster_format;
 #include "androidUTIL.h"
 #endif
 
+#ifdef __WXOSX__
+#include "DarkMode.h"
+#endif
 
 #include "OCPNPlatform.h"
 
@@ -293,6 +296,7 @@ extern float g_ShipScaleFactorExp;
 extern double g_config_display_size_mm;
 extern bool g_config_display_size_manual;
 extern bool g_bInlandEcdis;
+extern bool g_bDarkDecorations;
 extern bool g_bSpaceDropMark;
 
 extern "C" bool CheckSerialAccess(void);
@@ -4585,7 +4589,13 @@ void options::CreatePanel_UI(size_t parent, int border_size,
   pInlandEcdis = new wxCheckBox(itemPanelFont, ID_INLANDECDISBOX,
                                 _("Use Settings for Inland ECDIS Version 2.3"));
   miscOptions->Add(pInlandEcdis, 0, wxALL, border_size);
-  
+
+#ifdef __WXOSX__
+  pDarkDecorations = new wxCheckBox(itemPanelFont, ID_DARKDECORATIONSBOX,
+                                  _("Use dark window decorations"));
+  miscOptions->Add(pDarkDecorations, 0, wxALL, border_size);
+#endif
+    
   miscOptions->AddSpacer(10);
 
   wxFlexGridSizer* sliderSizer;
@@ -5051,8 +5061,10 @@ void options::SetInitialSettings(void) {
   pResponsive->SetValue(g_bresponsive);
   pOverzoomEmphasis->SetValue(!g_fog_overzoom);
   pOZScaleVector->SetValue(!g_oz_vector_scale);
-  pInlandEcdis->SetValue(g_bInlandEcdis); 
-
+  pInlandEcdis->SetValue(g_bInlandEcdis);
+#ifdef __WXOSX__
+  pDarkDecorations->SetValue(g_bDarkDecorations);
+#endif
   pOpenGL->SetValue(g_bopengl);
   pSmoothPanZoom->SetValue(g_bsmoothpanzoom);
   pCBTrueShow->SetValue(g_bShowTrue);
@@ -6448,6 +6460,15 @@ void options::OnApplyClick(wxCommandEvent& event) {
         SwitchInlandEcdisMode( g_bInlandEcdis );
         m_returnChanges |= TOOLBAR_CHANGED;    
     }
+#ifdef __WXOSX__
+    if ( g_bDarkDecorations != pDarkDecorations->GetValue() ) {
+        g_bDarkDecorations = pDarkDecorations->GetValue();
+       
+        OCPNMessageBox(this,
+                       _("The changes to the window decorations will take full effect the next time you start OpenCPN."),
+                       _("OpenCPN"));
+    }
+#endif
   // PlugIn Manager Panel
 
   // Pick up any changes to selections


### PR DESCRIPTION
I personally prefer the black window decorations always, but especially in night mode the default macOS light titlebar is annoying...
With this change:
<img width="200" alt="screen shot 2018-05-26 at 17 08 23" src="https://user-images.githubusercontent.com/249856/40579854-d2b1de7c-6107-11e8-86ab-36802f1ae447.png">
Without this change:
<img width="198" alt="screen shot 2018-05-26 at 17 09 05" src="https://user-images.githubusercontent.com/249856/40579855-d44d5324-6107-11e8-8d06-acaf49e43d5d.png">

There is still a lot of room for improvement in the dark modes, especially on macOS where wxWidgets toolkit does not exactly shine in combination with the theme support provided by the OS.