### PR TITLE
Compiler travis

### DIFF
--- a/include/OCPNPlatform.h
+++ b/include/OCPNPlatform.h
@@ -160,9 +160,9 @@ public:
 
     void SetLocaleSearchPrefixes( void );
     wxString GetDefaultSystemLocale();
-    wxString GetAdjustedAppLocale();
     
 #if wxUSE_XLOCALE    
+    wxString GetAdjustedAppLocale();
     wxString ChangeLocale(wxString &newLocaleID, wxLocale *presentLocale, wxLocale** newLocale);
 #endif
     

--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -818,6 +818,7 @@ wxString OCPNPlatform::GetDefaultSystemLocale()
 }
 
 
+#if wxUSE_XLOCALE || !wxCHECK_VERSION(3,0,0)
 wxString OCPNPlatform::GetAdjustedAppLocale()
 {
     wxString adjLocale = g_locale;
@@ -851,7 +852,6 @@ wxString OCPNPlatform::GetAdjustedAppLocale()
 }
 
 
-#if wxUSE_XLOCALE || !wxCHECK_VERSION(3,0,0)
 
 wxString OCPNPlatform::ChangeLocale(wxString &newLocaleID, wxLocale *presentLocale, wxLocale** newLocale)
 {

--- a/travisci_build.sh
+++ b/travisci_build.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# bailout on errror
+set -e
+
 mkdir build && cd build
 if [[ "$TRAVIS_OS_NAME" == "linux" ]];
   then cmake -DCMAKE_BUILD_TYPE=Debug ..


### PR DESCRIPTION
Hi,
-travis script doesn't always return an error on failure.
for example:
https://travis-ci.org/did-g/OpenCPN/jobs/501481402
should have failed.

- there are ifdef in case wx is compiled without locale but it doesn't compile.

Regards
Didier