### PR TITLE
Set Focus on the canvas when right mouse button is clicked.

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -8324,6 +8324,7 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
     }           // left up
     
     if( event.RightDown() ) {
+        SetFocus();           //  This is to let a plugin know which canvas is right-clicked
         last_drag.x = mx;
         last_drag.y = my;
         


### PR DESCRIPTION
This way a plugin can get the canvas clicked with PluginGetFocusCanvas()

Currently a right button click does not set focus. Therefore the plugin is ignorant of the canvas on which the context menu is clicked. Normally windows applications do set focus with a right button mouse click