### PR TITLE
AIS target list dialog, save columns order

### DIFF
--- a/src/AISTargetListDialog.cpp
+++ b/src/AISTargetListDialog.cpp
@@ -614,7 +614,10 @@ void AISTargetListDialog::CreateControls()
         a_order[i] = l_order;
         s_order= tkz_order.GetNextToken();
     }
+
+#ifdef wxHAS_LISTCTRL_COLUMN_ORDER 
     m_pListCtrlAISTargets->SetColumnsOrder(a_order);
+#endif
 
     topSizer->Add( m_pListCtrlAISTargets, 1, wxEXPAND | wxALL, 0 );
     

--- a/src/AISTargetListDialog.cpp
+++ b/src/AISTargetListDialog.cpp
@@ -600,7 +600,8 @@ void AISTargetListDialog::CreateControls()
     item.SetImage( g_bAisTargetList_sortReverse ? 1 : 0 );
     g_AisTargetList_sortColumn = wxMax(g_AisTargetList_sortColumn, 0);
     m_pListCtrlAISTargets->SetColumn( g_AisTargetList_sortColumn, item );
-    
+
+#ifdef wxHAS_LISTCTRL_COLUMN_ORDER 
     wxStringTokenizer tkz_order(g_AisTargetList_column_order, _T(";"));
     wxString s_order = tkz_order.GetNextToken();
     int i_columns = m_pListCtrlAISTargets->GetColumnCount();
@@ -615,7 +616,6 @@ void AISTargetListDialog::CreateControls()
         s_order= tkz_order.GetNextToken();
     }
 
-#ifdef wxHAS_LISTCTRL_COLUMN_ORDER 
     m_pListCtrlAISTargets->SetColumnsOrder(a_order);
 #endif
 

--- a/src/AISTargetListDialog.cpp
+++ b/src/AISTargetListDialog.cpp
@@ -46,6 +46,7 @@ extern bool g_bAisTargetList_sortReverse;
 extern bool g_bAisTargetList_autosort;
 extern int g_AisTargetList_sortColumn;
 extern wxString g_AisTargetList_column_spec;
+extern wxString g_AisTargetList_column_order;
 extern ocpnStyle::StyleManager* g_StyleManager;
 extern int g_AisTargetList_range;
 extern wxString g_AisTargetList_perspective;
@@ -600,6 +601,21 @@ void AISTargetListDialog::CreateControls()
     g_AisTargetList_sortColumn = wxMax(g_AisTargetList_sortColumn, 0);
     m_pListCtrlAISTargets->SetColumn( g_AisTargetList_sortColumn, item );
     
+    wxStringTokenizer tkz_order(g_AisTargetList_column_order, _T(";"));
+    wxString s_order = tkz_order.GetNextToken();
+    int i_columns = m_pListCtrlAISTargets->GetColumnCount();
+    wxArrayInt a_order(i_columns);    
+    for (int i = 0; i < i_columns; i++) {
+        long l_order=(long)i;
+        s_order.ToLong(&l_order);
+        if (l_order<0 || l_order>i_columns) {
+            l_order = i;
+        }
+        a_order[i] = l_order;
+        s_order= tkz_order.GetNextToken();
+    }
+    m_pListCtrlAISTargets->SetColumnsOrder(a_order);
+
     topSizer->Add( m_pListCtrlAISTargets, 1, wxEXPAND | wxALL, 0 );
     
     wxBoxSizer* boxSizer02 = new wxBoxSizer( wxVERTICAL );

--- a/src/ConfigMgr.cpp
+++ b/src/ConfigMgr.cpp
@@ -210,6 +210,7 @@ extern int              g_AisTargetList_range;
 extern int              g_AisTargetList_sortColumn;
 extern bool             g_bAisTargetList_sortReverse;
 extern wxString         g_AisTargetList_column_spec;
+extern wxString         g_AisTargetList_column_order;
 extern bool             g_bShowAreaNotices;
 extern bool             g_bDrawAISSize;
 extern bool             g_bShowAISName;
@@ -1221,6 +1222,7 @@ bool ConfigMgr::SaveTemplate( wxString fileName)
     conf->Write( _T ( "AISTargetListSortColumn" ), g_AisTargetList_sortColumn );
     conf->Write( _T ( "bAISTargetListSortReverse" ), g_bAisTargetList_sortReverse );
     conf->Write( _T ( "AISTargetListColumnSpec" ), g_AisTargetList_column_spec );
+    conf->Write( _T ("AISTargetListColumnOrder"), g_AisTargetList_column_order);
     conf->Write( _T ( "S57QueryDialogSizeX" ), g_S57_dialog_sx );
     conf->Write( _T ( "S57QueryDialogSizeY" ), g_S57_dialog_sy );
     conf->Write( _T ( "bAISRolloverShowClass" ), g_bAISRolloverShowClass );
@@ -1650,6 +1652,7 @@ bool ConfigMgr::CheckTemplate( wxString fileName)
     CHECK_INT( _T ( "AISTargetListSortColumn" ), &g_AisTargetList_sortColumn );
     CHECK_INT( _T ( "bAISTargetListSortReverse" ), &g_bAisTargetList_sortReverse );
     CHECK_STR( _T ( "AISTargetListColumnSpec" ), g_AisTargetList_column_spec );
+    CHECK_STR( _T ("AISTargetListColumnOrder"), g_AisTargetList_column_order);
     CHECK_INT( _T ( "bAISRolloverShowClass" ), &g_bAISRolloverShowClass );
     CHECK_INT( _T ( "bAISRolloverShowCOG" ), &g_bAISRolloverShowCOG );
     CHECK_INT( _T ( "bAISRolloverShowCPA" ), &g_bAISRolloverShowCPA );

--- a/src/OCPNListCtrl.cpp
+++ b/src/OCPNListCtrl.cpp
@@ -26,6 +26,7 @@
 #include "AIS_Target_Data.h"
 
 extern wxString g_AisTargetList_column_spec;
+extern wxString g_AisTargetList_column_order;
 extern bool bGPSValid;
 
 OCPNListCtrl::OCPNListCtrl( AISTargetListDialog* parent, wxWindowID id, const wxPoint& pos,
@@ -44,6 +45,16 @@ OCPNListCtrl::~OCPNListCtrl()
         wxString sitem;
         sitem.Printf( _T("%d;"), item.m_width );
         g_AisTargetList_column_spec += sitem;
+    }
+
+    int i_columns = GetColumnCount();
+    wxArrayInt a_order(i_columns);
+    a_order = GetColumnsOrder();
+    g_AisTargetList_column_order.Clear();
+    for (int i = 0; i < i_columns; i++) {
+        wxString sitem;
+        sitem.Printf(_T("%d;"), a_order[i]);
+        g_AisTargetList_column_order += sitem;
     }
 }
 

--- a/src/OCPNListCtrl.cpp
+++ b/src/OCPNListCtrl.cpp
@@ -47,6 +47,7 @@ OCPNListCtrl::~OCPNListCtrl()
         g_AisTargetList_column_spec += sitem;
     }
 
+#ifdef wxHAS_LISTCTRL_COLUMN_ORDER 
     int i_columns = GetColumnCount();
     wxArrayInt a_order(i_columns);
     a_order = GetColumnsOrder();
@@ -56,6 +57,7 @@ OCPNListCtrl::~OCPNListCtrl()
         sitem.Printf(_T("%d;"), a_order[i]);
         g_AisTargetList_column_order += sitem;
     }
+#endif
 }
 
 wxString OCPNListCtrl::OnGetItemText( long item, long column ) const

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -664,6 +664,7 @@ int                       g_AisTargetList_range;
 int                       g_AisTargetList_sortColumn;
 bool                      g_bAisTargetList_sortReverse;
 wxString                  g_AisTargetList_column_spec;
+wxString                  g_AisTargetList_column_order;
 int                       g_AisTargetList_count;
 bool                      g_bAisTargetList_autosort;
 

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -3617,14 +3617,11 @@ void MyFrame::OnCloseWindow( wxCloseEvent& event )
     TrackOff();
 
     if( g_MainToolbar ) {
-        wxPoint tbp_incanvas = GetPrimaryCanvas()->GetToolbarPosition();        
+        wxPoint tbp_incanvas = GetPrimaryCanvas()->GetToolbarPosition();
         g_maintoolbar_x = tbp_incanvas.x;
         g_maintoolbar_y = tbp_incanvas.y;
         g_maintoolbar_orient = GetPrimaryCanvas()->GetToolbarOrientation();
         //g_toolbarConfig = GetPrimaryCanvas()->GetToolbarConfigString();
-        if (g_MainToolbar) {
-            g_MainToolbar->GetScreenPosition(&g_maintoolbar_x, &g_maintoolbar_y);
-        }
     }
 
     if(g_iENCToolbar){
@@ -9681,7 +9678,7 @@ void MyFrame::RequestNewMasterToolbar(bool bforcenew)
         g_MainToolbar->EnableRolloverBitmaps( false );
         
         g_MainToolbar->CreateConfigMenu();
-        g_MainToolbar->MoveDialogInScreenCoords(wxPoint(g_maintoolbar_x, g_maintoolbar_y), wxPoint(0, 0));
+
         g_bmasterToolbarFull = true;
         
     }

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -3617,11 +3617,14 @@ void MyFrame::OnCloseWindow( wxCloseEvent& event )
     TrackOff();
 
     if( g_MainToolbar ) {
-        wxPoint tbp_incanvas = GetPrimaryCanvas()->GetToolbarPosition();
+        wxPoint tbp_incanvas = GetPrimaryCanvas()->GetToolbarPosition();        
         g_maintoolbar_x = tbp_incanvas.x;
         g_maintoolbar_y = tbp_incanvas.y;
         g_maintoolbar_orient = GetPrimaryCanvas()->GetToolbarOrientation();
         //g_toolbarConfig = GetPrimaryCanvas()->GetToolbarConfigString();
+        if (g_MainToolbar) {
+            g_MainToolbar->GetScreenPosition(&g_maintoolbar_x, &g_maintoolbar_y);
+        }
     }
 
     if(g_iENCToolbar){
@@ -9678,7 +9681,7 @@ void MyFrame::RequestNewMasterToolbar(bool bforcenew)
         g_MainToolbar->EnableRolloverBitmaps( false );
         
         g_MainToolbar->CreateConfigMenu();
-
+        g_MainToolbar->MoveDialogInScreenCoords(wxPoint(g_maintoolbar_x, g_maintoolbar_y), wxPoint(0, 0));
         g_bmasterToolbarFull = true;
         
     }

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -2310,8 +2310,8 @@ void MyConfig::UpdateSettings()
     Write( _T ( "AnchorWatch1GUID" ), g_AW1GUID );
     Write( _T ( "AnchorWatch2GUID" ), g_AW2GUID );
 
-    //Write( _T ( "ToolbarX" ), g_maintoolbar_x );
-    //Write( _T ( "ToolbarY" ), g_maintoolbar_y );
+    Write( _T ( "ToolbarX" ), g_maintoolbar_x );
+    Write( _T ( "ToolbarY" ), g_maintoolbar_y );
     //Write( _T ( "ToolbarOrient" ), g_maintoolbar_orient );
 
     Write( _T ( "iENCToolbarX" ), g_iENCToolbarPosX );

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -220,6 +220,7 @@ extern int              g_AisTargetList_range;
 extern int              g_AisTargetList_sortColumn;
 extern bool             g_bAisTargetList_sortReverse;
 extern wxString         g_AisTargetList_column_spec;
+extern wxString         g_AisTargetList_column_order;
 extern bool             g_bShowAreaNotices;
 extern bool             g_bDrawAISSize;
 extern bool             g_bShowAISName;
@@ -1089,6 +1090,7 @@ int MyConfig::LoadMyConfigRaw( bool bAsTemplate )
     Read( _T ( "AISTargetListSortColumn" ), &g_AisTargetList_sortColumn );
     Read( _T ( "bAISTargetListSortReverse" ), &g_bAisTargetList_sortReverse );
     Read( _T ( "AISTargetListColumnSpec" ), &g_AisTargetList_column_spec );
+    Read( _T ("AISTargetListColumnOrder"), &g_AisTargetList_column_order);
 
     Read( _T ( "bAISRolloverShowClass" ), &g_bAISRolloverShowClass );
     Read( _T ( "bAISRolloverShowCOG" ), &g_bAISRolloverShowCOG );
@@ -2471,6 +2473,7 @@ void MyConfig::UpdateSettings()
     Write( _T ( "AISTargetListSortColumn" ), g_AisTargetList_sortColumn );
     Write( _T ( "bAISTargetListSortReverse" ), g_bAisTargetList_sortReverse );
     Write( _T ( "AISTargetListColumnSpec" ), g_AisTargetList_column_spec );
+    Write( _T ("AISTargetListColumnOrder"), g_AisTargetList_column_order);
 
     Write( _T ( "S57QueryDialogSizeX" ), g_S57_dialog_sx );
     Write( _T ( "S57QueryDialogSizeY" ), g_S57_dialog_sy );

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -2310,8 +2310,8 @@ void MyConfig::UpdateSettings()
     Write( _T ( "AnchorWatch1GUID" ), g_AW1GUID );
     Write( _T ( "AnchorWatch2GUID" ), g_AW2GUID );
 
-    Write( _T ( "ToolbarX" ), g_maintoolbar_x );
-    Write( _T ( "ToolbarY" ), g_maintoolbar_y );
+    //Write( _T ( "ToolbarX" ), g_maintoolbar_x );
+    //Write( _T ( "ToolbarY" ), g_maintoolbar_y );
     //Write( _T ( "ToolbarOrient" ), g_maintoolbar_orient );
 
     Write( _T ( "iENCToolbarX" ), g_iENCToolbarPosX );

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -2405,35 +2405,6 @@ void ocpnToolBarSimple::OnMouseEvent( wxMouseEvent & event )
         return;
     }
 
-    if (tool->GetId() == ID_MASTERTOGGLE) {
-        static wxPoint s_pos_m_old;
-        static bool s_drag;
-
-        wxPoint pos_m = ClientToScreen(wxPoint(x, y));
-        if (event.LeftDown()) {
-            s_pos_m_old = pos_m;
-        }
-
-        if (event.Dragging()) {
-            s_drag = true;
-            wxPoint pos_old = GetScreenPosition();
-            wxPoint pos_new = pos_old;
-
-            pos_new.x += pos_m.x - s_pos_m_old.x;
-            pos_new.y += pos_m.y - s_pos_m_old.y;
-
-            ocpnFloatingToolbarDialog *parentFloatingToolBar = dynamic_cast<ocpnFloatingToolbarDialog*>(GetParent());
-            parentFloatingToolBar->MoveDialogInScreenCoords(pos_new, pos_old);
-            s_pos_m_old = pos_m;
-            return;
-        }
-
-        if (event.LeftUp() && s_drag) {
-            s_drag = false;
-            return;
-        }
-    }
-
     if( !event.IsButton() ) {
         if( tool->GetId() != m_currentTool ) {
             // If the left button is kept down and moved over buttons,

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -2405,6 +2405,35 @@ void ocpnToolBarSimple::OnMouseEvent( wxMouseEvent & event )
         return;
     }
 
+    if (tool->GetId() == ID_MASTERTOGGLE) {
+        static wxPoint s_pos_m_old;
+        static bool s_drag;
+
+        wxPoint pos_m = ClientToScreen(wxPoint(x, y));
+        if (event.LeftDown()) {
+            s_pos_m_old = pos_m;
+        }
+
+        if (event.Dragging()) {
+            s_drag = true;
+            wxPoint pos_old = GetScreenPosition();
+            wxPoint pos_new = pos_old;
+
+            pos_new.x += pos_m.x - s_pos_m_old.x;
+            pos_new.y += pos_m.y - s_pos_m_old.y;
+
+            ocpnFloatingToolbarDialog *parentFloatingToolBar = dynamic_cast<ocpnFloatingToolbarDialog*>(GetParent());
+            parentFloatingToolBar->MoveDialogInScreenCoords(pos_new, pos_old);
+            s_pos_m_old = pos_m;
+            return;
+        }
+
+        if (event.LeftUp() && s_drag) {
+            s_drag = false;
+            return;
+        }
+    }
+
     if( !event.IsButton() ) {
         if( tool->GetId() != m_currentTool ) {
             // If the left button is kept down and moved over buttons,


### PR DESCRIPTION
The column order, in the AIS target list dialog, will now be saved and reloaded in the same way as the column width.