### PR TITLE
Correct; WP arrival circle default, add watchdogs, string consistency

### DIFF
--- a/src/ConfigMgr.cpp
+++ b/src/ConfigMgr.cpp
@@ -1027,7 +1027,7 @@ bool ConfigMgr::SaveTemplate( wxString fileName)
     conf->Write( _T ( "OwnShipSogCogCalc" ), g_own_ship_sog_cog_calc );
     conf->Write( _T ( "OwnShipSogCogCalcDampSec"), g_own_ship_sog_cog_calc_damp_sec );
     
-    conf->Write( _T ( "RouteArrivalCircleRadius" ), wxString::Format( _T("%.2f"), g_n_arrival_circle_radius ));
+    conf->Write( _T ( "RouteArrivalCircleRadius" ), wxString::Format( _T("%.3f"), g_n_arrival_circle_radius ));
     conf->Write( _T ( "ChartQuilting" ), g_bQuiltEnable );
     
     conf->Write( _T ( "StartWithTrackActive" ), g_bTrackCarryOver );

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -592,7 +592,7 @@ int MyConfig::LoadMyConfig()
     g_bPreserveScaleOnX = 1;
     g_navobjbackups = 5;
     g_benableAISNameCache = true;
-    g_n_arrival_circle_radius = 50;
+    g_n_arrival_circle_radius = 0.05;
     
     g_AISShowTracks_Mins = 20;
     g_ShowScaled_Num = 10L;
@@ -690,8 +690,8 @@ int MyConfig::LoadMyConfig()
         g_n_ownship_min_mm = wxMax(g_n_ownship_min_mm, 1);
         if( g_navobjbackups > 99 ) g_navobjbackups = 99;
         if( g_navobjbackups < 0 ) g_navobjbackups = 0;
-        g_n_arrival_circle_radius = wxMax(g_n_arrival_circle_radius, .001);
-        
+        g_n_arrival_circle_radius = wxClip(g_n_arrival_circle_radius, 0.001, 0.6);
+
         g_Show_Target_Name_Scale = wxMax( 5000, g_Show_Target_Name_Scale );
 
         if( ( g_ais_alert_dialog_x < 0 ) || ( g_ais_alert_dialog_x > display_width ) )

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6398,6 +6398,7 @@ void options::OnApplyClick(wxCommandEvent& event) {
   g_OwnShipIconType = m_pShipIconType->GetSelection();
 
   m_pText_ACRadius->GetValue().ToDouble(&g_n_arrival_circle_radius);
+  g_n_arrival_circle_radius = wxClip(g_n_arrival_circle_radius, 0.001, 0.6); // Correct abnormally
 
   //  Any Font changes?
   if(m_bfontChanged)


### PR DESCRIPTION
Correct default from 50 to 0.05
Check and correct old scrap from testers config.
Check and correct user abnormally setting in options.
Make all string consistent to three decimals.
Note: My max value on values check is 0.6. Pls change if also abnormal??