### PR TITLE
mmsi_prop update after OK Btn click

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -706,7 +706,7 @@ void MMSIEditDialog::OnMMSIEditOKClick(wxCommandEvent& event) {
     long nmmsi;
     m_MMSICtl->GetValue().ToLong(&nmmsi);
     m_props->MMSI = nmmsi;
-
+    Persist();
     
       
     if (m_MMSICtl->GetValue().Length() != 9)


### PR DESCRIPTION
After clicking OK in the mmsi editing dlg nothing was updated (unless you did an explicit update of the mmsi number itself)