### PR TITLE
Adaptation of API level 116

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -462,7 +462,6 @@ class DECL_EXP opencpn_plugin_18 : public opencpn_plugin
 
             virtual bool RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp);
             virtual bool RenderGLOverlay(wxGLContext *pcontext, PlugIn_ViewPort *vp);
-
             virtual void SetPluginMessage(wxString &message_id, wxString &message_body);
             virtual void SetPositionFixEx(PlugIn_Position_Fix_Ex &pfix);
 
@@ -537,7 +536,7 @@ class DECL_EXP opencpn_plugin_116 : public opencpn_plugin_115
 public:
     opencpn_plugin_116(void *pmgr);
     virtual ~opencpn_plugin_116();
-
+    virtual bool RenderGLOverlayMultiCanvas(wxGLContext *pcontext, PlugIn_ViewPort *vp, int max_canvas);
 };
 
 //------------------------------------------------------------------

--- a/include/pluginmanager.h
+++ b/include/pluginmanager.h
@@ -247,7 +247,7 @@ public:
       ArrayOfPlugIns *GetPlugInArray(){ return &plugin_array; }
 
       bool RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &vp);
-      bool RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, const ViewPort &vp);
+      bool RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, const ViewPort &vp, bool render);
       void SendCursorLatLonToAllPlugIns( double lat, double lon);
       void SendViewPortToRequestingPlugIns( ViewPort &vp );
 

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -2175,14 +2175,12 @@ void glChartCanvas::DrawFloatingOverlayObjects( ocpnDC &dc )
             pluginOverlayRender = false;
     }
     
-    if(pluginOverlayRender){
-        g_overlayCanvas = m_pParentCanvas;
-        if( g_pi_manager ) {
-            g_pi_manager->SendViewPortToRequestingPlugIns( vp );
-            g_pi_manager->RenderAllGLCanvasOverlayPlugIns( m_pcontext, vp );
-        }
+    g_overlayCanvas = m_pParentCanvas;
+    if (g_pi_manager) {
+         g_pi_manager->SendViewPortToRequestingPlugIns(vp);
+         g_pi_manager->RenderAllGLCanvasOverlayPlugIns(m_pcontext, vp, pluginOverlayRender);
     }
-
+   
     // all functions called with m_pParentCanvas-> are still slow because they go through ocpndc
     AISDrawAreaNotices( dc, m_pParentCanvas->GetVP(), m_pParentCanvas );
 

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -135,6 +135,7 @@ extern double           g_display_size_mm;
 extern bool             g_bopengl;
 
 extern ChartGroupArray  *g_pGroupArray;
+extern unsigned int     g_canvasConfig;
 
 static const char* const DEFAULT_DATA_DIRS =
     "~/.local/share:/usr/local/share:/usr/share";
@@ -1577,7 +1578,7 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &v
     return true;
 }
 
-bool PlugInManager::RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, const ViewPort &vp)
+bool PlugInManager::RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, const ViewPort &vp, bool render)
 {
     for(unsigned int i = 0; i < plugin_array.GetCount(); i++)
     {
@@ -1593,7 +1594,7 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, cons
                 case 107:
                 {
                     opencpn_plugin_17 *ppi = dynamic_cast<opencpn_plugin_17 *>(pic->m_pplugin);
-                    if(ppi)
+                    if(ppi && render)
                         ppi->RenderGLOverlay(pcontext, &pivp);
                     break;
                 }
@@ -1608,10 +1609,14 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, cons
                 case 115:
                 case 116:    
                 {
-                    opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
-                    if(ppi)
-                        ppi->RenderGLOverlay(pcontext, &pivp);
-                    break;
+                     opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
+                     if (ppi && render)
+                          ppi->RenderGLOverlay(pcontext, &pivp);
+                     opencpn_plugin_116 *ppi116 = dynamic_cast<opencpn_plugin_116 *>(pic->m_pplugin);
+                     if (ppi116) {
+                          ppi116->RenderGLOverlayMultiCanvas(pcontext, &pivp, g_canvasConfig);
+                     }
+                     break;
                 }
                 default:
                     break;
@@ -3921,6 +3926,11 @@ opencpn_plugin_116::opencpn_plugin_116(void *pmgr)
 
 opencpn_plugin_116::~opencpn_plugin_116(void)
 {
+}
+
+bool opencpn_plugin_116::RenderGLOverlayMultiCanvas(wxGLContext *pcontext, PlugIn_ViewPort *vp, int max_canvas)
+{
+     return false;
 }
 
 //          Helper and interface classes


### PR DESCRIPTION
- added virtual bool RenderGLOverlayMultiCanvas(wxGLContext *pcontext, PlugIn_ViewPort *vp, int max_canvas);
Functions like RenderGLOverlay(wxGLContext *pcontext, PlugIn_ViewPort *vp) but is called for all canvasses.
max_canvas == 0 for single canvas, max_canvas > 0 for multi canvas.
