### PR TITLE
Fix two ordering issues in destroy

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -3703,6 +3703,8 @@ void MyFrame::OnCloseWindow( wxCloseEvent& event )
     pthumbwin = NULL;
     
     // Finally ready to destroy the canvases
+    g_focusCanvas = NULL;
+
     // ..For each canvas...
     for(unsigned int i=0 ; i < g_canvasArray.GetCount() ; i++){
         ChartCanvas *cc = g_canvasArray.Item(i);
@@ -3711,7 +3713,7 @@ void MyFrame::OnCloseWindow( wxCloseEvent& event )
     }
         
     g_canvasArray.Clear();
-    g_focusCanvas = NULL;
+
     
     g_pauimgr->UnInit();
     delete g_pauimgr;

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -956,7 +956,12 @@ ChartCanvas::~ChartCanvas()
 #endif        
     }
 #endif
-
+    
+    // Delete the MUI bar, but make sure there is no pointer to it during destroy.
+    // wx tries to deliver events to this canvas during destroy.
+    MUIBar *muiBar = m_muiBar;
+    m_muiBar = 0;
+    delete muiBar;
 }
 
 void ChartCanvas::SetupGlCanvas( )


### PR DESCRIPTION
During destroy of the chart canvas wxWidgets tries to show the MUI bar that was just destroyed.
Reset pointers a little earlier so that this is no longer an issue.