### PR TITLE
Expect a variation = 0.0 to be a fake from a device wo updated wmm table

### DIFF
--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -669,9 +669,15 @@ void dashboard_pi::SetNMEASentence( wxString &sentence )
         }
 
         else if( m_NMEA0183.LastSentenceIDReceived == _T("HDG") ) {
-            if( m_NMEA0183.Parse() ) {
-                if( mPriVar >= 2 ) {
-                    if( !std::isnan( m_NMEA0183.Hdg.MagneticVariationDegrees ) ){
+            if( m_NMEA0183.Parse() )
+            {
+                if( mPriVar >= 2 ) 
+                {
+                    // Any device sending VAR=0.0 can be assumed to not really know
+                    // what the actual variation is, so in this case we use WMM if available
+                    if( (!std::isnan( m_NMEA0183.Hdg.MagneticVariationDegrees )) &&
+                               0.0 != m_NMEA0183.Hdg.MagneticVariationDegrees)
+                    {
                         mPriVar = 2;
                         if( m_NMEA0183.Hdg.MagneticVariationDirection == East )
                             mVar =  m_NMEA0183.Hdg.MagneticVariationDegrees;
@@ -931,16 +937,21 @@ void dashboard_pi::SetNMEASentence( wxString &sentence )
                         }
                     }
 
-                    if( mPriVar >= 3 ) {
-                        if( !std::isnan( m_NMEA0183.Rmc.MagneticVariation ) ){
+                    if( mPriVar >= 3 )
+                    {
+                        // Any device sending VAR=0.0 can be assumed to not really know
+                        // what the actual variation is, so in this case we use WMM if available
+                        if( (!std::isnan( m_NMEA0183.Rmc.MagneticVariation)) &&
+                                   0.0 != m_NMEA0183.Rmc.MagneticVariation )
+                        {
                             mPriVar = 3;
-                            if( m_NMEA0183.Rmc.MagneticVariationDirection == East )
+                            if (m_NMEA0183.Rmc.MagneticVariationDirection == East)
                                 mVar = m_NMEA0183.Rmc.MagneticVariation;
-                            else if( m_NMEA0183.Rmc.MagneticVariationDirection == West )
+                            else if (m_NMEA0183.Rmc.MagneticVariationDirection == West)
                                 mVar = -m_NMEA0183.Rmc.MagneticVariation;
                             mVar_Watchdog = gps_watchdog_timeout_ticks;
 
-                            SendSentenceToAllInstruments( OCPN_DBP_STC_HMV, mVar, _T("\u00B0") );
+                            SendSentenceToAllInstruments(OCPN_DBP_STC_HMV, mVar, _T("\u00B0"));
                         }
                     }
 

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -8472,14 +8472,17 @@ void MyFrame::OnEvtOCPN_NMEA( OCPN_DataStreamEvent & event )
                         cog_sog_valid = true;
                     }
                     
-                    if( !std::isnan(m_NMEA0183.Rmc.MagneticVariation) )
+                    // Any device sending VAR=0.0 can be assumed to not really know 
+                    // what the actual variation is, so in this case we use WMM if available
+                    if( (!std::isnan(m_NMEA0183.Rmc.MagneticVariation)) && 
+                              0.0 != m_NMEA0183.Rmc.MagneticVariation )
                     {
-                        if( m_NMEA0183.Rmc.MagneticVariationDirection == East )
+                        if (m_NMEA0183.Rmc.MagneticVariationDirection == East)
                             gVar = m_NMEA0183.Rmc.MagneticVariation;
                         else
-                            if( m_NMEA0183.Rmc.MagneticVariationDirection == West )
+                            if (m_NMEA0183.Rmc.MagneticVariationDirection == West)
                                 gVar = -m_NMEA0183.Rmc.MagneticVariation;
-                        
+
                         g_bVAR_Rx = true;
                         gVAR_Watchdog = gps_watchdog_timeout_ticks;
                     }
@@ -8502,13 +8505,16 @@ void MyFrame::OnEvtOCPN_NMEA( OCPN_DataStreamEvent & event )
                 if( !std::isnan(m_NMEA0183.Hdg.MagneticSensorHeadingDegrees) )
                     gHDx_Watchdog = gps_watchdog_timeout_ticks;
 
-                if( m_NMEA0183.Hdg.MagneticVariationDirection == East )
-                    gVar = m_NMEA0183.Hdg.MagneticVariationDegrees;
-                else if( m_NMEA0183.Hdg.MagneticVariationDirection == West )
-                    gVar = -m_NMEA0183.Hdg.MagneticVariationDegrees;
-
-                if( !std::isnan(m_NMEA0183.Hdg.MagneticVariationDegrees) )
+                // Any device sending VAR=0.0 can be assumed to not really know 
+                // what the actual variation is, so in this case we use WMM if available
+                if( (!std::isnan(m_NMEA0183.Hdg.MagneticVariationDegrees)) &&
+                     0.0 != m_NMEA0183.Hdg.MagneticVariationDegrees )
                 {
+                    if( m_NMEA0183.Hdg.MagneticVariationDirection == East )
+                        gVar = m_NMEA0183.Hdg.MagneticVariationDegrees;
+                    else if( m_NMEA0183.Hdg.MagneticVariationDirection == West )
+                        gVar = -m_NMEA0183.Hdg.MagneticVariationDegrees;
+                    
                     g_bVAR_Rx = true;
                     gVAR_Watchdog = gps_watchdog_timeout_ticks;
                 }


### PR DESCRIPTION
Any device sending VAR=0.0 can be assumed to not really know what the actual variation is, so in this case we use WMM if available. This can happen for old GPS navigators without an updated WMM table. For certain devices are the only available options to send 0.0 or a manual variation.
Also a heading from some system can read RMC from the GPS and use that variation to create the HDG.
