### PR TITLE
probable fix for ships bells

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -6859,7 +6859,7 @@ void MyFrame::OnBellsTimer(wxTimerEvent& event)
     bells_sound[bells - 1].Play();
     m_BellsToPlay -= bells;
 
-    BellsTimer.Start(2000, wxTIMER_ONE_SHOT);
+    BellsTimer.Start(3000, wxTIMER_ONE_SHOT);
 }
 
 int ut_index;


### PR DESCRIPTION
On OS X, ships bells do not seem to be working correctly. I have heard 2, 3, and 4 bells, but I have definitely never heard 8 bells. This bug also describes malfunctioning bells,

https://opencpn.org/flyspray/index.php?do=details&task_id=2336

It is my hypothesis that this line is the problem,

https://github.com/OpenCPN/OpenCPN/blob/master/src/chart1.cpp#L6862

The `2bells.wav` is 2.533 seconds long -- but that one-shot timer is only 2 seconds. So I believe what happens is that some attempts to play bells are being lost because the previous `.Play()` has not completed.

My patch makes the timer 3 seconds -- which should avoid that race condition.

I have not tested this change because I do not currently have the means to build OpenCPN from source. I did, however, shorten the `2bell.wav` file on my machine to be less than 2 seconds and things started working correctly.

EDIT: I am on OS X Sierra 10.12.6