### PR TITLE
Handle case where configuration Settings/Locale is empty for MSW build

### DIFF
--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -690,15 +690,20 @@ wxString OCPNPlatform::GetAdjustedAppLocale()
     //  user's selected install language.
     //  If so, override the config file value and use this selection for opencpn...
     #if defined(__WXMSW__)
-    if( g_bFirstRun ) {
+    if ( g_bFirstRun || wxIsEmpty(adjLocale) ) {
         wxRegKey RegKey( wxString( _T("HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenCPN") ) );
         if( RegKey.Exists() ) {
             wxLogMessage( _("Retrieving initial language selection from Windows Registry") );
             RegKey.QueryValue( wxString( _T("InstallerLanguage") ), adjLocale );
         }
     }
+    if (wxIsEmpty(adjLocale)) {
+        if (g_localeOverride.Length())
+            adjLocale = g_localeOverride;
+        else
+           adjLocale = GetDefaultSystemLocale();
+    }
     #endif
-    
     #if defined(__OCPN__ANDROID__)
     if(g_localeOverride.Length())
         adjLocale = g_localeOverride;
@@ -706,7 +711,7 @@ wxString OCPNPlatform::GetAdjustedAppLocale()
         adjLocale = GetDefaultSystemLocale();
     #endif
         
-        return adjLocale;
+    return adjLocale;
 }
 
 


### PR DESCRIPTION
In testing latest master I found it is possible for gLocale to be blank in config file. In the Windows build it remains blank so makes UI difficult to use.