### PR TITLE
Enhancements to the AIS and DSC handling as requested by SAR services

### DIFF
--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -37,6 +37,7 @@
 #include "Track.h"
 #include <multiplexer.h>
 #include "config.h"
+#include <cstdio>
 
 #if !defined(NAN)
     static const long long lNaN = 0xfff8000000000000;
@@ -1131,7 +1132,7 @@ AIS_Error AIS_Decoder::Decode( const wxString& str )
                                 ( *AISTargetNamesNC )[mmsi] = ship_name;
                             }
                             if ( g_bUseOnlyConfirmedAISName ){ //copy back previous name
-                                strncpy(pTargetData->ShipName, "Unknown             ", 21);
+                                strncpy(pTargetData->ShipName, "Unknown             ", SHIP_NAME_LEN);
                             }
                         }
                     }
@@ -1321,10 +1322,11 @@ AIS_Target_Data *AIS_Decoder::ProcessDSx( const wxString& str, bool b_take_dsc )
         m_ptentative_dsctarget->Class = AIS_DSC;
         m_ptentative_dsctarget->b_nameValid = true;
         if( dsc_fmt == 12 ) {
-            strncpy( m_ptentative_dsctarget->ShipName, "DISTRESS            ", 21 );
+            snprintf( m_ptentative_dsctarget->ShipName, SHIP_NAME_LEN, "DISTRESS %d", mmsi);
         }
-        else
-            strncpy( m_ptentative_dsctarget->ShipName, "POSITION REPORT     ", 21 );
+        else {
+            snprintf( m_ptentative_dsctarget->ShipName, SHIP_NAME_LEN, "POSITION %d", mmsi);
+        }
         
         m_ptentative_dsctarget->b_active = true;
         m_ptentative_dsctarget->b_lost = false;
@@ -1391,7 +1393,6 @@ AIS_Target_Data *AIS_Decoder::ProcessDSx( const wxString& str, bool b_take_dsc )
            //    Update this target's track
             if( pTargetData->b_show_track )
                 UpdateOneTrack( pTargetData );
-                    
         }
         
     }

--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -1322,10 +1322,10 @@ AIS_Target_Data *AIS_Decoder::ProcessDSx( const wxString& str, bool b_take_dsc )
         m_ptentative_dsctarget->Class = AIS_DSC;
         m_ptentative_dsctarget->b_nameValid = true;
         if( dsc_fmt == 12 ) {
-            snprintf( m_ptentative_dsctarget->ShipName, SHIP_NAME_LEN, "DISTRESS %d", mmsi);
+            snprintf( m_ptentative_dsctarget->ShipName, SHIP_NAME_LEN, "DISTRESS %d", std::abs(mmsi));
         }
         else {
-            snprintf( m_ptentative_dsctarget->ShipName, SHIP_NAME_LEN, "POSITION %d", mmsi);
+            snprintf( m_ptentative_dsctarget->ShipName, SHIP_NAME_LEN, "POSITION %d", std::abs(mmsi));
         }
         
         m_ptentative_dsctarget->b_active = true;

--- a/src/AIS_Target_Data.cpp
+++ b/src/AIS_Target_Data.cpp
@@ -85,9 +85,9 @@ static wxString html_escape ( const wxString &src)
 
 AIS_Target_Data::AIS_Target_Data()
 {
-    strncpy(ShipName, "Unknown             ", 21);
+    strncpy(ShipName, "Unknown             ", SHIP_NAME_LEN);
     strncpy(CallSign, "       ", 8);
-    strncpy(Destination, "                    ", 21);
+    strncpy(Destination, "                    ", SHIP_NAME_LEN);
     ShipNameExtension[0] = 0;
     b_show_AIS_CPA = false;
 
@@ -173,9 +173,9 @@ AIS_Target_Data::AIS_Target_Data()
 
 void AIS_Target_Data::CloneFrom( AIS_Target_Data* q )
 {
-    strncpy(ShipName, q->ShipName, 21);
+    strncpy(ShipName, q->ShipName, SHIP_NAME_LEN);
     strncpy(CallSign, q->CallSign, 8);
-    strncpy(Destination, q->Destination, 21);
+    strncpy(Destination, q->Destination, SHIP_NAME_LEN);
     ShipNameExtension[0] = 0;
     b_show_AIS_CPA = q->b_show_AIS_CPA;;
     

--- a/src/ConfigMgr.cpp
+++ b/src/ConfigMgr.cpp
@@ -189,6 +189,7 @@ extern bool             g_bTrackDaily;
 extern int              g_track_rotate_time;
 extern int              g_track_rotate_time_type;
 extern double           g_AISShowTracks_Mins;
+extern double           g_AISShowTracks_Limit;
 extern bool             g_bHideMoored;
 extern double           g_ShowMoored_Kts;
 extern bool             g_bAllowShowScaled;
@@ -1626,6 +1627,7 @@ bool ConfigMgr::CheckTemplate( wxString fileName)
     CHECK_FLT( _T ( "CogArrowMinutes" ), &g_ShowCOG_Mins, 1 );
     CHECK_INT( _T ( "bShowTargetTracks" ), &g_bAISShowTracks );
     CHECK_FLT( _T ( "TargetTracksMinutes" ), &g_AISShowTracks_Mins, 1 )
+    CHECK_FLT( _T ( "TargetTracksLimit" ), &g_AISShowTracks_Limit, 300 )
     CHECK_INT( _T ( "bHideMooredTargets" ), &g_bHideMoored )
     CHECK_FLT( _T ( "MooredTargetMaxSpeedKnots" ), &g_ShowMoored_Kts, .1 )
     CHECK_INT( _T ( "bShowScaledTargets"), &g_bAllowShowScaled );

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -576,6 +576,7 @@ bool                      g_bShowCOG;
 double                    g_ShowCOG_Mins;
 bool                      g_bAISShowTracks;
 double                    g_AISShowTracks_Mins;
+double                    g_AISShowTracks_Limit;
 bool                      g_bHideMoored;
 bool                      g_bAllowShowScaled;
 double                    g_ShowMoored_Kts;

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -202,6 +202,7 @@ extern bool             g_bTrackDaily;
 extern int              g_track_rotate_time;
 extern int              g_track_rotate_time_type;
 extern double           g_AISShowTracks_Mins;
+extern double           g_AISShowTracks_Limit;
 extern bool             g_bHideMoored;
 extern double           g_ShowMoored_Kts;
 extern bool             g_bAllowShowScaled;
@@ -611,6 +612,7 @@ int MyConfig::LoadMyConfig()
     g_n_arrival_circle_radius = 0.05;
     
     g_AISShowTracks_Mins = 20;
+    g_AISShowTracks_Limit = 300.0;
     g_ShowScaled_Num = 10;
     g_ScaledNumWeightSOG = 50;
     g_ScaledNumWeightCPA = 60;
@@ -1071,10 +1073,15 @@ int MyConfig::LoadMyConfigRaw( bool bAsTemplate )
 
     Read( _T ( "bShowTargetTracks" ), &g_bAISShowTracks );
 
+    
+    if( Read( _T ( "TargetTracksLimit" ), &s ) ) {
+        s.ToDouble( &g_AISShowTracks_Limit );
+        g_AISShowTracks_Limit = wxMax(300.0, g_AISShowTracks_Limit);
+    }
     if( Read( _T ( "TargetTracksMinutes" ), &s ) ) {
         s.ToDouble( &g_AISShowTracks_Mins );
         g_AISShowTracks_Mins = wxMax(1.0, g_AISShowTracks_Mins);
-        g_AISShowTracks_Mins = wxMin(300.0, g_AISShowTracks_Mins);
+        g_AISShowTracks_Mins = wxMin(g_AISShowTracks_Limit, g_AISShowTracks_Mins);
     }
 
     Read( _T ( "bHideMooredTargets" ), &g_bHideMoored );


### PR DESCRIPTION
- Allows overriding the allowed maximum for AIS target tracks via `TargetTracksLimit` variable in `Settings/AIS` section of the configuration file
- Adds MMSI to the name of DSC targets to allow easy identification of the vessels in distress or reporting position