### PR TITLE
Prevent compiler warnings

### DIFF
--- a/include/options.h
+++ b/include/options.h
@@ -774,7 +774,7 @@ class SentenceListDlg : private Uncopyable, public wxDialog {
   void OnClearAllClick(wxCommandEvent &event);
 
   void Populate(const wxArrayString &list);
-  const wxString GetBoxLabel(void) const;
+  wxString GetBoxLabel(void) const;
 
   wxCheckListBox *m_clbSentences;
   wxButton *m_btnDel;
@@ -788,21 +788,21 @@ class SentenceListDlg : private Uncopyable, public wxDialog {
 class OpenGLOptionsDlg : private Uncopyable, public wxDialog {
  public:
   explicit OpenGLOptionsDlg(wxWindow *parent);
-  const bool GetAcceleratedPanning(void) const;
-  const bool GetTextureCompression(void) const;
-  const bool GetPolygonSmoothing(void) const;
-  const bool GetLineSmoothing(void) const;
-  const bool GetShowFPS(void) const;
-  const bool GetSoftwareGL(void) const;
-  const bool GetTextureCompressionCaching(void) const;
-  const bool GetRebuildCache(void) const;
-  const int GetTextureMemorySize(void) const;
+  bool GetAcceleratedPanning(void) const;
+  bool GetTextureCompression(void) const;
+  bool GetPolygonSmoothing(void) const;
+  bool GetLineSmoothing(void) const;
+  bool GetShowFPS(void) const;
+  bool GetSoftwareGL(void) const;
+  bool GetTextureCompressionCaching(void) const;
+  bool GetRebuildCache(void) const;
+  int GetTextureMemorySize(void) const;
 
  private:
   void Populate(void);
   void OnButtonRebuild(wxCommandEvent &event);
   void OnButtonClear(wxCommandEvent &event);
-  const wxString GetTextureCacheSize(void);
+  wxString GetTextureCacheSize(void);
 
   wxCheckBox *m_cbUseAcceleratedPanning, *m_cbTextureCompression;
   wxCheckBox *m_cbTextureCompressionCaching, *m_cbShowFPS, *m_cbSoftwareGL,

--- a/plugins/grib_pi/src/GribRecord.cpp
+++ b/plugins/grib_pi/src/GribRecord.cpp
@@ -437,14 +437,14 @@ void  GribRecord::multiplyAllData(double k)
     if (data == 0 || !isOk())
         return;
 
-	for (zuint j=0; j<Nj; j++) {
-		for (zuint i=0; i<Ni; i++)
-		{
-			if (isDefined(i,j)) {
-				data[j*Ni+i] *= k;
-			}
-		}
-	}
+    for (zuint j=0; j<Nj; j++) {
+        for (zuint i=0; i<Ni; i++)
+        {
+            if (isDefined(i,j)) {
+                data[j*Ni+i] *= k;
+            }
+        }
+    }
 }
 
 //----------------------------------------------

--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -1750,6 +1750,7 @@ bool AIS_Decoder::Parse_VDXBitstring( AIS_Bitstring *bstr, AIS_Target_Data *ptd 
                                     case AIS8_001_22_SHAPE_CIRCLE:
                                     case AIS8_001_22_SHAPE_SECTOR:
                                         sa.radius_m = bstr->GetInt( base + 58, 12 ) * scale_factor;
+                                        // FALL THROUGH
                                     case AIS8_001_22_SHAPE_RECT:
                                         sa.longitude = bstr->GetInt( base + 6, 25, true ) / 60000.0;
                                         sa.latitude = bstr->GetInt( base + 31, 24, true ) / 60000.0;

--- a/src/OCP_DataStreamInput_Thread.cpp
+++ b/src/OCP_DataStreamInput_Thread.cpp
@@ -302,7 +302,7 @@ void *OCP_DataStreamInput_Thread::Entry()
             strncpy( msg, qmsg, MAX_OUT_QUEUE_MESSAGE_LENGTH-1 );
             free(qmsg);
             
-            if( -1 == WriteComPortPhysical(msg) && 10 < retries++ ) {
+            if( static_cast<size_t>(-1) == WriteComPortPhysical(msg) && 10 < retries++ ) {
                 // We failed to write the port 10 times, let's close the port so that the reconnection logic kicks in and tries to fix our connection.
                 retries = 0;
                 CloseComPortPhysical();

--- a/src/RolloverWin.cpp
+++ b/src/RolloverWin.cpp
@@ -159,9 +159,9 @@ void RolloverWin::SetBitmap( int rollover )
                 memcpy(e+4*i, d+3*i, 3);
                 e[4*i+3] = 255 - d[3*i+2];
             }
-            glTexImage2D( g_texture_rectangle_format, 0, GL_RGBA,
-                          m_size.x, m_size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, e );
-            delete [] e;
+        glTexImage2D( g_texture_rectangle_format, 0, GL_RGBA,
+                      m_size.x, m_size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, e );
+        delete [] e;
     }
     #endif
     

--- a/src/ais.cpp
+++ b/src/ais.cpp
@@ -563,6 +563,7 @@ void AISDrawAreaNotices( ocpnDC& dc, ViewPort& vp, ChartCanvas *cp )
                         }
                         case AIS8_001_22_SHAPE_POLYGON:
                             draw_polygon = true;
+                            // FALL THROUGH
                         case AIS8_001_22_SHAPE_POLYLINE: {
                             double lat = sa->latitude;
                             double lon = sa->longitude;

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -4358,6 +4358,7 @@ void MyFrame::OnToolLeftClick( wxCommandEvent& event )
  #else
             DoSettings();
  #endif
+            break;
         }
 
         case ID_MENU_UI_FULLSCREEN: {

--- a/src/chartimg.cpp
+++ b/src/chartimg.cpp
@@ -35,6 +35,8 @@
 // headers
 // ----------------------------------------------------------------------------
 
+#include <assert.h>
+
 // For compilers that support precompilation, includes "wx.h".
 #include "wx/wxprec.h"
 
@@ -1324,7 +1326,7 @@ InitReturn ChartKAP::Init( const wxString& name, ChartInitFlag init_flags )
                               i = tkz.GetPosition();
 
                               char date_string[40];
-                              char date_buf[10];
+                              char date_buf[16];
                               date_string[0] = 0;
                               date_buf[0] = 0;
                               sscanf(&buffer[i], "%s\r\n", date_string);
@@ -1346,6 +1348,7 @@ InitReturn ChartKAP::Init( const wxString& name, ChartInitFlag init_flags )
                                       iyear += 1900;
                                       dt.SetYear(iyear);
                                   }
+                                  assert(iyear <= 9999);
                                   sprintf(date_buf, "%d", iyear);
 
                               //    Initialize the wxDateTime menber for Edition Date
@@ -3809,8 +3812,10 @@ bool ChartBaseBSB::GetAndScaleData(unsigned char *ppn, size_t data_size, wxRect&
       if((target_height == 0) || (target_width == 0))
             return false;
 
-      unsigned char *target_data = ppn;
-      unsigned char *data = ppn;
+      // `volatile` may be needed with regard to `sigsetjmp()` below;
+      // at least it prevents compiler warning about clobbering the variable.
+      unsigned char * volatile target_data = ppn;
+      unsigned char * data = ppn;
 
       if(factor > 1)                // downsampling
       {

--- a/src/datastream.cpp
+++ b/src/datastream.cpp
@@ -637,6 +637,7 @@ void DataStream::OnSocketEvent(wxSocketEvent& event)
                 break;
             }
         }
+        // FALL THROUGH
 
         case wxSOCKET_CONNECTION :
         {
@@ -1733,8 +1734,9 @@ GARMIN_USB_Thread::~GARMIN_USB_Thread()
 void *GARMIN_USB_Thread::Entry()
 {
       garmin_usb_packet iresp;
-          int n_short_read = 0;
+      int n_short_read = 0;
       m_receive_state = rs_fromintr;
+      memset(&iresp, 0, (sizeof iresp));    // Prevent compiler warnings.
 
       //    Here comes the big while loop
       while(m_parent->m_Thread_run_flag > 0)

--- a/src/garmin/jeeps/gpsapp.c
+++ b/src/garmin/jeeps/gpsapp.c
@@ -1617,7 +1617,7 @@ static void GPS_D109_Get(GPS_PWay *way, UC *s, int protoid)
     p += 4; /* Skip over "outbound link ete in seconds */
     if (protoid == 110) {
 	float gps_temp;
-	int gps_time;
+	uint32 gps_time;
 	gps_temp = GPS_Util_Get_Float(p);
 	p+=4;
 	if (gps_temp <= 1.0e24) {
@@ -1632,7 +1632,7 @@ static void GPS_D109_Get(GPS_PWay *way, UC *s, int protoid)
 	 */
 	if (gps_time != 0xffffffff && gps_time != 0) {
 		(*way)->time_populated = 1;
-		(*way)->time = GPS_Math_Gtime_To_Utime(gps_time);
+		(*way)->time = GPS_Math_Gtime_To_Utime((long int)gps_time);
 	}
 	(*way)->category = GPS_Util_Get_Short(p);
 	p += 2;

--- a/src/garmin/jeeps/gpsprot.c
+++ b/src/garmin/jeeps/gpsprot.c
@@ -44,6 +44,7 @@ struct COMMANDDATA COMMAND_ID[2]=
     /* Device Command Protocol 2 (A011) */
     {
 	0,4,0,17,8,20,0,21,26,0,0
+	/* explicit initializers */,12,13,14,15,16,17,18,19,20,21,21,23,24
     }
 };
 

--- a/src/garmin/jeeps/gpssend.c
+++ b/src/garmin/jeeps/gpssend.c
@@ -143,7 +143,7 @@ int32 GPS_Serial_Write_Packet(gpsdevh *fd, GPS_PPacket packet)
 
     GPS_Diag("Tx Data:");
     Diag(&ser_pkt.dle, 3);
-    if((ret=GPS_Serial_Write(fd,(const void *) &ser_pkt.dle,(size_t)3)) == -1)
+    if((ret=GPS_Serial_Write(fd,(const void *) &ser_pkt.dle,(size_t)3)) == (size_t)-1)
     {
 	perror("write");
 	GPS_Error("SEND: Write to GPS failed");
@@ -156,7 +156,7 @@ int32 GPS_Serial_Write_Packet(gpsdevh *fd, GPS_PPacket packet)
     }
 
     Diag(ser_pkt.data, bytes);
-    if((ret=GPS_Serial_Write(fd,(const void *)ser_pkt.data,(size_t)bytes)) == -1)
+    if((ret=GPS_Serial_Write(fd,(const void *)ser_pkt.data,(size_t)bytes)) == (size_t)-1)
     {
 	perror("write");
 	GPS_Error("SEND: Write to GPS failed");
@@ -177,7 +177,7 @@ int32 GPS_Serial_Write_Packet(gpsdevh *fd, GPS_PPacket packet)
     m1 = Get_Pkt_Type(ser_pkt.type, ser_pkt.data[0], &m2);
     GPS_Diag("(%-8s%s)\n", m1, m2 ? m2 : "");
 
-    if((ret=GPS_Serial_Write(fd,(const void *)&ser_pkt.chk,(size_t)3)) == -1)
+    if((ret=GPS_Serial_Write(fd,(const void *)&ser_pkt.chk,(size_t)3)) == (size_t)-1)
     {
 	perror("write");
 	GPS_Error("SEND: Write to GPS failed");

--- a/src/glTextureManager.cpp
+++ b/src/glTextureManager.cpp
@@ -952,7 +952,9 @@ void glTextureManager::OnTimer(wxTimerEvent &event)
             itt != m_chart_texfactory_hash.end(); ++itt ) {
             glTexFactory *ptf = itt->second;
             if(ptf && ptf->OnTimer())
-                ;//break;
+            {
+                //break;
+            }
         }
     }
 

--- a/src/mygdal/ogrfeature.cpp
+++ b/src/mygdal/ogrfeature.cpp
@@ -1390,7 +1390,9 @@ void OGRFeature::SetField( int iField, int nValue )
         pauFields[iField].String = CPLStrdup( szTempBuffer );
     }
     else
+    {
         /* do nothing for other field types */;
+    }
 }
 
 /************************************************************************/
@@ -1466,7 +1468,9 @@ void OGRFeature::SetField( int iField, double dfValue )
         pauFields[iField].String = CPLStrdup( szTempBuffer );
     }
     else
+    {
         /* do nothing for other field types */;
+    }
 }
 
 /************************************************************************/
@@ -1537,7 +1541,9 @@ void OGRFeature::SetField( int iField, const char * pszValue )
         pauFields[iField].Real = atof(pszValue);
     }
     else
+    {
         /* do nothing for other field types */;
+    }
 }
 
 /************************************************************************/
@@ -1855,7 +1861,9 @@ void OGRFeature::SetField( int iField, OGRField * puValue )
         }
     }
     else
+    {
         /* do nothing for other field types */;
+    }
 }
 
 /************************************************************************/

--- a/src/mygdal/ogrs57layer.cpp
+++ b/src/mygdal/ogrs57layer.cpp
@@ -303,9 +303,13 @@ OGRErr OGRS57Layer::CreateFeature( OGRFeature *poFeature )
     if( iRCNMFld != -1 )
     {
         if( !poFeature->IsFieldSet( iRCNMFld ) )
+        {
             poFeature->SetField( iRCNMFld, nRCNM );
+        }
         else
+        {
             CPLAssert( poFeature->GetFieldAsInteger( iRCNMFld ) == nRCNM );
+        }
     }
 
 /* -------------------------------------------------------------------- */
@@ -316,9 +320,13 @@ OGRErr OGRS57Layer::CreateFeature( OGRFeature *poFeature )
         int iOBJLFld = poFeature->GetFieldIndex( "OBJL" );
 
         if( !poFeature->IsFieldSet( iOBJLFld ) )
+        {
             poFeature->SetField( iOBJLFld, nOBJL );
+        }
         else
+        {
             CPLAssert( poFeature->GetFieldAsInteger( iOBJLFld ) == nOBJL );
+        }
     }
 
 /* -------------------------------------------------------------------- */

--- a/src/mygdal/s57reader.cpp
+++ b/src/mygdal/s57reader.cpp
@@ -29,6 +29,7 @@
  * *
  */
 
+#include <assert.h>
 #include "s57.h"
 #include "ogr_api.h"
 #include "cpl_conv.h"
@@ -863,15 +864,23 @@ void S57Reader::ApplyObjectClassAttributes( DDFRecord * poRecord,
             if( strlen(pszValue) == 0 )
             {
                 if( nOptionFlags & S57M_PRESERVE_EMPTY_NUMBERS )
+                {
                     poFeature->SetField( iField, EMPTY_NUMBER_MARKER );
+                }
                 else
+                {
                     /* leave as null if value was empty string */;
+                }
             }
             else
+            {
                 poFeature->SetField( iField, pszValue );
+            }
         }
         else
+        {
             poFeature->SetField( iField, pszValue );
+        }
     }
 
 /* -------------------------------------------------------------------- */
@@ -2683,10 +2692,11 @@ int S57Reader::FindAndApplyUpdates( const char * pszPath )
 
     for( iUpdate = 1; bSuccess; iUpdate++ )
     {
-        char    szExtension[4];
+        char    szExtension[16];
         char    *pszUpdateFilename;
         DDFModule oUpdateModule;
 
+        assert(iUpdate <= 999);
         sprintf( szExtension, "%03d", iUpdate );
 
         pszUpdateFilename = CPLStrdup(CPLResetExtension(pszPath,szExtension));

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -8541,7 +8541,7 @@ SentenceListDlg::SentenceListDlg(wxWindow* parent, FilterDirection dir,
   Populate(list);
 }
 
-const wxString SentenceListDlg::GetBoxLabel(void) const {
+wxString SentenceListDlg::GetBoxLabel(void) const {
   if (m_dir == FILTER_OUTPUT)
     return m_type == WHITELIST ? _("Transmit sentences") : _("Drop sentences");
   else
@@ -8723,39 +8723,39 @@ OpenGLOptionsDlg::OpenGLOptionsDlg(wxWindow* parent)
   Centre();
 }
 
-const bool OpenGLOptionsDlg::GetAcceleratedPanning(void) const {
+bool OpenGLOptionsDlg::GetAcceleratedPanning(void) const {
   return m_cbUseAcceleratedPanning->GetValue();
 }
 
-const bool OpenGLOptionsDlg::GetTextureCompression(void) const {
+bool OpenGLOptionsDlg::GetTextureCompression(void) const {
   return m_cbTextureCompression->GetValue();
 }
 
-const bool OpenGLOptionsDlg::GetPolygonSmoothing(void) const {
+bool OpenGLOptionsDlg::GetPolygonSmoothing(void) const {
     return m_cbPolygonSmoothing->GetValue();
 }
 
-const bool OpenGLOptionsDlg::GetLineSmoothing(void) const {
+bool OpenGLOptionsDlg::GetLineSmoothing(void) const {
     return m_cbLineSmoothing->GetValue();
 }
 
-const bool OpenGLOptionsDlg::GetShowFPS(void) const {
+bool OpenGLOptionsDlg::GetShowFPS(void) const {
   return m_cbShowFPS->GetValue();
 }
 
-const bool OpenGLOptionsDlg::GetSoftwareGL(void) const {
+bool OpenGLOptionsDlg::GetSoftwareGL(void) const {
   return m_cbSoftwareGL->GetValue();
 }
 
-const bool OpenGLOptionsDlg::GetTextureCompressionCaching(void) const {
+bool OpenGLOptionsDlg::GetTextureCompressionCaching(void) const {
   return m_cbTextureCompressionCaching->GetValue();
 }
 
-const bool OpenGLOptionsDlg::GetRebuildCache(void) const {
+bool OpenGLOptionsDlg::GetRebuildCache(void) const {
   return m_brebuild_cache;
 }
 
-const int OpenGLOptionsDlg::GetTextureMemorySize(void) const {
+int OpenGLOptionsDlg::GetTextureMemorySize(void) const {
   return m_sTextureMemorySize->GetValue();
 }
 
@@ -8833,7 +8833,7 @@ void OpenGLOptionsDlg::OnButtonClear(wxCommandEvent& event) {
   ::wxEndBusyCursor();
 }
 
-const wxString OpenGLOptionsDlg::GetTextureCacheSize(void) {
+wxString OpenGLOptionsDlg::GetTextureCacheSize(void) {
   wxString path = g_Platform->GetPrivateDataDir() +
                   wxFileName::GetPathSeparator() + _T( "raster_texture_cache" );
   long long total = 0;

--- a/src/pugixml.cpp
+++ b/src/pugixml.cpp
@@ -10192,9 +10192,8 @@ PUGI__NS_BEGIN
 
 				if (_rettype == xpath_type_boolean)
 					return _data.variable->get_boolean();
-
-				// fallthrough to type conversion
 			}
+			// FALL THROUGH
 
 			default:
 			{
@@ -10328,9 +10327,8 @@ PUGI__NS_BEGIN
 
 				if (_rettype == xpath_type_number)
 					return _data.variable->get_number();
-
-				// fallthrough to type conversion
 			}
+			// FALL THROUGH
 
 			default:
 			{
@@ -10612,9 +10610,8 @@ PUGI__NS_BEGIN
 
 				if (_rettype == xpath_type_string)
 					return xpath_string::from_const(_data.variable->get_string());
-
-				// fallthrough to type conversion
 			}
+			// FALL THROUGH
 
 			default:
 			{
@@ -10762,9 +10759,8 @@ PUGI__NS_BEGIN
 
 					return ns;
 				}
-
-				// fallthrough to type conversion
 			}
+			// FALL THROUGH
 
 			default:
 				assert(false && "Wrong expression for return type node set");

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -156,12 +156,12 @@ static uint64_t hash_fast64(const void *buf, size_t len, uint64_t seed)
     pc = (const unsigned char*)pos;
     v = 0;
     switch (len & 7) {
-        case 7: v ^= (uint64_t)pc[6] << 48;
-        case 6: v ^= (uint64_t)pc[5] << 40;
-        case 5: v ^= (uint64_t)pc[4] << 32;
-        case 4: v ^= (uint64_t)pc[3] << 24;
-        case 3: v ^= (uint64_t)pc[2] << 16;
-        case 2: v ^= (uint64_t)pc[1] << 8;
+        case 7: v ^= (uint64_t)pc[6] << 48;    // FALL THROUGH
+        case 6: v ^= (uint64_t)pc[5] << 40;    // FALL THROUGH
+        case 5: v ^= (uint64_t)pc[4] << 32;    // FALL THROUGH
+        case 4: v ^= (uint64_t)pc[3] << 24;    // FALL THROUGH
+        case 3: v ^= (uint64_t)pc[2] << 16;    // FALL THROUGH
+        case 2: v ^= (uint64_t)pc[1] << 8;     // FALL THROUGH
         case 1: v ^= (uint64_t)pc[0];
             v ^= v >> 23;
             v *= 0x2127599bf4325c37ULL;

--- a/src/serial/src/impl/list_ports/list_ports_linux.cc
+++ b/src/serial/src/impl/list_ports/list_ports_linux.cc
@@ -63,7 +63,7 @@ glob(const vector<string>& patterns)
         glob_retval = glob(iter->c_str(), GLOB_APPEND, NULL, &glob_results);
     }
 
-    for(int path_index = 0; path_index < glob_results.gl_pathc; path_index++)
+    for(size_t path_index = 0; path_index < glob_results.gl_pathc; path_index++)
     {
         paths_found.push_back(glob_results.gl_pathv[path_index]);
     }
@@ -243,11 +243,11 @@ format(const char* format, ...)
         {
             done = true;
         }
-        else if( return_value >= buffer_size_bytes )
+        else if( static_cast<size_t>(return_value) >= buffer_size_bytes )
         {
             // Realloc and try again.
 
-            buffer_size_bytes = return_value + 1;
+            buffer_size_bytes = static_cast<size_t>(return_value) + 1;
 
             char* new_buffer_ptr = (char*)realloc(buffer, buffer_size_bytes);
 

--- a/src/tcmgr.cpp
+++ b/src/tcmgr.cpp
@@ -2543,10 +2543,10 @@ NV_INT32 get_time (const NV_CHAR *string)
 NV_CHAR *ret_time (NV_INT32 time)
 {
     NV_INT32          hour, minute;
-    static NV_CHAR    tname[10];
+    static NV_CHAR    tname[16];
 
     hour = abs (time) / 100;
-    assert (hour < 100000); /* 9 chars: +99999:99 */
+    assert (hour <= 99999 && hour >= -99999); /* 9 chars: +99999:99 */
     minute = abs (time) % 100;
 
     if (time < 0)
@@ -2568,10 +2568,10 @@ NV_CHAR *ret_time (NV_INT32 time)
 NV_CHAR *ret_time_neat (NV_INT32 time)
 {
     NV_INT32          hour, minute;
-    static NV_CHAR    tname[10];
+    static NV_CHAR    tname[16];
 
     hour = abs (time) / 100;
-    assert (hour < 100000); /* 9 chars: +99999:99 */
+    assert (hour <= 99999 && hour >= -99999); /* 9 chars: +99999:99 */
     minute = abs (time) % 100;
 
     if (time < 0)

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -2754,7 +2754,7 @@ END_EVENT_TABLE()
              ToolbarMOBDialog mdlg( this );
              int dialog_ret = mdlg.ShowModal( );
              int answer = mdlg.GetSelection( );
-             if ( dialog_ret == wxID_OK )
+             if ( dialog_ret == wxID_OK ) {
                  if ( answer == 1 ) {
                      g_bPermanentMOBIcon = true;
                      cb->SetValue( true );
@@ -2762,8 +2762,7 @@ END_EVENT_TABLE()
                  else if ( answer == 0 ) {
                      cb->SetValue( true );
                  }
-                 else
-                     ;
+             }
              else { // wxID_CANCEL
                  g_toolbarConfig = g_toolbarConfigSave;
                  return;

--- a/src/wxsvg/include/wxSVG/CSSStyleDeclaration.h
+++ b/src/wxsvg/include/wxSVG/CSSStyleDeclaration.h
@@ -87,7 +87,9 @@ class wxCSSStyleDeclaration: public wxHashMapCSSValue
 {
   public:
     wxCSSStyleDeclaration() {}
-    wxCSSStyleDeclaration(const wxCSSStyleDeclaration& src) { Add(src); }
+    wxCSSStyleDeclaration(const wxCSSStyleDeclaration& src)
+        : wxHashMapCSSValue(src.size())
+        { Add(src); }
     ~wxCSSStyleDeclaration();
     wxCSSStyleDeclaration& operator=(const wxCSSStyleDeclaration& src);
     void Add(const wxCSSStyleDeclaration& style);

--- a/src/wxsvg/include/wxSVG/SVGPathSegList.h
+++ b/src/wxsvg/include/wxSVG/SVGPathSegList.h
@@ -19,7 +19,9 @@ class wxSVGPathSegList: public wxSVGPathSegListBase
 {
   public:
     wxSVGPathSegList() {}
-    wxSVGPathSegList(const wxSVGPathSegList& src) { DoCopy(src); }
+    wxSVGPathSegList(const wxSVGPathSegList& src)
+        : wxSVGPathSegListBase()
+        { DoCopy(src); }
     wxSVGPathSegList& operator=(const wxSVGPathSegList& src)
     { Clear(); DoCopy(src); return *this; }
     

--- a/src/wxsvg/src/CSSValue.cpp
+++ b/src/wxsvg/src/CSSValue.cpp
@@ -196,7 +196,9 @@ void wxCSSPrimitiveValue::CleanUp()
 /////////////////////////////  wxCSSValueList ////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
 
-wxCSSValueList::wxCSSValueList(const wxCSSValueList& src) {
+wxCSSValueList::wxCSSValueList(const wxCSSValueList& src)
+: wxCSSValue()
+{
 	m_values = src.m_values;
 }
 

--- a/src/wxsvg/src/SVGCanvas.cpp
+++ b/src/wxsvg/src/SVGCanvas.cpp
@@ -116,6 +116,7 @@ void wxSVGCanvas::DrawText(wxSVGTextElement* element,
 void wxSVGCanvas::DrawCanvasText(wxSVGCanvasText& canvasText,
   wxSVGMatrix& matrix, const wxCSSStyleDeclaration& style, wxSVGSVGElement& svgElem)
 {
+  (void) style;    // Unused.
   for (int i=0; i<(int)canvasText.m_chunks.Count(); i++)
   {
 	wxSVGCanvasTextChunk& chunk = canvasText.m_chunks[i];
@@ -127,21 +128,21 @@ void wxSVGCanvas::DrawCanvasText(wxSVGCanvasText& canvasText,
 }
 
 wxSVGPatternElement* wxSVGCanvas::GetPatternElement(const wxSVGSVGElement& svgElem, const wxString& href) {
-	if (href.length() == 0 || href[0] != wxT('#') || &svgElem == NULL)
+	if (href.length() == 0 || href[0] != wxT('#'))
 	    return NULL;
 	wxSVGElement* elem = (wxSVGElement*) svgElem.GetElementById(href.substr(1));
 	return elem != NULL && elem->GetDtd() == wxSVG_PATTERN_ELEMENT ? (wxSVGPatternElement*) elem : NULL;
 }
 
 wxSVGMarkerElement* wxSVGCanvas::GetMarkerElement(const wxSVGSVGElement& svgElem, const wxString& href) {
-	if (href.length() == 0 || href[0] != wxT('#') || &svgElem == NULL)
+	if (href.length() == 0 || href[0] != wxT('#'))
 		return NULL;
 	wxSVGElement* elem = (wxSVGElement*) svgElem.GetElementById(href.substr(1));
 	return elem != NULL && elem->GetDtd() == wxSVG_MARKER_ELEMENT ? (wxSVGMarkerElement*) elem : NULL;
 }
 
 wxSVGGradientElement* wxSVGCanvas::GetGradientElement(const wxSVGSVGElement& svgElem, const wxString& href) {
-	if (href.length() == 0 || href[0] != wxT('#') || &svgElem == NULL)
+	if (href.length() == 0 || href[0] != wxT('#'))
 	    return NULL;
 	wxSVGGradientElement* elem = (wxSVGGradientElement*) svgElem.GetElementById(href.substr(1));
 	return elem != NULL && (elem->GetDtd() == wxSVG_LINEARGRADIENT_ELEMENT

--- a/src/wxsvg/src/SVGTransformable.cpp
+++ b/src/wxsvg/src/SVGTransformable.cpp
@@ -59,7 +59,7 @@ case the_dtd:\
   return &((the_class&)element);
 
 wxSVGTransformable* wxSVGTransformable::GetSVGTransformable(wxSVGElement& element) {
-  if (&element == NULL || element.GetType() != wxSVGXML_ELEMENT_NODE) {
+  if (element.GetType() != wxSVGXML_ELEMENT_NODE) {
       return NULL;
   }
   switch (element.GetDtd()) {

--- a/src/wxsvg/src/svgxml/svgxml.cpp
+++ b/src/wxsvg/src/svgxml/svgxml.cpp
@@ -399,6 +399,7 @@ wxSvgXmlDocument::wxSvgXmlDocument(wxInputStream& stream, const wxString& encodi
 }
 
 wxSvgXmlDocument::wxSvgXmlDocument(const wxSvgXmlDocument& doc)
+: wxObject()
 {
     DoCopy(doc);
 }


### PR DESCRIPTION
Issues detected by GCC 7.3.1 at "Extra" level:

* comparing reference to NULL (impossible) by checking variable address;
* implicit fall through `switch` case;
* implicit type-casting in comparison of signed and unsigned integers;
* use of `int` type instead of `size_t` or `uint32`, etc;
* futile `const` qualifier on function return type;
* misleading indentation, including that was pointed out by PR 1083;
* ambiguous unbracketed `else` clause, including empty (comments, macros);
* bogus buffer overflow on `sprintf()` (GCC 7.x/8.x range deduction flaw);
* bogus uninitialized structure field (not deducible by compiler);
* implicit initialization of unused structure fields;
* implicit initialization of base class instance;
* automatic over-optimization incompatible with `sigsetjmp()`.

Warnings concisely left:

* possible wrapping of `localtime_r` for multi-threaded wxWidgets.

Before accepting this patchset, it is strongly recommended to inspect all occurrences of "**FALL THROUGH**" comments, as they only describe current flow of statements: fixes may be required to establish the intended behavior. **Other** changes relevant to control flow are also worth double-checking.