### PR TITLE
limit JumpToPosition scale

### DIFF
--- a/include/Quilt.h
+++ b/include/Quilt.h
@@ -100,7 +100,6 @@ public:
 
     void EnableHighDefinitionZoom( bool value ) { m_b_hidef = value;}
     
-    bool BuildExtendedChartStackAndCandidateArray(bool b_fullscreen, int ref_db_index, ViewPort &vp_in);
     void UnlockQuilt();
     bool Compose( const ViewPort &vp );
     bool IsComposed() {
@@ -169,7 +168,6 @@ public:
 
     int AdjustRefOnZoomOut( double proposed_scale_onscreen );
     int AdjustRefOnZoomIn( double proposed_scale_onscreen );
-    int AdjustRefOnZoom( bool b_zin, ChartFamilyEnum family, ChartTypeEnum type, double proposed_scale_onscreen );
     
     void SetHiliteIndex( int index ) {
         m_nHiLiteIndex = index;
@@ -232,6 +230,9 @@ public:
     int GetNomScaleMax(int scale, ChartTypeEnum type, ChartFamilyEnum family);
     
 private:
+    bool BuildExtendedChartStackAndCandidateArray(bool b_fullscreen, int ref_db_index, ViewPort &vp_in);
+    int AdjustRefOnZoom( bool b_zin, ChartFamilyEnum family, ChartTypeEnum type, double proposed_scale_onscreen );
+
     bool DoRenderQuiltRegionViewOnDC( wxMemoryDC &dc, ViewPort &vp, OCPNRegion &chart_region );
     bool DoRenderQuiltRegionViewOnDCTextOnly( wxMemoryDC& dc, ViewPort &vp, OCPNRegion &chart_region );
     

--- a/include/chcanv.h
+++ b/include/chcanv.h
@@ -320,7 +320,6 @@ public:
       int GetCanvasChartNativeScale();
       int FindClosestCanvasChartdbIndex(int scale);
       void UpdateCanvasOnGroupChange(void);
-      int AdjustQuiltRefChart( void );
       void ToggleCourseUp( );
       void ToggleLookahead( );
       void SetShowGPS( bool show );
@@ -517,6 +516,8 @@ public:
       void RenderAlertMessage( wxDC &dc, const ViewPort &vp);
 
 private:
+      int AdjustQuiltRefChart();
+
       bool UpdateS52State();
       
       void CallPopupMenu( int x, int y );

--- a/src/ConfigMgr.cpp
+++ b/src/ConfigMgr.cpp
@@ -93,8 +93,6 @@ extern int              g_LayerIdx;
 extern Select           *pSelect;
 extern MyConfig         *pConfig;
 extern ArrayOfCDI       g_ChartDirArray;
-extern double           vLat, vLon, gLat, gLon;
-extern double           kLat, kLon;
 extern double           initial_scale_ppm, initial_rotation;
 extern ColorScheme      global_color_scheme;
 extern int              g_nbrightness;

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -5747,25 +5747,11 @@ void MyFrame::JumpToPosition( ChartCanvas *cc, double lat, double lon, double sc
 {
     if (lon > 180.0)
         lon -= 360.0;
+    // XXX is vLat/vLon always equal to cc m_vLat, m_vLon after SetViewPoint? Does it matter?
     vLat = lat;
     vLon = lon;
-    cc->StopMovement();
-    cc->m_bFollow = false;
-    cc->UpdateFollowButtonState();
+    cc->JumpToPosition(lat, lon, scale);
     
-    if( !cc->GetQuiltMode() ) {
-        double skew = 0;
-        if(cc->m_singleChart)
-            skew = cc->m_singleChart->GetChartSkew() * PI / 180.;
-        cc->SetViewPoint( lat, lon, scale, skew, cc->GetVPRotation() );
-    } else {
-        cc->SetViewPoint( lat, lon, scale, 0, cc->GetVPRotation() );
-    }
-
-    cc->ReloadVP();
-
-    cc->SetCanvasToolbarItemState( ID_FOLLOW, false );
-
     if( g_pi_manager ) {
         g_pi_manager->SendViewPortToRequestingPlugIns( cc->GetVP() );
     }

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -4608,7 +4608,7 @@ void ChartCanvas::UpdateFollowButtonState( void )
    }
 }
 
-void ChartCanvas::JumpToPosition( double lat, double lon, double scale )
+void ChartCanvas::JumpToPosition( double lat, double lon, double scale_ppm )
 {
     if (lon > 180.0)
         lon -= 360.0;
@@ -4621,9 +4621,14 @@ void ChartCanvas::JumpToPosition( double lat, double lon, double scale )
         double skew = 0;
         if(m_singleChart)
             skew = m_singleChart->GetChartSkew() * PI / 180.;
-        SetViewPoint( lat, lon, scale, skew, GetVPRotation() );
+        SetViewPoint( lat, lon, scale_ppm, skew, GetVPRotation() );
     } else {
-        SetViewPoint( lat, lon, scale, 0, GetVPRotation() );
+        if (scale_ppm != GetVPScale()) {
+            // XXX should be done in SetViewPoint
+            VPoint.chart_scale = m_canvas_scale_factor / ( scale_ppm );
+            AdjustQuiltRefChart();
+        }
+        SetViewPoint( lat, lon, scale_ppm, 0, GetVPRotation() );
     }
     
     ReloadVP();
@@ -4777,7 +4782,7 @@ double ChartCanvas::GetBestStartScale(int dbi_hint, const ViewPort &vp)
 
 //      Verify and adjust the current reference chart,
 //      so that it will not lead to excessive overzoom or underzoom onscreen
-int ChartCanvas::AdjustQuiltRefChart( void )
+int ChartCanvas::AdjustQuiltRefChart()
 {
     int ret = -1;
     if(m_pQuilt){


### PR DESCRIPTION
Hi,
Currently JumpToPosition can request very big scales, eg while opening a 110 degrees latitude grib file.
There's code in SetViewPoint for limiting it but it doesn't work in all cases 
`renderable = chartMaxScale * 64 >= VPoint.chart_scale;` 
is part of the problem, a new reference chart is rarely recomputed, but trying to change SetViewPoint code has many unexpected effects.

JumpToPosition has fewer callers.

Regards
Didier