### PR TITLE
FontMgr: Avoid incorrect types and superfluous casts

### DIFF
--- a/src/FontMgr.cpp
+++ b/src/FontMgr.cpp
@@ -109,7 +109,7 @@ wxColour FontMgr::GetFontColor( const wxString &TextElement ) const
 {
     //    Look thru the font list for a match
     MyFontDesc *pmfd;
-    wxNode *node = (wxNode *) ( m_fontlist->GetFirst() );
+    auto node = m_fontlist->GetFirst();
     while( node ) {
         pmfd = (MyFontDesc *) node->GetData();
         if( pmfd->m_dialogstring == TextElement ) {
@@ -126,7 +126,7 @@ bool FontMgr::SetFontColor( const wxString &TextElement, const wxColour color ) 
 {
   //    Look thru the font list for a match
   MyFontDesc *pmfd;
-  wxNode *node = (wxNode *) ( m_fontlist->GetFirst() );
+  auto node = m_fontlist->GetFirst();
   while( node ) {
     pmfd = (MyFontDesc *) node->GetData();
     if( pmfd->m_dialogstring == TextElement ) {
@@ -172,7 +172,7 @@ wxFont *FontMgr::GetFont( const wxString &TextElement, int user_default_size )
 {
     //    Look thru the font list for a match
     MyFontDesc *pmfd;
-    wxNode *node = (wxNode *) ( m_fontlist->GetFirst() );
+    auto node = m_fontlist->GetFirst();
     while( node ) {
         pmfd = (MyFontDesc *) node->GetData();
         if( pmfd->m_dialogstring == TextElement ) {
@@ -233,7 +233,7 @@ bool FontMgr::SetFont(const wxString &TextElement, wxFont *pFont, wxColour color
 {
     //    Look thru the font list for a match
     MyFontDesc *pmfd;
-    wxNode *node = (wxNode *) ( m_fontlist->GetFirst() );
+    auto node = m_fontlist->GetFirst();
     while( node ) {
         pmfd = (MyFontDesc *) node->GetData();
         if( pmfd->m_dialogstring == TextElement ) {
@@ -302,7 +302,7 @@ MyFontDesc *FontMgr::FindFontByConfigString( wxString pConfigString )
 {
     //    Search for a match in the list
     MyFontDesc *pmfd;
-    wxNode *node = (wxNode *) ( m_fontlist->GetFirst() );
+    auto node = m_fontlist->GetFirst();
     
     while( node ) {
         pmfd = (MyFontDesc *) node->GetData();
@@ -329,7 +329,7 @@ void FontMgr::LoadFontNative( wxString *pConfigString, wxString *pNativeDesc )
 
     //    Search for a match in the list
     MyFontDesc *pmfd;
-    wxNode *node = (wxNode *) ( m_fontlist->GetFirst() );
+    auto node = m_fontlist->GetFirst();
 
     while( node ) {
         pmfd = (MyFontDesc *) node->GetData();
@@ -544,7 +544,7 @@ void FontMgr::ScrubList( )
         wxString trans = wxGetTranslation(candidate);
         
         MyFontDesc *pmfd;
-        wxNode *node = (wxNode *) ( m_fontlist->GetFirst() );
+        auto node = m_fontlist->GetFirst();
         while( node ) {
             pmfd = (MyFontDesc *) node->GetData();
             wxString tlocale = pmfd->m_configstring.BeforeFirst('-');
@@ -563,7 +563,7 @@ void FontMgr::ScrubList( )
     // If a list item's translation is not in the "good" array, mark it for removal
     
     MyFontDesc *pmfd;
-    wxNode *node = (wxNode *) ( m_fontlist->GetFirst() );
+    auto node = m_fontlist->GetFirst();
     while( node ) {
         pmfd = (MyFontDesc *) node->GetData();
         wxString tlocale = pmfd->m_configstring.BeforeFirst('-');
@@ -585,13 +585,13 @@ void FontMgr::ScrubList( )
     }
     
     //  Remove the marked list items
-    node = (wxNode *) ( m_fontlist->GetFirst() );
+    node = m_fontlist->GetFirst();
     while( node ) {
         pmfd = (MyFontDesc *) node->GetData();
         if( pmfd->m_dialogstring == _T("") ) {
             bool bd = m_fontlist->DeleteObject(pmfd);
             if(bd)
-                node = (wxNode *) ( m_fontlist->GetFirst() );
+                node = m_fontlist->GetFirst();
         }
         else
             node = node->GetNext();

--- a/src/FontMgr.cpp
+++ b/src/FontMgr.cpp
@@ -546,7 +546,7 @@ void FontMgr::ScrubList( )
         MyFontDesc *pmfd;
         auto node = m_fontlist->GetFirst();
         while( node ) {
-            pmfd = (MyFontDesc *) node->GetData();
+            pmfd = node->GetData();
             wxString tlocale = pmfd->m_configstring.BeforeFirst('-');
             if( tlocale == now_locale) {
                 if(trans == pmfd->m_dialogstring){
@@ -565,7 +565,7 @@ void FontMgr::ScrubList( )
     MyFontDesc *pmfd;
     auto node = m_fontlist->GetFirst();
     while( node ) {
-        pmfd = (MyFontDesc *) node->GetData();
+        pmfd = node->GetData();
         wxString tlocale = pmfd->m_configstring.BeforeFirst('-');
         if( tlocale == now_locale) {
             bool bfound = false;
@@ -587,7 +587,7 @@ void FontMgr::ScrubList( )
     //  Remove the marked list items
     node = m_fontlist->GetFirst();
     while( node ) {
-        pmfd = (MyFontDesc *) node->GetData();
+        pmfd = node->GetData();
         if( pmfd->m_dialogstring == _T("") ) {
             bool bd = m_fontlist->DeleteObject(pmfd);
             if(bd)

--- a/src/FontMgr.cpp
+++ b/src/FontMgr.cpp
@@ -111,7 +111,7 @@ wxColour FontMgr::GetFontColor( const wxString &TextElement ) const
     MyFontDesc *pmfd;
     auto node = m_fontlist->GetFirst();
     while( node ) {
-        pmfd = (MyFontDesc *) node->GetData();
+        pmfd = node->GetData();
         if( pmfd->m_dialogstring == TextElement ) {
             if(pmfd->m_configstring.BeforeFirst('-') == s_locale)
                 return pmfd->m_color;
@@ -128,7 +128,7 @@ bool FontMgr::SetFontColor( const wxString &TextElement, const wxColour color ) 
   MyFontDesc *pmfd;
   auto node = m_fontlist->GetFirst();
   while( node ) {
-    pmfd = (MyFontDesc *) node->GetData();
+    pmfd = node->GetData();
     if( pmfd->m_dialogstring == TextElement ) {
       if(pmfd->m_configstring.BeforeFirst('-') == s_locale) {
         pmfd->m_color = color;
@@ -174,7 +174,7 @@ wxFont *FontMgr::GetFont( const wxString &TextElement, int user_default_size )
     MyFontDesc *pmfd;
     auto node = m_fontlist->GetFirst();
     while( node ) {
-        pmfd = (MyFontDesc *) node->GetData();
+        pmfd = node->GetData();
         if( pmfd->m_dialogstring == TextElement ) {
             if(pmfd->m_configstring.BeforeFirst('-') == s_locale)
                 return pmfd->m_font;
@@ -235,7 +235,7 @@ bool FontMgr::SetFont(const wxString &TextElement, wxFont *pFont, wxColour color
     MyFontDesc *pmfd;
     auto node = m_fontlist->GetFirst();
     while( node ) {
-        pmfd = (MyFontDesc *) node->GetData();
+        pmfd = node->GetData();
         if( pmfd->m_dialogstring == TextElement ) {
             if(pmfd->m_configstring.BeforeFirst('-') == s_locale) {
                 
@@ -267,25 +267,25 @@ int FontMgr::GetNumFonts( void ) const
 
 const wxString & FontMgr::GetConfigString( int i ) const
 {
-    MyFontDesc * pfd = (MyFontDesc *) ( m_fontlist->Item( i )->GetData() );
+    MyFontDesc * pfd = m_fontlist->Item( i )->GetData();
     return pfd->m_configstring;
 }
 
 const wxString & FontMgr::GetDialogString( int i ) const
 {
-    MyFontDesc *pfd = (MyFontDesc *) ( m_fontlist->Item( i )->GetData() );
+    MyFontDesc *pfd = m_fontlist->Item( i )->GetData();
     return pfd->m_dialogstring;
 }
 
 const wxString & FontMgr::GetNativeDesc( int i ) const
 {
-    MyFontDesc *pfd = (MyFontDesc *) ( m_fontlist->Item( i )->GetData() );
+    MyFontDesc *pfd = m_fontlist->Item( i )->GetData();
     return pfd->m_nativeInfo;
 }
 
 wxString FontMgr::GetFullConfigDesc( int i ) const
 {
-    MyFontDesc *pfd = (MyFontDesc *) ( m_fontlist->Item( i )->GetData() );
+    MyFontDesc *pfd = m_fontlist->Item( i )->GetData();
     wxString ret = pfd->m_dialogstring;
     ret.Append( _T ( ":" ) );
     ret.Append( pfd->m_nativeInfo );
@@ -305,7 +305,7 @@ MyFontDesc *FontMgr::FindFontByConfigString( wxString pConfigString )
     auto node = m_fontlist->GetFirst();
     
     while( node ) {
-        pmfd = (MyFontDesc *) node->GetData();
+        pmfd = node->GetData();
         if( pmfd->m_configstring == pConfigString ) {
             return pmfd;
         }
@@ -332,7 +332,7 @@ void FontMgr::LoadFontNative( wxString *pConfigString, wxString *pNativeDesc )
     auto node = m_fontlist->GetFirst();
 
     while( node ) {
-        pmfd = (MyFontDesc *) node->GetData();
+        pmfd = node->GetData();
         if( pmfd->m_configstring == *pConfigString ) {
             if(pmfd->m_configstring.BeforeFirst('-') == g_locale) {
                 pmfd->m_nativeInfo = nativefont;


### PR DESCRIPTION
Undefined behavior sanitizer noticed the usage of wxNode (should have been wxFontListNode), cleaned code up and avoided casts. 
