### PR TITLE
Prevent Enter key from dropping mark at cursor

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -1739,7 +1739,8 @@ void ChartCanvas::OnKeyDown( wxKeyEvent &event )
 
         case 13:             // Ctrl M // Drop Marker at cursor
         {
-            DropMarker(false);
+            if(event.ControlDown())
+                DropMarker(false);
             break;
         }
 


### PR DESCRIPTION
The intended behavior is only for Ctrl-M/Cmd-M to do so