### PR TITLE
Provide a default value for theta so it can't be used uninitialized below.

### DIFF
--- a/src/ais.cpp
+++ b/src/ais.cpp
@@ -979,7 +979,7 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc, ViewPort& vp, ChartC
 
     bool b_hdgValid = true;
     
-    float theta;
+    float theta = (float)-PI / 2.;
     //    If the target reported a valid HDG, then use it for icon
     if( (int) ( td->HDG ) != 511 ) {
         theta = ( ( td->HDG - 90 ) * PI / 180. ) + vp.rotation;


### PR DESCRIPTION
The relevant wanting, which outlines how it could be used uninitialized:

```
/tmp/OpenCPN/src/ais.cpp:989:12: warning: variable 'theta' is used uninitialized whenever 'if' condition is false [-Wsometimes-uninitialized]
        if(!g_bInlandEcdis){
           ^~~~~~~~~~~~~~~
/tmp/OpenCPN/src/ais.cpp:1022:29: note: uninitialized use occurs here
    float sin_theta = sinf( theta ), cos_theta = cosf( theta );
                            ^~~~~
/tmp/OpenCPN/src/ais.cpp:989:9: note: remove the 'if' if its condition is always true
        if(!g_bInlandEcdis){
        ^~~~~~~~~~~~~~~~~~~
```