### PR TITLE
Provide API call for plugins to determine if OCPN is shutting down

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -1276,6 +1276,8 @@ extern DECL_EXP void PlugInHandleAutopilotRoute(bool enable);
  */
 extern DECL_EXP wxString GetPluginDataDir(const char* plugin_name);
 
+extern DECL_EXP bool ShuttingDown( void );
+
 //  Support for MUI MultiCanvas model
 
 extern DECL_EXP wxWindow* PluginGetFocusCanvas();

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -153,6 +153,7 @@ unsigned int      gs_plib_flags;
 wxString          g_lastPluginMessage;
 extern ChartCanvas      *g_focusCanvas;
 extern ChartCanvas      *g_overlayCanvas;
+extern bool       g_bquiting;
 
 enum
 {
@@ -6773,4 +6774,9 @@ void CanvasJumpToPosition( wxWindow *canvas, double lat, double lon, double scal
     if(oCanvas)
         gFrame->JumpToPosition( oCanvas, lat, lon, scale);
 
+}
+
+bool ShuttingDown( void )
+{
+    return g_bquiting;
 }


### PR DESCRIPTION
This change to the API allows a plugin to determine if OCPN is closing down, by effectively exposing the state of g_bquitting which is used by OCPN internally. Currently a plugin only knows it has to 'deactivate' but not why. For inter plugin communications it allows sensible decisions on how to react, i.e. if user deactivated plugin then a warning message about the impact on other plugins can be issued, but if the system is shutting down then there should be no message. This also impacts information saved into the conf/ini file as there is a difference between the two reasons for deactivation.

I have come across this issue with the integration of Squiddio and OD where OD is providing the POI for Squiddio. If the user deactivates OD then the system needs to revert to OCPN Waypoints, but if the system is closing down then OD needs to remain as the provider of POI. 