### PR TITLE
Mousecanvas

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -1305,4 +1305,6 @@ extern DECL_EXP std::unique_ptr<PlugIn_Waypoint> GetWaypoint_Plugin( const wxStr
 extern DECL_EXP std::unique_ptr<PlugIn_Route> GetRoute_Plugin( const wxString& );
 extern DECL_EXP std::unique_ptr<PlugIn_Track> GetTrack_Plugin( const wxString& );
 
+extern DECL_EXP wxWindow* GetCanvasUnderMouse( );
+
 #endif //_PLUGIN_H_

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -156,6 +156,8 @@ extern ChartCanvas      *g_focusCanvas;
 extern ChartCanvas      *g_overlayCanvas;
 extern bool       g_bquiting;
 
+extern MyFrame    *gFrame;
+
 enum
 {
     CurlThreadId = wxID_HIGHEST+1
@@ -6772,4 +6774,9 @@ void CanvasJumpToPosition( wxWindow *canvas, double lat, double lon, double scal
 bool ShuttingDown( void )
 {
     return g_bquiting;
+}
+
+wxWindow* PluginGetCanvasUnderMouse( void )
+{
+    return gFrame->GetCanvasUnderMouse();
 }

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -6776,7 +6776,7 @@ bool ShuttingDown( void )
     return g_bquiting;
 }
 
-wxWindow* PluginGetCanvasUnderMouse( void )
+wxWindow* GetCanvasUnderMouse( void )
 {
     return gFrame->GetCanvasUnderMouse();
 }


### PR DESCRIPTION
New API call to allow a plugin to find the canvas on which the mouse is. Allows plugins to then provision windows, i.e. rollover info boxes on the correct canvas and associated with the mouse.