### PR TITLE
Context Menu Changes 

### DIFF
--- a/src/canvasMenu.cpp
+++ b/src/canvasMenu.cpp
@@ -501,8 +501,7 @@ void CanvasMenuHandler::CanvasPopupMenu( int x, int y, int seltype )
     if( g_pGroupArray->GetCount() ) {
 
 #ifdef __WXMSW__
-          wxMenuItem* subItem1 = subMenuChart->AppendRadioItem( wxID_CANCEL , _T("temporary") );
-          SetMenuItemFont1(subItem1);
+		MenuAppend1(subMenuChart, wxID_CANCEL, _("temporary"));
 #endif
           wxMenuItem* subItem0 = subMenuChart->AppendRadioItem( ID_DEF_MENU_GROUPBASE ,
                   _("All Active Charts") );


### PR DESCRIPTION
this Pull request contains two patches
1)A small correction for Windows to apply correctly sub menu font when sub menu contains only check or radio items
2) A proposal for improvement
When right click or long touch on multiple object types, we get only one menu and this could be boring because if we don't get the desired menu, we have to zoom to separate (if possible) the different objects then click on the wanted one.
This patch adds as sub menus the menus of others objects which are selected under the cursor/thumb . For example, if we right click on an AIS target and there is a route under this target, we get now the AIS menu as before plus the route menu as sub menu, so we can access either the AIS menu commands or the route menu commands.
The main menu is systematically added as sub menu to AIS, Route, Track and waypoint menus.
In addition, the name of the selected objects are shown.
The priority order to show menus is not changed

Jean Pierre