### PR TITLE
Use gdk_screen_get_width_mm under Linux

### DIFF
--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -1750,7 +1750,7 @@ double  OCPNPlatform::GetDisplaySizeMM()
     
 #ifdef __WXGTK__
     GdkScreen *screen = gdk_screen_get_default();
-    double gdk_monitor_mm = gdk_screen_get_monitor_width_mm(screen, 0);
+    double gdk_monitor_mm = gdk_screen_get_width_mm(screen);
     if(gdk_monitor_mm > 0) // if gdk detects a valid screen width (returns -1 on raspberry pi)
         ret = gdk_monitor_mm;
 #endif    


### PR DESCRIPTION
This provides a better result for multi-monitor setups because
gdk_screen_get_monitor_width_mm returns the summary of the width
of all horizontally arranged monitors.

![before_fix](https://user-images.githubusercontent.com/1134209/53677143-206c3480-3c60-11e9-9fd8-b667b2b41288.png)
![after_fix](https://user-images.githubusercontent.com/1134209/53677144-206c3480-3c60-11e9-83c4-ee10513f2338.png)
