### PR TITLE
Use wxWebView for help display

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ matrix:
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get --allow-unauthenticated install libwxgtk3.0-dev libwxgtk3.0-0 libgps-dev libglu1-mesa-dev libgtk2.0-dev libbz2-dev libtinyxml-dev libportaudio2 portaudio19-dev libcurl4-openssl-dev libexpat1-dev libcairo2-dev libarchive-dev liblzma-dev libexif-dev libsqlite3-dev libelf-dev gettext; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get --allow-unauthenticated install libwxgtk3.0-dev libwxgtk-webview3.0-dev libgps-dev libglu1-mesa-dev libbz2-dev libtinyxml-dev libportaudio2 portaudio19-dev libcurl4-openssl-dev libexpat1-dev libcairo2-dev libarchive-dev liblzma-dev libexif-dev libsqlite3-dev libelf-dev gettext; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cairo libexif xz libarchive;
     wget http://opencpn.navnux.org/build_deps/wx312_opencpn50_macos109.tar.xz; tar xJf
     wx312_opencpn50_macos109.tar.xz -C /tmp; export PATH="/usr/local/opt/gettext/bin:$PATH";  echo

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,22 @@ matrix:
   include:
     - dist: trusty
       compiler: gcc
+      env:
+        - USE_WEBVIEW=OFF
+        - WX_PKG_NAME=libwxgtk3.0-0
+    - dist: xenial
+      compiler: gcc
+      env:
+        - USE_WEBVIEW=ON
+        - WX_PKG_NAME=libwxgtk3.0-0v5
     - os: osx
       compiler: clang
 
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get --allow-unauthenticated install libwxgtk3.0-dev libwxgtk-webview3.0-dev libgps-dev libglu1-mesa-dev libbz2-dev libtinyxml-dev libportaudio2 portaudio19-dev libcurl4-openssl-dev libexpat1-dev libcairo2-dev libarchive-dev liblzma-dev libexif-dev libsqlite3-dev libelf-dev gettext; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get --allow-unauthenticated install $WX_PKG_NAME libwxgtk3.0-dev libgps-dev libglu1-mesa-dev libgtk2.0-dev libbz2-dev libtinyxml-dev libportaudio2 portaudio19-dev libcurl4-openssl-dev libexpat1-dev libcairo2-dev libarchive-dev liblzma-dev libexif-dev libsqlite3-dev libelf-dev gettext; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$USE_WEBVIEW" == "ON" ]]; then sudo apt-get --allow-unauthenticated install libwxgtk-webview3.0-dev libgtk-3-dev; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install cairo libexif xz libarchive;
     wget http://opencpn.navnux.org/build_deps/wx312_opencpn50_macos109.tar.xz; tar xJf
     wx312_opencpn50_macos109.tar.xz -C /tmp; export PATH="/usr/local/opt/gettext/bin:$PATH";  echo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -415,16 +415,9 @@ ELSE()
   SET(wxWidgets_USE_LIBS net xml html adv aui core base)
 ENDIF()
 
-IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
-  execute_process(COMMAND lsb_release -cs
-    OUTPUT_VARIABLE RELEASE_CODENAME
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-ELSE()
-  SET(RELEASE_CODENAME "unknown")
-ENDIF()
+OPTION(USE_WEBVIEW "Use wxWebView for help display" ON)
 
-
-IF(RELEASE_CODENAME MATCHES "trusty")
+IF(USE_WEBVIEW)
   MESSAGE(STATUS "Not using wxWebView")
 ELSE()
   SET(wxWidgets_USE_LIBS ${wxWidgets_USE_LIBS} webview)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,9 +410,26 @@ IF((_wx_selected_config MATCHES "qt-armv7"))
 ENDIF()
 
 IF((_wx_selected_config MATCHES "qt-armv7"))
-  SET(wxWidgets_USE_LIBS base core xml html adv aui webview)
+  SET(wxWidgets_USE_LIBS base core xml html adv aui)
 ELSE()
-  SET(wxWidgets_USE_LIBS net xml html adv aui core base webview)
+  SET(wxWidgets_USE_LIBS net xml html adv aui core base)
+ENDIF()
+
+IF(CMAKE_SYSTEM_NAME MATCHES "Linux")
+  execute_process(COMMAND lsb_release -cs
+    OUTPUT_VARIABLE RELEASE_CODENAME
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+ELSE()
+  SET(RELEASE_CODENAME "unknown")
+ENDIF()
+
+
+IF(RELEASE_CODENAME MATCHES "trusty")
+  MESSAGE(STATUS "Not using wxWebView")
+ELSE()
+  SET(wxWidgets_USE_LIBS ${wxWidgets_USE_LIBS} webview)
+  ADD_DEFINITIONS(-DOCPN_USE_WEBVIEW)
+  MESSAGE(STATUS "Using wxWebView")
 ENDIF()
 
 OPTION (USE_GL "Enable OpenGL support" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -410,9 +410,9 @@ IF((_wx_selected_config MATCHES "qt-armv7"))
 ENDIF()
 
 IF((_wx_selected_config MATCHES "qt-armv7"))
-  SET(wxWidgets_USE_LIBS base core     xml html adv aui)
+  SET(wxWidgets_USE_LIBS base core xml html adv aui webview)
 ELSE()
-  SET(wxWidgets_USE_LIBS net xml html adv aui core base)
+  SET(wxWidgets_USE_LIBS net xml html adv aui core base webview)
 ENDIF()
 
 OPTION (USE_GL "Enable OpenGL support" ON)

--- a/include/AboutFrame.h
+++ b/include/AboutFrame.h
@@ -25,6 +25,7 @@
 #include <wx/hyperlink.h>
 #include <wx/scrolwin.h>
 #include <wx/html/htmlwin.h>
+#include <wx/webview.h>
 #include <wx/panel.h>
 #include <wx/frame.h>
 
@@ -57,7 +58,7 @@ class AboutFrame : public wxFrame
 		wxHyperlinkCtrl* m_hyperlinkIniFile;
 		wxHtmlWindow* m_htmlWinAuthors;
 		wxHtmlWindow* m_htmlWinLicense;
-		wxHtmlWindow* m_htmlWinHelp;
+		wxWebView* m_htmlWinHelp;
 		wxPanel* m_panelMainLinks;
 		wxHyperlinkCtrl* m_hyperlinkWebsite;
 		wxHyperlinkCtrl* m_hyperlinkHelp;

--- a/include/AboutFrame.h
+++ b/include/AboutFrame.h
@@ -25,7 +25,9 @@
 #include <wx/hyperlink.h>
 #include <wx/scrolwin.h>
 #include <wx/html/htmlwin.h>
+#ifdef OCPN_USE_WEBVIEW
 #include <wx/webview.h>
+#endif
 #include <wx/panel.h>
 #include <wx/frame.h>
 
@@ -58,7 +60,11 @@ class AboutFrame : public wxFrame
 		wxHyperlinkCtrl* m_hyperlinkIniFile;
 		wxHtmlWindow* m_htmlWinAuthors;
 		wxHtmlWindow* m_htmlWinLicense;
+#ifdef OCPN_USE_WEBVIEW
 		wxWebView* m_htmlWinHelp;
+#else
+        wxHtmlWindow* m_htmlWinHelp;
+#endif
 		wxPanel* m_panelMainLinks;
 		wxHyperlinkCtrl* m_hyperlinkWebsite;
 		wxHyperlinkCtrl* m_hyperlinkHelp;

--- a/include/AboutFrameImpl.h
+++ b/include/AboutFrameImpl.h
@@ -40,7 +40,7 @@ protected:
     void OnLinkLicense( wxHyperlinkEvent& event );
     void OnLinkAuthors( wxHyperlinkEvent& event );
     void AboutFrameOnActivate( wxActivateEvent& event );
-    void m_btnBackOnButtonClick( wxCommandEvent& event ) { m_htmlWinHelp->HistoryBack(); m_btnBack->Enable(m_htmlWinHelp->HistoryCanBack()); }
+    void m_btnBackOnButtonClick( wxCommandEvent& event ) { m_htmlWinHelp->GoBack(); m_btnBack->Enable(m_htmlWinHelp->CanGoBack()); }
     void m_htmlWinHelpOnHtmlLinkClicked( wxHtmlLinkEvent& event ) { m_btnBack->Enable(); event.Skip(); }
 
     

--- a/include/AboutFrameImpl.h
+++ b/include/AboutFrameImpl.h
@@ -40,7 +40,11 @@ protected:
     void OnLinkLicense( wxHyperlinkEvent& event );
     void OnLinkAuthors( wxHyperlinkEvent& event );
     void AboutFrameOnActivate( wxActivateEvent& event );
+#ifdef OCPN_USE_WEBVIEW
     void m_btnBackOnButtonClick( wxCommandEvent& event ) { m_htmlWinHelp->GoBack(); m_btnBack->Enable(m_htmlWinHelp->CanGoBack()); }
+#else
+    void m_btnBackOnButtonClick( wxCommandEvent& event ) { m_htmlWinHelp->HistoryBack(); m_btnBack->Enable(m_htmlWinHelp->HistoryCanBack()); }
+#endif
     void m_htmlWinHelpOnHtmlLinkClicked( wxHtmlLinkEvent& event ) { m_btnBack->Enable(); event.Skip(); }
 
     

--- a/src/AboutFrame.cpp
+++ b/src/AboutFrame.cpp
@@ -142,7 +142,11 @@ AboutFrame::AboutFrame( wxWindow* parent, wxWindowID id, const wxString& title, 
 	m_htmlWinLicense = new wxHtmlWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHW_SCROLLBAR_AUTO );
 	bSizerContent->Add( m_htmlWinLicense, 1, wxALL|wxEXPAND, 5 );
 
+#ifdef OCPN_USE_WEBVIEW
     m_htmlWinHelp = wxWebView::New( this, wxID_ANY );
+#else
+    m_htmlWinHelp = new wxHtmlWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHW_SCROLLBAR_AUTO );
+#endif
 	bSizerContent->Add( m_htmlWinHelp, 1, wxALL|wxEXPAND, 5 );
 
 

--- a/src/AboutFrame.cpp
+++ b/src/AboutFrame.cpp
@@ -142,7 +142,7 @@ AboutFrame::AboutFrame( wxWindow* parent, wxWindowID id, const wxString& title, 
 	m_htmlWinLicense = new wxHtmlWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHW_SCROLLBAR_AUTO );
 	bSizerContent->Add( m_htmlWinLicense, 1, wxALL|wxEXPAND, 5 );
 
-	m_htmlWinHelp = new wxHtmlWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHW_SCROLLBAR_AUTO );
+    m_htmlWinHelp = wxWebView::New( this, wxID_ANY );
 	bSizerContent->Add( m_htmlWinHelp, 1, wxALL|wxEXPAND, 5 );
 
 

--- a/src/AboutFrameImpl.cpp
+++ b/src/AboutFrameImpl.cpp
@@ -55,8 +55,11 @@ AboutFrameImpl::AboutFrameImpl( wxWindow* parent, wxWindowID id, const wxString&
     wxBitmap logo(wxString::Format("%s/opencpn.png", g_Platform->GetSharedDataDir().c_str()), wxBITMAP_TYPE_ANY);
 
     m_hyperlinkHelp->SetURL(wxString::Format("file://%s/doc/help_en_US.html", g_Platform->GetSharedDataDir().c_str()));
+#ifdef OCPN_USE_WEBVIEW
     m_htmlWinHelp->LoadURL(wxString::Format("file://%s/doc/help_en_US.html", g_Platform->GetSharedDataDir().c_str()));
-
+#else
+    m_htmlWinHelp->LoadFile(wxString::Format("%s/doc/help_en_US.html", g_Platform->GetSharedDataDir().c_str()));
+#endif
     m_bitmapLogo->SetBitmap(logo);
     
     int width = m_scrolledWindowAbout->GetSizer()->GetSize().GetWidth() + m_bitmapLogo->GetSize().GetWidth() + EXTEND_WIDTH;
@@ -89,7 +92,11 @@ void AboutFrameImpl::OnLinkHelp( wxHyperlinkEvent& event )
         m_htmlWinHelp->Show();
         m_scrolledWindowAbout->Hide();
         m_btnBack->Show();
+#ifdef OCPN_USE_WEBVIEW
         m_btnBack->Enable(m_htmlWinHelp->CanGoBack());
+#else
+        m_btnBack->Enable(m_htmlWinHelp->HistoryCanBack());
+#endif
         SetSize(m_parent->GetSize());
         Centre();
     }

--- a/src/AboutFrameImpl.cpp
+++ b/src/AboutFrameImpl.cpp
@@ -55,7 +55,7 @@ AboutFrameImpl::AboutFrameImpl( wxWindow* parent, wxWindowID id, const wxString&
     wxBitmap logo(wxString::Format("%s/opencpn.png", g_Platform->GetSharedDataDir().c_str()), wxBITMAP_TYPE_ANY);
 
     m_hyperlinkHelp->SetURL(wxString::Format("file://%s/doc/help_en_US.html", g_Platform->GetSharedDataDir().c_str()));
-    m_htmlWinHelp->LoadFile(wxString::Format("%s/doc/help_en_US.html", g_Platform->GetSharedDataDir().c_str()));
+    m_htmlWinHelp->LoadURL(wxString::Format("file://%s/doc/help_en_US.html", g_Platform->GetSharedDataDir().c_str()));
 
     m_bitmapLogo->SetBitmap(logo);
     
@@ -89,7 +89,7 @@ void AboutFrameImpl::OnLinkHelp( wxHyperlinkEvent& event )
         m_htmlWinHelp->Show();
         m_scrolledWindowAbout->Hide();
         m_btnBack->Show();
-        m_btnBack->Enable(m_htmlWinHelp->HistoryCanBack());
+        m_btnBack->Enable(m_htmlWinHelp->CanGoBack());
         SetSize(m_parent->GetSize());
         Centre();
     }


### PR DESCRIPTION
Replaces the `wxHtmlWindow` with `wxWebView` for help display to support broader set of HTML features and multibyte Unicode characters.

This can't be merged until support for older Linux distros like Precise and Trusty is completely abandoned as `wxWebView` is not available there.
On Xenial the dependency is `libwxgtk-webview3.0-dev`, while on later Ubuntu releases `libwxgtk-webview3.0-gtk3-dev`. How messy it is on other distributions is unknown ATM...

Once merged, the following further work is needed:
- Update the developer documentation for the added dependency (`libwxgtk-webview3.0-dev` / `libwxgtk-webview3.0-gtk3-dev`)
- Update the PPA packaging scripts for the added dependency (`libwxgtk-webview3.0-dev` / `libwxgtk-webview3.0-gtk3-dev`)