### PR TITLE
Projection

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -2035,9 +2035,8 @@ void ChartCanvas::SetupCanvasQuiltMode( void )
 //                 GetVP().SetProjectionType(g_sticky_projection);
 //             else
 //                 GetVP().SetProjectionType(PROJECTION_MERCATOR);
-            
-            
-            
+        GetVP().SetProjectionType(PROJECTION_UNKNOWN);
+
     } else                                                  // going to SC Mode
     {
         std::vector<int>  empty_array;

--- a/src/mbtiles.cpp
+++ b/src/mbtiles.cpp
@@ -703,44 +703,41 @@ void ChartMBTiles::PrepareTiles()
     
 }
 
-void ChartMBTiles::FlushTiles( void )
+void ChartMBTiles::FlushTiles()
 {
-    if(!bReadyToRender || m_tileArray == NULL)
+    if(!bReadyToRender || m_tileArray == nullptr)
         return;
     for(int iz=0 ; iz < (m_maxZoom - m_minZoom) + 1 ; iz++){
         mbTileZoomDescriptor *tzd = m_tileArray[iz];
 
-        std::unordered_map<unsigned int, mbTileDescriptor *>::iterator it = tzd->tileMap.begin();
-        while(it != tzd->tileMap.end())
+        for (auto const &it : tzd->tileMap)
         {
-            mbTileDescriptor *tile = it->second;
+            mbTileDescriptor *tile = it.second;
             if( tile ){
-                glDeleteTextures(1, &tile->glTextureName);
+                if (tile->glTextureName > 0)
+                    glDeleteTextures(1, &tile->glTextureName);
                 delete tile;
             }
-            it++;
         }
         delete tzd;
     }
 }
 
-void ChartMBTiles::FlushTextures( void )
+void ChartMBTiles::FlushTextures()
 {
-    if (m_tileArray == NULL) {
+    if (m_tileArray == nullptr) {
         return;
     }
     for(int iz=0 ; iz < (m_maxZoom - m_minZoom) + 1 ; iz++){
         mbTileZoomDescriptor *tzd = m_tileArray[iz];
 
-        std::unordered_map<unsigned int, mbTileDescriptor *>::iterator it = tzd->tileMap.begin();
-        while(it != tzd->tileMap.end())
+        for (auto const &it : tzd->tileMap)
         {
-            mbTileDescriptor *tile = it->second;
-            if( tile ){
+            mbTileDescriptor *tile = it.second;
+            if( tile && tile->glTextureName > 0){
                 glDeleteTextures(1, &tile->glTextureName);
                 tile->glTextureName = 0;
             }
-            it++;
         }
     }
 }
@@ -1040,7 +1037,7 @@ bool ChartMBTiles::RenderRegionViewOnGL(const wxGLContext &glc, const ViewPort& 
             return true;
         }
     }
-    
+
     ViewPort vp = VPoint;
 
     OCPNRegion screen_region(wxRect(0, 0, vp.pix_width, vp.pix_height));


### PR DESCRIPTION
Hi,
- In single chart mode projection used is the chart one, ie polyconic, web mercator, whatever but we can't keep it when switching to quilt mode. 
For testing either select a great lakes RNC or a MBTiles and switch between Quilt/Single chart mode.
There's still rendering glitches on switch but they are corrected by panning, zooming or periodic overlay (AIS) rewrite.

- testing a texture is not zero is done in most of O code, do it in mbtiles too, with some c11 cosmetic refactoring anyway  std::unordered_map is c11.

Regards
Didier
