### PR TITLE
MUI move the main toolbar.

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -3623,6 +3623,9 @@ void MyFrame::OnCloseWindow( wxCloseEvent& event )
         g_maintoolbar_y = tbp_incanvas.y;
         g_maintoolbar_orient = GetPrimaryCanvas()->GetToolbarOrientation();
         //g_toolbarConfig = GetPrimaryCanvas()->GetToolbarConfigString();
+        if (g_MainToolbar) {
+            g_MainToolbar->GetScreenPosition(&g_maintoolbar_x, &g_maintoolbar_y);
+        }
     }
 
     if(g_iENCToolbar){
@@ -9679,7 +9682,7 @@ void MyFrame::RequestNewMasterToolbar(bool bforcenew)
         g_MainToolbar->EnableRolloverBitmaps( false );
         
         g_MainToolbar->CreateConfigMenu();
-
+        g_MainToolbar->MoveDialogInScreenCoords(wxPoint(g_maintoolbar_x, g_maintoolbar_y), wxPoint(0, 0));
         g_bmasterToolbarFull = true;
         
     }

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -2321,8 +2321,8 @@ void MyConfig::UpdateSettings()
     Write( _T ( "AnchorWatch1GUID" ), g_AW1GUID );
     Write( _T ( "AnchorWatch2GUID" ), g_AW2GUID );
 
-    //Write( _T ( "ToolbarX" ), g_maintoolbar_x );
-    //Write( _T ( "ToolbarY" ), g_maintoolbar_y );
+    Write( _T ( "ToolbarX" ), g_maintoolbar_x );
+    Write( _T ( "ToolbarY" ), g_maintoolbar_y );
     //Write( _T ( "ToolbarOrient" ), g_maintoolbar_orient );
 
     Write( _T ( "iENCToolbarX" ), g_iENCToolbarPosX );

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -2405,6 +2405,36 @@ void ocpnToolBarSimple::OnMouseEvent( wxMouseEvent & event )
         return;
     }
 
+    if (tool->GetId() == ID_MASTERTOGGLE) {
+        static wxPoint s_pos_m_old;
+        static bool s_drag;
+        
+        wxPoint pos_m = ClientToScreen(wxPoint(x, y));
+        if (event.LeftDown()) {
+            s_pos_m_old = pos_m;
+            
+        }
+        
+        if (event.Dragging()) {
+            s_drag = true;
+            wxPoint pos_old = GetScreenPosition();
+            wxPoint pos_new = pos_old;
+            
+            pos_new.x += pos_m.x - s_pos_m_old.x;
+            pos_new.y += pos_m.y - s_pos_m_old.y;
+            
+            ocpnFloatingToolbarDialog * parentFloatingToolBar = dynamic_cast<ocpnFloatingToolbarDialog*>(GetParent());
+            parentFloatingToolBar->MoveDialogInScreenCoords(pos_new, pos_old);
+            s_pos_m_old = pos_m;
+            return;            
+        }
+        
+        if (event.LeftUp() && s_drag) {
+            s_drag = false;
+            return;    
+        }
+    }
+    
     if( !event.IsButton() ) {
         if( tool->GetId() != m_currentTool ) {
             // If the left button is kept down and moved over buttons,


### PR DESCRIPTION
I do not know the intention of the new MUI – so maybe this is a bad idea? 
However, I think it is handy and it will de-clutter my screen if it is possible to move the main toolbar. Added possibility to move the toolbar by dragging it. To keep the new layout it is without the GrabberWin by simply dragging in topmost part of the toolbar win.
