### PR TITLE
Wpsort

### DIFF
--- a/include/routemanagerdialog.h
+++ b/include/routemanagerdialog.h
@@ -62,7 +62,7 @@ class RouteManagerDialog : public wxDialog {
             void RecalculateSize();
             void UpdateRouteListCtrl();     // Rebuild route list
             void UpdateTrkListCtrl();
-            void UpdateWptListCtrl(RoutePoint *rp_select = NULL, bool b_retain_sort = false);
+            void UpdateWptListCtrl(RoutePoint *rp_select = NULL, bool b_retain_sort = true);
             void UpdateLayListCtrl();
             void UpdateWptListCtrlViz();
 

--- a/src/routeprop.cpp
+++ b/src/routeprop.cpp
@@ -513,6 +513,7 @@ RouteProp::RouteProp( wxWindow* parent, wxWindowID id, const wxString& caption, 
 #endif
     
     RecalculateSize();
+    Centre();
 }
 
 void RouteProp::RecalculateSize( void )
@@ -549,8 +550,6 @@ void RouteProp::RecalculateSize( void )
         if(m_wpList->GetItemCount())
             Layout();
     }
-    
-    Centre();
 }
 
 


### PR DESCRIPTION
- prevents (re)centering of Routeproperties dialogue every refresh.
- keeps sort order of waypoints, don't loose the sort order every time you change anything