### PR TITLE
Sound: new fix for 1277

### DIFF
--- a/include/SoundFactory.h
+++ b/include/SoundFactory.h
@@ -33,6 +33,5 @@
  */
 
 OcpnSound* SoundFactory();
-bool IsSoundFactorySynchronous( void );
 
 #endif // SOUND_FACTORY_H

--- a/include/chart1.h
+++ b/include/chart1.h
@@ -357,10 +357,10 @@ class MyFrame: public wxFrame
     void OnEvtOCPN_NMEA(OCPN_DataStreamEvent & event);
     void OnEvtPlugInMessage( OCPN_MsgEvent & event );
     void OnMemFootTimer(wxTimerEvent& event);
-    void OnBellsTimer(wxTimerEvent& event);
     void OnRecaptureTimer(wxTimerEvent& event);
     void OnSENCEvtThread( OCPN_BUILDSENC_ThreadEvent & event);
     void OnIconize(wxIconizeEvent& event);
+    void OnBellsFinished(wxCommandEvent& event);
 
 #ifdef wxHAS_POWER_EVENTS
     void OnSuspending(wxPowerEvent &event);

--- a/src/PortAudioSound.cpp
+++ b/src/PortAudioSound.cpp
@@ -147,8 +147,6 @@ static bool writeSynchronous(int deviceIx,
         }
     }
     Pa_CloseStream(stream);
-    soundLoader->Reset();
-    
     return pe == paNoError;
 }
 

--- a/src/SoundFactory.cpp
+++ b/src/SoundFactory.cpp
@@ -29,30 +29,20 @@
 #include "PortAudioSound.h"
 
 OcpnSound* SoundFactory(void) { return new PortAudioSound(); }
-bool IsSoundFactorySynchronous( void ) { return true; }
 
 #elif defined(__OCPN__ANDROID__)
 #include "AndroidSound.h"
 
 OcpnSound* SoundFactory(void) { return new AndroidSound(); }
-bool IsSoundFactorySynchronous( void ) { return false; }
 
 #elif defined(HAVE_SYSTEM_CMD_SOUND)
 #include "SystemCmdSound.h"
 
 OcpnSound* SoundFactory(void) { return new SystemCmdSound(SYSTEM_SOUND_CMD); }
-#if defined(__WXMAC__)
-bool IsSoundFactorySynchronous( void ) { return false; }
-#elif defined(_WINDOWS)
-bool IsSoundFactorySynchronous( void ) { return true; }
-#else
-bool IsSoundFactorySynchronous( void ) { return false; }        // Probably rPI
-#endif
 
 #else
 #include  "OcpnWxSound.h"
 
 OcpnSound* SoundFactory(void) { return new OcpnWxSound(); }
-bool IsSoundFactorySynchronous( void ) { return true; }
 
 #endif

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -6918,11 +6918,7 @@ void MyFrame::OnBellsTimer(wxTimerEvent& event)
     bells_sound[bells - 1]->Play();
     m_BellsToPlay -= bells;
 
-    if(IsSoundFactorySynchronous())
-        BellsTimer.Start(100, wxTIMER_ONE_SHOT);
-    else
-        BellsTimer.Start(2000, wxTIMER_ONE_SHOT);
-        
+    BellsTimer.Start(2000, wxTIMER_ONE_SHOT);
 }
 
 int ut_index;


### PR DESCRIPTION
I have re-enabled the tests and verified that the sound code seems to work fine under Linux. Attaching the patch which makes the tests available:
[0001-Sound-re-enable-test-code.patch.gz](https://github.com/OpenCPN/OpenCPN/files/2926987/0001-Sound-re-enable-test-code.patch.gz)

However, the actual use of the sound code in chart1 does not match the intended usage pattern. I just missed this part earlier. The top commit changes the old, timer-based code to using the new sound asynchronous capabilities.

Note that  bug basically is platform-agnostic and should hit all platforms  if not fixed.

Also, this PR reverts the earlier fix. This patch has some problems, the basic is assuming that  SoundFactories are either synchronous or not -- this is not correct, and will cause all sorts of problems if not reverted.
