### PR TITLE
macOS: partial fix for crash with > 1 chart and OpenGL enabled

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -980,7 +980,13 @@ void ChartCanvas::SetupGlCanvas( )
             wxLogMessage( _T("Creating glChartCanvas") );
             m_glcc = new glChartCanvas(this);
 
-        // We use one context for all GL windows, so that textures etc will be automatically shared
+#ifdef __WXOSX__
+            // The way wx works on macOS with 'peer' NS windows means we must have a 1-1
+            // relationship between wxGLContext and the wxFrame in glChartCanvas...
+            wxGLContext *pctx = new wxGLContext(m_glcc);
+            m_glcc->SetContext(pctx);
+#else
+            // We use one context for all GL windows, so that textures etc will be automatically shared
             if(IsPrimaryCanvas()){
                 wxGLContext *pctx = new wxGLContext(m_glcc);
                 m_glcc->SetContext(pctx);
@@ -989,6 +995,7 @@ void ChartCanvas::SetupGlCanvas( )
             else{
                 m_glcc->SetContext(g_pGLcontext);   // If not primary canvas, use the saved common context
             }
+#endif
         }
     }
 #endif


### PR DESCRIPTION
The macOS build crashes, at least for me, when enabling OpenGL mode and multiple charts. 

It turns this crashes on 

```
bool wxGLContext::SetCurrent(const wxGLCanvas& win) const
{
    if ( !m_glContext )
        return false;

    [m_glContext setView: win.GetHandle() ];  <<< CRASH
    [m_glContext update];

    [m_glContext makeCurrentContext];

    return true;
}
```

Delving into this it seems that wxWidgets has the concept of a "Peer" NSWindow which is the native real window class.

My guess is that this means that we're not allowed to share the wxGLContext, and need a new one for every glChartCanvas instance.

This does indeed make the crash go away, but now we're in deeper trouble as the code assumes that all textures are shared -- which they aren't.

So this is more of a "heads up" than something meant to be pulled in & merged right away.