### PR TITLE
Add multi canvas rendering to API 116

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -467,7 +467,6 @@ class DECL_EXP opencpn_plugin_18 : public opencpn_plugin
 
             virtual bool RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp);
             virtual bool RenderGLOverlay(wxGLContext *pcontext, PlugIn_ViewPort *vp);
-
             virtual void SetPluginMessage(wxString &message_id, wxString &message_body);
             virtual void SetPositionFixEx(PlugIn_Position_Fix_Ex &pfix);
 
@@ -542,7 +541,7 @@ class DECL_EXP opencpn_plugin_116 : public opencpn_plugin_115
 public:
     opencpn_plugin_116(void *pmgr);
     virtual ~opencpn_plugin_116();
-
+    virtual bool RenderGLOverlayMultiCanvas(wxGLContext *pcontext, PlugIn_ViewPort *vp, int max_canvas);
 };
 
 //------------------------------------------------------------------

--- a/include/pluginmanager.h
+++ b/include/pluginmanager.h
@@ -247,7 +247,7 @@ public:
       ArrayOfPlugIns *GetPlugInArray(){ return &plugin_array; }
 
       bool RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &vp);
-      bool RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, const ViewPort &vp);
+      bool RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, const ViewPort &vp, bool render);
       void SendCursorLatLonToAllPlugIns( double lat, double lon);
       void SendViewPortToRequestingPlugIns( ViewPort &vp );
 

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -2182,14 +2182,12 @@ void glChartCanvas::DrawFloatingOverlayObjects( ocpnDC &dc )
             pluginOverlayRender = false;
     }
     
-    if(pluginOverlayRender){
-        g_overlayCanvas = m_pParentCanvas;
-        if( g_pi_manager ) {
-            g_pi_manager->SendViewPortToRequestingPlugIns( vp );
-            g_pi_manager->RenderAllGLCanvasOverlayPlugIns( m_pcontext, vp );
-        }
+    g_overlayCanvas = m_pParentCanvas;
+    if (g_pi_manager) {
+         g_pi_manager->SendViewPortToRequestingPlugIns(vp);
+         g_pi_manager->RenderAllGLCanvasOverlayPlugIns(m_pcontext, vp, pluginOverlayRender);
     }
-
+   
     // all functions called with m_pParentCanvas-> are still slow because they go through ocpndc
     AISDrawAreaNotices( dc, m_pParentCanvas->GetVP(), m_pParentCanvas );
 
@@ -3830,6 +3828,7 @@ void glChartCanvas::Render()
     
      //  Some older MSW OpenGL drivers are generally very unstable.
      //  This helps...   
+
     if(g_b_needFinish)
         glFinish();
     

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -135,6 +135,7 @@ extern double           g_display_size_mm;
 extern bool             g_bopengl;
 
 extern ChartGroupArray  *g_pGroupArray;
+extern unsigned int     g_canvasConfig;
 
 #ifdef __WXMSW__
 static const char PATH_SEP = ';';
@@ -1583,7 +1584,7 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &v
     return true;
 }
 
-bool PlugInManager::RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, const ViewPort &vp)
+bool PlugInManager::RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, const ViewPort &vp, bool render)
 {
     for(unsigned int i = 0; i < plugin_array.GetCount(); i++)
     {
@@ -1599,7 +1600,7 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, cons
                 case 107:
                 {
                     opencpn_plugin_17 *ppi = dynamic_cast<opencpn_plugin_17 *>(pic->m_pplugin);
-                    if(ppi)
+                    if(ppi && render)
                         ppi->RenderGLOverlay(pcontext, &pivp);
                     break;
                 }
@@ -1614,10 +1615,14 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, cons
                 case 115:
                 case 116:    
                 {
-                    opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
-                    if(ppi)
-                        ppi->RenderGLOverlay(pcontext, &pivp);
-                    break;
+                     opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
+                     if (ppi && render)
+                          ppi->RenderGLOverlay(pcontext, &pivp);
+                     opencpn_plugin_116 *ppi116 = dynamic_cast<opencpn_plugin_116 *>(pic->m_pplugin);
+                     if (ppi116) {
+                          ppi116->RenderGLOverlayMultiCanvas(pcontext, &pivp, g_canvasConfig);
+                     }
+                     break;
                 }
                 default:
                     break;
@@ -3927,6 +3932,11 @@ opencpn_plugin_116::opencpn_plugin_116(void *pmgr)
 
 opencpn_plugin_116::~opencpn_plugin_116(void)
 {
+}
+
+bool opencpn_plugin_116::RenderGLOverlayMultiCanvas(wxGLContext *pcontext, PlugIn_ViewPort *vp, int max_canvas)
+{
+     return false;
 }
 
 //          Helper and interface classes


### PR DESCRIPTION
Add virtual bool RenderGLOverlayMultiCanvas(wxGLContext *pcontext, PlugIn_ViewPort *vp, int max_canvas);
Required for radar_pi to display radar overlay in both canvasses