### PR TITLE
Texture

### DIFF
--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -523,17 +523,33 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
     bool repeat = pGR->getLonMin() == 0 && pGR->getLonMax() + pGR->getDi() == 360;
 
     // create the texture to the size of the grib data plus a transparent border
-    int tw = pGR->getNi()+2*!repeat, th = pGR->getNj()+2;
+    int tw = pGR->getNi(), th = pGR->getNj();
     
     //    Dont try to create enormous GRIB textures
-    if( tw > 2048 || th > 2048 )
+    if( tw > 1022 || th > 1022 )
         return false;
 
+    double latstep = fabs(pGR->getDj()), lonstep = pGR->getDi();
+
+    // oversample up to 16x
+    for(int i=0; i<4; i++) {
+        if(tw >= 256 || th >= 256) // faster processor could handle larger sizes smoothly, how to test?
+            break;
+        tw *= 2, lonstep /= 2;
+        th *= 2, latstep /= 2;
+    }
+
+    tw += 2*!repeat;
+    th += 2;
+
     unsigned char *data = new unsigned char[tw*th*4];
-    memset(data, 0, tw*th*4); // ensure transparent
-    for( int y = 0; y < pGR->getNj(); y++ ) {
-        for( int x = 0; x < pGR->getNi(); x++ ) {
-            double v = pGR->getValue(x, y);
+
+    double lat = pGR->getLatMin();
+    for( int y = 0; y < th; y++ ) {
+        double lon = pGR->getLonMin();
+        for( int x = 0; x < tw; x++ ) {
+            // we could write a specially optimized version here for binary steps
+            double v = pGR->getInterpolatedValue(lon, lat);
             unsigned char r, g, b, a;
             if( v != GRIB_NOTDEF ) {
                 v = m_Settings.CalibrateValue(settings, v);
@@ -557,7 +573,12 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
                 a = 0;
             }
 
-            int doff = 4*((y+1)*tw + x+!repeat);
+            if(y == 0 || y == th - 1)
+                a = 0;
+            if(!repeat && (x == 0 || x == tw - 1))
+                a = 0;
+
+            int doff = 4*(y*tw + x);
             /* for some reason r g b values are inverted, but not alpha,
                this fixes it, but I would like to find the actual cause */
             data[doff + 0] = 255-r;
@@ -596,6 +617,8 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
     delete [] data;
 
     pGO->m_iTexture = texture;
+    pGO->m_iTextureDim[0] = tw;
+    pGO->m_iTextureDim[1] = th;
 
     return true;
 }
@@ -2189,7 +2212,7 @@ void GRIBOverlayFactory::DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugI
     // certainly not for all projections, and may result in
     // more tiles than actually needed in some cases
 
-    double pw = vp->view_scale_ppm * 3e6/(pow(2, fabs(vp->clat)/25));
+    double pw = vp->view_scale_ppm * 2e6/(pow(2, fabs(vp->clat)/25));
     if(pw < 20) // minimum 20 pixel to avoid too many tiles
         pw = 20;
 
@@ -2210,7 +2233,9 @@ void GRIBOverlayFactory::DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugI
     double xs = vp->pix_width/double(xsquares), ys = vp->pix_height/double(ysquares);
     int i = 0, j = 0;
     double lva[2][xsquares+1][2];
-    int tw = pGR->getNi()+2*!repeat, th = pGR->getNj()+2;
+    int tw = pGO->m_iTextureDim[0], th = pGO->m_iTextureDim[1];
+    double latstep = fabs(pGR->getDj()) / (th-2) * pGR->getNj();
+    double lonstep = pGR->getDi() / (tw-2*!repeat) * pGR->getNi();
     
     for(double y = 0; y < vp->pix_height+ys/2; y += ys) {
         i = 0;
@@ -2224,10 +2249,8 @@ void GRIBOverlayFactory::DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugI
             else if(lon - vp->clon > 180)
                 lon -= 360;
 
-            lva[j][i][0] = ((lon - lon_min) / pGR->getDi() - repeat + 1.5) / tw;
-            lva[j][i][1] = ((lat - lat_min) / fabs(pGR->getDj()) + 1.5) / th;
-            if(pGR->getDj() < 0)
-                lva[j][i][1] = 1 - lva[j][i][1];
+            lva[j][i][0] = ((lon - lon_min) / lonstep - repeat + 1.5) / tw;
+            lva[j][i][1] = ((lat - lat_min) / latstep          + 1.5) / th;
 
             if(x > 0 && y > 0) {
                 double u0 = lva[!j][i-1][0], v0 = lva[!j][i-1][1];

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -522,6 +522,10 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
 {
     bool repeat = pGR->getLonMin() == 0 && pGR->getLonMax() + pGR->getDi() == 360;
 
+    // texture rectangle doesn't repeat correctly
+    if( repeat && texture_format != GL_TEXTURE_2D )
+        return false;
+
     // create the texture to the size of the grib data plus a transparent border
     int tw = pGR->getNi()+2*!repeat, th = pGR->getNj()+2;
     
@@ -2154,8 +2158,8 @@ void GRIBOverlayFactory::drawLineBuffer(LineBuffer &buffer, int x, int y, double
 void GRIBOverlayFactory::texcoord(double u, double v, GribRecord *pGR)
 {
     if(texture_format != GL_TEXTURE_2D) {
-        u *= pGR->getNi();
-        v *= pGR->getNj();
+        u *= pGR->getNi() + 2;
+        v *= pGR->getNj() + 2;
     }
     glTexCoord2d(u, v);
 }

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -518,68 +518,22 @@ static inline bool isClearSky(int settings, double v) {
 }
 
 #ifdef ocpnUSE_GL
-bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, GribRecord *pGR,
-                                              PlugIn_ViewPort *vp, int grib_pixel_size )
+bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, GribRecord *pGR)
 {
-    const double scalef = 0.00005;
-    PlugIn_ViewPort uvp = *vp;
-    uvp.rotation = uvp.skew = 0;
-    uvp.view_scale_ppm = scalef;
-    double tp_scale = scalef;
-    wxPoint porg;
-    wxPoint pmin;
-    wxPoint pmax;
-    int width;
-    int height;
+    bool repeat = pGR->getLonMin() == 0 && pGR->getLonMax() + pGR->getDi() == 360;
 
-    int maxx = wxMin(1024, pGR->getNi() );
-    int maxy = wxMin(1024, pGR->getNj() );
-    int maxt = wxMax(maxx, maxy);
-    maxt = wxMax(256, maxt);
-    // find the biggest texture
-    do {
-        GetCanvasPixLL( &uvp, &porg, pGR->getLatMax(), pGR->getLonMin() );
-        GetCanvasPixLL( &uvp, &pmin, pGR->getLatMin(), pGR->getLonMin() );
-        GetCanvasPixLL( &uvp, &pmax, pGR->getLatMax(), pGR->getLonMax() );
-        width = abs( pmax.x - pmin.x );
-        height = abs( pmax.y - pmin.y );
-#if 0        
-        if (settings != GribOverlaySettings::CURRENT && settings != GribOverlaySettings::WAVE)
-            break;
-#endif
-        if( width > maxt || height > maxt || tp_scale > scalef * 1000.) { // arbitrary limit to loop
-            if (tp_scale == scalef)
-                break;
-            tp_scale /= 2.0;
-            uvp.view_scale_ppm = tp_scale;
-            GetCanvasPixLL( &uvp, &porg, pGR->getLatMax(), pGR->getLonMin() );
-            GetCanvasPixLL( &uvp, &pmin, pGR->getLatMin(), pGR->getLonMin() );
-            GetCanvasPixLL( &uvp, &pmax, pGR->getLatMax(), pGR->getLonMax() );
-            width = abs( pmax.x - pmin.x );
-            height = abs( pmax.y - pmin.y );
-            break;
-        }
-        tp_scale *= 2.0;
-        uvp.view_scale_ppm = tp_scale;
-        
-    } while (1);
-
-    if (width == 0 || height == 0)
-        return false;
+    // create the texture to the size of the grib data plus a transparent border
+    int tw = pGR->getNi()+2*!repeat, th = pGR->getNj()+2;
     
     //    Dont try to create enormous GRIB textures
-    if( width > 1024 || height > 1024 )
+    if( tw > 2048 || th > 2048 )
         return false;
 
-    unsigned char *data = new unsigned char[width*height*4];
-    for( int ipix = 0; ipix < width; ipix++ ) {
-        for( int jpix = 0; jpix < height; jpix++ ) {
-            wxPoint p;
-            p.x = grib_pixel_size*ipix + porg.x;
-            p.y = grib_pixel_size*jpix + porg.y;
-            double lat, lon;
-            GetCanvasLLPix( &uvp, p, &lat, &lon );
-            double v = pGR->getInterpolatedValue(lon, lat);
+    unsigned char *data = new unsigned char[tw*th*4];
+    memset(data, 0, tw*th*4); // ensure transparent
+    for( int y = 0; y < pGR->getNj(); y++ ) {
+        for( int x = 0; x < pGR->getNi(); x++ ) {
+            double v = pGR->getValue(x, y);
             unsigned char r, g, b, a;
             if( v != GRIB_NOTDEF ) {
                 v = m_Settings.CalibrateValue(settings, v);
@@ -603,7 +557,7 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
                 a = 0;
             }
 
-            int doff = 4*(jpix*width + ipix);
+            int doff = 4*((y+1)*tw + x+!repeat);
             /* for some reason r g b values are inverted, but not alpha,
                this fixes it, but I would like to find the actual cause */
             data[doff + 0] = 255-r;
@@ -617,7 +571,7 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
     glGenTextures(1, &texture);
     glBindTexture(texture_format, texture);
 
-    glTexParameteri( texture_format, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE );
+    glTexParameteri( texture_format, GL_TEXTURE_WRAP_S, repeat ? GL_REPEAT : GL_CLAMP_TO_EDGE );
     glTexParameteri( texture_format, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE );
     glTexParameteri( texture_format, GL_TEXTURE_MAG_FILTER, GL_LINEAR );
     glTexParameteri( texture_format, GL_TEXTURE_MIN_FILTER, GL_LINEAR );
@@ -627,9 +581,9 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
     glPixelStorei( GL_UNPACK_ALIGNMENT, 1 );
     glPixelStorei( GL_UNPACK_SKIP_PIXELS, 0 );
     glPixelStorei( GL_UNPACK_SKIP_ROWS, 0 );
-    glPixelStorei( GL_UNPACK_ROW_LENGTH, width );
+    glPixelStorei( GL_UNPACK_ROW_LENGTH, tw );
 
-    glTexImage2D(texture_format, 0, GL_RGBA, width, height,
+    glTexImage2D(texture_format, 0, GL_RGBA, tw, th,
                  0, GL_RGBA, GL_UNSIGNED_BYTE, data);
 
     glPopClientAttrib();
@@ -637,11 +591,6 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
     delete [] data;
 
     pGO->m_iTexture = texture;
-    pGO->m_width = width;
-    pGO->m_height = height;
-
-    pGO->m_dwidth = (pmax.x - pmin.x) / uvp.view_scale_ppm * grib_pixel_size;
-    pGO->m_dheight = (pmin.y - pmax.y) / uvp.view_scale_ppm * grib_pixel_size;
 
     return true;
 }
@@ -1453,11 +1402,10 @@ void GRIBOverlayFactory::RenderGribOverlayMap( int settings, GribRecord **pGR, P
                 m_Message_Hiden.Append(_("Overlays not supported by this graphics hardware (Disable OpenGL)"));
             else {
                 if( !pGO->m_iTexture )
-                    CreateGribGLTexture( pGO, settings, pGRA, vp, 1 );
+                    CreateGribGLTexture( pGO, settings, pGRA );
 
                 if( pGO->m_iTexture )
-                    DrawGLTexture( pGO->m_iTexture, pGO->m_width, pGO->m_height,
-                               porg.x, porg.y, pGO->m_dwidth, pGO->m_dheight, vp );
+                    DrawGLTexture( pGO, pGRA, vp );
                 else
                     m_Message_Hiden.IsEmpty()?
                         m_Message_Hiden.Append(_("Overlays too wide and can't be displayed:"))
@@ -2203,12 +2151,19 @@ void GRIBOverlayFactory::drawLineBuffer(LineBuffer &buffer, int x, int y, double
 }
 
 #ifdef ocpnUSE_GL
-void GRIBOverlayFactory::DrawGLTexture( GLuint texture, int width, int height,
-                                        int xd, int yd, double dwidth, double dheight,
-                                        PlugIn_ViewPort *vp )
+void GRIBOverlayFactory::texcoord(double u, double v, GribRecord *pGR)
+{
+    if(texture_format != GL_TEXTURE_2D) {
+        u *= pGR->getNi();
+        v *= pGR->getNj();
+    }
+    glTexCoord2d(u, v);
+}
+
+void GRIBOverlayFactory::DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugIn_ViewPort *vp )
 {
     glEnable(texture_format);
-    glBindTexture(texture_format, texture);
+    glBindTexture(texture_format, pGO->m_iTexture);
 
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -2217,36 +2172,90 @@ void GRIBOverlayFactory::DrawGLTexture( GLuint texture, int width, int height,
 
     glTexEnvi( GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_BLEND);
 
-    //    Adjust for rotation
-    glPushMatrix();
-    if( fabs( vp->rotation ) > 0.01 ) {
+    double lat_min = pGR->getLatMin(), lon_min = pGR->getLonMin();
 
-        //    Rotations occur around 0,0, so calculate a post-rotate translation factor
-        double angle = vp->rotation;
+    bool repeat = pGR->getLonMin() == 0 && pGR->getLonMax() + pGR->getDi() == 360;
 
-        glTranslatef( xd, yd, 0 );
-        glRotatef( angle * 180. / PI, 0, 0, 1 );
-        glTranslatef( -xd, -yd, 0 );
+    // how to break screen up, because projections may not be linear
+    // smaller values offer more precision but become irrelevant
+    // at lower zoom levels and near poles, use smaller tiles
+
+    // This formula is generally "good enough" but is not optimal,
+    // certainly not for all projections, and may result in
+    // more tiles than actually needed in some cases
+
+    double pw = vp->view_scale_ppm * 3e6/(pow(2, fabs(vp->clat)/25));
+    if(pw < 20) // minimum 20 pixel to avoid too many tiles
+        pw = 20;
+
+    int xsquares = ceil(vp->pix_width/pw), ysquares = ceil(vp->pix_height/pw);
+
+    // optimization for non-rotated mercator, since longitude is linear
+    if(vp->rotation == 0 && vp->m_projection_type == PI_PROJECTION_MERCATOR)
+        xsquares = 1;
+
+    // It is possible to have only 1 square when the viewport covers more than
+    // 180 longitudes but there is more logic needed.  This is simpler.
+    if(vp->lon_max - vp->lon_min >= 180) {
+        xsquares = wxMax(xsquares, 2);
+        ysquares = wxMax(ysquares, 2);
     }
 
-    double x = xd, y = yd;
-
-    double w = dwidth * vp->view_scale_ppm;
-    double h = dheight * vp->view_scale_ppm;
-
-    if(texture_format == GL_TEXTURE_2D)
-        width = height = 1;
-
     glBegin(GL_QUADS);
-    glTexCoord2i(0, 0),          glVertex2i(x, y);
-    glTexCoord2i(width, 0),      glVertex2i(x+w, y);
-    glTexCoord2i(width, height), glVertex2i(x+w, y+h);
-    glTexCoord2i(0, height),     glVertex2i(x, y+h);
+    double xs = vp->pix_width/double(xsquares), ys = vp->pix_height/double(ysquares);
+    int i = 0, j = 0;
+    double lva[2][xsquares+1][2];
+    int tw = pGR->getNi()+2*!repeat, th = pGR->getNj()+2;
+    
+    for(double y = 0; y < vp->pix_height+ys/2; y += ys) {
+        i = 0;
+        for(double x = 0; x < vp->pix_width+xs/2; x += xs) {
+            double lat, lon;
+            wxPoint p(x, y);
+            GetCanvasLLPix(vp, p, &lat, &lon);
+
+            if(vp->clon - lon > 180)
+                lon += 360;
+            else if(lon - vp->clon > 180)
+                lon -= 360;
+
+            lva[j][i][0] = ((lon - lon_min) / pGR->getDi() - repeat + 1.5) / tw;
+            lva[j][i][1] = ((lat - lat_min) / fabs(pGR->getDj()) + 1.5) / th;
+            if(pGR->getDj() < 0)
+                lva[j][i][1] = 1 - lva[j][i][1];
+
+            if(x > 0 && y > 0) {
+                double u0 = lva[!j][i-1][0], v0 = lva[!j][i-1][1];
+                double u1 = lva[!j][i  ][0], v1 = lva[!j][i  ][1];
+                double u2 = lva[ j][i  ][0], v2 = lva[ j][i  ][1];
+                double u3 = lva[ j][i-1][0], v3 = lva[ j][i-1][1];
+
+                if(repeat) { /* ensure all 4 texcoords are in the same phase */
+                    if(u1 - u0 > .5) u1--; else if(u0 - u1 > .5) u1++;
+                    if(u2 - u0 > .5) u2--; else if(u0 - u2 > .5) u2++;
+                    if(u3 - u0 > .5) u3--; else if(u0 - u3 > .5) u3++;
+                }
+
+                if((repeat ||
+                    ((u0 >= 0 || u1 >= 0 || u2 >= 0 || u3 >= 0) && // optimzations
+                     (u0 <= 1 || u1 <= 1 || u2 <= 1 || u3 <= 1))) &&
+                   (v0 >= 0 || v1 >= 0 || v2 >= 0 || v3 >= 0) &&
+                   (v0 <= 1 || v1 <= 1 || v2 <= 1 || v3 <= 1)) {
+                    texcoord(u0, v0, pGR), glVertex2f(x-xs, y-ys);
+                    texcoord(u1, v1, pGR), glVertex2f(x   , y-ys);
+                    texcoord(u2, v2, pGR), glVertex2f(x   , y);
+                    texcoord(u3, v3, pGR), glVertex2f(x-xs, y);
+                }
+            }
+
+            i++;
+        }
+        j = !j;
+    }
     glEnd();
 
     glDisable(GL_BLEND);
     glDisable(texture_format);
 
-    glPopMatrix();
 }
 #endif

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -522,38 +522,18 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
 {
     bool repeat = pGR->getLonMin() == 0 && pGR->getLonMax() + pGR->getDi() == 360;
 
-    // texture rectangle doesn't repeat correctly
-    if( repeat && texture_format != GL_TEXTURE_2D )
-        return false;
-
     // create the texture to the size of the grib data plus a transparent border
-    int tw = pGR->getNi(), th = pGR->getNj();
+    int tw = pGR->getNi()+2*!repeat, th = pGR->getNj()+2;
     
     //    Dont try to create enormous GRIB textures
-    if( tw > 1022 || th > 1022 )
+    if( tw > 2048 || th > 2048 )
         return false;
 
-    double latstep = fabs(pGR->getDj()), lonstep = pGR->getDi();
-
-    // oversample up to 16x
-    for(int i=0; i<4; i++) {
-        if(tw >= 256 || th >= 256) // faster processor could handle larger sizes smoothly, how to test?
-            break;
-        tw *= 2, lonstep /= 2;
-        th *= 2, latstep /= 2;
-    }
-
-    tw += 2*!repeat;
-    th += 2;
-
     unsigned char *data = new unsigned char[tw*th*4];
-
-    double lat = pGR->getLatMin();
-    for( int y = 0; y < th; y++ ) {
-        double lon = pGR->getLonMin();
-        for( int x = 0; x < tw; x++ ) {
-            // we could write a specially optimized version here for binary steps
-            double v = pGR->getInterpolatedValue(lon, lat);
+    memset(data, 0, tw*th*4); // ensure transparent
+    for( int y = 0; y < pGR->getNj(); y++ ) {
+        for( int x = 0; x < pGR->getNi(); x++ ) {
+            double v = pGR->getValue(x, y);
             unsigned char r, g, b, a;
             if( v != GRIB_NOTDEF ) {
                 v = m_Settings.CalibrateValue(settings, v);
@@ -577,12 +557,7 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
                 a = 0;
             }
 
-            if(y == 0 || y == th - 1)
-                a = 0;
-            if(!repeat && (x == 0 || x == tw - 1))
-                a = 0;
-
-            int doff = 4*(y*tw + x);
+            int doff = 4*((y+1)*tw + x+!repeat);
             /* for some reason r g b values are inverted, but not alpha,
                this fixes it, but I would like to find the actual cause */
             data[doff + 0] = 255-r;
@@ -621,8 +596,6 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
     delete [] data;
 
     pGO->m_iTexture = texture;
-    pGO->m_iTextureDim[0] = tw;
-    pGO->m_iTextureDim[1] = th;
 
     return true;
 }
@@ -2186,8 +2159,8 @@ void GRIBOverlayFactory::drawLineBuffer(LineBuffer &buffer, int x, int y, double
 void GRIBOverlayFactory::texcoord(double u, double v, GribRecord *pGR)
 {
     if(texture_format != GL_TEXTURE_2D) {
-        u *= pGR->getNi() + 2;
-        v *= pGR->getNj() + 2;
+        u *= pGR->getNi();
+        v *= pGR->getNj();
     }
     glTexCoord2d(u, v);
 }
@@ -2216,7 +2189,7 @@ void GRIBOverlayFactory::DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugI
     // certainly not for all projections, and may result in
     // more tiles than actually needed in some cases
 
-    double pw = vp->view_scale_ppm * 2e6/(pow(2, fabs(vp->clat)/25));
+    double pw = vp->view_scale_ppm * 3e6/(pow(2, fabs(vp->clat)/25));
     if(pw < 20) // minimum 20 pixel to avoid too many tiles
         pw = 20;
 
@@ -2237,9 +2210,7 @@ void GRIBOverlayFactory::DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugI
     double xs = vp->pix_width/double(xsquares), ys = vp->pix_height/double(ysquares);
     int i = 0, j = 0;
     double lva[2][xsquares+1][2];
-    int tw = pGO->m_iTextureDim[0], th = pGO->m_iTextureDim[1];
-    double latstep = fabs(pGR->getDj()) / (th-2) * pGR->getNj();
-    double lonstep = pGR->getDi() / (tw-2*!repeat) * pGR->getNi();
+    int tw = pGR->getNi()+2*!repeat, th = pGR->getNj()+2;
     
     for(double y = 0; y < vp->pix_height+ys/2; y += ys) {
         i = 0;
@@ -2253,8 +2224,10 @@ void GRIBOverlayFactory::DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugI
             else if(lon - vp->clon > 180)
                 lon -= 360;
 
-            lva[j][i][0] = ((lon - lon_min) / lonstep - repeat + 1.5) / tw;
-            lva[j][i][1] = ((lat - lat_min) / latstep          + 1.5) / th;
+            lva[j][i][0] = ((lon - lon_min) / pGR->getDi() - repeat + 1.5) / tw;
+            lva[j][i][1] = ((lat - lat_min) / fabs(pGR->getDj()) + 1.5) / th;
+            if(pGR->getDj() < 0)
+                lva[j][i][1] = 1 - lva[j][i][1];
 
             if(x > 0 && y > 0) {
                 double u0 = lva[!j][i-1][0], v0 = lva[!j][i-1][1];

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -527,17 +527,33 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
         return false;
 
     // create the texture to the size of the grib data plus a transparent border
-    int tw = pGR->getNi()+2*!repeat, th = pGR->getNj()+2;
+    int tw = pGR->getNi(), th = pGR->getNj();
     
     //    Dont try to create enormous GRIB textures
-    if( tw > 2048 || th > 2048 )
+    if( tw > 1022 || th > 1022 )
         return false;
 
+    double latstep = fabs(pGR->getDj()), lonstep = pGR->getDi();
+
+    // oversample up to 16x
+    for(int i=0; i<4; i++) {
+        if(tw >= 256 || th >= 256) // faster processor could handle larger sizes smoothly, how to test?
+            break;
+        tw *= 2, lonstep /= 2;
+        th *= 2, latstep /= 2;
+    }
+
+    tw += 2*!repeat;
+    th += 2;
+
     unsigned char *data = new unsigned char[tw*th*4];
-    memset(data, 0, tw*th*4); // ensure transparent
-    for( int y = 0; y < pGR->getNj(); y++ ) {
-        for( int x = 0; x < pGR->getNi(); x++ ) {
-            double v = pGR->getValue(x, y);
+
+    double lat = pGR->getLatMin();
+    for( int y = 0; y < th; y++ ) {
+        double lon = pGR->getLonMin();
+        for( int x = 0; x < tw; x++ ) {
+            // we could write a specially optimized version here for binary steps
+            double v = pGR->getInterpolatedValue(lon, lat);
             unsigned char r, g, b, a;
             if( v != GRIB_NOTDEF ) {
                 v = m_Settings.CalibrateValue(settings, v);
@@ -561,14 +577,24 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
                 a = 0;
             }
 
-            int doff = 4*((y+1)*tw + x+!repeat);
+            if(y == 0 || y == th - 1)
+                a = 0;
+            if(!repeat && (x == 0 || x == tw - 1))
+                a = 0;
+
+            int doff = 4*(y*tw + x);
             /* for some reason r g b values are inverted, but not alpha,
                this fixes it, but I would like to find the actual cause */
             data[doff + 0] = 255-r;
             data[doff + 1] = 255-g;
             data[doff + 2] = 255-b;
             data[doff + 3] = a;
+
+            if(repeat || (x != 0 && x != tw - 2))
+                lon += lonstep;
         }
+        if(y != 0 && y != th - 2)
+            lat += latstep;
     }
 
     GLuint texture;
@@ -595,6 +621,8 @@ bool GRIBOverlayFactory::CreateGribGLTexture( GribOverlay *pGO, int settings, Gr
     delete [] data;
 
     pGO->m_iTexture = texture;
+    pGO->m_iTextureDim[0] = tw;
+    pGO->m_iTextureDim[1] = th;
 
     return true;
 }
@@ -2188,7 +2216,7 @@ void GRIBOverlayFactory::DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugI
     // certainly not for all projections, and may result in
     // more tiles than actually needed in some cases
 
-    double pw = vp->view_scale_ppm * 3e6/(pow(2, fabs(vp->clat)/25));
+    double pw = vp->view_scale_ppm * 2e6/(pow(2, fabs(vp->clat)/25));
     if(pw < 20) // minimum 20 pixel to avoid too many tiles
         pw = 20;
 
@@ -2209,7 +2237,9 @@ void GRIBOverlayFactory::DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugI
     double xs = vp->pix_width/double(xsquares), ys = vp->pix_height/double(ysquares);
     int i = 0, j = 0;
     double lva[2][xsquares+1][2];
-    int tw = pGR->getNi()+2*!repeat, th = pGR->getNj()+2;
+    int tw = pGO->m_iTextureDim[0], th = pGO->m_iTextureDim[1];
+    double latstep = fabs(pGR->getDj()) / (th-2) * pGR->getNj();
+    double lonstep = pGR->getDi() / (tw-2*!repeat) * pGR->getNi();
     
     for(double y = 0; y < vp->pix_height+ys/2; y += ys) {
         i = 0;
@@ -2223,10 +2253,8 @@ void GRIBOverlayFactory::DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugI
             else if(lon - vp->clon > 180)
                 lon -= 360;
 
-            lva[j][i][0] = ((lon - lon_min) / pGR->getDi() - repeat + 1.5) / tw;
-            lva[j][i][1] = ((lat - lat_min) / fabs(pGR->getDj()) + 1.5) / th;
-            if(pGR->getDj() < 0)
-                lva[j][i][1] = 1 - lva[j][i][1];
+            lva[j][i][0] = ((lon - lon_min) / lonstep - repeat + 1.5) / tw;
+            lva[j][i][1] = ((lat - lat_min) / latstep          + 1.5) / th;
 
             if(x > 0 && y > 0) {
                 double u0 = lva[!j][i-1][0], v0 = lva[!j][i-1][1];

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -2307,7 +2307,9 @@ void GRIBOverlayFactory::DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugI
     glBegin(GL_QUADS);
     double xs = vp->pix_width/double(xsquares), ys = vp->pix_height/double(ysquares);
     int i = 0, j = 0;
-    double lva[2][xsquares+1][2];
+    typedef double mx[2][2];
+
+    mx *lva = new mx[xsquares+1];
     int tw = pGO->m_iTextureDim[0], th = pGO->m_iTextureDim[1];
     double latstep = fabs(pGR->getDj()) / (th-2-1) * (pGR->getNj()-1);
     double lonstep = pGR->getDi() / (tw-2*!repeat-1) * (pGR->getNi()-1);
@@ -2328,17 +2330,17 @@ void GRIBOverlayFactory::DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugI
                     lon -= 360;
             }
 
-            lva[j][i][0] = ((lon - lon_min) / lonstep - repeat + 1.5) / tw;
-            lva[j][i][1] = ((lat - lat_min) / latstep          + 1.5) / th;
+            lva[i][j][0] = ((lon - lon_min) / lonstep - repeat + 1.5) / tw;
+            lva[i][j][1] = ((lat - lat_min) / latstep          + 1.5) / th;
 
             if(pGR->getDj() < 0)
-                lva[j][i][1] = 1 - lva[j][i][1];
+                lva[i][j][1] = 1 - lva[i][j][1];
 
             if(x > 0 && y > 0) {
-                double u0 = lva[!j][i-1][0], v0 = lva[!j][i-1][1];
-                double u1 = lva[!j][i  ][0], v1 = lva[!j][i  ][1];
-                double u2 = lva[ j][i  ][0], v2 = lva[ j][i  ][1];
-                double u3 = lva[ j][i-1][0], v3 = lva[ j][i-1][1];
+                double u0 = lva[i-1][!j][0], v0 = lva[i-1][!j][1];
+                double u1 = lva[i  ][!j][0], v1 = lva[i  ][!j][1];
+                double u2 = lva[i  ][ j][0], v2 = lva[i  ][ j][1];
+                double u3 = lva[i-1][ j][0], v3 = lva[i-1][ j][1];
 
                 if(repeat) { /* ensure all 4 texcoords are in the same phase */
                     if(u1 - u0 > .5) u1--; else if(u0 - u1 > .5) u1++;
@@ -2363,6 +2365,7 @@ void GRIBOverlayFactory::DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugI
         j = !j;
     }
     glEnd();
+    delete [] lva;
 
     glDisable(GL_BLEND);
     glDisable(texture_format);

--- a/plugins/grib_pi/src/GribOverlayFactory.h
+++ b/plugins/grib_pi/src/GribOverlayFactory.h
@@ -165,7 +165,8 @@ public:
     GribTimelineRecordSet *m_pGribTimelineRecordSet;
 
     void DrawMessageZoomOut( PlugIn_ViewPort *vp );
-    wxColour GetGraphicColor(int config, double val);
+    void GetGraphicColor(int settings, double val, unsigned char &r, unsigned char &g, unsigned char &b);
+    wxColour GetGraphicColor(int settings, double val);
 
     wxSize  m_ParentSize;
 
@@ -201,6 +202,7 @@ private:
 #ifdef ocpnUSE_GL
     void texcoord(double u, double v, GribRecord *pGR);
     void DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugIn_ViewPort *vp );
+    void GetCalibratedGraphicColor(int settings, double val_in, unsigned char *data);
     bool CreateGribGLTexture( GribOverlay *pGO, int config, GribRecord *pGR );
 #endif
     wxImage CreateGribImage( int config, GribRecord *pGR, PlugIn_ViewPort *vp,

--- a/plugins/grib_pi/src/GribOverlayFactory.h
+++ b/plugins/grib_pi/src/GribOverlayFactory.h
@@ -61,7 +61,7 @@ public:
         delete m_pDCBitmap;
     }
 
-    unsigned int m_iTexture, m_iTextureDim[2]; /* opengl mode */
+    unsigned int m_iTexture; /* opengl mode */
     wxBitmap *m_pDCBitmap; /* dc mode */
 };
 

--- a/plugins/grib_pi/src/GribOverlayFactory.h
+++ b/plugins/grib_pi/src/GribOverlayFactory.h
@@ -47,7 +47,7 @@ public:
     GribOverlay( void )
     {
         m_iTexture = 0;
-        m_pDCBitmap = NULL, m_pRGBA = NULL;
+        m_pDCBitmap = NULL;
     }
 
     ~GribOverlay( void )
@@ -58,18 +58,11 @@ public:
           glDeleteTextures( 1, &m_iTexture );
         }
 #endif
-        delete m_pDCBitmap, delete[] m_pRGBA;
+        delete m_pDCBitmap;
     }
 
     unsigned int m_iTexture; /* opengl mode */
-
     wxBitmap *m_pDCBitmap; /* dc mode */
-    unsigned char *m_pRGBA;
-
-    int m_width;
-    int m_height;
-
-    double m_dwidth, m_dheight;
 };
 
 #define MAX_PARTICLE_HISTORY 8
@@ -206,11 +199,9 @@ private:
 
 
 #ifdef ocpnUSE_GL
-    void DrawGLTexture( GLuint texture, int width, int height,
-                        int xd, int yd, double dwidth, double dheight,
-                        PlugIn_ViewPort *vp );
-    bool CreateGribGLTexture( GribOverlay *pGO, int config, GribRecord *pGR,
-                              PlugIn_ViewPort *vp, int grib_pixel_size );
+    void texcoord(double u, double v, GribRecord *pGR);
+    void DrawGLTexture( GribOverlay *pGO, GribRecord *pGR, PlugIn_ViewPort *vp );
+    bool CreateGribGLTexture( GribOverlay *pGO, int config, GribRecord *pGR );
 #endif
     wxImage CreateGribImage( int config, GribRecord *pGR, PlugIn_ViewPort *vp,
                              int grib_pixel_size, const wxPoint &porg );

--- a/plugins/grib_pi/src/GribOverlayFactory.h
+++ b/plugins/grib_pi/src/GribOverlayFactory.h
@@ -61,7 +61,7 @@ public:
         delete m_pDCBitmap;
     }
 
-    unsigned int m_iTexture; /* opengl mode */
+    unsigned int m_iTexture, m_iTextureDim[2]; /* opengl mode */
     wxBitmap *m_pDCBitmap; /* dc mode */
 };
 


### PR DESCRIPTION
Hi,
Remerge Sean texture work with 2 fixes for:
- grib with more than 1024 points
- windows compatibility, replace variable array  with a heap allocation.

Is not power of two texture an issue?
So we can display:
![capture du 2018-06-14 13 18 00](https://user-images.githubusercontent.com/12138026/41410371-913f013c-6fd9-11e8-8145-828a4c075a47.png)

Regards
Didier