### PR TITLE
if there's other charts in the set don't use mbtiles as a reference chart

### DIFF
--- a/src/Quilt.cpp
+++ b/src/Quilt.cpp
@@ -884,6 +884,7 @@ struct scale {
 int Quilt::AdjustRefOnZoom( bool b_zin, ChartFamilyEnum family,  ChartTypeEnum type, double proposed_scale_onscreen )
 {
     std::vector<scale> scales;
+    std::vector<scale> scales_mbtiles;
 
     //  For Vector charts, or for ZoomIN operations, we can switch to any chart that is on screen.
     //  Otherwise, we can only switch to charts contining the VP center point
@@ -913,13 +914,18 @@ int Quilt::AdjustRefOnZoom( bool b_zin, ChartFamilyEnum family,  ChartTypeEnum t
                     nmax_scale = 1;
 
                 int nmin_scale = GetNomScaleMin(nscale, type, family);
-                scales.push_back(scale{test_db_index, nscale, nmin_scale, nmax_scale});
+                if (CHART_TYPE_MBTILES == ChartData->GetDBChartType( test_db_index ) )
+                    scales_mbtiles.push_back(scale{test_db_index, nscale, nmin_scale, nmax_scale});
+                else
+                    scales.push_back(scale{test_db_index, nscale, nmin_scale, nmax_scale});
 
                 i_first ++;
             }
         }
     }
-
+    // mbtiles charts only set
+    if (scales.empty())
+        scales = scales_mbtiles;
     //  If showing Vector charts,
     //  Find the smallest scale chart of the target type (i.e. skipping cm93)
     //  and make sure that its min scale is at least

--- a/src/mbtiles.cpp
+++ b/src/mbtiles.cpp
@@ -117,7 +117,7 @@ extern MyConfig        *pConfig;
 */
 
 // A "nominal" scale value, by zoom factor.  Estimated at equator, with monitor pixel size of 0.3mm 
-double OSM_zoomScale[] = { 5e8,
+static const double OSM_zoomScale[] = { 5e8,
                             2.5e8,
                             1.5e8,
                             7.0e7,
@@ -139,7 +139,7 @@ double OSM_zoomScale[] = { 5e8,
                             1.0e3};
         
 //  Meters per pixel, by zoom factor                            
-double OSM_zoomMPP[] = { 156412,
+static const double OSM_zoomMPP[] = { 156412,
                             78206,
                             39103,
                             19551,
@@ -161,7 +161,7 @@ double OSM_zoomMPP[] = { 156412,
                             0.298 };
                             
                             
-const double eps = 6e-6;  // about 1cm on earth's surface at equator
+static const double eps = 6e-6;  // about 1cm on earth's surface at equator
 extern MyFrame *gFrame;
 
 #if defined( __UNIX__ ) && !defined(__WXOSX__)  // high resolution stopwatch for profiling
@@ -187,7 +187,7 @@ private:
 // *********************************************
 
 // https://wiki.openstreetmap.org/wiki/Slippy_map_tilenames#C.2FC.2B.2B
-int long2tilex(double lon, int z)
+static int long2tilex(double lon, int z)
 {
     if(lon < -180)
         lon += 360;
@@ -195,7 +195,7 @@ int long2tilex(double lon, int z)
     return (int)(floor((lon + 180.0) / 360.0 * pow(2.0, z)));
 }
 
-int lat2tiley(double lat, int z)
+static int lat2tiley(double lat, int z)
 {
     int y = (int)(floor((1.0 - log( tan(lat * M_PI/180.0) + 1.0 / cos(lat * M_PI/180.0)) / M_PI) / 2.0 * pow(2.0, z)));
     int ymax  = 1 << z;
@@ -203,12 +203,12 @@ int lat2tiley(double lat, int z)
     return y;
 }
 
-double tilex2long(int x, int z)
+static double tilex2long(int x, int z)
 {
     return x / pow(2.0, z) * 360.0 - 180;
 }
 
-double tiley2lat(int y, int z)
+static double tiley2lat(int y, int z)
 {
     double n = pow(2.0,z);
     int ymax  = 1 << z;


### PR DESCRIPTION
Hi,

GetNativeScale of mbtiles is currently set to max zoom OSM_zoomScale meaning charts may not be included in the set if a mbtiles is used as reference chart.

Regards
Didier
