### PR TITLE
Give a waypoint from an ais-target an usefull name.

### DIFF
--- a/src/AISTargetQueryDialog.cpp
+++ b/src/AISTargetQueryDialog.cpp
@@ -112,7 +112,8 @@ void AISTargetQueryDialog::OnIdWptCreateClick( wxCommandEvent& event )
     if( m_MMSI != 0 ) { //  Faulty MMSI could be reported as 0
         AIS_Target_Data *td = g_pAIS->Get_Target_Data_From_MMSI( m_MMSI );
         if( td ) {
-            RoutePoint *pWP = new RoutePoint( td->Lat, td->Lon, g_default_wp_icon, wxEmptyString, wxEmptyString );
+            wxString n =  wxString::Format(wxT("\"%s\"  %i "),td->ShipName,  td->MMSI).append(wxDateTime::Now().Format(wxT("%H:%M")));
+            RoutePoint *pWP = new RoutePoint( td->Lat, td->Lon, g_default_wp_icon, n, wxEmptyString );
             pWP->m_bIsolatedMark = true;                      // This is an isolated mark
             pSelect->AddSelectableRoutePoint( td->Lat, td->Lon, pWP );
             pConfig->AddNewWayPoint( pWP, -1 );    // use auto next num


### PR DESCRIPTION
If a waypoint is made from an ais-target, give it an decent name. (Now there is no name)
![screenshot_20181124_115756](https://user-images.githubusercontent.com/2668258/48970348-6c795e80-f00b-11e8-87ee-82a81716383b.png)
