### PR TITLE
Style loading can deref a NULL pointer if the requested style is not found

### DIFF
--- a/src/styles.cpp
+++ b/src/styles.cpp
@@ -1137,6 +1137,7 @@ void StyleManager::SetStyle(wxString name)
         style = (Style*) ( styles[i] );
         if( style->name == name || selectFirst ) {
             if( style->graphics ) {
+                if (currentStyle) currentStyle->Unload();
                 currentStyle = style;
                 ok = true;
                 break;
@@ -1164,6 +1165,7 @@ void StyleManager::SetStyle(wxString name)
                 break;
             }
             style->graphics = new wxBitmap( img );
+            if (currentStyle) currentStyle->Unload();
             currentStyle = style;
             ok = true;
             break;
@@ -1177,17 +1179,12 @@ void StyleManager::SetStyle(wxString name)
         return;
     }
 
-    if(style) {
-        if (currentStyle) currentStyle->Unload();
-        if( (style->consoleTextBackgroundSize.x) && (style->consoleTextBackgroundSize.y)) {
-            style->consoleTextBackground = style->graphics->GetSubBitmap(
-            wxRect( style->consoleTextBackgroundLoc, style->consoleTextBackgroundSize ) );
-        }
+    if( (style->consoleTextBackgroundSize.x) && (style->consoleTextBackgroundSize.y)) {
+        style->consoleTextBackground = style->graphics->GetSubBitmap(
+        wxRect( style->consoleTextBackgroundLoc, style->consoleTextBackgroundSize ) );
     }
 
-    if(style)
-        nextInvocationStyle = style->name;
-    
+    nextInvocationStyle = style->name;
     return;
 }
 

--- a/src/styles.cpp
+++ b/src/styles.cpp
@@ -1127,9 +1127,7 @@ void StyleManager::Init(const wxString & fromPath)
 void StyleManager::SetStyle(wxString name)
 {
     Style* style = NULL;
-    bool ok = true;
-    if( currentStyle ) currentStyle->Unload();
-    else ok = false;
+    bool ok = false;
 
     bool selectFirst = false;
 
@@ -1180,6 +1178,7 @@ void StyleManager::SetStyle(wxString name)
     }
 
     if(style) {
+        if (currentStyle) currentStyle->Unload();
         if( (style->consoleTextBackgroundSize.x) && (style->consoleTextBackgroundSize.y)) {
             style->consoleTextBackground = style->graphics->GetSubBitmap(
             wxRect( style->consoleTextBackgroundLoc, style->consoleTextBackgroundSize ) );


### PR DESCRIPTION
I believe this is a real bug.  As it is now, the existing style is unconditionally unloaded and then if the requested one is not found we end up with null pointers that are later dereferenced.

I think what should happen is that we only unload the old style if we find or can load the bitmap of the requested style.

I found this while testing the MUI branch.  After switching back to master the MUI style is specified in opencpn.ini but is no longer present and O crashes.
