### PR TITLE
Add EXIF_INCLUDE_DIR to search path.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -894,6 +894,7 @@ ${CMAKE_SOURCE_DIR}/buildwin/archive.lib
             src/wxsvg/src/ExifHandler.cpp
         )
         ADD_DEFINITIONS(-DwxsvgUSE_EXIF) 
+        INCLUDE_DIRECTORIES(${EXIF_INCLUDE_DIR})
     endif()
 
     ADD_LIBRARY(WXSVG ${SRC_WXSVG})


### PR DESCRIPTION
Minor fix needed on my MacOS environment, for some reason /usr/local/include is not added by any thing so even if exif is installed there the build fails. (MacOS 10.13.5)

Fixes Issue: #1109 
