### PR TITLE
Correct dashboard instruments background colour

### DIFF
--- a/plugins/dashboard_pi/src/instrument.cpp
+++ b/plugins/dashboard_pi/src/instrument.cpp
@@ -117,6 +117,11 @@ void DashboardInstrument::OnPaint( wxPaintEvent& WXUNUSED(event) )
     wxColour cl;
     GetGlobalColor( _T("DASHB"), &cl );
     dc.SetBackground( cl );
+#ifdef __WXGTK__
+    dc.SetBrush( cl );
+    dc.SetPen( *wxTRANSPARENT_PEN );
+    dc.DrawRectangle( 0, 0, size.x, size.y );
+#endif
     dc.Clear();
 
     Draw( &dc );


### PR DESCRIPTION
Hi
I discovered a problem with instruments back colour with my Linux Mint machine
This back colour is OK when the instrument is at the first position on the top of a dashboard but no OK  in the others positions You can see this in the two first shots attached and in the next he result of this patch.
This don't happen with W10.

![Capture before1](https://user-images.githubusercontent.com/2202442/54748453-fa3c1380-4bd1-11e9-823e-743eb9c2236a.png)
![Capture before3](https://user-images.githubusercontent.com/2202442/54748457-fd370400-4bd1-11e9-827d-e13ed9540d29.png)
JP![Capture after1](https://user-images.githubusercontent.com/2202442/54748443-f1e3d880-4bd1-11e9-949b-81582de8ec28.png)
![Capture after3](https://user-images.githubusercontent.com/2202442/54748450-f7d9b980-4bd1-11e9-96d2-05293c6906e8.png)