### PR TITLE
Warnings: Fix gcc 8 warnings on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -586,6 +586,8 @@ IF(NOT WIN32 AND NOT APPLE )
   IF(CMAKE_BUILD_TYPE MATCHES "Debug")
     ADD_DEFINITIONS( " -O0")
   ENDIF(CMAKE_BUILD_TYPE MATCHES "Debug")
+  ADD_DEFINITIONS("-Wno-deprecated-declarations")
+  # TODO: Enable deprecation warnings again after the 5.0.0 cycle
 
   ADD_DEFINITIONS( " -DPREFIX=\\\"${CMAKE_INSTALL_PREFIX}\\\"")
   # profiling with gprof

--- a/include/AIS_Target_Data.h
+++ b/include/AIS_Target_Data.h
@@ -30,8 +30,13 @@
 
 #include "ais.h"
 
+#define SHIP_NAME_LEN  21
+#define CALL_SIGN_LEN  8
+
 void make_hash_ERI(int key, const wxString & description);
 void clear_hash_ERI( void );
+
+
 
 class AIS_Target_Data
 {
@@ -64,8 +69,8 @@ public:
     double                    Lat;
     int                       ROTAIS;
     int                       ROTIND;
-    char                      CallSign[8];                // includes terminator
-    char                      ShipName[21];
+    char                      CallSign[CALL_SIGN_LEN];                // includes terminator
+    char                      ShipName[SHIP_NAME_LEN];
     char                      ShipNameExtension[15];
     unsigned char             ShipType;
     int                       IMO;

--- a/include/AIS_Target_Data.h
+++ b/include/AIS_Target_Data.h
@@ -32,6 +32,7 @@
 
 #define SHIP_NAME_LEN  21
 #define CALL_SIGN_LEN  8
+#define EURO_VIN_LEN   9
 
 void make_hash_ERI(int key, const wxString & description);
 void clear_hash_ERI( void );
@@ -83,7 +84,7 @@ public:
     double                    Euro_Length;            // Extensions for European Inland AIS
     double                    Euro_Beam;
     double                    Euro_Draft;
-    char                      Euro_VIN[9];	      // includes terminator
+    char                      Euro_VIN[EURO_VIN_LEN];	      // includes terminator
     int                       UN_shiptype;
     bool                      b_isEuroInland;
     bool                      b_blue_paddle;

--- a/include/s52s57.h
+++ b/include/s52s57.h
@@ -36,6 +36,8 @@
 
 #define CURRENT_SENC_FORMAT_VERSION  200
 
+#define OBJL_NAME_LEN  6
+
 //    Fwd Defns
 class wxArrayOfS57attVal;
 class OGREnvelope;
@@ -264,7 +266,7 @@ typedef struct _S57attVal {
 WX_DEFINE_ARRAY( S57attVal *, wxArrayOfS57attVal );
 
 typedef struct _OBJLElement {
-    char OBJLName[6];
+    char OBJLName[OBJL_NAME_LEN];
     int nViz;
 } OBJLElement;
 

--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -1590,7 +1590,7 @@ bool chartdldr_pi::ExtractZipFiles( const wxString& aZipFile, const wxString& aT
 {
     bool ret = true;
 
-    std::auto_ptr<wxZipEntry> entry(new wxZipEntry());
+    std::unique_ptr<wxZipEntry> entry(new wxZipEntry());
 
     do
     {

--- a/plugins/grib_pi/src/GribV2Record.cpp
+++ b/plugins/grib_pi/src/GribV2Record.cpp
@@ -718,7 +718,7 @@ static bool unpackDS(GRIBMessage *grib_msg)
   struct {
     int *ref_vals,*widths;
     int *lengths;
-    int *first_vals,sign,omin;
+    int *first_vals = 0,sign,omin;
     long long miss_val,group_miss_val;
     int max_length;
   } groups;

--- a/plugins/grib_pi/src/jasper/jpc/jpc_util.c
+++ b/plugins/grib_pi/src/jasper/jpc/jpc_util.c
@@ -102,7 +102,7 @@ int jpc_atoaf(char *s, int *numvalues, double **values)
 	if ((cp = strtok(buf, delim))) {
 		++n;
 		while ((cp = strtok(0, delim))) {
-			if (cp != '\0') {
+			if (cp != NULL) {
 				++n;
 			}
 		}
@@ -120,7 +120,7 @@ int jpc_atoaf(char *s, int *numvalues, double **values)
 			vs[n] = atof(cp);
 			++n;
 			while ((cp = strtok(0, delim))) {
-				if (cp != '\0') {
+				if (cp != NULL) {
 					vs[n] = atof(cp);
 					++n;
 				}

--- a/plugins/wmm_pi/src/WMM_SubLibrary.c
+++ b/plugins/wmm_pi/src/WMM_SubLibrary.c
@@ -382,7 +382,7 @@ void WMM_DegreeToDMSstring (double DegreesOfArc, int UnitDepth, char *DMSstring)
 	{
 	int DMS[3], i;
 	double temp = DegreesOfArc;
-	char tempstring[20] = "";
+	char tempstring[32] = "";
 	char tempstring2[20] = "";
 	strcpy(DMSstring, "");
 	if(UnitDepth >= 3)
@@ -405,7 +405,8 @@ void WMM_DegreeToDMSstring (double DegreesOfArc, int UnitDepth, char *DMSstring)
 		temp = (temp - DMS[i])*60;
 		if(i == UnitDepth - 1 && temp >= 30)
 			DMS[i]++;
-		sprintf(tempstring, "%4d%4s", DMS[i], tempstring2);
+		snprintf(tempstring ,sizeof(tempstring),
+                         "%4d%4s", DMS[i], tempstring2);
 		strcat(DMSstring, tempstring);
 	}
 	} /*WMM_DegreeToDMSstring*/

--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -910,7 +910,7 @@ AIS_Error AIS_Decoder::Decode( const wxString& str )
                 pTargetData->SOG = gpsg_sog;
                 pTargetData->ShipType = 52; // buddy
                 pTargetData->Class = AIS_GPSG_BUDDY;
-                strncpy( pTargetData->ShipName, gpsg_name_str, strlen( gpsg_name_str ) + 1 );
+                memcpy( pTargetData->ShipName, gpsg_name_str, SHIP_NAME_LEN );
                 pTargetData->b_nameValid = true;
                 pTargetData->b_active = true;
                 pTargetData->b_lost = false;
@@ -946,7 +946,7 @@ AIS_Error AIS_Decoder::Decode( const wxString& str )
                 pTargetData->ShipType = 55; // arpa
                 pTargetData->Class = AIS_ARPA;
 
-                strncpy( pTargetData->ShipName, arpa_name_str, strlen( arpa_name_str ) + 1 );
+                memcpy( pTargetData->ShipName, arpa_name_str, SHIP_NAME_LEN );
                 if( arpa_status != _T("Q") )
                     pTargetData->b_nameValid = true;
                 else
@@ -975,7 +975,7 @@ AIS_Error AIS_Decoder::Decode( const wxString& str )
                 pTargetData->b_positionOnceValid = true;
                 pTargetData->ShipType = 56; // aprs
                 pTargetData->Class = AIS_APRS;
-                strncpy( pTargetData->ShipName, aprs_name_str, strlen( aprs_name_str ) + 1 );
+                memcpy( pTargetData->ShipName, aprs_name_str, SHIP_NAME_LEN );
                 pTargetData->b_nameValid = true;
                 pTargetData->b_active = true;
                 pTargetData->b_lost = false;

--- a/src/AIS_Target_Data.cpp
+++ b/src/AIS_Target_Data.cpp
@@ -231,7 +231,7 @@ void AIS_Target_Data::CloneFrom( AIS_Target_Data* q )
     Euro_Length = q->Euro_Length;            // Extensions for European Inland AIS
     Euro_Beam = q->Euro_Beam;
     Euro_Draft = q->Euro_Draft;
-    strncpy(Euro_VIN, q->Euro_VIN, 8);
+    memcpy(Euro_VIN, q->Euro_VIN, EURO_VIN_LEN);
     UN_shiptype = q->UN_shiptype;
     
     b_isEuroInland = q->b_isEuroInland;

--- a/src/ConfigMgr.cpp
+++ b/src/ConfigMgr.cpp
@@ -548,7 +548,7 @@ bool OCPNConfigCatalog::IsOpenCPN()
     for (pugi::xml_attribute attr = root().first_child().first_attribute(); attr; attr = attr.next_attribute())
         if( !strcmp(attr.name(), "creator") && !strcmp(attr.value(), "OpenCPN") )
             return true;
-        return false;
+    return false;
 }
 
 bool OCPNConfigCatalog::SaveFile( const wxString filename )

--- a/src/OCPN_AUIManager.cpp
+++ b/src/OCPN_AUIManager.cpp
@@ -140,28 +140,27 @@ void OCPN_AUIManager::OnMotionx(wxMouseEvent& event)
             else
                 pos.x = wxMax(0, event.m_x - m_actionOffset.x);
             
-
-                wxSize client_size = m_frame->GetClientSize();
-                int used_width = 0, used_height = 0;
-                
-                size_t dock_i, dock_count = m_docks.GetCount();
-                for (dock_i = 0; dock_i < dock_count; ++dock_i)
+            wxSize client_size = m_frame->GetClientSize();
+            int used_width = 0, used_height = 0;
+            
+            size_t dock_i, dock_count = m_docks.GetCount();
+            for (dock_i = 0; dock_i < dock_count; ++dock_i)
+            {
+                wxAuiDockInfo& dock = m_docks.Item(dock_i);
+                if (dock.dock_direction == wxAUI_DOCK_TOP ||
+                    dock.dock_direction == wxAUI_DOCK_BOTTOM)
                 {
-                    wxAuiDockInfo& dock = m_docks.Item(dock_i);
-                    if (dock.dock_direction == wxAUI_DOCK_TOP ||
-                        dock.dock_direction == wxAUI_DOCK_BOTTOM)
-                    {
-                        used_height += dock.size;
-                    }
-                    if (dock.dock_direction == wxAUI_DOCK_LEFT ||
-                        dock.dock_direction == wxAUI_DOCK_RIGHT)
-                    {
-                        used_width += dock.size;
-                    }
-                    //                     if (dock.resizable)
-                    //                         used_width += sashSize;
+                    used_height += dock.size;
                 }
-                
+                if (dock.dock_direction == wxAUI_DOCK_LEFT ||
+                    dock.dock_direction == wxAUI_DOCK_RIGHT)
+                {
+                    used_width += dock.size;
+                }
+                //                     if (dock.resizable)
+                //                         used_width += sashSize;
+            }
+
             if (OAuiManager_HasLiveResize(*this))
             {
  

--- a/src/RoutePropDlgImpl.cpp
+++ b/src/RoutePropDlgImpl.cpp
@@ -61,7 +61,9 @@ extern TCMgr *ptcmgr;
 // adapted by author's permission from QBASIC source as published at
 //     http://www.stargazing.net/kepler
 
+#ifndef PI
 #define    PI      (4.*atan(1.0))
+#endif
 #define    TPI     (2.*PI)
 #define    DEGS    (180./PI)
 #define    RADS    (PI/180.)

--- a/src/TCDS_Binary_Harmonic.cpp
+++ b/src/TCDS_Binary_Harmonic.cpp
@@ -445,7 +445,8 @@ TC_Error_Code TCDS_Binary_Harmonic::LoadData(const wxString &data_file_path)
             psd->zone_offset = zone_offset;
 
             // Get units
-            strncpy (psd->unit, get_level_units (ptiderec->level_units), 40);
+            strncpy (psd->unit, get_level_units (ptiderec->level_units), 40 - 1);
+            psd->unit[40 -1] = '\0';
 
             psd->have_BOGUS = (findunit(psd->unit) != -1) && (known_units[findunit(psd->unit)].type == BOGUS);
 
@@ -460,8 +461,10 @@ TC_Error_Code TCDS_Binary_Harmonic::LoadData(const wxString &data_file_path)
                 strncpy (psd->units_abbrv, known_units[unit_c].abbrv, sizeof(psd->units_abbrv)-1);
             }
             else {
-                strncpy (psd->units_conv, psd->unit, sizeof(psd->units_conv)-1);
-                strncpy (psd->units_abbrv, psd->unit, sizeof(psd->units_abbrv)-1);
+                strncpy (psd->units_conv, psd->unit, 40 - 1);
+                psd->units_conv[40 - 1] = '\0';
+                strncpy (psd->units_abbrv, psd->unit, 20 - 1);
+                psd->units_abbrv[20 - 1] = '\0';
             }
 
 
@@ -552,7 +555,9 @@ TC_Error_Code TCDS_Binary_Harmonic::LoadHarmonicData(IDX_entry *pIDX)
 {
     // Find the indicated Master station
     if(!strlen(pIDX->IDX_reference_name)) {
-        strncpy(pIDX->IDX_reference_name, get_station (pIDX->IDX_ref_dbIndex), MAXNAMELEN );
+        strncpy(pIDX->IDX_reference_name, get_station (pIDX->IDX_ref_dbIndex),
+                MAXNAMELEN - 1 );
+        pIDX->IDX_reference_name[MAXNAMELEN - 1] = '\0';
 
 //        TIDE_RECORD *ptiderec = (TIDE_RECORD *)calloc(sizeof(TIDE_RECORD), 1);
 //        read_tide_record (pIDX->IDX_ref_dbIndex, ptiderec);

--- a/src/TCDataSource.cpp
+++ b/src/TCDataSource.cpp
@@ -77,7 +77,9 @@ TC_Error_Code TCDataSource::LoadData(const wxString &data_file_path)
             IDX_entry *pIDX = GetIndexEntry( i );
             if(pIDX){
                 pIDX->pDataSource = this;
-                strncpy(pIDX->source_ident, m_data_source_path.mb_str(), MAXNAMELEN );
+                strncpy(pIDX->source_ident, m_data_source_path.mb_str(),
+                        MAXNAMELEN - 1);
+                pIDX->source_ident[MAXNAMELEN -1] = '\0';
             }
         }
     }

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -11143,7 +11143,7 @@ int get_static_line( char *d, const char **p, int index, int n )
 static void InitializeUserColors( void )
 {
     const char **p = usercolors;
-    char buf[80];
+    char buf[81];
     int index = 0;
     char TableName[20];
     colTable *ctp;
@@ -11170,7 +11170,7 @@ static void InitializeUserColors( void )
     ct->color = new wxArrayPtrVoid;
     UserColorTableArray->Add( (void *) ct );
 
-    while( ( get_static_line( buf, p, index, 80 ) ) ) {
+    while( ( get_static_line( buf, p, index, sizeof(buf) - 1 ) ) ) {
         if( !strncmp( buf, "Table", 5 ) ) {
             sscanf( buf, "Table:%s", TableName );
 

--- a/src/chartsymbols.cpp
+++ b/src/chartsymbols.cpp
@@ -638,7 +638,7 @@ void ChartSymbols::BuildLookup( Lookup &lookup )
     LUP->RPRI = lookup.radarPrio;
     LUP->TNAM = lookup.tableName;
     LUP->OBCL[6] = 0;
-    strncpy( LUP->OBCL, lookup.name.mb_str(), 7 );
+    memcpy( LUP->OBCL, lookup.name.mb_str(), 7 );
 
     LUP->ATTArray = lookup.attributeCodeArray;
 
@@ -750,7 +750,7 @@ void ChartSymbols::BuildLineStyle( LineStyle &lineStyle )
     plib->pAlloc->Add( lnst );
 
     lnst->RCID = lineStyle.RCID;
-    strncpy( lnst->name.PANM, lineStyle.name.mb_str(), 8 );
+    memcpy( lnst->name.PANM, lineStyle.name.mb_str(), 8 );
     lnst->bitmap.PBTM = NULL;
 
     lnst->vector.LVCT = (char *) malloc( lineStyle.HPGL.Len() + 1 );
@@ -890,7 +890,7 @@ void ChartSymbols::BuildPattern( OCPNPattern &pattern )
 
     patt->RCID = pattern.RCID;
     patt->exposition.PXPO = new wxString( pattern.description );
-    strncpy( patt->name.PANM, pattern.name.mb_str(), 8 );
+    memcpy( patt->name.PANM, pattern.name.mb_str(), 8 );
     patt->bitmap.PBTM = NULL;
     patt->fillType.PATP = pattern.fillType;
     patt->spacing.PASP = pattern.spacing;
@@ -1067,7 +1067,7 @@ void ChartSymbols::BuildSymbol( ChartSymbol& symbol )
     wxString SCRF;
 
     symb->RCID = symbol.RCID;
-    strncpy( symb->name.SYNM, symbol.name.char_str(), 8 );
+    memcpy( symb->name.SYNM, symbol.name.char_str(), 8 );
 
     symb->exposition.SXPO = new wxString( symbol.description );
 

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -11477,7 +11477,7 @@ void ChartCanvas::DrawAllCurrentsInBBox( ocpnDC& dc, LLBBox& BBox )
                         else
                             continue;
                         
-                        if( ( type == 'c' ) )
+                        if( type == 'c' )
                         {
                             {
 

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -8978,8 +8978,8 @@ void pupHandler_PasteRoute() {
         }
     }
 
-    Route* newRoute = NULL;
-    RoutePoint* newPoint;
+    Route* newRoute = 0;
+    RoutePoint* newPoint = 0;
 
     if( createNewRoute ) {
         newRoute = new Route();

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -1550,15 +1550,15 @@ bool ChartCanvas::DoCanvasUpdate( void )
         else
             m_pCurrentStack = new ChartStack;
             
-            //  This logic added to enable opening a chart when there is no
-                //  previous chart indication, either from inital startup, or from adding new chart directory
-            if( m_bautofind && (-1 == GetQuiltReferenceChartIndex()) && m_pCurrentStack ){
-                if(m_pCurrentStack->nEntry){
-                    int new_dbIndex = m_pCurrentStack->GetDBIndex(m_pCurrentStack->nEntry-1);    // smallest scale
+        //  This logic added to enable opening a chart when there is no
+            //  previous chart indication, either from inital startup, or from adding new chart directory
+        if( m_bautofind && (-1 == GetQuiltReferenceChartIndex()) && m_pCurrentStack ){
+            if (m_pCurrentStack->nEntry) {
+                int new_dbIndex = m_pCurrentStack->GetDBIndex(m_pCurrentStack->nEntry-1);    // smallest scale
                 SelectQuiltRefdbChart(new_dbIndex, true);
                 m_bautofind = false;
-             }
-         }
+            }
+        }
                 
          ChartData->BuildChartStack( m_pCurrentStack, tLat, tLon, m_groupIndex );
          m_pCurrentStack->SetCurrentEntryFromdbIndex( current_db_index );
@@ -12196,12 +12196,12 @@ void ChartCanvas::UpdateGPSCompassStatusBox( bool b_force_new )
                 m_Compass->Move( wxPoint( GetSize().x - rect.width - cc1_edge_comp,
                                           GetSize().y - ( rect.height + cc1_edge_comp ) ) );
                 
-                if(rect != m_Compass->GetRect()) {
-                    Refresh(true);
-                    m_brepaint_piano = true;
-                    b_update = true;
-                }
-                m_mainlast_tb_rect = tb_rect;
+            if (rect != m_Compass->GetRect()) {
+                Refresh(true);
+                m_brepaint_piano = true;
+                b_update = true;
+            }
+            m_mainlast_tb_rect = tb_rect;
             
         }
     }

--- a/src/cm93.cpp
+++ b/src/cm93.cpp
@@ -3398,7 +3398,7 @@ S57Obj *cm93chart::CreateS57Obj ( int cell_index, int iobject, int subcell, Obje
       char u[201];
       strncpy ( u, sclass_sub.mb_str(), 199 );
       u[200] = '\0';
-      strncpy ( pobj->FeatureName, u, 7 );
+      memcpy ( pobj->FeatureName, u, 7 );
 
       //  Touch up the geom types
       int geomtype_sub = geomtype;

--- a/src/garmin/jeeps/garmin_wrapper_utils.c
+++ b/src/garmin/jeeps/garmin_wrapper_utils.c
@@ -191,7 +191,8 @@ fix_win_serial_name_r(const char *comname, char *obuf, size_t len)
            ((strlen(comname) == 5) && (comname[4] == ':')) ||
            ((strlen(comname) == 4) && (case_ignore_strncmp(comname, "com", 3) == 0))
          ) {
-            strncpy(obuf, comname, len);
+            strncpy(obuf, comname, len - 1);
+            obuf[len - 1] = '\0';
          } else {
                size_t l;
                snprintf(obuf, len, DEV_PREFIX "%s", comname);

--- a/src/glTexCache.cpp
+++ b/src/glTexCache.cpp
@@ -27,6 +27,7 @@
 #include <wx/wxprec.h>
 #include <wx/tokenzr.h>
 #include <wx/filename.h>
+#include <wx/wx.h>
 
 #include <stdint.h>
 

--- a/src/glTextureManager.cpp
+++ b/src/glTextureManager.cpp
@@ -26,6 +26,7 @@
 
 #include <wx/wxprec.h>
 #include <wx/progdlg.h>
+#include <wx/wx.h>
 
 #include "dychart.h"
 #include "viewport.h"

--- a/src/mygdal/cpl_path.cpp
+++ b/src/mygdal/cpl_path.cpp
@@ -441,7 +441,7 @@ const char *CPLFormFilename( const char * pszPath,
                strlen(pszBasename) + strlen(pszAddedExtSep) +
                strlen(pszExtension) + 1 < CPL_PATH_BUF_SIZE );
 
-    strncpy( szStaticResult, pszPath, CPL_PATH_BUF_SIZE );
+    strncpy( szStaticResult, pszPath, CPL_PATH_BUF_SIZE - 1 );
     strncat( szStaticResult, pszAddedPathSep, sizeof(szStaticResult)-strlen(szStaticResult)-1);
     strncat( szStaticResult, pszBasename,     sizeof(szStaticResult)-strlen(szStaticResult)-1);
     strncat( szStaticResult, pszAddedExtSep,  sizeof(szStaticResult)-strlen(szStaticResult)-1);

--- a/src/mygdal/ogrlinestring.cpp
+++ b/src/mygdal/ogrlinestring.cpp
@@ -409,7 +409,7 @@ void OGRLineString::setNumPoints( int nNewPointCount )
 
         assert( paoPoints != NULL );
 
-        memset( paoPoints + nPointCount,
+        memset( (void*) (paoPoints + nPointCount),
                 0, sizeof(OGRRawPoint) * (nNewPointCount - nPointCount) );
 
         if( getCoordinateDimension() == 3 )

--- a/src/myiso8211/ddfmodule.cpp
+++ b/src/myiso8211/ddfmodule.cpp
@@ -471,7 +471,7 @@ int DDFModule::Create( const char *pszFilename )
     achLeader[9] = _appIndicator;
     sprintf( achLeader+10, "%02d", (int) _fieldControlLength );
     sprintf( achLeader+12, "%05d", (int) _fieldAreaStart );
-    strncpy( achLeader+17, _extendedCharSet, 3 );
+    memcpy( achLeader+17, _extendedCharSet, 3 );
     sprintf( achLeader+20, "%1d", (int) _sizeFieldLength );
     sprintf( achLeader+21, "%1d", (int) _sizeFieldPos );
     achLeader[22] = '0';

--- a/src/myiso8211/ddfsubfielddefn.cpp
+++ b/src/myiso8211/ddfsubfielddefn.cpp
@@ -939,6 +939,10 @@ int DDFSubfieldDefn::FormatIntValue( char *pachData, int nBytesAvailable,
                                      int *pnBytesUsed, int nNewValue )
 
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
+
     int nSize;
     char szWork[30];
 
@@ -1011,6 +1015,7 @@ int DDFSubfieldDefn::FormatIntValue( char *pachData, int nBytesAvailable,
     }
 
     return TRUE;
+#pragma GCC diagnostic pop
 }
 
 /************************************************************************/
@@ -1028,6 +1033,9 @@ int DDFSubfieldDefn::FormatFloatValue( char *pachData, int nBytesAvailable,
                                        int *pnBytesUsed, double dfNewValue )
 
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
     int nSize;
     char szWork[120];
 
@@ -1075,4 +1083,5 @@ int DDFSubfieldDefn::FormatFloatValue( char *pachData, int nBytesAvailable,
     }
 
     return TRUE;
+#pragma GCC diagnostic pop
 }

--- a/src/myiso8211/ddfsubfielddefn.cpp
+++ b/src/myiso8211/ddfsubfielddefn.cpp
@@ -940,8 +940,10 @@ int DDFSubfieldDefn::FormatIntValue( char *pachData, int nBytesAvailable,
 
 {
 #pragma GCC diagnostic push
+#if defined(__GNUC__) && __GNUC >= 8
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
 
     int nSize;
     char szWork[30];
@@ -1034,8 +1036,10 @@ int DDFSubfieldDefn::FormatFloatValue( char *pachData, int nBytesAvailable,
 
 {
 #pragma GCC diagnostic push
+#if defined(__GNUC__) && __GNUC >= 8
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
     int nSize;
     char szWork[120];
 

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -1565,7 +1565,7 @@ void MyConfig::LoadS57Config()
 
                 if( bNeedNew ) {
                     pOLE = (OBJLElement *) calloc( sizeof(OBJLElement), 1 );
-                    strncpy( pOLE->OBJLName, sObj.mb_str(), 6 );
+                    memcpy( pOLE->OBJLName, sObj.mb_str(), OBJL_NAME_LEN );
                     pOLE->nViz = 1;
 
                     ps52plib->pOBJLArray->Add( (void *) pOLE );

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -4068,8 +4068,8 @@ PlugIn_AIS_Target *Create_PI_AIS_Target(AIS_Target_Data *ptarget)
 
     pret->alarm_state =     (plugin_ais_alarm_type)ptarget->n_alert_state;
 
-    strncpy(pret->CallSign, ptarget->CallSign, sizeof(ptarget->CallSign));
-    strncpy(pret->ShipName, ptarget->ShipName, sizeof(ptarget->ShipName));
+    memcpy(pret->CallSign, ptarget->CallSign, CALL_SIGN_LEN);
+    memcpy(pret->ShipName, ptarget->ShipName, SHIP_NAME_LEN);
 
     return pret;
 }

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -6852,7 +6852,7 @@ int GetCanvasIndexUnderMouse( void )
 {
     ChartCanvas *l_canvas = gFrame->GetCanvasUnderMouse();
     if(l_canvas) {
-        for(int i = 0; i < g_canvasArray.GetCount(); ++i) {
+        for(unsigned int i  = 0; i < g_canvasArray.GetCount(); ++i) {
             if(l_canvas == g_canvasArray[i])
                 return i;
         }

--- a/src/s52cnsy.cpp
+++ b/src/s52cnsy.cpp
@@ -46,6 +46,14 @@ bool GetDoubleAttr(S57Obj *obj, const char *AttrName, double &val);
 
 #define UNKNOWN 1e6 //HUGE_VAL   // INFINITY/NAN
 
+#ifndef chk_snprintf
+#define chk_snprintf(buf, len, fmt, ...) \
+{ \
+    int r = snprintf(buf, len, fmt, ##__VA_ARGS__); \
+    if (r == -1 || r >= len) wxLogWarning("snprint overrun"); \
+}
+#endif
+
 WX_DEFINE_ARRAY_DOUBLE(double, ArrayOfSortedDoubles);
 
 
@@ -2943,7 +2951,7 @@ wxString SNDFRM02(S57Obj *obj, double depth_value_in)
         _parseList(tecsoustr->mb_str(), tecsou, sizeof(tecsou));
         if (strpbrk(tecsou, "\006"))
         {
-            snprintf(temp_str, LISTSIZE, ";SY(%sB1)", symbol_prefix_a);
+            chk_snprintf(temp_str, LISTSIZE, ";SY(%sB1)", symbol_prefix_a);
             sndfrm02.Append(wxString(temp_str, wxConvUTF8));
         }
     }
@@ -2953,9 +2961,8 @@ wxString SNDFRM02(S57Obj *obj, double depth_value_in)
     
     if (strpbrk(quasou, "\003\004\005\010\011") || strpbrk(status, "\022"))
     {
-        snprintf(temp_str, LISTSIZE, ";SY(%sC2)", symbol_prefix_a);
+        chk_snprintf(temp_str, LISTSIZE, ";SY(%sC2)", symbol_prefix_a);
         sndfrm02.Append(wxString(temp_str, wxConvUTF8));
-        
     }
     else
     {
@@ -2965,7 +2972,8 @@ wxString SNDFRM02(S57Obj *obj, double depth_value_in)
         {
             if (2 <= quapos && quapos < 10)
             {
-                snprintf(temp_str, LISTSIZE, ";SY(%sC2)", symbol_prefix_a);
+                chk_snprintf(temp_str, LISTSIZE,
+                             ";SY(%sC2)", symbol_prefix_a);
                 sndfrm02.Append(wxString(temp_str, wxConvUTF8));
             }
         }
@@ -2986,17 +2994,20 @@ wxString SNDFRM02(S57Obj *obj, double depth_value_in)
             int fraction = (int)ABS((fabs(depth_value) - leading_digit)*10);
             
             
-            snprintf(temp_str, LISTSIZE, ";SY(%s1%1i)", symbol_prefix_a, (int)ABS(leading_digit));
+            chk_snprintf(temp_str, LISTSIZE, ";SY(%s1%1i)",
+                         symbol_prefix_a, (int)ABS(leading_digit));
             sndfrm02.Append(wxString(temp_str, wxConvUTF8));
             if(fraction > 0) {
-                snprintf(temp_str, LISTSIZE, ";SY(%s5%1i)", symbol_prefix_a, fraction);
+                chk_snprintf(temp_str, LISTSIZE,
+                             ";SY(%s5%1i)", symbol_prefix_a, fraction);
                 sndfrm02.Append(wxString(temp_str, wxConvUTF8));
             }
             
             // above sea level (negative)
             if (depth_value < 0.0)
             {
-                snprintf(temp_str, LISTSIZE, ";SY(%sA1)", symbol_prefix_a);
+                chk_snprintf(temp_str, LISTSIZE,
+                             ";SY(%sA1)", symbol_prefix_a);
                 sndfrm02.Append(wxString(temp_str, wxConvUTF8));
             }
             goto return_point;
@@ -3022,25 +3033,28 @@ wxString SNDFRM02(S57Obj *obj, double depth_value_in)
             fraction = fraction * 10;
             if (leading_digit >= 10.0)
             {
-                snprintf(temp_str, LISTSIZE, ";SY(%s2%1i)", symbol_prefix_a, (int)leading_digit/10);
+                chk_snprintf(temp_str, LISTSIZE, ";SY(%s2%1i)",
+                             symbol_prefix_a, (int)leading_digit/10);
                 sndfrm02.Append(wxString(temp_str, wxConvUTF8));
             }
             
             double first_digit = floor(leading_digit / 10);
             int secnd_digit = (int)(floor(leading_digit - (first_digit * 10)));
-            snprintf(temp_str, LISTSIZE, ";SY(%s1%1i)", symbol_prefix_a, secnd_digit/*(int)leading_digit*/);
+            chk_snprintf(temp_str, LISTSIZE, ";SY(%s1%1i)",
+                         symbol_prefix_a, secnd_digit/*(int)leading_digit*/);
             sndfrm02.Append(wxString(temp_str, wxConvUTF8));
             
             if(!b_2digit){
                 if((int)fraction > 0) {
-                    snprintf(temp_str, LISTSIZE, ";SY(%s5%1i)", symbol_prefix_a, (int)fraction);
+                    chk_snprintf(temp_str, LISTSIZE, ";SY(%s5%1i)",
+                                 symbol_prefix_a, (int)fraction);
                     sndfrm02.Append(wxString(temp_str, wxConvUTF8));
                 }
             }
             
             if (depth_value < 0.0)
             {
-                snprintf(temp_str, LISTSIZE, ";SY(%sA1)", symbol_prefix_a);
+                chk_snprintf(temp_str, LISTSIZE, ";SY(%sA1)", symbol_prefix_a);
                 sndfrm02.Append(wxString(temp_str, wxConvUTF8));
             }
             
@@ -3058,17 +3072,21 @@ wxString SNDFRM02(S57Obj *obj, double depth_value_in)
 
         if (depth_value < 0.0)
         {
-            snprintf(temp_str, LISTSIZE, ";SY(%s2%1i)", symbol_prefix_a, (int)first_digit);
+            chk_snprintf(temp_str, LISTSIZE, ";SY(%s2%1i)",
+                         symbol_prefix_a, (int)first_digit);
             sndfrm02.Append(wxString(temp_str, wxConvUTF8));
-            snprintf(temp_str, LISTSIZE, ";SY(%s1%1i)", symbol_prefix_a, (int)secnd_digit);
+            chk_snprintf(temp_str, LISTSIZE, ";SY(%s1%1i)",
+                         symbol_prefix_a, (int)secnd_digit);
             sndfrm02.Append(wxString(temp_str, wxConvUTF8));
-            snprintf(temp_str, LISTSIZE, ";SY(%sA1)", symbol_prefix_a);
+            chk_snprintf(temp_str, LISTSIZE, ";SY(%sA1)", symbol_prefix_a);
             sndfrm02.Append(wxString(temp_str, wxConvUTF8));
         }
         else{
-            snprintf(temp_str, LISTSIZE, ";SY(%s1%1i)", symbol_prefix_a, (int)first_digit);
+            chk_snprintf(temp_str, LISTSIZE, ";SY(%s1%1i)",
+                         symbol_prefix_a, (int)first_digit);
             sndfrm02.Append(wxString(temp_str, wxConvUTF8));
-            snprintf(temp_str, LISTSIZE, ";SY(%s0%1i)", symbol_prefix_a, (int)secnd_digit);
+            chk_snprintf(temp_str, LISTSIZE, ";SY(%s0%1i)",
+                         symbol_prefix_a, (int)secnd_digit);
             sndfrm02.Append(wxString(temp_str, wxConvUTF8));
         }
         goto return_point;
@@ -3080,11 +3098,14 @@ wxString SNDFRM02(S57Obj *obj, double depth_value_in)
         double secnd_digit = floor((leading_digit - (first_digit * 100)) / 10);
         double third_digit = floor(leading_digit - (first_digit * 100) - (secnd_digit * 10));
         
-        snprintf(temp_str, LISTSIZE, ";SY(%s2%1i)", symbol_prefix_a, (int)first_digit);
+        chk_snprintf(temp_str, LISTSIZE, ";SY(%s2%1i)",
+                     symbol_prefix_a, (int)first_digit);
         sndfrm02.Append(wxString(temp_str, wxConvUTF8));
-        snprintf(temp_str, LISTSIZE, ";SY(%s1%1i)", symbol_prefix_a, (int)secnd_digit);
+        chk_snprintf(temp_str, LISTSIZE, ";SY(%s1%1i)",
+                     symbol_prefix_a, (int)secnd_digit);
         sndfrm02.Append(wxString(temp_str, wxConvUTF8));
-        snprintf(temp_str, LISTSIZE, ";SY(%s0%1i)", symbol_prefix_a, (int)third_digit);
+        chk_snprintf(temp_str, LISTSIZE, ";SY(%s0%1i)",
+                     symbol_prefix_a, (int)third_digit);
         sndfrm02.Append(wxString(temp_str, wxConvUTF8));
         
         goto return_point;
@@ -3097,13 +3118,17 @@ wxString SNDFRM02(S57Obj *obj, double depth_value_in)
         double third_digit = floor((leading_digit - (first_digit * 1000) - (secnd_digit * 100)) / 10);
         double last_digit  = floor(leading_digit - (first_digit * 1000) - (secnd_digit * 100) - (third_digit * 10)) ;
         
-        snprintf(temp_str, LISTSIZE, ";SY(%s2%1i)", symbol_prefix_a, (int)first_digit);
+        chk_snprintf(temp_str, LISTSIZE, ";SY(%s2%1i)",
+                     symbol_prefix_a, (int)first_digit);
         sndfrm02.Append(wxString(temp_str, wxConvUTF8));
-        snprintf(temp_str, LISTSIZE, ";SY(%s1%1i)", symbol_prefix_a, (int)secnd_digit);
+        chk_snprintf(temp_str, LISTSIZE, ";SY(%s1%1i)",
+                     symbol_prefix_a, (int)secnd_digit);
         sndfrm02.Append(wxString(temp_str, wxConvUTF8));
-        snprintf(temp_str, LISTSIZE, ";SY(%s0%1i)", symbol_prefix_a, (int)third_digit);
+        chk_snprintf(temp_str, LISTSIZE, ";SY(%s0%1i)",
+                     symbol_prefix_a, (int)third_digit);
         sndfrm02.Append(wxString(temp_str, wxConvUTF8));
-        snprintf(temp_str, LISTSIZE, ";SY(%s4%1i)", symbol_prefix_a, (int)last_digit);
+        chk_snprintf(temp_str, LISTSIZE, ";SY(%s4%1i)",
+                     symbol_prefix_a, (int)last_digit);
         sndfrm02.Append(wxString(temp_str, wxConvUTF8));
         
         goto return_point;
@@ -3117,15 +3142,20 @@ wxString SNDFRM02(S57Obj *obj, double depth_value_in)
         double fourth_digit = floor((leading_digit - (first_digit * 10000) - (secnd_digit * 1000) - (third_digit * 100)) / 10 ) ;
         double last_digit   = floor(leading_digit - (first_digit * 10000) - (secnd_digit * 1000) - (third_digit * 100) - (fourth_digit * 10)) ;
         
-        snprintf(temp_str, LISTSIZE, ";SY(%s3%1i)", symbol_prefix_a, (int)first_digit);
+        chk_snprintf(temp_str, LISTSIZE, ";SY(%s3%1i)",
+                     symbol_prefix_a, (int)first_digit);
         sndfrm02.Append(wxString(temp_str, wxConvUTF8));
-        snprintf(temp_str, LISTSIZE, ";SY(%s2%1i)", symbol_prefix_a, (int)secnd_digit);
+        chk_snprintf(temp_str, LISTSIZE, ";SY(%s2%1i)",
+                     symbol_prefix_a, (int)secnd_digit);
         sndfrm02.Append(wxString(temp_str, wxConvUTF8));
-        snprintf(temp_str, LISTSIZE, ";SY(%s1%1i)", symbol_prefix_a, (int)third_digit);
+        chk_snprintf(temp_str, LISTSIZE, ";SY(%s1%1i)",
+                     symbol_prefix_a, (int)third_digit);
         sndfrm02.Append(wxString(temp_str, wxConvUTF8));
-        snprintf(temp_str, LISTSIZE, ";SY(%s0%1i)", symbol_prefix_a, (int)fourth_digit);
+        chk_snprintf(temp_str, LISTSIZE, ";SY(%s0%1i)",
+                     symbol_prefix_a, (int)fourth_digit);
         sndfrm02.Append(wxString(temp_str, wxConvUTF8));
-        snprintf(temp_str, LISTSIZE, ";SY(%s4%1i)", symbol_prefix_a, (int)last_digit);
+        chk_snprintf(temp_str, LISTSIZE, ";SY(%s4%1i)",
+                     symbol_prefix_a, (int)last_digit);
         sndfrm02.Append(wxString(temp_str, wxConvUTF8));
         
         goto return_point;

--- a/src/s52plib.cpp
+++ b/src/s52plib.cpp
@@ -54,6 +54,7 @@
     #define PROJECTION_MERCATOR 1
 #endif
 
+
 extern float g_GLMinCartographicLineWidth;
 extern float g_GLMinSymbolLineWidth;
 extern double  g_overzoom_emphasis_base;
@@ -923,7 +924,7 @@ Rules *s52plib::StringToRules( const wxString& str_in )
 
     size_t len = strlen( buffer.data() );
     char *str0 = (char *) calloc( len + 1, 1 );
-    strncpy( str0, buffer.data(), len );
+    memcpy( str0, buffer.data(), len );
     char *str = str0;
 
     Rules *top;
@@ -1594,7 +1595,7 @@ char *s52plib::_getParamVal( ObjRazRules *rzRules, char *str, char *buf, int bsz
         wxCharBuffer buffer=value.ToUTF8();
         if(buffer.data()){
             unsigned int len = wxMin(strlen(buffer.data()), (unsigned int)bsz-1);
-            strncpy( buf, buffer.data(), len );
+            memcpy( buf, buffer.data(), len );
             buf[len] = 0;
         }
         else
@@ -5804,7 +5805,7 @@ bool s52plib::PreloadOBJLFromCSV(const wxString &csv_file)
                 wxCharBuffer buffer=token.ToUTF8();
                 if(buffer.data()) {
                     OBJLElement *pOLE = (OBJLElement *) calloc( sizeof(OBJLElement), 1 );
-                    strncpy( pOLE->OBJLName, buffer.data(), 6 );
+                    memcpy( pOLE->OBJLName, buffer.data(), 6 );
                     pOLE->nViz = 0;
 
                     pOBJLArray->Add( (void *) pOLE );
@@ -5836,7 +5837,7 @@ void s52plib::UpdateOBJLArray( S57Obj *obj )
     //    Not found yet, so add an element
     if( bNeedNew ) {
         pOLE = (OBJLElement *) calloc( sizeof(OBJLElement), 1 );
-        strncpy( pOLE->OBJLName, obj->FeatureName, 6 );
+        memcpy( pOLE->OBJLName, obj->FeatureName, OBJL_NAME_LEN );
         pOLE->nViz = 1;
 
         pOBJLArray->Add( (void *) pOLE );
@@ -8452,7 +8453,7 @@ void s52plib::GetAndAddCSRules( ObjRazRules *rzRules, Rules *rules )
 
         //sscanf(pBuf+11, "%d", &LUP->RCID);
 
-        strncpy( NewLUP->OBCL, rzRules->LUP->OBCL, 6 ); // the object class name
+        memcpy( NewLUP->OBCL, rzRules->LUP->OBCL, 6 ); // the object class name
 
 //      Add the complete CS string to the LUP
         wxString *pINST = new wxString( cs_string );
@@ -8717,7 +8718,7 @@ void s52plib::AddObjNoshow( const char *objcl )
 {
     if( !IsObjNoshow( objcl ) ){
         noshow_element element;
-        strncpy(element.obj, objcl, 6);
+        memcpy(element.obj, objcl, 6);
         m_noshow_array.Add( element );
     }
 }
@@ -8844,7 +8845,7 @@ void s52plib::PLIB_LoadS57Config()
                 
                 if( bNeedNew ) {
                     pOLE = (OBJLElement *) calloc( sizeof(OBJLElement), 1 );
-                    strncpy( pOLE->OBJLName, sObj.mb_str(), 6 );
+                    memcpy( pOLE->OBJLName, sObj.mb_str(), OBJL_NAME_LEN );
                     pOLE->nViz = 1;
                     
                     pOBJLArray->Add( (void *) pOLE );

--- a/src/wxcurl/base.cpp
+++ b/src/wxcurl/base.cpp
@@ -157,6 +157,9 @@ extern "C"
     /* reads from a string */
     size_t wxcurl_string_read(void* ptr, size_t size, size_t nmemb, void* pcharbuf)
     {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
         size_t iRealSize = size * nmemb;
         size_t iRetVal = 0;
 
@@ -182,6 +185,7 @@ extern "C"
         }
 
         return iRetVal;
+#pragma GCC diagnostic pop
     }
 
     /* reads from a stream */
@@ -201,7 +205,6 @@ extern "C"
         return 0;
     }
 }
-
 
 // base.cpp: implementation of the wxCurlProgressBaseEvent class.
 //

--- a/src/wxcurl/base.cpp
+++ b/src/wxcurl/base.cpp
@@ -158,8 +158,10 @@ extern "C"
     size_t wxcurl_string_read(void* ptr, size_t size, size_t nmemb, void* pcharbuf)
     {
 #pragma GCC diagnostic push
+#if defined(__GNUC__) && __GNUC >= 8
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
+#endif
         size_t iRealSize = size * nmemb;
         size_t iRetVal = 0;
 


### PR DESCRIPTION
Before these fixes, gcc emits so many warnings that new problems probably  isn't  detected. Warnings are handled in different ways:
  - A large number of the new stringop warnings have been fixed by enhanced overflow checking, snprintf return value checks and replacing strncpy() with memcpy()
  - A number of remaining warnings of different kind are just fixed
  - In  two files the warnings are muted using pragmas. These represent old, stable but yet tricky code where the risks taken by making changes cannot be justified.
  - The odd localtime_r wrapper warning is fixed by changing inclusion order. See the commit.
  - One deprecation warning is disabled in CMakelists with the idea to enable it in next cycle after 5.0.0
  - Perhaps scary warnings in libtess2 about applying delete to a void* is left as-is as the sole warnings left.

Since all commits carries a risk  but still builds, I have not squashed them to larger ones should a bisect be necessary... 