### PR TITLE
Improve command line sound system.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1132,7 +1132,7 @@ ELSEIF (AFPLAY)
   SET(SYSTEM_SOUND_CMD "\"afplay %s\"")
 ELSEIF (WIN32)
   SET(SYSTEM_SOUND_CMD
-      "\"PowerShell -Command (New-Object Media.SoundPlayer \\\"%s\\\").PlaySync();\"")
+    "\"PowerShell (New-Object Media.SoundPlayer \\\\\\\"%s\\\\\\\").PlaySync();\"")
 ENDIF ()
 
 OPTION(ENABLE_SYSTEM_CMD_SOUND

--- a/include/AIS_Decoder.h
+++ b/include/AIS_Decoder.h
@@ -75,7 +75,8 @@ public:
     AIS_Error DecodeSingleVDO( const wxString& str, GenericPosDatEx *pos, wxString *acc );
     void DeletePersistentTrack( Track *track );
     std::map<int, Track*> m_persistent_tracks;
-    
+    bool AIS_AlertPlaying(void) { return m_bAIS_AlertPlaying; };
+
 private:
     wxString GetShipNameFromFile(int nmmsi);
     
@@ -122,6 +123,7 @@ private:
     wxString         m_dsc_last_string;
     std::vector<int> m_MMSI_MismatchVec;
     
+    bool             m_bAIS_AlertPlaying;
 DECLARE_EVENT_TABLE()
 };
 

--- a/include/OCPN_Sound.h
+++ b/include/OCPN_Sound.h
@@ -99,6 +99,12 @@ class OcpnSound
         /** Reflects loading errors. */
         virtual bool IsOk() const { return m_OK; }
 
+        /**
+         * Set system command string in case program wants to change from
+         * default string.
+         */
+        virtual void SetCmd( const char *cmd ) { };    // does nothing if not overridden
+
     protected:
 
         bool m_OK;

--- a/include/SystemCmdSound.h
+++ b/include/SystemCmdSound.h
@@ -39,13 +39,18 @@ class SystemCmdSound: public OcpnSound
 {
 
     public:
-        SystemCmdSound(const char* cmd = SYSTEM_SOUND_CMD) 
-            :m_path("") { m_cmd = cmd; }
+        SystemCmdSound(const char* cmd = SYSTEM_SOUND_CMD)
+            :m_isPlaying(false), m_cmd(cmd), m_path("")  {};
         ~SystemCmdSound() {};
 
         bool Load(const char* path, int deviceIndex = -1) override;
         bool Play() override;
         bool Stop() override;
+        /**
+         * Set system command string in case program wants to change from
+         * default string.
+         */
+        void SetCmd( const char *cmd ) { m_cmd = cmd; };
 
     private:
         void worker();
@@ -55,5 +60,6 @@ class SystemCmdSound: public OcpnSound
         std::string m_path;
 };
 
+const unsigned maxPlayTime = 200;   // maximum stall time time is 200mS
 
 #endif // __WX_SOUND_H__

--- a/include/options.h
+++ b/include/options.h
@@ -373,6 +373,9 @@ class options : private Uncopyable,
   wxCheckBox *pOZScaleVector, *pToolbarAutoHideCB, *pInlandEcdis, *pDarkDecorations;
   wxTextCtrl *pCOGUPUpdateSecs, *m_pText_OSCOG_Predictor, *pScreenMM;
   wxTextCtrl *pToolbarHideSecs, *m_pText_OSHDT_Predictor;
+
+  wxTextCtrl *pCmdSoundString;
+
   wxChoice *m_pShipIconType, *m_pcTCDatasets;
   wxSlider *m_pSlider_Zoom, *m_pSlider_GUI_Factor, *m_pSlider_Chart_Factor, *m_pSlider_Ship_Factor;
   wxSlider *m_pSlider_Zoom_Vector;

--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -36,6 +36,7 @@
 #include "pluginmanager.h"
 #include "Track.h"
 #include <multiplexer.h>
+#include "config.h"
 
 #if !defined(NAN)
     static const long long lNaN = 0xfff8000000000000;
@@ -98,6 +99,8 @@ extern OCPNPlatform     *g_Platform;
 extern PlugInManager             *g_pi_manager;
 extern Multiplexer      *g_pMUX;
 
+extern wxString g_CmdSoundString;
+
 bool g_benableAISNameCache;
 bool g_bUseOnlyConfirmedAISName;
 wxString GetShipNameFromFile(int);
@@ -122,13 +125,15 @@ static double arpa_ref_hdg = NAN;
 
 extern  const wxEventType wxEVT_OCPN_DATASTREAM;
 extern int              gps_watchdog_timeout_ticks;
-
+extern bool g_bquiting;
 
 static void onSoundFinished(void* ptr)
 {
-   auto aisDecoder = static_cast<AIS_Decoder*>(ptr);
-   wxCommandEvent ev(SOUND_PLAYED_EVTYPE);
-   wxPostEvent(aisDecoder, ev);
+    if (!g_bquiting) {
+        auto aisDecoder = static_cast<AIS_Decoder*>(ptr);
+        wxCommandEvent ev(SOUND_PLAYED_EVTYPE);
+        wxPostEvent(aisDecoder, ev);
+    }
 }
 
 
@@ -174,6 +179,8 @@ AIS_Decoder::AIS_Decoder( wxFrame *parent )
     m_n_targets = 0;
 
     m_parent_frame = parent;
+
+    m_bAIS_AlertPlaying = false;
 
     TimerAIS.SetOwner(this, TIMER_AIS1);
     TimerAIS.Start(TIMER_AIS_MSEC,wxTIMER_CONTINUOUS);
@@ -2308,11 +2315,9 @@ void AIS_Decoder::UpdateOneCPA( AIS_Target_Data *ptarget )
 
 void AIS_Decoder::OnSoundFinishedAISAudio( wxCommandEvent& event )
 {
-    if( g_bAIS_CPA_Alert_Audio && m_bAIS_Audio_Alert_On ) {
-        m_AIS_Sound->Load( g_sAIS_Alert_Sound_File, g_iSoundDeviceIndex);
-        m_AIS_Sound->SetFinishedCallback(onSoundFinished, this);
-        m_AIS_Sound->Play();
-    }
+    // By clearing this flag the main event loop will trigger repeated
+    // sounds for as long as the alert condition remains.
+    m_bAIS_AlertPlaying = false;
 }
 
 void AIS_Decoder::OnTimerDSC( wxTimerEvent& event )
@@ -2598,9 +2603,18 @@ void AIS_Decoder::OnTimerAIS( wxTimerEvent& event )
         if (!m_AIS_Sound) {
             m_AIS_Sound = SoundFactory();
         }
-        m_AIS_Sound->Load(g_sAIS_Alert_Sound_File, g_iSoundDeviceIndex);
-        m_AIS_Sound->SetFinishedCallback(onSoundFinished, this);
-        m_AIS_Sound->Play();
+        if ( !AIS_AlertPlaying() ) {
+            m_bAIS_AlertPlaying = true;
+            m_AIS_Sound->SetCmd( g_CmdSoundString.mb_str( wxConvUTF8 ) );
+            m_AIS_Sound->Load(g_sAIS_Alert_Sound_File, g_iSoundDeviceIndex);
+            if ( m_AIS_Sound->IsOk( ) ) {
+                m_AIS_Sound->SetFinishedCallback( onSoundFinished, this );
+                if ( !m_AIS_Sound->Play( ) )
+                    m_bAIS_AlertPlaying = false;
+            }
+            else
+                m_bAIS_AlertPlaying = false;
+        }
     }
     //  If a SART Alert is active, check to see if the MMSI has special properties set 
     //  indicating that this Alert is a MOB for THIS ship.

--- a/src/ConfigMgr.cpp
+++ b/src/ConfigMgr.cpp
@@ -24,6 +24,7 @@
 #include <wx/tokenzr.h>
 
 #include "ConfigMgr.h"
+#include "config.h"
 
 #include <wx/filename.h>
 #include <wx/fileconf.h>
@@ -307,6 +308,9 @@ extern int              g_BSBImgDebug;
 
 extern int             n_NavMessageShown;
 extern wxString        g_config_version_string;
+extern wxString        g_config_version_string;
+
+extern wxString        g_CmdSoundString;
 
 extern bool             g_bAISRolloverShowClass;
 extern bool             g_bAISRolloverShowCOG;

--- a/src/OCPN_Sound.cpp
+++ b/src/OCPN_Sound.cpp
@@ -30,8 +30,6 @@
 #include <wx/string.h>
 #include <wx/wxchar.h>
 
-extern int g_iSoundDeviceIndex;
-
 
 OcpnSound::OcpnSound()
 {

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -738,6 +738,8 @@ extern options          *g_pOptions;
 int n_NavMessageShown;
 wxString g_config_version_string;
 
+wxString g_CmdSoundString;
+
 bool             g_btouch;
 bool             g_bresponsive;
 
@@ -6877,6 +6879,7 @@ void MyFrame::OnBellsTimer(wxTimerEvent& event)
         appendOSDirSlash( &soundfile );
         soundfile += wxString( bells_sound_file_name[bells - 1], wxConvUTF8 );
         soundfile.Prepend( g_Platform->GetSharedDataDir() );
+        bells_sound[bells - 1]->SetCmd( g_CmdSoundString.mb_str( wxConvUTF8 ) );
         bells_sound[bells - 1]->Load( soundfile );
         if( !bells_sound[bells - 1]->IsOk() ) {
             wxLogMessage( _T("Failed to load bells sound file: ") + soundfile );

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -322,6 +322,8 @@ extern bool              g_bAutoHideToolbar;
 extern int               g_nAutoHideToolbar;
 extern bool              g_bDeferredInitDone;
 
+extern wxString          g_CmdSoundString;
+
 //  TODO why are these static?
 static int mouse_x;
 static int mouse_y;
@@ -6142,6 +6144,14 @@ void ChartCanvas::JaggyCircle( ocpnDC &dc, wxPen pen, int x, int y, int radius )
     dc.SetPen( pen_save );
 }
 
+static bool bAnchorSoundPlaying = false;
+
+static void onSoundFinished( void* ptr )
+{
+    bAnchorSoundPlaying = false;
+}
+
+
 void ChartCanvas::AlertDraw( ocpnDC& dc )
 {
 // Just for prototyping, visual alert for anchorwatch goes here
@@ -6168,10 +6178,14 @@ void ChartCanvas::AlertDraw( ocpnDC& dc )
     } else
         AnchorAlertOn2 = false;
 
-    if( play_sound ) {
-        if( !g_anchorwatch_sound->IsOk() )
-            g_anchorwatch_sound->Load( g_sAIS_Alert_Sound_File );
-        g_anchorwatch_sound->Play();
+    if( play_sound && !bAnchorSoundPlaying) {
+        g_anchorwatch_sound->SetCmd( g_CmdSoundString.mb_str( wxConvUTF8) );
+        g_anchorwatch_sound->Load( g_sAIS_Alert_Sound_File );
+        if ( g_anchorwatch_sound->IsOk( ) ) {
+            bAnchorSoundPlaying = true;
+            g_anchorwatch_sound->SetFinishedCallback( onSoundFinished, NULL );
+            g_anchorwatch_sound->Play( );
+        }
     } else if( g_anchorwatch_sound->IsOk() ) {
         g_anchorwatch_sound->Stop();
     }

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -74,6 +74,7 @@
 #include "Track.h"
 #include "chartdb.h"
 #include "CanvasConfig.h"
+#include "config.h"
 
 #ifdef USE_S57
 #include "s52plib.h"
@@ -329,6 +330,8 @@ extern int              g_BSBImgDebug;
 
 extern int             n_NavMessageShown;
 extern wxString        g_config_version_string;
+
+extern wxString        g_CmdSoundString;
 
 extern bool             g_bAISRolloverShowClass;
 extern bool             g_bAISRolloverShowCOG;
@@ -753,6 +756,11 @@ int MyConfig::LoadMyConfigRaw( bool bAsTemplate )
     
     // Some undocumented values
     Read( _T ( "ConfigVersionString" ), &g_config_version_string );
+#ifdef SYSTEM_SOUND_CMD
+    Read(_T("CmdSoundString"), &g_CmdSoundString, wxString(SYSTEM_SOUND_CMD) );
+    if ( wxIsEmpty( g_CmdSoundString ) )
+        g_CmdSoundString = wxString( SYSTEM_SOUND_CMD );
+#endif /* SYSTEM_SOUND_CMD */
     Read( _T ( "NavMessageShown" ), &n_NavMessageShown );
 
     Read( _T ( "UIexpert" ), &g_bUIexpert );
@@ -2227,6 +2235,11 @@ void MyConfig::UpdateSettings()
     Write( _T ( "LastAppliedTemplate" ), g_lastAppliedTemplateGUID );
     
     Write( _T ( "ConfigVersionString" ), g_config_version_string );
+#ifdef SYSTEM_SOUND_CMD
+    if ( wxIsEmpty( g_CmdSoundString ) )
+        g_CmdSoundString = wxString( SYSTEM_SOUND_CMD );
+    Write( _T( "CmdSoundString" ), g_CmdSoundString );
+#endif /* SYSTEM_SOUND_CMD */
     Write( _T ( "NavMessageShown" ), n_NavMessageShown );
     Write( _T ( "InlandEcdis" ), g_bInlandEcdis );
     

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -138,6 +138,8 @@ extern bool             g_bopengl;
 extern ChartGroupArray  *g_pGroupArray;
 extern unsigned int     g_canvasConfig;
 
+extern wxString         g_CmdSoundString;
+
 #ifdef __WXMSW__
 static const char PATH_SEP = ';';
 #else
@@ -5986,18 +5988,23 @@ void SetCanvasProjection(int projection)
     gFrame->GetPrimaryCanvas()->SetVPProjection(projection);
 }
 
-// Play a sound to a given device
+OcpnSound* g_PluginSound = SoundFactory( );
+static void onPlugInPlaySoundExFinished( void* ptr ) { }
+
+// Start playing a sound to a given device and return status to plugin
 bool PlugInPlaySoundEx( wxString &sound_file, int deviceIndex )
 {
-    OcpnSound* sound = SoundFactory();
-    bool ok = sound->Load(sound_file, deviceIndex);
-    if (!ok) {
-        wxLogWarning("Cannot load sound file: %s", sound_file);
+    bool ok = g_PluginSound->Load( sound_file, deviceIndex );
+    if ( !ok ) {
+        wxLogWarning( "Cannot load sound file: %s", sound_file );
         return false;
     }
-    ok = sound->Play();
-    if (!ok) {
-        wxLogWarning("Cannot play sound file: %s", sound_file);
+    g_PluginSound->SetCmd( g_CmdSoundString.mb_str( wxConvUTF8 ) );
+
+    g_PluginSound->SetFinishedCallback( onPlugInPlaySoundExFinished, NULL );
+    ok = g_PluginSound->Play( );
+    if ( !ok ) {
+        wxLogWarning( "Cannot play sound file: %s", sound_file );
     }
     return ok;
 }


### PR DESCRIPTION
    Make command line editable by expert user
    Play most sounds so as to not block the UI.
    Do not start another alert sound until previous is finished.
    Use native Windows createProcessA() instead of system() because
      then we don't see a popup window flash.
    Now multiple instances of SoundFactory() objects can play at the
      same time.
    Do more runtime checks and less conditional build sections.
    Prevent creating large number of command windows.
    Allow spaces in the sound file path.

Break do_play() into 2 distinct functions Win/non-Win

Note: Will not compile with VS2013 due to use of safer snprintf().
