### PR TITLE
EMCWF generatingProcessIdentifier (idModel) isn't constant

### DIFF
--- a/plugins/grib_pi/src/GribV1Record.cpp
+++ b/plugins/grib_pi/src/GribV1Record.cpp
@@ -141,7 +141,7 @@ void  GribV1Record::translateDataType()
 	//------------------------
 	// EMCWF grib1...
 	//------------------------
-	else if (idCenter==98 && idModel==148 && idGrid==255)
+	else if (idCenter==98 /*&& idModel==148*/ && idGrid==255)
 	{
         dataCenterModel = OTHER_DATA_CENTER;
 		if (dataType == GRB_PRECIP_RATE) {	// mm/s -> mm/h


### PR DESCRIPTION
Hi,
It seems they don't use only one idModel, there's also 149 but because it's the only entry for idCenter 98 catch all idModel

Regards
Didier
