### PR TITLE
Implement centrally configured selection radius

### DIFF
--- a/include/OCPNPlatform.h
+++ b/include/OCPNPlatform.h
@@ -99,6 +99,7 @@ public:
     double GetDisplaySizeMM();
     void SetDisplaySizeMM( double size );
     double GetDisplayDPmm();
+    unsigned int GetSelectRadiusPix();
     double GetToolbarScaleFactor( int GUIScaleFactor );
     double GetCompassScaleFactor( int GUIScaleFactor );
     void onStagedResizeFinal();

--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -209,6 +209,9 @@ extern double                    g_display_size_mm;
 extern double                    g_config_display_size_mm;
 extern bool                      g_config_display_size_manual;
 
+extern float                     g_selection_radius_mm;
+extern float                     g_selection_radius_touch_mm;
+
 extern bool                     g_bTrackDaily;
 extern double                   g_PlanSpeed;
 extern bool                     g_bFullScreenQuilt;
@@ -1659,6 +1662,11 @@ double OCPNPlatform::GetDisplayDPmm()
     double r = getDisplaySize().x;            // dots
     return r / GetDisplaySizeMM();
 #endif    
+}
+                    
+unsigned int OCPNPlatform::GetSelectRadiusPix()
+{
+    return GetDisplayDPmm() * (g_btouch ? g_selection_radius_touch_mm : g_selection_radius_mm);
 }
 
 void OCPNPlatform::onStagedResizeFinal()

--- a/src/Select.cpp
+++ b/src/Select.cpp
@@ -30,18 +30,15 @@
 #include "Track.h"
 #include "routeman.h"
 #include "Route.h"
+#include "OCPNPlatform.h"
 
 extern Routeman    *g_pRouteMan;
+extern OCPNPlatform *g_Platform;
 
 Select::Select()
 {
     pSelectList = new SelectableItemList;
-    pixelRadius = 8;
-    int w,h;
-    wxDisplaySize( &w, &h );
-    if( h > 800 ) pixelRadius = 10;
-    if( h > 1024 ) pixelRadius = 12;
-    
+    pixelRadius = g_Platform->GetSelectRadiusPix();
 }
 
 Select::~Select()

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -375,6 +375,8 @@ int                       g_lastClientRecth;
 double                    g_display_size_mm;
 double                    g_config_display_size_mm;
 bool                      g_config_display_size_manual;
+float                     g_selection_radius_mm = 2.0;
+float                     g_selection_radius_touch_mm = 10.0;
 
 int                       g_GUIScaleFactor;
 int                       g_ChartScaleFactor;

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -6804,17 +6804,6 @@ bool ChartCanvas::MouseEventSetup( wxMouseEvent& event,  bool b_handle_dclick )
 //  Retrigger the cursor tracking timer
     pCurTrackTimer->Start( m_curtrack_timer_msec, wxTIMER_ONE_SHOT );
 
-
-/*    
-    //    Calculate meaningful SelectRadius
-    float SelectRadius;
-    int sel_rad_pix = 8;
-    if(g_btouch)
-        sel_rad_pix = 50;
-
-    SelectRadius = sel_rad_pix / ( m_true_scale_ppm * 1852 * 60 );  // Degrees, approximately
-*/
-
 //      Show cursor position on Status Bar, if present
 //      except for GTK, under which status bar updates are very slow
 //      due to Update() call.
@@ -7219,9 +7208,7 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
     
     //    Calculate meaningful SelectRadius
     float SelectRadius;
-    int sel_rad_pix = 8;
-    if(g_btouch) sel_rad_pix = 50;
-    SelectRadius = sel_rad_pix / ( m_true_scale_ppm * 1852 * 60 );  // Degrees, approximately
+    SelectRadius = g_Platform->GetSelectRadiusPix() / ( m_true_scale_ppm * 1852 * 60 );  // Degrees, approximately
 
 ///
     // We start with Double Click processing. The first left click just starts a timer and
@@ -7382,8 +7369,7 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
                 RoutePoint *pMousePoint = NULL;
                 
                 //    Calculate meaningful SelectRadius
-                int nearby_sel_rad_pix = 8;
-                double nearby_radius_meters = nearby_sel_rad_pix / m_true_scale_ppm;
+                double nearby_radius_meters = g_Platform->GetSelectRadiusPix() / m_true_scale_ppm;
                 
                 RoutePoint *pNearbyPoint = pWayPointMan->GetNearbyWaypoint( rlat, rlon,
                                                                             nearby_radius_meters );
@@ -7854,8 +7840,7 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
                 RoutePoint *pMousePoint = NULL;
                 
                 //    Calculate meaningful SelectRadius
-                int nearby_sel_rad_pix = 8;
-                double nearby_radius_meters = nearby_sel_rad_pix / m_true_scale_ppm;
+                double nearby_radius_meters = g_Platform->GetSelectRadiusPix() / m_true_scale_ppm;
                 
                 RoutePoint *pNearbyPoint = pWayPointMan->GetNearbyWaypoint( rlat, rlon,
                                                                             nearby_radius_meters );
@@ -8813,8 +8798,7 @@ void pupHandler_PasteWaypoint() {
     RoutePoint* pasted = kml.GetParsedRoutePoint();
     if( ! pasted ) return;
 
-    int nearby_sel_rad_pix = 8;
-    double nearby_radius_meters = nearby_sel_rad_pix / gFrame->GetPrimaryCanvas()->GetCanvasTrueScale();
+    double nearby_radius_meters = g_Platform->GetSelectRadiusPix() / gFrame->GetPrimaryCanvas()->GetCanvasTrueScale();
 
     RoutePoint *nearPoint = pWayPointMan->GetNearbyWaypoint( pasted->m_lat, pasted->m_lon,
                                nearby_radius_meters );
@@ -8853,8 +8837,7 @@ void pupHandler_PasteRoute() {
     Route* pasted = kml.GetParsedRoute();
     if( ! pasted ) return;
 
-    int nearby_sel_rad_pix = 8;
-    double nearby_radius_meters = nearby_sel_rad_pix / gFrame->GetPrimaryCanvas()->GetCanvasTrueScale();
+    double nearby_radius_meters = g_Platform->GetSelectRadiusPix() / gFrame->GetPrimaryCanvas()->GetCanvasTrueScale();
 
     RoutePoint* curPoint;
     RoutePoint* nearPoint;
@@ -10390,6 +10373,8 @@ bool ChartCanvas::SetCursor( const wxCursor &c )
 
 void ChartCanvas::Refresh( bool eraseBackground, const wxRect *rect )
 {
+    if( g_bquiting )
+        return;
     //  Keep the mouse position members up to date
     GetCanvasPixPoint( mouse_x, mouse_y, m_cursor_lat, m_cursor_lon );
 

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -404,6 +404,9 @@ extern double           g_display_size_mm;
 extern double           g_config_display_size_mm;
 extern bool             g_config_display_size_manual;
 
+extern float            g_selection_radius_mm;
+extern float            g_selection_radius_touch_mm;
+
 extern bool             g_benable_rotate;
 extern bool             g_bEmailCrashReport;
 
@@ -703,6 +706,9 @@ int MyConfig::LoadMyConfig()
         if( g_navobjbackups > 99 ) g_navobjbackups = 99;
         if( g_navobjbackups < 0 ) g_navobjbackups = 0;
         g_n_arrival_circle_radius = wxClip(g_n_arrival_circle_radius, 0.001, 0.6);
+        
+        g_selection_radius_mm = wxMax(g_selection_radius_mm, 0.5);
+        g_selection_radius_touch_mm = wxMax(g_selection_radius_touch_mm, 1.0);
 
         g_Show_Target_Name_Scale = wxMax( 5000, g_Show_Target_Name_Scale );
 
@@ -789,6 +795,9 @@ int MyConfig::LoadMyConfigRaw( bool bAsTemplate )
     
     int size_mm = -1;
     Read( _T ( "DisplaySizeMM" ), &size_mm );
+    
+    Read( _T ( "SelectionRadiusMM" ), &g_selection_radius_mm);
+    Read( _T ( "SelectionRadiusTouchMM" ), &g_selection_radius_touch_mm);
     
     if(!bAsTemplate){
         if(size_mm > 0){
@@ -2350,6 +2359,9 @@ void MyConfig::UpdateSettings()
     
     Write( _T ( "DisplaySizeMM" ), g_config_display_size_mm );
     Write( _T ( "DisplaySizeManual" ), g_config_display_size_manual );
+    
+    Write( _T ( "SelectionRadiusMM" ), g_selection_radius_mm );
+    Write( _T ( "SelectionRadiusTouchMM" ), g_selection_radius_touch_mm );
     
     wxString st0;
     st0.Printf( _T ( "%g" ), g_PlanSpeed );


### PR DESCRIPTION
- defined in mm instead of pixels (Should work better on HiDPI displays)
- Can be user configured in the config file
- Defaults to 2mm for normal UI, 10 for touch