### PR TITLE
Grib 

### DIFF
--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -50,7 +50,7 @@ enum GRIB_OVERLAP { _GIN, _GON, _GOUT };
 // If they do not intersect, two scenario's are possible:
 // other is outside this -> return _OUT
 // other is inside this -> return _IN
-GRIB_OVERLAP Intersect( PlugIn_ViewPort *vp, double lat_min, double lat_max, double lon_min,
+static GRIB_OVERLAP Intersect( PlugIn_ViewPort *vp, double lat_min, double lat_max, double lon_min,
                    double lon_max, double Marge )
 {
 
@@ -68,7 +68,7 @@ GRIB_OVERLAP Intersect( PlugIn_ViewPort *vp, double lat_min, double lat_max, dou
 }
 
 // Is the given point in the vp ??
-bool PointInLLBox( PlugIn_ViewPort *vp, double x, double y )
+static bool PointInLLBox( PlugIn_ViewPort *vp, double x, double y )
 {
     double m_miny = vp->lat_min;
     double m_maxy = vp->lat_max;

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -1112,11 +1112,11 @@ void GRIBOverlayFactory::RenderGribBarbedArrows( int settings, GribRecord **pGR,
         wxPoint oldpy(-1000, -1000);
 
         for( int i = 0; i < imax; i++ ) {
-            double lonl = pGRX->getX( i );
+            double lonl, latl;
 
             /* at midpoint of grib so as to avoid problems in projection on
                gribs that go all the way to the north or south pole */
-            double latl = pGRX->getY( pGRX->getNj()/2 );
+            pGRX->getXY( i, pGRX->getNj()/2, &lonl, &latl);
             wxPoint pl;
             GetCanvasPixLL( vp, &pl, latl, lonl );
 
@@ -1417,8 +1417,9 @@ void GRIBOverlayFactory::RenderGribDirectionArrows( int settings, GribRecord **p
         wxPoint oldpy(-1000, -1000);
 
         for( int i = 0; i < imax; i++ ) {
-            double lonl = pGRX->getX( i );
-            double latl = pGRX->getY( pGRX->getNj()/2 );
+            double lonl,latl;
+            pGRX->getXY( i, pGRX->getNj()/2, &lonl, &latl);
+
             wxPoint pl;
             GetCanvasPixLL( vp, &pl, latl, lonl );
 
@@ -1433,8 +1434,9 @@ void GRIBOverlayFactory::RenderGribDirectionArrows( int settings, GribRecord **p
                 firstpx = pl;
                 
             for( int j = 0; j < jmax; j++ ) {
-                double lon = pGRX->getX( i );
-                double lat = pGRX->getY( j );
+                double lon,  lat; 
+                pGRX->getXY( i,j, &lon, &lat );
+
                 wxPoint p;
                 GetCanvasPixLL( vp, &p, lat, lon );
 
@@ -1672,8 +1674,9 @@ void GRIBOverlayFactory::RenderGribNumbers( int settings, GribRecord **pGR, Plug
 		wxPoint oldpy(-1000, -1000);
 
 		for( int i = 0; i < imax; i++ ) {
-			double lonl = pGRA->getX( i );
-			double latl = pGRA->getY( pGRA->getNj()/2 );
+			double lonl, latl;
+			pGRA->getXY( i, pGRA->getNj()/2, &lonl, &latl );
+
 			wxPoint pl;
 			GetCanvasPixLL( vp, &pl, latl, lonl );
 
@@ -1686,8 +1689,9 @@ void GRIBOverlayFactory::RenderGribNumbers( int settings, GribRecord **pGR, Plug
 				    firstpx = pl;
 				
 				for( int j = 0; j < jmax; j++ ) {
-					double lon = pGRA->getX( i );
-					double lat = pGRA->getY( j );
+					double lon, lat;
+					pGRA->getXY( i, j, &lon, &lat );
+
 					wxPoint p;
 					GetCanvasPixLL( vp, &p, lat, lon );
 

--- a/plugins/grib_pi/src/GribReader.cpp
+++ b/plugins/grib_pi/src/GribReader.cpp
@@ -443,8 +443,8 @@ void GribReader::readGribFileContent()
 					for (zuint i=0; i<(zuint)recModel->getNi(); i++)
 					    for (zuint j=0; j<(zuint)recModel->getNj(); j++)
 					    {
-					        double x = recModel->getX(i);
-						double y = recModel->getY(j);
+					        double x, y;
+					        recModel->getXY(i, j, &x, &y);
 						double dp = computeDewPoint(x, y, date);
 						recDewpoint->setValue(i, j, dp);
                                             }
@@ -568,35 +568,6 @@ double 	GribReader::get2GribsInterpolatedValueByDate (
 	return val;
 }
 
-//---------------------------------------------------
-// Rectangle de la zone couverte par les données
-bool GribReader::getZoneExtension(double *x0,double *y0, double *x1,double *y1)
-{
-    std::vector<GribRecord *> *ls = getFirstNonEmptyList();
-    if (ls != NULL) {
-        GribRecord *rec = ls->at(0);
-        if (rec != NULL) {
-            *x0 = rec->getX(0);
-            *y0 = rec->getY(0);
-            *x1 = rec->getX( rec->getNi()-1 );
-            *y1 = rec->getY( rec->getNj()-1 );
-            if (*x0 > *x1) {
-				double tmp = *x0;
-				*x0 = *x1;
-				*x1 = tmp;
-            }
-            if (*y0 > *y1) {
-				double tmp = *y0;
-				*y0 = *y1;
-				*y1 = tmp;
-            }
-        }
-        return true;
-    }
-    else {
-        return false;
-    }
-}
 //---------------------------------------------------
 // Premier GribRecord trouvé (pour récupérer la grille)
 GribRecord * GribReader::getFirstGribRecord()

--- a/plugins/grib_pi/src/GribReader.h
+++ b/plugins/grib_pi/src/GribReader.h
@@ -80,9 +80,6 @@ class GribReader
 
       int	   getDewpointDataStatus(int levelType,int levelValue);
 
-        // Rectangle de la zone couverte par les données
-      bool getZoneExtension (double *x0,double *y0, double *x1,double *y1);
-
       enum GribFileDataStatus {DATA_IN_FILE, NO_DATA_IN_FILE, COMPUTED_DATA};
 
       void  copyFirstCumulativeRecord   ();

--- a/plugins/grib_pi/src/GribRecord.cpp
+++ b/plugins/grib_pi/src/GribRecord.cpp
@@ -397,8 +397,50 @@ void GribRecord::Substract(const GribRecord &rec, bool pos)
     } 
 }
 
-
 //------------------------------------------------------------------------------
+void GribRecord::Average(const GribRecord &rec)
+{
+
+    // for now only average records of same size
+    // this : 6-12
+    // rec  : 6-9
+    // compute average 9-12
+    //
+    // this : 0-12
+    // rec  : 0-11
+    // compute average 11-12
+
+    if (rec.data == 0 || !rec.isOk())
+        return;
+
+    if (data == 0 || !isOk())
+        return;
+
+    if (Ni != rec.Ni || Nj != rec.Nj)
+        return;
+
+    if (getPeriodP1() != rec.getPeriodP1())
+        return;
+
+    double d2 = getPeriodP2() - getPeriodP1();
+    double d1 = rec.getPeriodP2() - rec.getPeriodP1();
+
+    if (d2 <= d1)
+        return;
+
+    zuint size = Ni *Nj;
+    double diff = d2 -d1;
+    for (zuint i=0; i<size; i++) {
+        if (rec.data[i] == GRIB_NOTDEF)
+           continue;
+        if (data[i] == GRIB_NOTDEF)
+           continue;
+
+        data[i] = (data[i]*d2 -rec.data[i]*d1)/diff;
+    }
+}
+
+//-------------------------------------------------------------------------------
 void  GribRecord::setDataType(const zuchar t)
 {
 	dataType = t;

--- a/plugins/grib_pi/src/GribRecord.h
+++ b/plugins/grib_pi/src/GribRecord.h
@@ -211,10 +211,6 @@ class GribRecord
         double  getLatMax() const   { return latMax;}
         double  getLonMax() const   { return lonMax;}
 
-        // Is a point within the extent of the grid?
-        inline bool   isPointInMap(double x, double y) const;
-        inline bool   isXInMap(double x) const;
-        inline bool   isYInMap(double y) const;
         // Is there a value at a particular grid point ?
         inline bool   hasValue(int i, int j) const;
         // Is there a value that is not GRIB_NOTDEF ?
@@ -232,6 +228,12 @@ class GribRecord
         void   print();
         bool isFilled(){ return m_bfilled; }
         void setFilled(bool val=true){ m_bfilled = val;}
+
+    private:
+        // Is a point within the extent of the grid?
+        inline bool   isPointInMap(double x, double y) const;
+        inline bool   isXInMap(double x) const;
+        inline bool   isYInMap(double y) const;
 
     protected:
     //private:

--- a/plugins/grib_pi/src/GribRecord.h
+++ b/plugins/grib_pi/src/GribRecord.h
@@ -205,6 +205,7 @@ class GribRecord
         // coordiantes of grid point
         inline double  getX(int i) const   { return Lo1+i*Di;}
         inline double  getY(int j) const   { return La1+j*Dj;}
+        void    getXY(int i, int j, double *x, double *y) const { *x = getX(i); *y = getY(j);};
 
         double  getLatMin() const   { return latMin;}
         double  getLonMin() const   { return lonMin;}

--- a/plugins/grib_pi/src/GribRecord.h
+++ b/plugins/grib_pi/src/GribRecord.h
@@ -153,6 +153,7 @@ class GribRecord
 
         void   multiplyAllData(double k);
         void Substract(const GribRecord &rec, bool positive=true);
+        void   Average(const GribRecord &rec);
 
         bool  isOk()  const   {return ok;};
         bool  isDataKnown()  const   {return knownData;};

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -1734,7 +1734,8 @@ GRIBFile::GRIBFile( const wxArrayString & file_names, bool CumRec, bool WaveRec,
 
     // fixup Accumulation records
     m_pGribReader->computeAccumulationRecords(GRB_PRECIP_TOT, LV_GND_SURF, 0);
-
+    m_pGribReader->computeAccumulationRecords(GRB_PRECIP_RATE,LV_GND_SURF, 0);
+    m_pGribReader->computeAccumulationRecords(GRB_CLOUD_TOT,  LV_ATMOS_ALL, 0);
 
     if( CumRec ) m_pGribReader->copyFirstCumulativeRecord();            //add missing records if option selected
     if( WaveRec ) m_pGribReader->copyMissingWaveRecords ();             //  ""                   ""

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -536,7 +536,7 @@ bool GRIBUICtrlBar::GetGribZoneLimits(GribTimelineRecordSet *timelineSet, double
     //calculate the largest overlay size
     GribRecord **pGR = timelineSet->m_GribRecordPtrArray;
     double ltmi = -GRIB_NOTDEF, ltma = GRIB_NOTDEF, lnmi = -GRIB_NOTDEF, lnma = GRIB_NOTDEF;
-    for( int i = 0; i<36; i++){
+    for( unsigned int i = 0; i < Idx_COUNT; i++){
         GribRecord *pGRA = pGR[i];
         if(!pGRA) continue;
         if(pGRA->getLatMin() < ltmi) ltmi = pGRA->getLatMin();

--- a/plugins/grib_pi/src/GribUIDialog.h
+++ b/plugins/grib_pi/src/GribUIDialog.h
@@ -244,7 +244,7 @@ public:
     GRIBUICData( GRIBUICtrlBar &parent );
     ~GRIBUICData() {}
 
-    GribGrabberWin      *m_gGrabber;
+    // GribGrabberWin      *m_gGrabber;
     GRIBUICtrlBar       &m_gpparent;
     CursorData          *m_gCursorData;
 private:

--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -11,9 +11,10 @@
 
 GRIBUICtrlBarBase::GRIBUICtrlBarBase( wxWindow* parent, wxWindowID id, const wxString& title, const wxPoint& pos, const wxSize& size, long style ) : wxDialog( parent, id, title, pos, size, style )
 {
-    bool m_bcompact = false;
 #ifdef __OCPN__ANDROID__
-    m_bcompact = true;
+    const bool m_bcompact = true;
+#else
+    const bool m_bcompact = false;
 #endif    
 
     if(m_bcompact){

--- a/plugins/grib_pi/src/GribV2Record.cpp
+++ b/plugins/grib_pi/src/GribV2Record.cpp
@@ -918,6 +918,9 @@ static bool unpackDS(GRIBMessage *grib_msg)
 	delete [] jvals;
 	break;
 #endif
+    default:
+        erreur("Unknown packing %d", grib_msg->md.drs_templ_num);
+        break;
   }
   return true;
 }
@@ -1028,7 +1031,7 @@ static zuchar GRBV2_TO_DATA(int productDiscipline, int dataCat, int dataNum)
     }
 #if 1
     if (ret == 255) {
-        erreur("unknown %d %d %d\n", productDiscipline,  dataCat,dataNum);
+        erreur("unknown %d %d %d", productDiscipline,  dataCat,dataNum);
     }
 #endif    
     return ret;    

--- a/plugins/grib_pi/src/GribV2Record.cpp
+++ b/plugins/grib_pi/src/GribV2Record.cpp
@@ -967,11 +967,13 @@ static zuchar GRBV2_TO_DATA(int productDiscipline, int dataCat, int dataNum)
             case 22: ret = GRB_WIND_GUST; break; // 
             }
             break;
-        case 3: // dataCat
+        case 3: // dataCat mass
             switch (dataNum) {
             case 0: ret = GRB_PRESSURE; break; //DATA_TO_GRBV2[DATA_PRESSURE] = grb2DataType(0,3,0);
             case 1: ret = GRB_PRESSURE; break; // PRSMSL //DATA_TO_GRBV2[DATA_PRESSURE] = grb2DataType(0,3,0);
             case 5: ret = GRB_GEOPOT_HGT; break; // DATA_TO_GRBV2[DATA_GEOPOT_HGT]= grb2DataType(0,3,5);
+
+            case 192: ret = GRB_PRESSURE; break; //DATA_TO_GRBV2[DATA_MSLET] = grb2DataType(0,3,192);
             }
             break;
         case 6: // dataCat

--- a/plugins/grib_pi/src/GribV2Record.cpp
+++ b/plugins/grib_pi/src/GribV2Record.cpp
@@ -195,6 +195,7 @@ static int dec_jpeg2000(char *injpc,int bufsize,int *outfld)
 *
 *   RETURN VALUES :
 *          0 = Successful decode
+*         -2 = no memory Error.
 *         -3 = Error decode jpeg2000 code stream.
 *         -5 = decoded image had multiple color components.
 *              Only grayscale is expected.
@@ -226,7 +227,10 @@ static int dec_jpeg2000(char *injpc,int bufsize,int *outfld)
 //       
 
     jpcstream=jas_stream_memopen(injpc,bufsize);
-
+    if (jpcstream == nullptr) {
+        printf(" dec_jpeg2000: no memory\n");
+        return -2;
+    }
 //   
 //     Decode JPEG200 codestream into jas_image_t structure.
 //       

--- a/plugins/grib_pi/src/IsoLine.cpp
+++ b/plugins/grib_pi/src/IsoLine.cpp
@@ -739,34 +739,35 @@ Segment::Segment(int I, int w, int J,
 void Segment::intersectionAreteGrille(int i,int j, int k,int l, double *x, double *y,
                                       const GribRecord *rec, double pressure)
 {
-    double a,b, pa, pb, dec;
+    double xa, xb, ya, yb, pa, pb, dec;
     pa = rec->getValue(i,j);
     pb = rec->getValue(k,l);
+
+    rec->getXY(i, j, &xa, &ya);
+    rec->getXY(k, l, &xb, &yb);
+
     // Abscisse
-    a = rec->getX(i);
-    b = rec->getX(k);
     if (pb != pa)
         dec = (pressure-pa)/(pb-pa);
     else
         dec = 0.5;
     if (fabs(dec)>1)
         dec = 0.5;
-    double xd = b-a;
+    double xd = xb -xa;
     if(xd < -180)
         xd += 360;
     else if(xd > 180)
         xd -= 360;
-    *x = a+xd*dec;
+    *x = xa +xd*dec;
+
     // Ordonnée
-    a = rec->getY(j);
-    b = rec->getY(l);
     if (pb != pa)
         dec = (pressure-pa)/(pb-pa);
     else
         dec = 0.5;
     if (fabs(dec)>1)
         dec = 0.5;
-    *y = a+(b-a)*dec;
+    *y = ya +(yb -ya)*dec;
 }
 //---------------------------------------------------------------
 void Segment::traduitCode(int I, int w, int J, char c1, int &i, int &j) {

--- a/plugins/grib_pi/src/zuFile.cpp
+++ b/plugins/grib_pi/src/zuFile.cpp
@@ -103,6 +103,7 @@ ZUFILE * zu_open(const char *fname, const char *mode, int type)
     }
 
     if (f->zfile == NULL) {
+        free(f->fname);
         free(f);
         f = NULL;
     }


### PR DESCRIPTION
Hi,
- Some cleanups

- NOAA MSLET is a pressure too.

- make overlapping average work, there's still  issues with Section 4 (Product Definition Section)  template 8 if time is in minute or reference time and valid time aren't using the same unit, need more data for testing.

- Don't use wx function for computing reference time, O logic didn't work if grib time and now() weren't in the same DST period, moreover wx is designed for one time zone and isn't that reliable with computations date  . Use zygrib crude method.

Regards
Didier