### PR TITLE
Mui progress dialog

### DIFF
--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -1205,7 +1205,7 @@ void GRIBOverlayFactory::RenderGribIsobar( int settings, GribRecord **pGR,
         pIsobarArray[idx] = new wxArrayPtrVoid;
         IsoLine *piso;
 
-        wxProgressDialog *progressdialog = NULL;
+        wxGenericProgressDialog *progressdialog = nullptr;
         wxDateTime start = wxDateTime::Now();
 
         double min = m_Settings.GetMin(settings);
@@ -1221,7 +1221,7 @@ void GRIBOverlayFactory::RenderGribIsobar( int settings, GribRecord **pGR,
             else {
                 wxDateTime now = wxDateTime::Now();
                 if((now-start).GetSeconds() > 3 && press-min < (max-min)/2) {
-                    progressdialog = new wxProgressDialog(
+                    progressdialog = new wxGenericProgressDialog(
                         _("Building Isobar map"), _("Wind"), max-min+1, NULL,
                         wxPD_SMOOTH | wxPD_ELAPSED_TIME | wxPD_REMAINING_TIME);
                 }

--- a/plugins/wmm_pi/src/MagneticPlotMap.cpp
+++ b/plugins/wmm_pi/src/MagneticPlotMap.cpp
@@ -353,7 +353,7 @@ bool MagneticPlotMap::Recompute(wxDateTime date)
     /* clear out old data */
   ClearMap();
 
-  wxGenericProgressDialog *progressdialog = new wxGenericProgressDialog(
+  wxGenericProgressDialog progressdialog(
       _("Building Magnetic Map"),
       m_type==DECLINATION_PLOT?_("Variation"):
       m_type==INCLINATION_PLOT?_("Inclination"):_("Field Strength"), 180, NULL,
@@ -366,8 +366,7 @@ bool MagneticPlotMap::Recompute(wxDateTime date)
   BuildParamCache(m_Cache[cachepage], -MAX_LAT);
 
   for(double lat = -MAX_LAT; lat + m_Step <= MAX_LAT; lat += m_Step) {
-      if(!progressdialog->Update(lat + 90)) {
-          delete progressdialog;
+      if(!progressdialog.Update(lat + 90)) {
           return false;
       }
 
@@ -383,7 +382,6 @@ bool MagneticPlotMap::Recompute(wxDateTime date)
       }
   }
 
-  delete progressdialog;
   return true;
 }
 

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -3637,8 +3637,6 @@ void MyFrame::OnCloseWindow( wxCloseEvent& event )
     pConfig->DeleteGroup( _T ( "/Marks" ) );
     pConfig->Flush();
 
-    delete pConfig;             // All done
-    pConfig = NULL;
 
     delete g_printData;
     delete g_pageSetupData;
@@ -3729,6 +3727,9 @@ void MyFrame::OnCloseWindow( wxCloseEvent& event )
         delete g_pi_manager;
         g_pi_manager = NULL;
     }
+
+    delete pConfig;             // All done
+    pConfig = NULL;
 
     if( g_pAIS ) {
         if(g_pMUX)

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -1425,7 +1425,7 @@ void ParseAllENC(wxWindow* parent)
         workers[t] = NULL;
     #endif
     
-    wxGenericProgressDialog *prog = NULL;
+    wxGenericProgressDialog *prog = nullptr;
     wxSize csz = GetOCPNCanvasWindow()->GetClientSize();
     
     if(1){    
@@ -6398,7 +6398,7 @@ bool MyFrame::UpdateChartDatabaseInplace( ArrayOfCDI &DirArray, bool b_force, bo
 
     OCPNPlatform::ShowBusySpinner();
 
-    wxGenericProgressDialog *pprog = NULL;
+    wxGenericProgressDialog *pprog = nullptr;
     if( b_prog ) {
         wxString longmsg = _("OpenCPN Chart Update");
         longmsg += _T("..........................................................................");

--- a/src/glTextureManager.cpp
+++ b/src/glTextureManager.cpp
@@ -1628,6 +1628,6 @@ void glTextureManager::BuildCompressedCache()
     m_timer.Start(500);
     
     delete m_progDialog;
-    m_progDialog = NULL;
+    m_progDialog = nullptr;
 }
 

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -2861,10 +2861,10 @@ void ExportGPX( wxWindow* parent, bool bviz_only, bool blayer )
 
         NavObjectCollection1 *pgpx = new NavObjectCollection1;
 
-        wxProgressDialog *pprog = NULL;
+        wxGenericProgressDialog *pprog = nullptr;
         int count = pWayPointMan->GetWaypointList()->GetCount();
         if( count > 200) {
-            pprog = new wxProgressDialog( _("Export GPX file"), _T("0/0"), count, NULL,
+            pprog = new wxGenericProgressDialog( _("Export GPX file"), _T("0/0"), count, NULL,
                                           wxPD_APP_MODAL | wxPD_SMOOTH |
                                           wxPD_ELAPSED_TIME | wxPD_ESTIMATED_TIME | wxPD_REMAINING_TIME );
             pprog->SetSize( 400, wxDefaultCoord );
@@ -2941,8 +2941,7 @@ void ExportGPX( wxWindow* parent, bool bviz_only, bool blayer )
         delete pgpx;
         ::wxEndBusyCursor();
 
-        if( pprog)
-            delete pprog;
+        delete pprog;
 
     }
 }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -7706,7 +7706,7 @@ They can be decompressed again using unxz or 7 zip programs."),
     filespecs.Add("*.A"), filespecs.Add("*.B"), filespecs.Add("*.C"), filespecs.Add("*.D");
     filespecs.Add("*.E"), filespecs.Add("*.F"), filespecs.Add("*.G"), filespecs.Add("*.Z");
 
-    wxProgressDialog prog1(_("OpenCPN Compress Charts"), wxEmptyString,
+    wxGenericProgressDialog prog1(_("OpenCPN Compress Charts"), wxEmptyString,
                            filespecs.GetCount()*pListBoxSelections.GetCount()+1, this,
                           wxPD_SMOOTH | wxPD_ELAPSED_TIME | wxPD_ESTIMATED_TIME |
                           wxPD_REMAINING_TIME | wxPD_CAN_SKIP);
@@ -7757,7 +7757,7 @@ They can be decompressed again using unxz or 7 zip programs."),
     
   // TODO: make this use threads
   unsigned long total_size = 0, total_compressed_size = 0, count = 0;
-  wxProgressDialog prog(_("OpenCPN Compress Charts"), wxEmptyString, charts.GetCount()+1, this,
+  wxGenericProgressDialog prog(_("OpenCPN Compress Charts"), wxEmptyString, charts.GetCount()+1, this,
                         wxPD_SMOOTH | wxPD_ELAPSED_TIME | wxPD_ESTIMATED_TIME |
                         wxPD_REMAINING_TIME | wxPD_CAN_SKIP);
 

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -1081,7 +1081,7 @@ bool PlugInManager::CheckPluginCompatibility(wxString plugin_file)
         LPSTR libname[256];
         size_t i = 0;
         // Walk until you reached an empty IMAGE_IMPORT_DESCRIPTOR
-        while (pImportDescriptor->Name != NULL)
+        while (pImportDescriptor->Name != 0)
         {
             //Get the name of each DLL
             libname[i] = (PCHAR)((DWORD_PTR)virtualpointer + Rva2Offset(pImportDescriptor->Name, pSech, ntheaders));

--- a/src/routeman.cpp
+++ b/src/routeman.cpp
@@ -979,11 +979,11 @@ void Routeman::DeleteTrack( Track *pTrack )
 
         ::wxBeginBusyCursor();
 
-        wxProgressDialog *pprog = NULL;
+        wxGenericProgressDialog *pprog = nullptr;
 
         int count = pTrack->GetnPoints();
         if( count > 10000) {
-            pprog = new wxProgressDialog( _("OpenCPN Track Delete"), _T("0/0"), count, NULL, 
+            pprog = new wxGenericProgressDialog( _("OpenCPN Track Delete"), _T("0/0"), count, NULL, 
                                           wxPD_APP_MODAL | wxPD_SMOOTH |
                                           wxPD_ELAPSED_TIME | wxPD_ESTIMATED_TIME | wxPD_REMAINING_TIME );
             pprog->SetSize( 400, wxDefaultCoord );
@@ -1028,8 +1028,7 @@ void Routeman::DeleteTrack( Track *pTrack )
 
         ::wxEndBusyCursor();
 
-        if( pprog)
-            delete pprog;
+        delete pprog;
     }
 }
 

--- a/src/routemanagerdialog.cpp
+++ b/src/routemanagerdialog.cpp
@@ -1869,19 +1869,18 @@ void RouteManagerDialog::TrackToRoute( Track *track )
     if( !track ) return;
     if( track->m_bIsInLayer ) return;
 
-    wxProgressDialog *pprog = new wxProgressDialog( _("OpenCPN Converting Track to Route...."),
+    wxGenericProgressDialog pprog( _("OpenCPN Converting Track to Route...."),
             _("Processing Waypoints..."), 101, NULL,
             wxPD_AUTO_HIDE | wxPD_SMOOTH | wxPD_ELAPSED_TIME | wxPD_ESTIMATED_TIME
                     | wxPD_REMAINING_TIME );
 
     ::wxBeginBusyCursor();
 
-    Route *route = track->RouteFromTrack( pprog );
+    Route *route = track->RouteFromTrack( &pprog );
 
     pRouteList->Append( route );
 
-    pprog->Update( 101, _("Done.") );
-    delete pprog;
+    pprog.Update( 101, _("Done.") );
 
     gFrame->RefreshAllCanvas();
     

--- a/src/toolbar.cpp
+++ b/src/toolbar.cpp
@@ -2637,7 +2637,7 @@ void ocpnToolBarSimple::DrawTool( wxDC& dc, wxToolBarToolBase *toolBase )
     }
 
     //      Clear the last drawn tool if necessary
-    if( tool->last_rect.width && ((tool->last_rect.x != drawAt.x) || (tool->last_rect.y != drawAt.y)) || bNeedClear )
+    if( (tool->last_rect.width && (tool->last_rect.x != drawAt.x || tool->last_rect.y != drawAt.y)) || bNeedClear )
     {
         wxBrush bb(GetGlobalColor( _T("GREY3") ));
         dc.SetBrush(bb);


### PR DESCRIPTION
Hi
- It seems WX 3.1.2 has UI glitches with  the OS progress dialog on Windows.
Use the generic dialog everywhere, it's already the most used anyway.
 
- some plugins save their config in the DTOR, which is likely a bad idea, but when closing the config was already deleted.

- remove a couple of warnings.

Regards
Didier