### PR TITLE
Allow chart source master catalog update from the internet

### DIFF
--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -1700,15 +1700,20 @@ bool ChartDldrGuiAddSourceDlg::LoadSources()
     wxTreeItemId tree = m_treeCtrlPredefSrcs->AddRoot(_T("root"));
 
     wxFileName fn;
-    fn.SetPath(*GetpSharedDataLocation());
-    fn.AppendDir(_T("plugins"));
-    fn.AppendDir(_T("chartdldr_pi"));
-    fn.AppendDir(_T("data"));
-    fn.SetFullName(_T("chart_sources.xml"));
+    fn.SetPath(*GetpPrivateApplicationDataLocation());
+    fn.SetFullName(_T("chartdldr_pi-chart_sources.xml"));
     if( !fn.FileExists() )
     {
-        wxLogMessage( wxString::Format(_T("Error: chartdldr_pi::LoadSources() %s not found!"), fn.GetFullPath().c_str()) );
-        return false;
+        fn.SetPath(*GetpSharedDataLocation());
+        fn.AppendDir(_T("plugins"));
+        fn.AppendDir(_T("chartdldr_pi"));
+        fn.AppendDir(_T("data"));
+        fn.SetFullName(_T("chart_sources.xml"));
+        if( !fn.FileExists() )
+        {
+            wxLogMessage( wxString::Format(_T("Error: chartdldr_pi::LoadSources() %s not found!"), fn.GetFullPath().c_str()) );
+            return false;
+        }
     }
     wxString path = fn.GetFullPath();
     TiXmlDocument * doc = new TiXmlDocument();

--- a/plugins/chartdldr_pi/src/chartdldrgui.h
+++ b/plugins/chartdldr_pi/src/chartdldrgui.h
@@ -138,10 +138,12 @@ class ChartDldrPrefsDlg : public wxDialog
 		wxStdDialogButtonSizer* m_sdbSizerBtns;
 		wxButton* m_sdbSizerBtnsOK;
 		wxButton* m_sdbSizerBtnsCancel;
-                wxButton* m_buttonChartDirectory;
-                wxTextCtrl* m_tcDefaultDir;
-                
-                void OnDirSelClick( wxCommandEvent& event );
+        wxButton* m_buttonChartDirectory;
+        wxButton* m_buttonDownloadMasterCatalog;
+        wxTextCtrl* m_tcDefaultDir;
+    
+        void OnDirSelClick( wxCommandEvent& event );
+        void OnDownloadMasterCatalog( wxCommandEvent& event );
                 
                 
 		// Virtual event handlers, overide them in your derived class


### PR DESCRIPTION
Allows the user to update the list of support chart catalog sources from the GUI instead of having to replace the data file in the install location.

<img width="442" alt="Chart_Downloader_Preferences_and_Options_and_OpenCPN_4_99_1508" src="https://user-images.githubusercontent.com/249856/54158525-6b890300-4429-11e9-807d-b4e55bb5f96b.png">
