### PR TITLE
Warnings: Fix gcc 8 warnings.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -586,8 +586,12 @@ IF(NOT WIN32 AND NOT APPLE )
   IF(CMAKE_BUILD_TYPE MATCHES "Debug")
     ADD_DEFINITIONS( " -O0")
   ENDIF(CMAKE_BUILD_TYPE MATCHES "Debug")
-  ADD_DEFINITIONS("-Wno-deprecated-declarations")
   # TODO: Enable deprecation warnings again after the 5.0.0 cycle
+  ADD_DEFINITIONS(" -Wno-deprecated-declarations ")
+  # TODO: For libtess2, needs better handling after 5.0.0 cycle.
+  IF (CMAKE_COMPILER_IS_GNUCXX)
+    ADD_DEFINITIONS(" -Wno-delete-incomplete ")
+  ENDIF ()
 
   ADD_DEFINITIONS( " -DPREFIX=\\\"${CMAKE_INSTALL_PREFIX}\\\"")
   # profiling with gprof

--- a/src/chartsymbols.cpp
+++ b/src/chartsymbols.cpp
@@ -289,7 +289,7 @@ void ChartSymbols::ProcessLookups( pugi::xml_node &node )
             else if( !strcmp( lookupNode.name(), "attrib-code") ) {
                 int nc = strlen(nodeText);
                 char *attVal = (char *)calloc(nc+2, sizeof(char));
-                strncpy(attVal, nodeText, nc);
+                memcpy(attVal, nodeText, nc);
                 
                 if( attVal[6] == '\0')
                     attVal[6] = ' ';

--- a/src/libtess2/CMakeLists.txt
+++ b/src/libtess2/CMakeLists.txt
@@ -16,6 +16,12 @@ IF(NOT WIN32 AND NOT APPLE )
 #  ADD_DEFINITIONS( " -g -fno-strict-aliasing -O2")
 ENDIF(NOT WIN32 AND NOT APPLE)
 
+# FIXME: Might need better handling after the 5.0.0 cycle
+IF (CMAKE_COMPILER_IS_GNUCXX)
+  ADD_DEFINITIONS(" -Wno-delete-incomplete ")
+ENDIF ()
+
+
 INCLUDE_DIRECTORIES(${CMAKE_SOURCE_DIR}/include)
 INCLUDE_DIRECTORIES(Include)
 

--- a/src/myiso8211/ddfsubfielddefn.cpp
+++ b/src/myiso8211/ddfsubfielddefn.cpp
@@ -940,7 +940,7 @@ int DDFSubfieldDefn::FormatIntValue( char *pachData, int nBytesAvailable,
 
 {
 #pragma GCC diagnostic push
-#if defined(__GNUC__) && __GNUC >= 8
+#if defined(__GNUC__) && __GNUC__ >= 8
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
@@ -1036,7 +1036,7 @@ int DDFSubfieldDefn::FormatFloatValue( char *pachData, int nBytesAvailable,
 
 {
 #pragma GCC diagnostic push
-#if defined(__GNUC__) && __GNUC >= 8
+#if defined(__GNUC__) && __GNUC__ >= 8
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif

--- a/src/wxcurl/base.cpp
+++ b/src/wxcurl/base.cpp
@@ -158,7 +158,7 @@ extern "C"
     size_t wxcurl_string_read(void* ptr, size_t size, size_t nmemb, void* pcharbuf)
     {
 #pragma GCC diagnostic push
-#if defined(__GNUC__) && __GNUC >= 8
+#if defined(__GNUC__) && __GNUC__ >= 8
 #pragma GCC diagnostic ignored "-Wstringop-truncation"
 #pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif


### PR DESCRIPTION
Fix misspelled and copied __GNUC, use memcpy instead of strncpy
in some late code.

Mute the libtess warnings about delete on void* pointer during
current cycle. Needs better handling after 5.0.0.

Builds without warnings on gcc 8.2.0.

Someone should IMHO give at least the MacOS/clang build some love....