### PR TITLE
Downloader cleanup

### DIFF
--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -95,22 +95,6 @@
 
 #define CHART_DIR "Charts"
 
-void write_file( const wxString extract_file, char *data, unsigned long datasize )
-{
-    wxFileName fn(extract_file);
-    if( wxDirExists( fn.GetPath() ) )
-    {
-        if( !wxFileName::Mkdir(fn.GetPath(), 0755, wxPATH_MKDIR_FULL) )
-        {
-            wxLogError(_T("Can not create directory '") + fn.GetPath() + _T("'."));
-            return;
-        }
-    }
-    wxFileOutputStream f(extract_file);
-    f.Write(data, datasize);
-    f.Close();
-}
-
 // the class factories, used to create and destroy instances of the PlugIn
 
 extern "C" DECL_EXP opencpn_plugin* create_pi(void *ppimgr)

--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -1003,83 +1003,82 @@ void ChartDldrPanelImpl::DownloadCharts()
 
     for( int i = 0; i < m_clCharts->GetItemCount(); i++ )
     {
-        //Prepare download queues
-        if( m_clCharts->IsChecked(i) )
-        {
-            m_bTransferComplete = false;
-            m_bTransferSuccess = true;
-            m_totalsize = _("Unknown");
-            m_transferredsize = _T("0");
-            m_downloading++;
-            if( pPlugIn->m_pChartCatalog->charts.Item(i).NeedsManualDownload() )
-            {
-                if( wxYES ==
-                        wxMessageBox(
-                                wxString::Format( _("The selected chart '%s' can't be downloaded automatically, do you want me to open a browser window and download them manually?\n\n \
-After downloading the charts, please extract them to %s"), pPlugIn->m_pChartCatalog->charts.Item(i).title.c_str(), pPlugIn->m_pChartSource->GetDir().c_str() ), _("Chart Downloader"), wxYES_NO | wxCENTRE | wxICON_QUESTION ) )
-                {
-                    wxLaunchDefaultBrowser( pPlugIn->m_pChartCatalog->charts.Item(i).GetManualDownloadUrl() );
-                }
-            }
-            else
-            {
-                //download queue
-                wxURI url(pPlugIn->m_pChartCatalog->charts.Item(i).GetDownloadLocation());
-                if( url.IsReference() )
-                {
-                    wxMessageBox(wxString::Format(_("Error, the URL to the chart (%s) data seems wrong."), url.BuildURI().c_str()), _("Error"));
-                    this->Enable();
-                    return;
-                }
-                //construct local file path
-                wxString file = pPlugIn->m_pChartCatalog->charts.Item(i).GetChartFilename();
-                wxFileName fn;
-                fn.SetFullName(file);
-                fn.SetPath(cs->GetDir());
-                wxString path = fn.GetFullPath();
-                if( wxFileExists( path ) )
-                    wxRemoveFile( path );
-                wxString title = pPlugIn->m_pChartCatalog->charts.Item(i).GetChartTitle();
-
-                //  Ready to start download
-#ifdef __OCPN__ANDROID__
-                wxString file_path = _T("file://") + fn.GetFullPath();
-#else
-                wxString file_path = fn.GetFullPath();
-#endif
-                
-                long handle;
-                OCPN_downloadFileBackground( url.BuildURI(), file_path, this, &handle);
-
-                while( !m_bTransferComplete && m_bTransferSuccess  && !cancelled )
-                {
-                    m_stCatalogInfo->SetLabel( wxString::Format( _("Downloading chart %u of %u, %u downloads failed (%s / %s)"),
-                                                                 m_downloading, to_download, m_failed_downloads,
-                                                                 m_transferredsize.c_str(), m_totalsize.c_str() ) );
-                    wxMilliSleep(30);
-                    wxYield();
-//                    if( !IsShownOnScreen() )
-//                        cancelled = true;
-                }
-                
-                if(cancelled){
-                    OCPN_cancelDownloadFileBackground( handle );
-                }
-                    
-                if( m_bTransferSuccess && !cancelled )
-                {
-                    wxFileName myfn(path);
-                    pPlugIn->ProcessFile(path, myfn.GetPath(), true, pPlugIn->m_pChartCatalog->charts.Item(i).GetUpdateDatetime());
-                    cs->ChartUpdated( pPlugIn->m_pChartCatalog->charts.Item(i).number, pPlugIn->m_pChartCatalog->charts.Item(i).GetUpdateDatetime().GetTicks() );
-                } else {
-                    if( wxFileExists( path ) )
-                        wxRemoveFile( path );
-                    m_failed_downloads++;
-                }
-            }
-        }
         if( cancelled )
             break;
+        //Prepare download queues
+        if( !m_clCharts->IsChecked(i) )
+            continue;
+
+        m_bTransferComplete = false;
+        m_bTransferSuccess = true;
+        m_totalsize = _("Unknown");
+        m_transferredsize = _T("0");
+        m_downloading++;
+        if( pPlugIn->m_pChartCatalog->charts.Item(i).NeedsManualDownload() )
+        {
+            if( wxYES == wxMessageBox(
+                            wxString::Format( _("The selected chart '%s' can't be downloaded automatically, do you want me to open a browser window and download them manually?\n\n \
+After downloading the charts, please extract them to %s"), pPlugIn->m_pChartCatalog->charts.Item(i).title.c_str(), pPlugIn->m_pChartSource->GetDir().c_str() ), _("Chart Downloader"), wxYES_NO | wxCENTRE | wxICON_QUESTION ) )
+            {
+                wxLaunchDefaultBrowser( pPlugIn->m_pChartCatalog->charts.Item(i).GetManualDownloadUrl() );
+            }
+            continue;
+        }
+
+        //download queue
+        wxURI url(pPlugIn->m_pChartCatalog->charts.Item(i).GetDownloadLocation());
+        if( url.IsReference() )
+        {
+            wxMessageBox(wxString::Format(_("Error, the URL to the chart (%s) data seems wrong."), url.BuildURI().c_str()), _("Error"));
+            this->Enable();
+            /// XXX undo anything?
+            return;
+        }
+        //construct local file path
+        wxString file = pPlugIn->m_pChartCatalog->charts.Item(i).GetChartFilename();
+        wxFileName fn;
+        fn.SetFullName(file);
+        fn.SetPath(cs->GetDir());
+        wxString path = fn.GetFullPath();
+        if( wxFileExists( path ) )
+            wxRemoveFile( path );
+        wxString title = pPlugIn->m_pChartCatalog->charts.Item(i).GetChartTitle();
+
+        //  Ready to start download
+#ifdef __OCPN__ANDROID__
+        wxString file_path = _T("file://") + fn.GetFullPath();
+#else
+        wxString file_path = fn.GetFullPath();
+#endif
+        
+        long handle;
+        OCPN_downloadFileBackground( url.BuildURI(), file_path, this, &handle);
+
+        while( !m_bTransferComplete && m_bTransferSuccess  && !cancelled )
+        {
+            m_stCatalogInfo->SetLabel( wxString::Format( _("Downloading chart %u of %u, %u downloads failed (%s / %s)"),
+                                                         m_downloading, to_download, m_failed_downloads,
+                                                         m_transferredsize.c_str(), m_totalsize.c_str() ) );
+            wxMilliSleep(30);
+            wxYield();
+//            if( !IsShownOnScreen() )
+//                cancelled = true;
+        }
+        
+        if(cancelled){
+            OCPN_cancelDownloadFileBackground( handle );
+        }
+            
+        if( m_bTransferSuccess && !cancelled )
+        {
+            wxFileName myfn(path);
+            pPlugIn->ProcessFile(path, myfn.GetPath(), true, pPlugIn->m_pChartCatalog->charts.Item(i).GetUpdateDatetime());
+            cs->ChartUpdated( pPlugIn->m_pChartCatalog->charts.Item(i).number, pPlugIn->m_pChartCatalog->charts.Item(i).GetUpdateDatetime().GetTicks() );
+        } else {
+            if( wxFileExists( path ) )
+                wxRemoveFile( path );
+            m_failed_downloads++;
+        }
     }
     DisableForDownload( true );
 #ifdef __OCPN__ANDROID__

--- a/plugins/chartdldr_pi/src/chartdldr_pi.h
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.h
@@ -168,9 +168,8 @@ private:
     bool            DownloadChart( wxString url, wxString file, wxString title );
     bool            downloadInProgress;
     int             to_download;
-    int             downloading;
-	int             updatingAll;
-    int             failed_downloads;
+
+    int             updatingAll;
     bool            cancelled;
     bool            DownloadIsCancel;
     chartdldr_pi   *pPlugIn;
@@ -185,6 +184,9 @@ private:
     bool            m_bTransferSuccess;
     wxString        m_totalsize;
     wxString        m_transferredsize;
+    int		    m_failed_downloads;
+    int             m_downloading;
+
     void            DisableForDownload( bool enabled );
     bool            m_bconnected;
 

--- a/src/wxcurl/base.cpp
+++ b/src/wxcurl/base.cpp
@@ -404,7 +404,6 @@ wxCurlBase::wxCurlBase(const wxString& szURL /*= wxEmptyString*/,
                     long flags /*=wxCURL_DEFAULT_FLAGS*/)
  : m_pCURL(NULL),
 m_bAbortHungTransfer(false),
-m_szBaseURL(wxCURL_STRING2BUF(szURL)),
 m_szCurrFullURL(wxCURL_STRING2BUF(szURL)),
 m_szUsername(wxCURL_STRING2BUF(szUserName)),
 m_szPassword(wxCURL_STRING2BUF(szPassword)),
@@ -632,7 +631,7 @@ std::string wxCurlBase::GetBaseURL() const
 
 void wxCurlBase::SetURL(const wxString& szRelativeURL)
 {
-    wxString str = wxCURL_BUF2STRING(m_szCurrFullURL) + szRelativeURL;
+    wxString str = wxCURL_BUF2STRING(m_szBaseURL) + szRelativeURL;
     m_szCurrFullURL = wxCURL_STRING2BUF(str);
 }
 


### PR DESCRIPTION
Hi,
Cleanup, a bug in wxcurl (we don't use this method) and when downloading a list start to download next item in the background before unziping. 
This one really help with the next patch: keeping curl handler around between requests with a c++11 shared pointer, eg for using http 1.1 pipeline aka faster downloading of NOAA grib subset and co.

Regards
Didier