### PR TITLE
Correct somme mal-function related with touch mode and draghandle

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -6503,6 +6503,10 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
                 bool b_was_editing_route = m_bRouteEditing;
                 FindRoutePointsAtCursor( SelectRadius, true );    // Possibly selecting a point in a route for later dragging
                 
+				/*route and a mark points in layer can't be dragged so should't be selected and no draghandle icon*/
+				if (m_pRoutePointEditTarget && m_pRoutePointEditTarget->m_bIsInLayer)
+					m_pRoutePointEditTarget = NULL;
+
                 if( !b_was_editing_route ) {
                     if( m_pEditRouteArray ) {
                         b_startedit_route = true;

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -6480,6 +6480,13 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
                     if( g_bWayPointPreventDragging ) bSelectAllowed = false;
                 } else if( !pMarkPropDialog->IsShown() && g_bWayPointPreventDragging )
                     bSelectAllowed = false;
+
+				/*if this left up happens at the end of a route point dragging and if the cursor/thumb is on the 
+				draghandle icon, not on the point iself a new selection will select nothing and the drag will never
+				be ended, so the legs around this point never selectable. At this step we don't need a new selection,
+				just keep the previoulsly selected and dragged point */
+				if (m_bRoutePoinDragging)
+					bSelectAllowed = false;
                 
                 if(bSelectAllowed){
                     

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -5399,6 +5399,13 @@ void ChartCanvas::CallPopupMenu(int x, int y)
         m_pFoundRoutePoint->Draw( dc );
         RefreshRect( m_pFoundRoutePoint->CurrentRect_in_DC );
     }
+
+	/**in touch mode a route point could have been selected and draghandle icon shown so clear the selection*/
+	if (g_btouch && m_pRoutePointEditTarget) {
+		m_pRoutePointEditTarget->m_bIsBeingEdited = false;
+		m_pRoutePointEditTarget->m_bPtIsSelected = false;
+		m_pRoutePointEditTarget->EnableDragHandle(false);
+	}
     
     //      Get all the selectable things at the cursor
     pFindAIS = pSelectAIS->FindSelection( slat, slon, SELTYPE_AISTARGET );

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -5742,6 +5742,8 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
             else {
                 m_pRoutePointEditTarget->m_bIsBeingEdited = false;
                 m_pRoutePointEditTarget->m_bPtIsSelected = false;
+				if (g_btouch)
+					m_pRoutePointEditTarget->EnableDragHandle(false);
                 wxRect wp_rect;
                 m_pRoutePointEditTarget->CalculateDCRect( m_dc_route, &wp_rect );
                 m_pRoutePointEditTarget = NULL;         //cancel selection


### PR DESCRIPTION
1) When dragging a route point, the legs around this point are not selectable. The dragging action is not correctly ended.
2) If a route point is selected and drag-handle icon is shown, then a double click/tap anywhere deselect the point but the drag-handle icon stay visible.
2) when a route point is selected and drag-handle icon is shown, then a rightclick/long touch keep the selection witch can make confusion.
These small patches propose a solution to correct that
JP