### PR TITLE
Memory leak and deleting open files

### DIFF
--- a/include/Osenc.h
+++ b/include/Osenc.h
@@ -545,7 +545,6 @@ private:
     int                 m_read_last_applied_update;
     
     S57Reader           *poReader;
-    OGRS57DataSource    *poS57DS;
     
     wxDateTime          m_date000;
     wxString            m_sdate000;

--- a/plugins/grib_pi/src/GribRequestDialog.cpp
+++ b/plugins/grib_pi/src/GribRequestDialog.cpp
@@ -179,10 +179,11 @@ void GribRequestSetting::InitRequestConfig()
     m_MailImage->SetValue( WriteMail() );
 }
 
+wxWindow *GetGRIBCanvas();
 void GribRequestSetting::OnClose( wxCloseEvent& event )
 {
     m_RenderZoneOverlay = 0;                                    //eventually stop graphical zone display
-    RequestRefresh( PluginGetOverlayRenderCanvas() );
+    RequestRefresh( GetGRIBCanvas() );
 
     //allow to be back to old value if changes have not been saved
     m_ZoneSelMode = m_SavedZoneSelMode;
@@ -311,7 +312,7 @@ void GribRequestSetting::OnMouseEventTimer( wxTimerEvent & event)
         m_spMinLon->SetValue( (int) floor(lon) );
     }
 
-    RequestRefresh( PluginGetOverlayRenderCanvas() );
+    RequestRefresh( GetGRIBCanvas() );
 }
 
 void GribRequestSetting::SetCoordinatesText()
@@ -326,7 +327,7 @@ void GribRequestSetting::StopGraphicalZoneSelection()
 {
     m_RenderZoneOverlay = 0;                                                //eventually stop graphical zone display
 
-    RequestRefresh( PluginGetOverlayRenderCanvas() );
+    RequestRefresh( GetGRIBCanvas() );
 }
 
 void GribRequestSetting::OnVpChange(PlugIn_ViewPort *vp)

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -103,6 +103,17 @@ static wxString TToString( const wxDateTime date_time, const int time_zone )
     }
 }
 
+wxWindow *GetGRIBCanvas()
+{
+    wxWindow *wx;
+    // If multicanvas are active, render the overlay on the right canvas only
+    if(GetCanvasCount() > 1)            // multi?
+        wx = GetCanvasByIndex(1);
+    else
+        wx = GetOCPNCanvasWindow();
+    return wx;
+}
+
 //---------------------------------------------------------------------------------------
 //          GRIB Control Implementation
 //---------------------------------------------------------------------------------------
@@ -1150,7 +1161,7 @@ void GRIBUICtrlBar::TimelineChanged()
     UpdateTrackingControl();
 
     pPlugIn->SendTimelineMessage(time);
-    RequestRefresh( PluginGetOverlayRenderCanvas() );
+    RequestRefresh( GetGRIBCanvas() );
 }
 
 void GRIBUICtrlBar::RestaureSelectionString()
@@ -1607,9 +1618,10 @@ void GRIBUICtrlBar::DoZoomToCenter( )
     DistanceBearingMercator_Plugin(clat, lonmin, clat, lonmax, NULL, &ow );
     DistanceBearingMercator_Plugin( latmin, clon, latmax, clon, NULL, &oh );
 
+    wxWindow *wx = GetGRIBCanvas();
     //calculate screen size
-    int w = PluginGetOverlayRenderCanvas()->GetSize().x;
-    int h = PluginGetOverlayRenderCanvas()->GetSize().y;
+    int w = wx->GetSize().x;
+    int h = wx->GetSize().y;
 
     //calculate final ppm scale to use
     double ppm;
@@ -1617,7 +1629,7 @@ void GRIBUICtrlBar::DoZoomToCenter( )
 
     ppm = wxMin(ppm, 1.0);
 
-    CanvasJumpToPosition(PluginGetOverlayRenderCanvas(), clat, clon, ppm);
+    CanvasJumpToPosition(wx, clat, clon, ppm);
 
 }
 
@@ -1705,8 +1717,7 @@ void GRIBUICtrlBar::ComputeBestForecastForNow()
     UpdateTrackingControl();
 
     pPlugIn->SendTimelineMessage(now);
-    RequestRefresh( PluginGetOverlayRenderCanvas() );
-
+    RequestRefresh( GetGRIBCanvas());
 }
 
 void GRIBUICtrlBar::SetGribTimelineRecordSet(GribTimelineRecordSet *pTimelineSet)
@@ -1750,7 +1761,7 @@ void GRIBUICtrlBar::SetFactoryOptions()
     pPlugIn->GetGRIBOverlayFactory()->ClearCachedData();
 
     UpdateTrackingControl();
-    RequestRefresh( PluginGetOverlayRenderCanvas() );
+    RequestRefresh( GetGRIBCanvas() );
 }
 
 //----------------------------------------------------------------------------------------------------------

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -534,16 +534,21 @@ bool grib_pi::RenderGLOverlay(wxGLContext *pcontext, PlugIn_ViewPort *vp)
 bool grib_pi::RenderGLOverlayMultiCanvas(wxGLContext *pcontext, PlugIn_ViewPort *vp, int canvasIndex)
 {
     // If multicanvas are active, render the overlay on the right canvas only
-    
-    if(GetCanvasCount() > 1){            // multi?
-        if(canvasIndex == 1){
-            return RenderGLOverlay( pcontext, vp);
-        }
-        else
-            return false;
+    if(GetCanvasCount() > 1 && canvasIndex != 1){            // multi?
+        return false;
     }
 
     return RenderGLOverlay( pcontext, vp);
+}
+
+bool grib_pi::RenderOverlayMultiCanvas(wxDC &dc, PlugIn_ViewPort *vp, int canvasIndex)
+{
+    // If multicanvas are active, render the overlay on the right canvas only
+    if(GetCanvasCount() > 1 && canvasIndex != 1) {            // multi?
+        return false;
+    }
+
+    return RenderOverlay( dc, vp);
 }
 
 void grib_pi::SetCursorLatLon(double lat, double lon)

--- a/plugins/grib_pi/src/grib_pi.h
+++ b/plugins/grib_pi/src/grib_pi.h
@@ -84,6 +84,7 @@ public:
 //    The override PlugIn Methods
       bool MouseEventHook( wxMouseEvent &event);
       bool RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp);
+      bool RenderOverlayMultiCanvas(wxDC &dc, PlugIn_ViewPort *vp, int canvasIndex);
       void SetCursorLatLon(double lat, double lon);
       void OnContextMenuItemCallback(int id);
       void SetPluginMessage(wxString &message_id, wxString &message_body);

--- a/src/ChartDataInputStream.cpp
+++ b/src/ChartDataInputStream.cpp
@@ -171,10 +171,11 @@ ChartDataInputStream::ChartDataInputStream(const wxString& fileName)
 
 ChartDataInputStream::~ChartDataInputStream()
 {
+    // close it
+    delete m_stream;
     // delete the temp file, how do we remove temp files if the program crashed?
     if(!m_tempfilename.empty())
         wxRemoveFile(m_tempfilename);
-    delete m_stream;
 }
 
 size_t ChartDataInputStream::OnSysRead(void *buffer, size_t size)

--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -645,6 +645,7 @@ bool OCPNPlatform::BuildGLCaps( void *pbuf )
     char *str = (char *) glGetString( GL_RENDERER );
     if (str == NULL){
         delete tcanvas;
+        delete pctx;
         return false;
     }
     
@@ -712,6 +713,7 @@ bool OCPNPlatform::BuildGLCaps( void *pbuf )
 
 
     delete tcanvas;
+    delete pctx;
     
     return true;
 }

--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -637,6 +637,7 @@ bool OCPNPlatform::BuildGLCaps( void *pbuf )
     gFrame->Show();
     glTestCanvas *tcanvas = new glTestCanvas(gFrame);
     tcanvas->Show();
+    wxYield();
     wxGLContext *pctx = new wxGLContext(tcanvas);
     tcanvas->SetCurrent(*pctx);
     

--- a/src/Osenc.cpp
+++ b/src/Osenc.cpp
@@ -260,7 +260,7 @@ Osenc::~Osenc()
     free( m_pCOVRTable );
     free( m_pNoCOVRTablePoints );
     free( m_pNoCOVRTable );
-    
+    delete m_UpFiles;
     CPLPopErrorHandler();
     
     
@@ -291,7 +291,8 @@ void Osenc::init( void )
     m_pauxInstream = NULL;
     m_pOutstream = NULL;
     m_pInstream = NULL;
-    
+    m_UpFiles = nullptr;
+
     m_bVerbose = true;
     g_OsencVerbose = true;
     m_NoErrDialog = false;
@@ -1515,8 +1516,8 @@ int Osenc::createSenc200(const wxString& FullPath000, const wxString& SENCFileNa
         return ERROR_BASEFILE_ATTRIBUTES;
     }
     
-    
-    OGRS57DataSource *poS57DS = new OGRS57DataSource;
+    OGRS57DataSource S57DS;
+    OGRS57DataSource *poS57DS = &S57DS;
     poS57DS->SetS57Registrar( m_poRegistrar );
     
 
@@ -1761,8 +1762,6 @@ int Osenc::createSenc200(const wxString& FullPath000, const wxString& SENCFileNa
     delete m_ProgDialog;
 #endif    
     
-    delete poS57DS;
-
     lockCR.unlock();
    
     return ret_code;
@@ -3647,8 +3646,8 @@ int Osenc::GetBaseFileInfo(const wxString& FullPath000, const wxString& SENCFile
         return ERROR_BASEFILE_ATTRIBUTES;
     }
     
-    OGRS57DataSource *poS57DS = new OGRS57DataSource;
-    poS57DS->SetS57Registrar( m_poRegistrar );
+    OGRS57DataSource oS57DS;
+    oS57DS.SetS57Registrar( m_poRegistrar );
 
     bool b_current_debug = g_bGDAL_Debug;
     g_bGDAL_Debug = false;
@@ -3656,13 +3655,13 @@ int Osenc::GetBaseFileInfo(const wxString& FullPath000, const wxString& SENCFile
     
     //  Ingest the .000 cell, with updates applied
     
-    if(ingestCell( poS57DS, FullPath000, SENCfile.GetPath())){
+    if(ingestCell( &oS57DS, FullPath000, SENCfile.GetPath())){
         errorMessage = _T("Error ingesting: ") + FullPath000;
         return ERROR_INGESTING000;
     }
 
     
-    S57Reader *poReader = poS57DS->GetModule( 0 );
+    S57Reader *poReader = oS57DS.GetModule( 0 );
     
     CalculateExtent( poReader, m_poRegistrar );
     
@@ -3670,7 +3669,6 @@ int Osenc::GetBaseFileInfo(const wxString& FullPath000, const wxString& SENCFile
     g_bGDAL_Debug = b_current_debug;
     
     //    delete poReader;
-    delete poS57DS;
     
     return SENC_NO_ERROR;
     

--- a/src/Quilt.cpp
+++ b/src/Quilt.cpp
@@ -1046,6 +1046,19 @@ int Quilt::AdjustRefOnZoomIn( double proposed_scale_onscreen )
 
     int proposed_ref_index = AdjustRefOnZoom( true, (ChartFamilyEnum)current_family, current_type, proposed_scale_onscreen );
 
+    if (current_db_index == -1) {
+        SetReferenceChart( proposed_ref_index );
+        return proposed_ref_index;
+    }
+
+    if (proposed_ref_index != -1) {
+        if (ChartData->GetDBChartScale(current_db_index) >= ChartData->GetDBChartScale(proposed_ref_index)) {
+            SetReferenceChart( proposed_ref_index );
+            return proposed_ref_index;
+        }
+    }
+    proposed_ref_index = current_db_index;
+
     SetReferenceChart( proposed_ref_index );
 
     return proposed_ref_index;


### PR DESCRIPTION
Hi,

- A trivial memory leak.

- On window you can't delete an open file, xz compressed chart is using a temporary file and was trying to delete it while open. 
The same issue exists with Osenc temporary SENC/foo.000 (delete in ingestcell while open) but fixing it is way more intrusive and it's not that bad as with xz, it's always using the same name.
 
Regards
Didier
