### PR TITLE
Fix ship bells on Linux

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -6855,7 +6855,7 @@ void MyFrame::OnBellsTimer(wxTimerEvent& event)
     bells_sound[bells - 1].Play();
     m_BellsToPlay -= bells;
 
-    BellsTimer.Start(2000, wxTIMER_ONE_SHOT);
+    BellsTimer.Start(3000, wxTIMER_ONE_SHOT);
 }
 
 int ut_index;


### PR DESCRIPTION
We need to wait a bit longer than the wav files duration (around 2.5 secs)
before calling Play() again or some calls will be ignored. This causes the
wrong number of bells to be played, as reported in FS#2336.