### PR TITLE
Implement switchable SOG/VMG for TTG calculation in console window

### DIFF
--- a/include/concanv.h
+++ b/include/concanv.h
@@ -36,6 +36,9 @@
 #include "chart1.h"             // for ColorScheme
 
 
+#define SPEED_VMG 0
+#define SPEED_SOG 1
+
 #define ID_LEGROUTE 1000
 #define SECONDS_PER_DAY 86400
 
@@ -124,7 +127,7 @@ public:
       void ToggleRouteTotalDisplay();
       
       wxWindow          *m_pParent;
-      wxStaticText       *pThisLegText;
+      wxStaticText      *pThisLegText;
       wxBoxSizer        *m_pitemBoxSizerLeg;
 
       AnnunText         *pXTE;
@@ -141,6 +144,7 @@ public:
 private:
       void OnPaint(wxPaintEvent& event);
       void OnShow(wxShowEvent& event);
+      char m_speedUsed;
 
 DECLARE_EVENT_TABLE()
 };

--- a/src/concanv.cpp
+++ b/src/concanv.cpp
@@ -62,7 +62,7 @@ bool             g_bShowRouteTotal;
 extern ocpnStyle::StyleManager* g_StyleManager;
 
 enum eMenuItems {
-    ID_NAVLEG,
+    ID_NAVLEG = 1,
     ID_NAVROUTE,
     ID_NAVHIGHWAY
 } menuItems;
@@ -83,6 +83,7 @@ END_EVENT_TABLE()
 // Define a constructor for my canvas
 ConsoleCanvas::ConsoleCanvas( wxWindow *frame )
 {
+    m_speedUsed = SPEED_VMG;
     pbackBrush = NULL;
     m_bNeedClear = false;
 
@@ -126,7 +127,7 @@ long style = wxSIMPLE_BORDER | wxCLIP_CHILDREN;
     m_pitemBoxSizerLeg->Add( pRNG, 1, wxALIGN_LEFT | wxALL, 2 );
 
     pTTG = new AnnunText( this, -1, _("Console Legend"), _("Console Value") );
-    pTTG->SetALabel( _T("TTG") );
+    pTTG->SetALabel( _T("TTG  @VMG") );
     m_pitemBoxSizerLeg->Add( pTTG, 1, wxALIGN_LEFT | wxALL, 2 );
 
 //    Create CDI Display Window
@@ -256,7 +257,12 @@ void ConsoleCanvas::OnContextMenuSelection( wxCommandEvent& event ) {
 
 void ConsoleCanvas::ToggleRouteTotalDisplay()
 {
-    g_bShowRouteTotal = !g_bShowRouteTotal;
+    if( m_speedUsed == SPEED_VMG ) {
+        m_speedUsed = SPEED_SOG;
+    } else {
+        m_speedUsed = SPEED_VMG;
+        g_bShowRouteTotal = !g_bShowRouteTotal;
+    }
     LegRoute();
 }
     
@@ -284,16 +290,22 @@ void ConsoleCanvas::UpdateRouteData()
             
             pBRG->SetAValue( cogstr );
 
-            // VMG
-            // VMG is always to next waypoint, not to end of route
-            // VMG is SOG x cosine (difference between COG and BRG to Waypoint)
-            double VMG = 0.;
+            double speed = 0.;
             if( !std::isnan(gCog) && !std::isnan(gSog) )
             {
                 double BRG;
                 BRG = g_pRouteMan->GetCurrentBrgToActivePoint();
-                VMG = gSog * cos( ( BRG - gCog ) * PI / 180. ) ;
-                str_buf.Printf( _T("%6.2f"), toUsrSpeed( VMG ) );
+                double vmg = gSog * cos( ( BRG - gCog ) * PI / 180. );
+                str_buf.Printf( _T("%6.2f"), toUsrSpeed( vmg ) );
+
+                if( m_speedUsed == SPEED_VMG ) {
+                    // VMG
+                    // VMG is always to next waypoint, not to end of route
+                    // VMG is SOG x cosine (difference between COG and BRG to Waypoint)
+                    speed = vmg;
+                } else {
+                    speed = gSog;
+                }
             }
             else
                 str_buf = _T("---");
@@ -333,9 +345,9 @@ void ConsoleCanvas::UpdateRouteData()
                 // In all cases, ttg/eta are declared invalid if VMG <= 0.
                 // If showing only "this leg", use VMG for calculation of ttg
                 wxString ttg_s;
-                if( ( VMG > 0. ) && !std::isnan(gCog) && !std::isnan(gSog) )
+                if( ( speed > 0. ) && !std::isnan(gCog) && !std::isnan(gSog) )
                 {
-                    float ttg_sec = ( rng / VMG ) * 3600.;
+                    float ttg_sec = ( rng / speed ) * 3600.;
                     wxTimeSpan ttg_span( 0, 0, long( ttg_sec ), 0 );
                     ttg_s = ttg_span.Format();
                 }
@@ -343,6 +355,11 @@ void ConsoleCanvas::UpdateRouteData()
                     ttg_s = _T("---");
 
                 pTTG->SetAValue( ttg_s );
+                if( m_speedUsed == SPEED_VMG ) {
+                    pTTG->SetALabel( wxString( _("TTG  @VMG") ) );
+                } else {
+                    pTTG->SetALabel( wxString( _("TTG  @SOG") ) );
+                }
             }
             else
             {
@@ -381,7 +398,7 @@ void ConsoleCanvas::UpdateRouteData()
                 wxString tttg_s;
                 wxTimeSpan tttg_span;
                 float tttg_sec;
-                if( VMG > 0. )
+                if( speed > 0. )
                 {
                     tttg_sec = ( trng / gSog ) * 3600.;
                     tttg_span = wxTimeSpan::Seconds( (long) tttg_sec );
@@ -403,7 +420,7 @@ void ConsoleCanvas::UpdateRouteData()
                 eta = dtnow.Add( tttg_span );
                 wxString seta;
 
-                if (VMG > 0.) {
+                if (speed > 0.) {
                   // Show date, e.g. Feb 15, if TTG > 24 h
                   seta = tttg_sec > SECONDS_PER_DAY ?
                     eta.Format(_T("%b %d %H:%M")) : eta.Format(_T("%H:%M"));
@@ -411,7 +428,13 @@ void ConsoleCanvas::UpdateRouteData()
                   seta = _T("---");
                 }
                 pXTE->SetAValue( seta );
-                pXTE->SetALabel( wxString( _("ETA          ") ) );
+                if( m_speedUsed == SPEED_VMG ) {
+                    pTTG->SetALabel( wxString( _("TTG  @VMG") ) );
+                    pXTE->SetALabel( wxString( _("ETA  @VMG") ) );
+                } else {
+                    pTTG->SetALabel( wxString( _("TTG  @SOG") ) );
+                    pXTE->SetALabel( wxString( _("ETA  @SOG") ) );
+                }
             }
 
             pRNG->Refresh();


### PR DESCRIPTION
- Step 1 to #1260 implementation (To be finished at some later moment as we currently don't have any framework to collect and calculate performance averages)
- Clicking on the console cycles between the speed used for the calculations, instead of the original 2 states it now has 4
| <img width="94" alt="screen shot 2019-02-23 at 7 46 21 pm" src="https://user-images.githubusercontent.com/249856/53292649-58790080-37a4-11e9-8114-ec96a4a41678.png"> | <img width="101" alt="screen shot 2019-02-23 at 7 46 14 pm" src="https://user-images.githubusercontent.com/249856/53292650-58790080-37a4-11e9-93c1-5139806b0f74.png"> | <img width="95" alt="screen shot 2019-02-23 at 7 52 38 pm" src="https://user-images.githubusercontent.com/249856/53292667-a2fa7d00-37a4-11e9-9bde-61dbc150aa7d.png"> | <img width="97" alt="screen shot 2019-02-23 at 7 52 29 pm" src="https://user-images.githubusercontent.com/249856/53292668-a2fa7d00-37a4-11e9-913e-4022e55382e1.png">
