### PR TITLE
Remove dead code.

### DIFF
--- a/plugins/grib_pi/src/GribV2Record.cpp
+++ b/plugins/grib_pi/src/GribV2Record.cpp
@@ -1203,8 +1203,6 @@ static bool mapTimeRange(GRIBMessage *grid, zuint *p1, zuint *p2, zuchar *t_rang
 	fprintf(stderr,"Unable to map time range for Product Definition Template %d into GRIB1\n",grid->md.pds_templ_num);
 	return false;
   }
-  if (*p2 < 0)
-      return false;
   return true;
 }
 


### PR DESCRIPTION
The test here is never true, because p2 is a zuint.  I'm a bit unclear on what the intended behavior actually was, since this check can never have actually worked.  Given that it never worked, I think it's safe to assume nobody has ever found a test case where it would trigger.