### PR TITLE
Make CPN_GLCaps a class, fixes segfault

### DIFF
--- a/include/glChartCanvas.h
+++ b/include/glChartCanvas.h
@@ -47,7 +47,8 @@ class ChartCanvas;
 
 #define GESTURE_EVENT_TIMER 78334
 
-typedef struct{
+typedef class{
+  public:
     wxString Renderer;
     GLenum TextureRectangleFormat;
     

--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -717,7 +717,7 @@ bool OCPNPlatform::BuildGLCaps( void *pbuf )
 
 bool OCPNPlatform::IsGLCapable()
 {
-    OCPN_GLCaps *pcaps = (OCPN_GLCaps * )calloc( 1, sizeof(OCPN_GLCaps));
+    OCPN_GLCaps *pcaps = new OCPN_GLCaps;
     
     BuildGLCaps(pcaps);
 


### PR DESCRIPTION
CPN_GLCaps includes at last one class (wxString Renderer) which needs
its constructor to be run (I get a NULL pointer dereference deep in the
libc++ internals otherwise), so make CPN_GLCaps a class too, and allocate
with the new operator.

This is probably dependant on the libstdc++ implementation (the one from gcc 5.5.0 in my case)