### PR TITLE
Logging: new framework (#1218).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1304,6 +1304,7 @@ SET(HDRS
                 include/concanv.h
                 include/cutil.h
                 include/georef.h
+                include/logger.h
                 include/navutil.h
                 include/routeman.h
                 include/routemanagerdialog.h
@@ -1406,6 +1407,7 @@ SET(SRCS
         src/concanv.cpp
         src/cutil.cpp
         src/georef.cpp
+        src/logger.cpp
         src/navutil.cpp
         src/routeman.cpp
         src/routemanagerdialog.cpp

--- a/include/logger.h
+++ b/include/logger.h
@@ -1,10 +1,10 @@
 #ifndef LOGGER_H
 #define LOGGER_H
 
-#include <memory>
 #include <cstdarg>
 #include <ostream>
 #include <sstream>
+#include <mutex>
 #include <stdio.h>
 
 /**
@@ -14,7 +14,7 @@
  *
  *     LOG_WARNING("Error running something: %s", message);
  *
- * C++ ostream logging uses the <LEVEL>_LOG macros e. g.;
+ * C++ ostream logging uses the <LEVEL>_LOG macros e. g.:
  * 
  *     WARNING_LOG << "Error running something " << message;
  */
@@ -53,6 +53,8 @@ class LogBackend
         FILE* f;
         std::stringstream buffer;
         bool isBuffering;
+        std::mutex log_lock;
+
 };
 
 /** Transient logger class, instantiated by the *LOG* macros. */

--- a/include/logger.h
+++ b/include/logger.h
@@ -1,0 +1,106 @@
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <memory>
+#include <cstdarg>
+#include <ostream>
+#include <sstream>
+#include <stdio.h>
+
+/**
+ * Simple Logging framework
+ *
+ * Supports C-style logging using the LOG_<LEVEL> printf-style macros e. g.:
+ *
+ *     LOG_WARNING("Error running something: %s", message);
+ *
+ * C++ ostream logging uses the <LEVEL>_LOG macros e. g.;
+ * 
+ *     WARNING_LOG << "Error running something " << message;
+ */
+
+
+enum class LogLevel {
+    BadLevel,
+    Error,
+    Warning,
+    Notice,
+    Info,
+    Debug,
+    Trace
+};
+
+
+/** The underpinning logfile object, a singleton. */
+class LogBackend
+{
+    public :
+        static LogBackend& getInstance();
+
+        /** Set logfile path and dump buffered data onto it. */
+        bool setLogfile(const char* path);
+
+        /** Write some data to log or buffer it until there is a log file. */
+        void write(const char* s);
+
+        LogBackend(const LogBackend&) = delete;
+        void operator=(const LogBackend&) = delete;
+
+        ~LogBackend();
+
+    private:
+        LogBackend();
+        FILE* f;
+        std::stringstream buffer;
+        bool isBuffering;
+};
+
+/** Transient logger class, instantiated by the *LOG* macros. */
+class Logger
+{
+    public:
+        Logger();
+        ~Logger();
+        void write(LogLevel level, const char* file, int line,
+                   const char* fmt, ...);
+        void write(LogLevel level, const char* file, int line,
+                   wxString fmt, ...);
+        std::ostream& get(LogLevel level = LogLevel::Info);
+        std::ostream& get(LogLevel level, const char* path, int line);
+        static LogLevel getLevel();
+        static void setLevel(LogLevel level);
+        static LogLevel string2level(const char* level);
+
+    protected:
+        std::stringstream os;
+
+};
+
+
+#define LOG_MESSAGE(level, fmt, ...)  { \
+    if (level  <= Logger::getLevel()) { \
+        Logger().write(level, __FILE__, __LINE__, fmt, ##__VA_ARGS__); \
+    } \
+}
+
+#define LOG(level) \
+    if (level > Logger::getLevel()) ;  \
+    else Logger().get(level, __FILE__, __LINE__)
+
+
+#define TRACE_LOG    LOG(LogLevel::Trace)
+#define DEBUG_LOG    LOG(LogLevel::Debug)
+#define INFO_LOG     LOG(LogLevel::Info)
+#define NOTICE_LOG   LOG(LogLevel::Notice)
+#define WARNING_LOG  LOG(LogLevel::Warning)
+#define ERROR_LOG    LOG(LogLevel::Error)
+
+#define LOG_TRACE(fmt, ...)   LOG_MESSAGE(LogLevel::Trace, fmt, ##__VA_ARGS__);
+#define LOG_DEBUG(fmt, ...)   LOG_MESSAGE(LogLevel::Debug, fmt, ##__VA_ARGS__);
+#define LOG_INFO(fmt, ...)    LOG_MESSAGE(LogLevel::Info, fmt, ##__VA_ARGS__);
+#define LOG_NOTICE(fmt, ...)  LOG_MESSAGE(LogLevel::Notice, fmt, ##__VA_ARGS__);
+#define LOG_WARNING(fmt, ...) LOG_MESSAGE(LogLevel::Warning, fmt, ##__VA_ARGS__);
+#define LOG_ERROR(fmt, ...)   LOG_MESSAGE(LogLevel::Error, fmt, ##__VA_ARGS__);
+
+
+#endif   // LOGGER_H

--- a/opencpn.1
+++ b/opencpn.1
@@ -23,6 +23,12 @@ Show help info.
 .B \-p
 Run in portable mode.
 .TP
+.B  \-l, \-\-loglevel=<level>
+Set amount of logged information. Level is any of \fItrace\fR,
+\fIdebug\fR, \fIinfo\fR, \fInotice\fR, \fIwarning\fR or \fIerror\fR,
+defaulting to \fIinfo\fR if not set in environment; see ENVIRONMENT.
+
+.TP
 .B  \-fullscreen
 Switch to full screen mode on start.
 .TP
@@ -65,10 +71,19 @@ properly.
 On other platforms, the plugin data directories always lives in a common
 parent defined at installation time.
 
+.SH ENVIRONMENT
+.TP
+.B OPENCPN_PLUGIN_DIRS
+Plugin load path, see PLUGIN LOADING
+.TP
+.B OPENCPN_LOGLEVEL
+Default loglevel if not defined on command line using -l/--loglevel. See
+the --loglevel option for allowed values.
+
 .SH NOTES
 
 The support for OPENCPN_PLUGIN_DIRS and XDG_DATA_DIRS was introduced in
-version TBD. Prior to this, all plugins was loaded from a single directory
+version 5.0.0. Prior to this, all plugins was loaded from a single directory
 and all plugin data directories had a common parent.
 
 .SH SEE ALSO

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -1033,7 +1033,7 @@ bool MyApp::OnCmdLineParsed( wxCmdLineParser& parser )
 
 bool MyApp::OnExceptionInMainLoop()
 {
-    wxLogWarning(_T("Caught MainLoopException, continuing..."));
+    LOG_WARNING(_T("Caught MainLoopException, continuing..."));
     return true;
 }
 #endif
@@ -1220,7 +1220,7 @@ void LoadS57()
         appendOSDirSlash( &plib_data );
         plib_data.Append( _T("S52RAZDS.RLE") );
 
-        wxLogMessage( _T("Looking for s57data in ") + look_data_dir );
+        LOG_INFO( _T("Looking for s57data in ") + look_data_dir );
         ps52plib = new s52plib( plib_data );
 
         if( ps52plib->m_bOK ) {
@@ -1243,14 +1243,14 @@ void LoadS57()
         appendOSDirSlash( &plib_data );
         plib_data.Append( _T("S52RAZDS.RLE") );
 
-        wxLogMessage( _T("Looking for s57data in ") + look_data_dir );
+        LOG_INFO( _T("Looking for s57data in ") + look_data_dir );
         ps52plib = new s52plib( plib_data );
 
         if( ps52plib->m_bOK ) g_csv_locn = look_data_dir;
     }
 
     if( ps52plib->m_bOK ) {
-        wxLogMessage( _T("Using s57data in ") + g_csv_locn );
+        LOG_INFO( _T("Using s57data in ") + g_csv_locn );
         m_pRegistrarMan = new s57RegistrarMgr( g_csv_locn, g_Platform->GetLogFilePtr() );
 
 
@@ -1285,7 +1285,7 @@ void LoadS57()
             
             
     } else {
-        wxLogMessage( _T("   S52PLIB Initialization failed, disabling Vector charts.") );
+        LOG_INFO( _T("   S52PLIB Initialization failed, disabling Vector charts.") );
         delete ps52plib;
         ps52plib = NULL;
     }
@@ -1468,7 +1468,7 @@ void ParseAllENC()
     if(count == 0)
         return;
     
-    wxLogMessage(wxString::Format(_T("ParseAllENC() count = %d"), count ));
+    LOG_INFO(wxString::Format(_T("ParseAllENC() count = %d"), count ));
     
     //  Build another array of sorted compression targets.
     //  We need to do this, as the chart table will not be invariant
@@ -1741,20 +1741,20 @@ bool MyApp::OnInit()
 #endif
 
 //      Send init message
-    wxLogMessage( _T("\n\n________\n") );
+    LOG_INFO( _T("\n\n________\n") );
 
     wxDateTime date_now = wxDateTime::Now();
 
     wxString imsg = date_now.FormatISODate();
-    wxLogMessage( imsg );
+    LOG_INFO( imsg );
 
     imsg = _T(" ------- Starting OpenCPN -------");
-    wxLogMessage( imsg );
+    LOG_INFO( imsg );
 
     wxString version = OpenCPNVersion;
     wxString vs = version.Trim( true );
     vs = vs.Trim( false );
-    wxLogMessage( vs );
+    LOG_INFO( vs );
 
     wxString wxver(wxVERSION_STRING);
     wxver.Prepend( _T("wxWidgets version: ") );
@@ -1772,9 +1772,9 @@ bool MyApp::OnInit()
     platforminfo.GetArchName()+ _T(" ") +
     platforminfo.GetPortIdName();
 
-    wxLogMessage( wxver + _T(" ") + platform );
+    LOG_INFO( wxver + _T(" ") + platform );
 
-    wxLogMessage( _T("MemoryStatus:  mem_total: %d mb,  mem_initial: %d mb"), g_mem_total / 1024,
+    LOG_INFO( _T("MemoryStatus:  mem_total: %d mb,  mem_initial: %d mb"), g_mem_total / 1024,
             g_mem_initial / 1024 );
 
     //    Initialize embedded PNG icon graphics
@@ -1783,7 +1783,7 @@ bool MyApp::OnInit()
 
     imsg = _T("SData_Locn is ");
     imsg += g_Platform->GetSharedDataDir();
-    wxLogMessage( imsg );
+    LOG_INFO( imsg );
 
 #ifdef __OCPN_ANDROID__
     //  Now we can load a Qt StyleSheet, if present
@@ -1793,11 +1793,11 @@ bool MyApp::OnInit()
     style_file += _T("qtstylesheet.qss");
     if(LoadQtStyleSheet(style_file)){
         wxString smsg = _T("Loaded Qt Stylesheet: ") + style_file;
-        wxLogMessage( smsg );
+        LOG_INFO( smsg );
     }
     else{
         wxString smsg = _T("Qt Stylesheet not found: ") + style_file;
-        wxLogMessage( smsg );
+        LOG_INFO( smsg );
     }
 #endif
 
@@ -1810,7 +1810,7 @@ bool MyApp::OnInit()
 
     imsg = _T("PrivateDataDir is ");
     imsg += g_Platform->GetPrivateDataDir();
-    wxLogMessage( imsg );
+    LOG_INFO( imsg );
 
 
 //      Create an array string to hold repeating messages, so they don't
@@ -1870,18 +1870,14 @@ bool MyApp::OnInit()
     bool b_initial_load = false;
 
     wxFileName config_test_file_name( g_Platform->GetConfigFileName() );
-    if( config_test_file_name.FileExists() ) wxLogMessage(
-        _T("Using existing Config_File: ") + g_Platform->GetConfigFileName() );
-    else {
-        {
-            wxLogMessage( _T("Creating new Config_File: ") + g_Platform->GetConfigFileName() );
-
+    if( config_test_file_name.FileExists() ) {
+        LOG_INFO( _T("Using existing Config_File: ") + g_Platform->GetConfigFileName() );
+    } else {
+            LOG_INFO( _T("Creating new Config_File: ") + g_Platform->GetConfigFileName() );
             b_initial_load = true;
-
             if( true != config_test_file_name.DirExists( config_test_file_name.GetPath() ) )
                 if( !config_test_file_name.Mkdir(config_test_file_name.GetPath() ) )
-                    wxLogMessage( _T("Cannot create config file directory for ") + g_Platform->GetConfigFileName() );
-        }
+                    LOG_INFO( _T("Cannot create config file directory for ") + g_Platform->GetConfigFileName() );
     }
 
     //      Open/Create the Config Object
@@ -1926,14 +1922,14 @@ bool MyApp::OnInit()
     g_display_size_mm = wxMax(100, g_Platform->GetDisplaySizeMM());
     wxString msg;
     msg.Printf(_T("Detected display size (horizontal): %d mm"), (int) g_display_size_mm);
-    wxLogMessage(msg);
+    LOG_INFO(msg);
     
     // User override....
     if((g_config_display_size_mm > 0) &&(g_config_display_size_manual)){
         g_display_size_mm = g_config_display_size_mm;
         wxString msg;
         msg.Printf(_T("Display size (horizontal) config override: %d mm"), (int) g_display_size_mm);
-        wxLogMessage(msg);
+        LOG_INFO(msg);
         g_Platform->SetDisplaySizeMM(g_display_size_mm);
     }
 
@@ -1963,15 +1959,15 @@ bool MyApp::OnInit()
     wxString def_lang_canonical = g_Platform->GetDefaultSystemLocale();
     
     imsg = _T("System default Language:  ") + def_lang_canonical;
-    wxLogMessage( imsg );
+    LOG_INFO( imsg );
 
     wxString cflmsg = _T("Config file language:  ") + g_locale;
-    wxLogMessage( cflmsg );
+    LOG_INFO( cflmsg );
 
     //  Make any adjustments necessary
     g_locale = g_Platform->GetAdjustedAppLocale();
     cflmsg = _T("Adjusted App language:  ") + g_locale;
-    wxLogMessage( cflmsg );
+    LOG_INFO( cflmsg );
 
 
     // Set the desired locale
@@ -1979,13 +1975,13 @@ bool MyApp::OnInit()
     
     imsg = _T("Opencpn language set to:  ");
     imsg += g_locale;
-    wxLogMessage( imsg );
+    LOG_INFO( imsg );
 
     //  French language locale is assumed to include the AZERTY keyboard
     //  This applies to either the system language, or to OpenCPN language selection
     if( g_locale == _T("fr_FR") ) g_b_assume_azerty = true;
 #else
-    wxLogMessage( _T("wxLocale support not available") );
+    LOG_INFO( _T("wxLocale support not available") );
 #endif
 
 //  Send the Welcome/warning message if it has never been sent before,
@@ -2001,7 +1997,7 @@ bool MyApp::OnInit()
 
     //  log deferred log restart message, if it exists.
     if( !g_Platform->GetLargeLogMessage().IsEmpty() )
-        wxLogMessage( g_Platform->GetLargeLogMessage() );
+        LOG_INFO( g_Platform->GetLargeLogMessage() );
 
     //  Validate OpenGL functionality, if selected
 #ifdef ocpnUSE_GL
@@ -2014,7 +2010,7 @@ bool MyApp::OnInit()
         bool b_test_result = TestGLCanvas(fn.GetPathWithSep() );
 
         if( !b_test_result )
-            wxLogMessage( _T("OpenGL disabled due to test app failure.") );
+            LOG_INFO( _T("OpenGL disabled due to test app failure.") );
 
         g_bdisable_opengl = !b_test_result;
     }
@@ -2174,7 +2170,7 @@ bool MyApp::OnInit()
     wxSize asz = getAndroidDisplayDimensions();
     ch = asz.y;
     cw = asz.x;
-//    qDebug() << cw << ch;
+    LOG_DEBUG << cw << ch;
 
     if((cw > 200) && (ch > 200) )
         new_frame_size.Set( cw, ch );
@@ -2198,7 +2194,7 @@ bool MyApp::OnInit()
 
     wxString fmsg;
     fmsg.Printf(_T("Creating MyFrame...size(%d, %d)  position(%d, %d)"), new_frame_size.x, new_frame_size.y, position.x, position.y);
-    wxLogMessage(fmsg);
+    LOG_INFO(fmsg);
 
     gFrame = new MyFrame( NULL, myframe_window_title, position, new_frame_size, app_style ); //Gunther
     
@@ -2275,7 +2271,7 @@ bool MyApp::OnInit()
 
         wxRegKey RegKey( wxString( _T("HKEY_LOCAL_MACHINE\\SOFTWARE\\OpenCPN") ) );
         if( RegKey.Exists() ) {
-            wxLogMessage( _("Retrieving initial Chart Directory set from Windows Registry") );
+            LOG_INFO( _("Retrieving initial Chart Directory set from Windows Registry") );
             wxString dirs;
             RegKey.QueryValue( wxString( _T("ChartDirs") ), dirs );
 
@@ -2355,7 +2351,7 @@ bool MyApp::OnInit()
 
         else            // No chart database, no config hints, so bail to Options....
         {
-            wxLogMessage(
+            LOG_INFO(
                     _T("Chartlist file not found, config chart dir array is empty.  Chartlist target file is:")
                             + ChartListFileName );
 
@@ -2440,7 +2436,7 @@ extern ocpnGLOptions g_GLOptions;
 
     wxString dogmsg;
     dogmsg.Printf( _T("GPS Watchdog Timeout is: %d sec."), gps_watchdog_timeout_ticks );
-    wxLogMessage( dogmsg );
+    LOG_INFO( dogmsg );
 
     sat_watchdog_timeout_ticks = 12;
 
@@ -2528,7 +2524,7 @@ extern ocpnGLOptions g_GLOptions;
     // Start delayed initialization chain after 100 milliseconds
     gFrame->InitTimer.Start( 100, wxTIMER_CONTINUOUS );
 
-    wxLogMessage( wxString::Format(_("OpenCPN Initialized in %ld ms."), init_sw.Time() ) );
+    LOG_INFO( wxString::Format(_("OpenCPN Initialized in %ld ms."), init_sw.Time() ) );
 
     OCPNPlatform::Initialize_3( );
     
@@ -2547,7 +2543,7 @@ extern ocpnGLOptions g_GLOptions;
 
 int MyApp::OnExit()
 {
-    wxLogMessage( _T("opencpn::MyApp starting exit.") );
+    LOG_INFO( _T("opencpn::MyApp starting exit.") );
 
     //  Send current nav status data to log file   // pjotrc 2010.02.09
 
@@ -2584,7 +2580,7 @@ int MyApp::OnExit()
         data.Printf( _T("OFF: Lat %10.5f Lon %10.5f"), gLat, gLon );
         navmsg += data;
     }
-    wxLogMessage( navmsg );
+    LOG_INFO( navmsg );
     g_loglast_time = lognow;
 
     if( ptcmgr ) delete ptcmgr;
@@ -2609,7 +2605,7 @@ int MyApp::OnExit()
 
     delete pDummyChart;
 
-    wxLogMessage( _T("opencpn::MyApp exiting cleanly...\n") );
+    LOG_INFO( _T("opencpn::MyApp exiting cleanly...\n") );
     wxLog::FlushActive();
 
     g_Platform->CloseLogFile();
@@ -3484,7 +3480,7 @@ void MyFrame::OnCloseWindow( wxCloseEvent& event )
     //    It is possible that double clicks on application exit box could cause re-entrance here
     //    Not good, and don't need it anyway, so simply return.
     if( b_inCloseWindow ) {
-//            wxLogMessage(_T("opencpn::MyFrame re-entering OnCloseWindow"));
+//            LOG_INFO(_T("opencpn::MyFrame re-entering OnCloseWindow"));
         return;
     }
 
@@ -3571,7 +3567,7 @@ void MyFrame::OnCloseWindow( wxCloseEvent& event )
         g_pi_manager->DeactivateAllPlugIns();
     }
 
-    wxLogMessage( _T("opencpn::MyFrame exiting cleanly.") );
+    LOG_INFO( _T("opencpn::MyFrame exiting cleanly.") );
 
     quitflag++;
 
@@ -3811,7 +3807,7 @@ void MyFrame::OnCloseWindow( wxCloseEvent& event )
     if(g_bopengl && g_glTextureManager && g_glTextureManager->GetRunningJobCount()){
         g_glTextureManager->ClearAllRasterTextures();
 
-        wxLogMessage(_T("Starting compressor pool drain"));
+        LOG_INFO(_T("Starting compressor pool drain"));
         wxDateTime now = wxDateTime::Now();
         time_t stall = now.GetTicks();
         time_t end = stall + THREAD_WAIT_SECONDS;
@@ -3823,7 +3819,7 @@ void MyFrame::OnCloseWindow( wxCloseEvent& event )
 
             wxString msg;
             msg.Printf(_T("Time: %d  Job Count: %d"), n_comploop, g_glTextureManager->GetRunningJobCount());
-            wxLogMessage(msg);
+            LOG_INFO(msg);
             if(!g_glTextureManager->GetRunningJobCount())
                 break;
             wxYield();
@@ -3833,7 +3829,7 @@ void MyFrame::OnCloseWindow( wxCloseEvent& event )
         wxString fmsg;
         fmsg.Printf(_T("Finished compressor pool drain..Time: %d  Job Count: %d"),
                     n_comploop, g_glTextureManager->GetRunningJobCount());
-        wxLogMessage(fmsg);
+        LOG_INFO(fmsg);
     }
     delete g_glTextureManager;
 #endif
@@ -3842,7 +3838,7 @@ void MyFrame::OnCloseWindow( wxCloseEvent& event )
     gFrame = NULL;
 
 #ifdef __OCPN__ANDROID__
-    qDebug() << "Calling OnExit()";
+    LOG_DEBUG << "Calling OnExit()";
     wxTheApp->OnExit();
 #endif
 
@@ -4130,11 +4126,11 @@ void MyFrame::ODoSetSize( void )
 #ifdef __OCPN__ANDROID__
         min_height = ( pstat_font->GetPointSize() * getAndroidDisplayDensity() ) + 10;
         m_pStatusBar->SetMinHeight( min_height );
-//        qDebug() <<"StatusBar min height:" << min_height << "StatusBar font points:" << pstat_font->GetPointSize();
+        LOG_DEBUG <<"StatusBar min height:" << min_height << "StatusBar font points:" << pstat_font->GetPointSize();
 #endif
 //        wxString msg;
 //        msg.Printf(_T("StatusBar min height: %d    StatusBar font points: %d"), min_height, pstat_font->GetPointSize());
-//        wxLogMessage(msg);
+//        LOG_INFO(msg);
 
     }
 
@@ -4948,7 +4944,7 @@ void MyFrame::ActivateMOB( void )
     mob_message += toSDMM( 1, gLat );
     mob_message += _T("   ");
     mob_message += toSDMM( 2, gLon );
-    wxLogMessage( mob_message );
+    LOG_INFO( mob_message );
 
 }
 void MyFrame::TrackOn( void )
@@ -6435,14 +6431,14 @@ bool MyFrame::UpdateChartDatabaseInplace( ArrayOfCDI &DirArray, bool b_force, bo
         pprog->Raise();
     }
     
-    wxLogMessage( _T("   ") );
-    wxLogMessage( _T("Starting chart database Update...") );
+    LOG_INFO( _T("   ") );
+    LOG_INFO( _T("Starting chart database Update...") );
     wxString gshhg_chart_loc = gWorldMapLocation;
     gWorldMapLocation = wxEmptyString;
     ChartData->Update( DirArray, b_force, pprog );
     ChartData->SaveBinary(ChartListFileName);
-    wxLogMessage( _T("Finished chart database Update") );
-    wxLogMessage( _T("   ") );
+    LOG_INFO( _T("Finished chart database Update") );
+    LOG_INFO( _T("   ") );
     if( gWorldMapLocation.empty() ) { //Last resort. User might have deleted all GSHHG data, but we still might have the default dataset distributed with OpenCPN or from the package repository...
        gWorldMapLocation = gDefaultWorldMapLocation;
        gshhg_chart_loc = wxEmptyString;
@@ -6597,7 +6593,7 @@ void MyFrame::OnInitTimer(wxTimerEvent& event)
             if( wxDir::Exists( layerdir ) ) {
                 wxString laymsg;
                 laymsg.Printf( wxT("Getting .gpx layer files from: %s"), layerdir.c_str() );
-                wxLogMessage( laymsg );
+                LOG_INFO( laymsg );
                 pConfig->LoadLayers(layerdir);
             }
 
@@ -6902,11 +6898,11 @@ void MyFrame::OnBellsTimer(wxTimerEvent& event)
         soundfile.Prepend( g_Platform->GetSharedDataDir() );
         bells_sound[bells - 1]->Load( soundfile );
         if( !bells_sound[bells - 1]->IsOk() ) {
-            wxLogMessage( _T("Failed to load bells sound file: ") + soundfile );
+            LOG_INFO( _T("Failed to load bells sound file: ") + soundfile );
             return;
         }
 
-        wxLogMessage( _T("Using bells sound file: ") + soundfile );
+        LOG_INFO( _T("Using bells sound file: ") + soundfile );
     }
 
     bells_sound[bells - 1]->Play();
@@ -7033,7 +7029,7 @@ void MyFrame::OnFrameTimer1( wxTimerEvent& event )
 
 //      Listen for quitflag to be set, requesting application close
     if( quitflag ) {
-        wxLogMessage( _T("Got quitflag from SIGNAL") );
+        LOG_INFO( _T("Got quitflag from SIGNAL") );
         FrameTimer1.Stop();
         Close();
         return;
@@ -7064,7 +7060,7 @@ void MyFrame::OnFrameTimer1( wxTimerEvent& event )
         if( gGPS_Watchdog == 0  ){
             wxString msg;
             msg.Printf( _T("   ***GPS Watchdog timeout at Lat:%g   Lon: %g"), gLat, gLon );
-            wxLogMessage(msg);
+            LOG_INFO(msg);
         }
         gSog = NAN;
         gCog = NAN;
@@ -7074,7 +7070,7 @@ void MyFrame::OnFrameTimer1( wxTimerEvent& event )
     gHDx_Watchdog--;
     if( gHDx_Watchdog <= 0 ) {
         gHdm = NAN;
-        if( g_nNMEADebug && ( gHDx_Watchdog == 0 ) ) wxLogMessage(
+        if( g_nNMEADebug && ( gHDx_Watchdog == 0 ) ) LOG_INFO(
                 _T("   ***HDx Watchdog timeout...") );
     }
 
@@ -7083,7 +7079,7 @@ void MyFrame::OnFrameTimer1( wxTimerEvent& event )
     if( gHDT_Watchdog <= 0 ) {
         g_bHDT_Rx = false;
         gHdt = NAN;
-        if( g_nNMEADebug && ( gHDT_Watchdog == 0 ) ) wxLogMessage(
+        if( g_nNMEADebug && ( gHDT_Watchdog == 0 ) ) LOG_INFO(
                 _T("   ***HDT Watchdog timeout...") );
     }
 
@@ -7091,7 +7087,7 @@ void MyFrame::OnFrameTimer1( wxTimerEvent& event )
     gVAR_Watchdog--;
     if( gVAR_Watchdog <= 0 ) {
         g_bVAR_Rx = false;
-        if( g_nNMEADebug && ( gVAR_Watchdog == 0 ) ) wxLogMessage(
+        if( g_nNMEADebug && ( gVAR_Watchdog == 0 ) ) LOG_INFO(
             _T("   ***VAR Watchdog timeout...") );
     }
     //  Update and check watchdog timer for GSV (Satellite data)
@@ -7099,7 +7095,7 @@ void MyFrame::OnFrameTimer1( wxTimerEvent& event )
     if( gSAT_Watchdog <= 0 ) {
         g_bSatValid = false;
         g_SatsInView = 0;
-        if( g_nNMEADebug && ( gSAT_Watchdog == 0 ) ) wxLogMessage(
+        if( g_nNMEADebug && ( gSAT_Watchdog == 0 ) ) LOG_INFO(
                 _T("   ***SAT Watchdog timeout...") );
     }
 
@@ -7208,7 +7204,7 @@ void MyFrame::OnFrameTimer1( wxTimerEvent& event )
                 data.Printf( _T(" DR Lat %10.5f Lon %10.5f"), gLat, gLon );
                 navmsg += data;
             }
-            wxLogMessage( navmsg );
+            LOG_INFO( navmsg );
             g_loglast_time = lognow;
 
             int bells = ( hourLOC % 4 ) * 2;     // 2 bells each hour
@@ -7746,7 +7742,7 @@ void MyFrame::SetChartThumbnail( int index )
                     }
 
                     else {
-                        wxLogMessage(
+                        LOG_INFO(
                                 _T("    chart1.cpp:SetChartThumbnail...Could not create thumbnail") );
                         pthumbwin->pThumbChart = NULL;
                         pthumbwin->Show( false );
@@ -7757,7 +7753,7 @@ void MyFrame::SetChartThumbnail( int index )
                 {
                     wxString fp = ChartData->GetFullPath( pCurrentStack, index );
                     fp.Prepend( _T("    chart1.cpp:SetChartThumbnail...Could not open chart ") );
-                    wxLogMessage( fp );
+                    LOG_INFO( fp );
                     pthumbwin->pThumbChart = NULL;
                     pthumbwin->Show( false );
                     cc1->Refresh( FALSE );
@@ -8347,7 +8343,7 @@ void MyFrame::OnEvtPlugInMessage( OCPN_MsgEvent & event )
 
 void MyFrame::OnEvtTHREADMSG( OCPN_ThreadMessageEvent & event )
 {
-    wxLogMessage( wxString(event.GetSString().c_str(), wxConvUTF8 ));
+    LOG_INFO( wxString(event.GetSString().c_str(), wxConvUTF8 ));
 }
 
 
@@ -8416,7 +8412,7 @@ bool MyFrame::EvalPriority(const wxString & message, DataStream *pDS )
                                             msg_type.c_str(),
                                             new_port.c_str(),
                                             pcontainer->current_priority);
-         wxLogMessage(logmsg );
+         LOG_INFO(logmsg );
 
          if (NMEALogWindow::Get().Active())
          {
@@ -8509,7 +8505,7 @@ void MyFrame::OnEvtOCPN_NMEA( OCPN_DataStreamEvent & event )
         g_total_NMEAerror_messages++;
         wxString msg( _T("MEH.NMEA Sentence received...") );
         msg.Append( str_buf );
-        wxLogMessage( msg );
+        LOG_INFO( msg );
     }
 
     //  The message must be at least reasonably formed...
@@ -8525,7 +8521,7 @@ void MyFrame::OnEvtOCPN_NMEA( OCPN_DataStreamEvent & event )
                 g_total_NMEAerror_messages++;
                 wxString msg( _T(">>>>>>NMEA Sentence Checksum Bad...") );
                 msg.Append( str_buf );
-                wxLogMessage( msg );
+                LOG_INFO( msg );
             }
             return;
         }
@@ -8678,7 +8674,7 @@ void MyFrame::OnEvtOCPN_NMEA( OCPN_DataStreamEvent & event )
             msg.Append( m_NMEA0183.ErrorMessage );
             msg.Append( _T(" : ") );
             msg.Append( str_buf );
-            wxLogMessage( msg );
+            LOG_INFO( msg );
         }
     }
         //      Process ownship (AIVDO) messages from any source
@@ -8727,7 +8723,7 @@ void MyFrame::OnEvtOCPN_NMEA( OCPN_DataStreamEvent & event )
                 g_total_NMEAerror_messages++;
                 wxString msg( _T("   Invalid AIVDO Sentence...") );
                 msg.Append( str_buf );
-                wxLogMessage( msg );
+                LOG_INFO( msg );
             }
         }
     }
@@ -8739,7 +8735,7 @@ void MyFrame::OnEvtOCPN_NMEA( OCPN_DataStreamEvent & event )
             g_total_NMEAerror_messages++;
             wxString msg( _T("   Unrecognized NMEA Sentence...") );
             msg.Append( str_buf );
-            wxLogMessage( msg );
+            LOG_INFO( msg );
         }
     }
 
@@ -8807,7 +8803,7 @@ void MyFrame::PostProcessNNEA( bool pos_valid, bool cog_sog_valid, const wxStrin
     if( pos_valid ) {
         if( g_nNMEADebug ) {
             wxString msg( _T("PostProcess NMEA with valid position") );
-            wxLogMessage( msg );
+            LOG_INFO( msg );
         }
 
         //      Maintain the validity flags
@@ -8938,7 +8934,7 @@ void MyFrame::PostProcessNNEA( bool pos_valid, bool cog_sog_valid, const wxStrin
 
             wxString msg;
             msg.Printf(_T("Setting system time, delta t is %d seconds"), b);
-            wxLogMessage(msg);
+            LOG_INFO(msg);
 
             wxString sdate(Fix_Time.Format(_T("%D")));
             sdate.Prepend(_T("sudo /bin/date -s \""));
@@ -8950,7 +8946,7 @@ void MyFrame::PostProcessNNEA( bool pos_valid, bool cog_sog_valid, const wxStrin
 
             msg.Printf(_T("Linux command is:"));
             msg += sdate;
-            wxLogMessage(msg);
+            LOG_INFO(msg);
             wxExecute(sdate, wxEXEC_ASYNC);
 
 #endif      //__WXMSW__
@@ -9151,7 +9147,7 @@ void MyFrame::ActivateAISMOBRoute( AIS_Target_Data *ptarget )
     mob_message += toSDMM( 1, ptarget->Lat );
     mob_message += _T("   ");
     mob_message += toSDMM( 2, ptarget->Lon );
-    wxLogMessage( mob_message );
+    LOG_INFO( mob_message );
 
 }
 
@@ -9196,7 +9192,7 @@ void MyFrame::UpdateAISMOBRoute( AIS_Target_Data *ptarget )
         mob_message += _T("   ");
         mob_message += toSDMM( 2, ptarget->Lon );
 
-        wxLogMessage( mob_message );
+        LOG_INFO( mob_message );
     }
 
 }
@@ -9238,7 +9234,7 @@ void MyFrame::applySettingsString( wxString settings)
         if(!ChartData->CompareChartDirArray( NewDirArray )){
             rr |= VISIT_CHARTS;
             rr |= CHANGE_CHARTS;
-            wxLogMessage(_T("Chart Dir List change detected"));
+            LOG_INFO(_T("Chart Dir List change detected"));
         }
     }
 
@@ -9616,14 +9612,14 @@ void MyFrame::OnSuspending(wxPowerEvent& event)
  //   wxDateTime now = wxDateTime::Now();
  //   printf("OnSuspending...%d\n", now.GetTicks());
 
-    wxLogMessage(_T("System suspend starting..."));
+    LOG_INFO(_T("System suspend starting..."));
 }
 
 void MyFrame::OnSuspended(wxPowerEvent& WXUNUSED(event))
 {
 //    wxDateTime now = wxDateTime::Now();
 //    printf("OnSuspended...%d\n", now.GetTicks());
-    wxLogMessage(_T("System is going to suspend."));
+    LOG_INFO(_T("System is going to suspend."));
 
 }
 
@@ -9631,7 +9627,7 @@ void MyFrame::OnSuspendCancel(wxPowerEvent& WXUNUSED(event))
 {
 //    wxDateTime now = wxDateTime::Now();
 //    printf("OnSuspendCancel...%d\n", now.GetTicks());
-    wxLogMessage(_T("System suspend was cancelled."));
+    LOG_INFO(_T("System suspend was cancelled."));
 }
 
 int g_last_resume_ticks;
@@ -9639,10 +9635,10 @@ void MyFrame::OnResume(wxPowerEvent& WXUNUSED(event))
 {
     wxDateTime now = wxDateTime::Now();
 //    printf("OnResume...%d\n", now.GetTicks());
-    wxLogMessage(_T("System resumed from suspend."));
+    LOG_INFO(_T("System resumed from suspend."));
 
     if((now.GetTicks() - g_last_resume_ticks) > 5){
-        wxLogMessage(_T("Restarting streams."));
+        LOG_INFO(_T("Restarting streams."));
  //       printf("   Restarting streams\n");
         g_last_resume_ticks = now.GetTicks();
         if(g_pMUX){
@@ -9989,7 +9985,7 @@ void MyCPLErrorHandler( CPLErr eErrClass, int nError, const char * pszErrorMsg )
             snprintf( msg, 255, "CPL ERROR %d: %s", nError, pszErrorMsg );
 
     wxString str( msg, wxConvUTF8 );
-    wxLogMessage( str );
+    LOG_INFO( str );
 }
 #endif
 
@@ -10257,7 +10253,7 @@ wxArrayString *EnumerateSerialPorts( void )
     if( hdeviceinfo != INVALID_HANDLE_VALUE ) {
         
         if(GarminProtocolHandler::IsGarminPlugged()){
-            wxLogMessage( _T("EnumerateSerialPorts() Found Garmin USB Device.") );
+            LOG_INFO( _T("EnumerateSerialPorts() Found Garmin USB Device.") );
             preturn->Add( _T("Garmin-USB") );         // Add generic Garmin selectable device
         }
     }
@@ -10335,7 +10331,7 @@ wxArrayString *EnumerateSerialPorts( void )
 //  Return to user privileges
         seteuid(user_user_id);
 
-        wxLogMessage(_T("Warning: ocpnhelper failed...."));
+        LOG_INFO(_T("Warning: ocpnhelper failed...."));
         _exit(0);// If exec fails then exit forked process.
     }
 
@@ -10350,7 +10346,7 @@ wxArrayString *EnumerateSerialPorts( void )
 
     if (f != NULL)
     {
-        wxLogMessage(_T("Parsing copy of /proc/tty/driver/serial..."));
+        LOG_INFO(_T("Parsing copy of /proc/tty/driver/serial..."));
 
         /* read in each line of the file */
         while(fgets(buf, sizeof(buf), f) != NULL)
@@ -10358,7 +10354,7 @@ wxArrayString *EnumerateSerialPorts( void )
             wxString sm(buf, wxConvUTF8);
             sm.Prepend(_T("   "));
             sm.Replace(_T("\n"), _T(" "));
-            wxLogMessage(sm);
+            LOG_INFO(sm);
 
             /* if the line doesn't start with a number get the next line */
             if (buf[0] < '0' || buf[0] > '9')
@@ -10402,7 +10398,7 @@ wxArrayString *EnumerateSerialPorts( void )
 
     if (f != NULL)
     {
-        wxLogMessage(_T("Parsing copy of /proc/tty/driver/usbserial..."));
+        LOG_INFO(_T("Parsing copy of /proc/tty/driver/usbserial..."));
 
         /* read in each line of the file */
         while(fgets(buf, sizeof(buf), f) != NULL)
@@ -10411,7 +10407,7 @@ wxArrayString *EnumerateSerialPorts( void )
             wxString sm(buf, wxConvUTF8);
             sm.Prepend(_T("   "));
             sm.Replace(_T("\n"), _T(" "));
-            wxLogMessage(sm);
+            LOG_INFO(sm);
 
             /* if the line doesn't start with a number get the next line */
             if (buf[0] < '0' || buf[0] > '9')
@@ -10653,7 +10649,7 @@ wxArrayString *EnumerateSerialPorts( void )
     if( hdeviceinfo != INVALID_HANDLE_VALUE ) {
 
         if(GarminProtocolHandler::IsGarminPlugged()){
-            wxLogMessage( _T("EnumerateSerialPorts() Found Garmin USB Device.") );
+            LOG_INFO( _T("EnumerateSerialPorts() Found Garmin USB Device.") );
             preturn->Add( _T("Garmin-USB") );         // Add generic Garmin selectable device
         }
     }
@@ -10668,7 +10664,7 @@ wxArrayString *EnumerateSerialPorts( void )
                     0,
                     &deviceinterface))
     {
-        wxLogMessage(_T("Found Garmin Device."));
+        LOG_INFO(_T("Found Garmin Device."));
 
         preturn->Add(_T("GARMIN"));         // Add generic Garmin selectable device
     }
@@ -10830,7 +10826,7 @@ wxColour GetGlobalColor(wxString colorName)
     //    Default
     if( !ret_color.Ok() ) {
         ret_color.Set( 128, 128, 128 );  // Simple Grey
-        wxLogMessage(_T("Warning: Color not found ") + colorName);
+        LOG_INFO(_T("Warning: Color not found ") + colorName);
         // Avoid duplicate warnings:
         if (pcurrent_user_color_hash)
             ( *pcurrent_user_color_hash )[colorName] = ret_color;

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -980,9 +980,29 @@ void MyApp::OnInitCmdLine( wxCmdLineParser& parser )
     parser.AddSwitch( _T("no_opengl"), wxEmptyString, _("Disable OpenGL video acceleration. This setting will be remembered.") );
     parser.AddSwitch( _T("rebuild_gl_raster_cache"), wxEmptyString, _T("Rebuild OpenGL raster cache on start.") );
     parser.AddSwitch( _T("parse_all_enc"), wxEmptyString, _T("Convert all S-57 charts to OpenCPN's internal format on start.") );
+    parser.AddOption( _T("l"), _T("loglevel"), _("Amount of logging: error, warning, notice, debug or trace"));
     parser.AddOption( _T("unit_test_1"), wxEmptyString, _("Display a slideshow of <num> charts and then exit. Zero or negative <num> specifies no limit."), wxCMD_LINE_VAL_NUMBER );
 
     parser.AddSwitch( _T("unit_test_2") );
+}
+
+/** Parse --loglevel and set up logging, falling back to defaults. */
+static void ParseLoglevel(wxCmdLineParser& parser)
+{
+    const char* strLevel = std::getenv("OPENCPN_LOGLEVEL");
+    strLevel = strLevel ? strLevel : "info";
+    wxString wxLevel;
+    if (parser.Found("l", &wxLevel)) {
+        strLevel = wxLevel.c_str();
+    }
+    LogLevel level = Logger::string2level(strLevel);
+    if (level == LogLevel::BadLevel) {
+        fprintf(stderr, "Bad loglevel %s, using \"info\"", strLevel);
+        strLevel = "info";
+        level = LogLevel::Info;
+    }
+    Logger::setLevel(level);
+    LOG_NOTICE("Log initiated using level %s", strLevel);
 }
 
 bool MyApp::OnCmdLineParsed( wxCmdLineParser& parser )
@@ -1001,6 +1021,7 @@ bool MyApp::OnCmdLineParsed( wxCmdLineParser& parser )
         if( g_unit_test_1 == 0 )
             g_unit_test_1 = -1;
     }
+    ParseLoglevel(parser);
 
     return true;
 }

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -80,6 +80,7 @@
 #include "piano.h"
 #include "concanv.h"
 #include "options.h"
+#include "logger.h"
 #include "about.h"
 #include "thumbwin.h"
 #include "tcmgr.h"
@@ -1705,6 +1706,10 @@ bool MyApp::OnInit()
     //      Establish Log File location
     if(!g_Platform->InitializeLogFile())
         return false;
+    if (!LogBackend::getInstance().setLogfile(g_Platform->GetLogFileName())) {
+        fprintf(stderr, "Cannot initialize logging.\n");
+        return false;
+    }
 
 
 #ifdef __WXMSW__

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -1741,8 +1741,6 @@ bool MyApp::OnInit()
 #endif
 
 //      Send init message
-    LOG_INFO( _T("\n\n________\n") );
-
     wxDateTime date_now = wxDateTime::Now();
 
     wxString imsg = date_now.FormatISODate();

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -11000,7 +11000,7 @@ int get_static_line( char *d, const char **p, int index, int n )
 static void InitializeUserColors( void )
 {
     const char **p = usercolors;
-    char buf[80];
+    char buf[81];
     int index = 0;
     char TableName[20];
     colTable *ctp;
@@ -11027,7 +11027,7 @@ static void InitializeUserColors( void )
     ct->color = new wxArrayPtrVoid;
     UserColorTableArray->Add( (void *) ct );
 
-    while( ( get_static_line( buf, p, index, 80 ) ) ) {
+    while( ( get_static_line( buf, p, index, sizeof(buf) - 1 ) ) ) {
         if( !strncmp( buf, "Table", 5 ) ) {
             sscanf( buf, "Table:%s", TableName );
 

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -22,12 +22,7 @@
  ***************************************************************************
  */
 
-#include <algorithm>
 #include <iomanip>
-#include <iostream>
-#include <ostream>
-#include <sstream>
-#include <streambuf>
 
 #include <ctype.h>
 
@@ -109,6 +104,7 @@ bool LogBackend::setLogfile(const char* path)
  
 void LogBackend::write(const char* text)
 {
+    std::unique_lock<std::mutex> lock(log_lock);
     if (isBuffering) {
         buffer << text; 
     } else {

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -1,0 +1,223 @@
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ *
+ ***************************************************************************
+ *   Copyright (C) 2013 by David S. Register                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ */
+
+#include <algorithm>
+#include <iomanip>
+#include <iostream>
+#include <ostream>
+#include <sstream>
+#include <streambuf>
+
+#include <ctype.h>
+
+#include <wx/datetime.h>
+
+#include "OCPNPlatform.h"
+#include "logger.h"
+
+
+
+/** Use log path transformation to support both new and old style logging. */
+#define LOG_TRANSITIONAL_PATH 1
+
+
+extern OCPNPlatform*    g_Platform;
+
+static LogLevel level;
+
+
+static std::string timeStamp()
+{
+    wxDateTime now = wxDateTime::UNow();
+    std::stringstream stamp;
+    stamp << std::setfill('0') 
+          << std::setw(2) << now.GetHour() << ":" 
+          << std::setw(2) << now.GetMinute() << ":" 
+          << std::setw(2) << now.GetSecond() << "." 
+          << std::setw(3) << now.GetMillisecond();
+    return  std::string(stamp.str());
+}
+
+
+static std::string basename(const std::string path) 
+{
+    unsigned int pos = path.rfind('/', path.length());
+    if (pos == std::string::npos) {
+        pos = path.rfind('\\', path.length());
+    }
+    return pos == std::string::npos ? path : path.substr(pos + 1);
+}
+
+
+LogBackend::LogBackend() : isBuffering(true) {};
+
+
+LogBackend::~LogBackend()
+{
+    fclose(f);
+}
+
+
+LogBackend& LogBackend::getInstance()
+{
+    static LogBackend instance;
+    return instance;
+}
+
+
+bool LogBackend::setLogfile(const char* path)
+{
+    f = fopen(path, "a");
+    if (f == NULL) {
+        return false;
+    }
+    time_t ticks =  wxDateTime::GetTimeNow();
+    wxDateTime now = wxDateTime(ticks);
+    std::string stamp(
+            (now.FormatISODate() +  " " + now.FormatISOTime()).mb_str());
+    fprintf(f, "------- OpenCPN restarted at %s -------\n", stamp.c_str()); 
+    fprintf(f, buffer.str().c_str());
+    isBuffering = false;
+    return true;
+}
+
+ 
+void LogBackend::write(const char* text)
+{
+    if (isBuffering) {
+        buffer << text; 
+    } else {
+        fprintf(f, text);
+    }
+}
+
+
+Logger::Logger() {}
+
+
+Logger::~Logger()
+{
+    LogBackend::getInstance().write(os.str().c_str());
+    LogBackend::getInstance().write("\n");
+}
+
+
+static std::string level2str(LogLevel l)
+{
+    switch (l) {
+        case LogLevel::Error:
+            return std::string("Error");
+        case LogLevel::Warning:
+            return std::string("Warning");
+        case LogLevel::Notice:
+            return std::string("Notice");
+        case LogLevel::Info:
+            return std::string("Info");
+        case LogLevel::Debug:
+            return std::string("Debug");
+        case LogLevel::Trace:
+            return std::string("Trace");
+        default:
+            break;
+    };
+    return std::string("unknown level: ")
+        + std::to_string(static_cast<int>(l));
+}
+
+
+LogLevel Logger::string2level(const char* string)
+{
+    std::string level(string);
+    for (auto& c: level)
+        c = tolower(c);
+    if (level == "error")
+        return LogLevel::Error;
+    if (level == "warning")
+        return LogLevel::Warning;
+    if (level == "notice")
+        return LogLevel::Notice;
+    if (level == "info")
+        return LogLevel::Info;
+    if (level == "debug")
+        return LogLevel::Debug;
+    if (level == "trace")
+        return LogLevel::Trace;
+    return LogLevel::BadLevel;
+}
+
+
+void Logger::setLevel(LogLevel l)
+{
+    level = l;
+}
+
+
+LogLevel Logger::getLevel()
+{
+   return level;
+}
+
+
+std::ostream& Logger::get(LogLevel level)
+{
+    os << timeStamp() << " " << level2str(level) << ": ";
+    return os;
+}
+
+
+std::ostream& Logger::get(LogLevel l, const char* path, int line)
+{
+    std::string filename(basename(path));
+    os << timeStamp() << " " << level2str(l) << ": ";
+    os << filename << ":" << line << " ";
+    return os;
+}
+
+
+void Logger::write(LogLevel level, const char* path, int line,
+                   const char* fmt, ...)
+{
+    char buf[1024];
+    std::string filename(basename(path));
+    snprintf(buf, sizeof(buf), "%s %s %s:%d ",
+             timeStamp().c_str(), level2str(level).c_str(), filename.c_str(), line);
+    LogBackend::getInstance().write(buf);
+    va_list ap;
+    va_start(ap, fmt);
+    vsnprintf(buf, sizeof(buf), fmt, ap);
+    va_end(ap);
+    LogBackend::getInstance().write(buf);
+    LogBackend::getInstance().write("\n");
+}
+
+void Logger::write(LogLevel level, const char* file, int line,
+                   wxString fmt, ...)
+{
+    const char* wxfmt = fmt.mb_str();
+    va_list ap;
+    va_start(ap, fmt);
+    write(level, file, line, wxfmt, ap);
+    va_end(ap);
+}
+

--- a/src/logger.cpp
+++ b/src/logger.cpp
@@ -37,7 +37,6 @@
 #include "logger.h"
 
 
-
 /** Use log path transformation to support both new and old style logging. */
 #define LOG_TRANSITIONAL_PATH 1
 
@@ -88,6 +87,11 @@ LogBackend& LogBackend::getInstance()
 
 bool LogBackend::setLogfile(const char* path)
 {
+#ifdef LOG_TRANSITIONAL_PATH
+    std::string newpath(path);
+    newpath.replace(newpath.rfind("."), 1, "-new.");
+    path = newpath.c_str();
+#endif
     f = fopen(path, "a");
     if (f == NULL) {
         return false;


### PR DESCRIPTION
New logging framework draft.  Key capabilites
  - configured in runtime using command line option and environment (see manpage). Users can
   enable detailed logging without re-building opencpn.
  - Supports c-style logging using LOG_INFO and friends  aimed  to replace  wxLogMessage() 
    with the same type of parameters.
  - Supports C++ style logging using DEBUG_LOG and friends aimed to replace qDebug() witjh
     similar  semantics.

This is much simpler than existing libs like logforcplusplus etc. Here is just a single backend, and no configuration of log layout; it's all hardcoded. So is  available log levels..

The PR does not address the need to support logging in the plugin interface.