### PR TITLE
Royal Dutch Lifeboat Association

### DIFF
--- a/include/AIS_Decoder.h
+++ b/include/AIS_Decoder.h
@@ -97,7 +97,8 @@ private:
     
     AIS_Target_Hash *AISTargetList;
     AIS_Target_Hash *AIS_AreaNotice_Sources;
-    AIS_Target_Name_Hash *AISTargetNames;
+    AIS_Target_Name_Hash *AISTargetNamesC;
+    AIS_Target_Name_Hash *AISTargetNamesNC;
 
     bool              m_busy;
     wxTimer           TimerAIS;

--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -967,7 +967,8 @@ AIS_Error AIS_Decoder::Decode( const wxString& str )
                         AIS_Target_Name_Hash::iterator it = AISTargetNames->find( mmsi );
                         if(  it != AISTargetNames->end()  ) {
                         // If we don't have a name yet but have one in the MMSI->ShipName hash, use the one in the hash
-                            wxString ship_name = ( *AISTargetNames )[mmsi];
+                            // Prevent writing more then 20 char, this will give a crash
+                            wxString ship_name = ( *AISTargetNames )[mmsi].Left(20); 
                             strncpy( pTargetData->ShipName, ship_name.mb_str(), ship_name.length() + 1 );
                             pTargetData->b_nameValid = true;
                             pTargetData->b_nameFromCache = true;

--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -1946,7 +1946,20 @@ void AIS_Decoder::UpdateAllTracks( void )
 
 void AIS_Decoder::UpdateOneTrack( AIS_Target_Data *ptarget )
 {
-    if( !ptarget->b_positionOnceValid ) return;
+   if( !ptarget->b_positionOnceValid ) return;
+    // Reject for unbelievable jumps (corrupted/bad data)
+    if ( ptarget->m_ptrack->GetCount() > 0 )
+    {
+        AISTargetTrackPoint *LastTrackpoint =  ptarget->m_ptrack->GetLast()->GetData();
+        if ( fabs( LastTrackpoint->m_lat - ptarget->Lat ) > .1  || fabs( LastTrackpoint->m_lon - ptarget->Lon ) > .1 )
+        {
+            // after an unlikely jump in pos, the last trackpoint might also be wrong
+            // just to be sure we do delete this one as well.
+            ptarget->m_ptrack->pop_back();
+            ptarget->b_positionDoubtful = true;            
+            return;
+        }        
+    }
 
     //    Add the newest point
     AISTargetTrackPoint *ptrackpoint = new AISTargetTrackPoint;

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -220,6 +220,7 @@ extern bool             g_bShowAISName;
 extern int              g_Show_Target_Name_Scale;
 extern bool             g_bWplIsAprsPosition;
 extern bool             g_benableAISNameCache;
+extern bool             g_bUseOnlyConfirmedAISName;
 extern int              g_ScaledNumWeightSOG;
 extern int              g_ScaledNumWeightCPA;
 extern int              g_ScaledNumWeightTCPA;
@@ -852,6 +853,9 @@ int MyConfig::LoadMyConfig()
     //    AIS
     wxString s;
     SetPath( _T ( "/Settings/AIS" ) );
+    
+    g_bUseOnlyConfirmedAISName = false;
+    Read( _T ( "UseOnlyConfirmedAISName" ),  &g_bUseOnlyConfirmedAISName );
 
     Read( _T ( "bNoCPAMax" ), &g_bCPAMax );
 


### PR DESCRIPTION
Recently I came in contact with the Royal Dutch Lifeboat Association(KNRM). The KNRM is running 48 lifeboat station with voluntary crews. Most lifeboat station use OpenCPN to track there boats when in action. For this tracking 10+ base stations do have AIS receivers and the data of this receivers is merged and made available to every station. This leads to a few attention points that don't bother an ordinary user to much.
First the huge number of targets (4000+) also gives a larger number of corrupted messages. Most of the time a corrupted message will be blocked by the nmea checksum being wrong. However the checksum is relative small (255) which means there is a change of 1 : 255 (0.4%) that a corrupted message does have the correct checksum. And wit a lot of data this does happen.
The first problem was an crash of O every now and then. I found it caused by an entry in the mmsitoname.cvs file where shipsname was to long (more then 20 char) due to corruption. The first commit does avoid this.
When tracking the previous bug I found that O is using always the last received shipsname to show, even if this name is corrupted. Therefore I changed the behaviour of the shipname saving by dividing it in confirmed and non-confirmed names. Where a confirmed name means two subsequent messages using the same name. Now O is using the confirmed name if available and otherwise the non-confirmed. By adding 
_[Settings/AIS]
UseOnlyConfirmedAISName=1_
to the config file it is possible to only allow the use of confirmed names. 
This does clear the AIS targetlist nicely from all corrupted data. And the mmsitoname.cvs does stay backwards compatible with older O versions.

With corrupted data not only the name is wrong, but also the position, resulting in a target going all over the world. Normally the next data packet will be OK again and the target is where it should be again. However if you have target-track drawn you also get a track to 'anywhere' and back. Commit no 3 is to stop drawing the track if there is a jump in positions of more then 6 Nm. (Picture above new, under = old)
![screenshot_20181215_153125](https://user-images.githubusercontent.com/2668258/50384080-aba8d700-06bf-11e9-9c04-ac6baaef243d.png)

And the last commit is to make the entry under MMSI Properties VDM->VDO realy work. This is changing the name of the AIVDM sentence into AIVDO recalc the checksum and re-enter it as a new sentence.  At the KNRM the man/woman at the base-station are using this to follow there  boat as if they where onboard.



