### PR TITLE
Fix undefined behavior caused by use of va_start with types requiring default argument promotion.

### DIFF
--- a/src/wxcurl/base.cpp
+++ b/src/wxcurl/base.cpp
@@ -435,7 +435,7 @@ wxCurlBase::~wxCurlBase()
 //////////////////////////////////////////////////////////////////////
 
 typedef int (*func_T)(void);
-bool wxCurlBase::SetOpt(CURLoption option, ...)
+bool wxCurlBase::SetOpt(int opt, ...)
 {
     va_list arg;
 
@@ -444,7 +444,8 @@ bool wxCurlBase::SetOpt(CURLoption option, ...)
     void *param_obj = NULL;
     curl_off_t param_offset = 0;
 
-    va_start(arg, option);
+    va_start(arg, opt);
+    CURLoption option = (CURLoption)opt;
 
     CURLcode res = CURLE_OK;
 
@@ -491,7 +492,7 @@ bool wxCurlBase::SetStringOpt(CURLoption option, const wxCharBuffer &str)
     return SetOpt(option, (const char*)str);
 }
 
-bool wxCurlBase::GetInfo(CURLINFO info, ...) const
+bool wxCurlBase::GetInfo(int info, ...) const
 {
     va_list arg;
     void* pParam;
@@ -500,8 +501,8 @@ bool wxCurlBase::GetInfo(CURLINFO info, ...) const
     pParam = va_arg(arg, void*);
 
     CURLcode res = CURLE_OK;
-
-    res = curl_easy_getinfo(m_pCURL, info, pParam);
+    CURLINFO cInfo = (CURLINFO)info;
+    res = curl_easy_getinfo(m_pCURL, cInfo, pParam);
 
     DumpErrorIfNeed(res);
     va_end(arg);

--- a/src/wxcurl/wx/curl/base.h
+++ b/src/wxcurl/wx/curl/base.h
@@ -380,11 +380,11 @@ public:
 
     //! Sets a transfer option for this libCURL session instance.
     //! See the curl_easy_setopt() function call for more info.
-    bool SetOpt(CURLoption option, ...);
+    bool SetOpt(int option, ...);
 
     //! Gets an info from this libCURL session instance.
     //! See the curl_easy_getinfo() function call for more info.
-    bool GetInfo(CURLINFO info, ...) const;
+    bool GetInfo(int info, ...) const;
 
     //! Start the operation as described by the options set previously with #SetOpt.
     //! If you set CURLOPT_UPLOAD to zero and the CURLOPT_WRITEFUNCTION and CURLOPT_WRITEDATA


### PR DESCRIPTION
This fixes warnings like the following warning with clang.  These warnings represents a portability problem, in that compilers on other platforms (or even GCC/clang with -fshort-enums) could choose a different size for the enum.

> /tmp/OpenCPN/src/wxcurl/base.cpp:500:19: warning: passing an object that undergoes default argument promotion to 'va_start' has undefined behavior [-Wvarargs]
>     va_start(arg, info);