### PR TITLE
lock displayed single charts in memory

### DIFF
--- a/include/chart1.h
+++ b/include/chart1.h
@@ -261,6 +261,8 @@ class OCPN_DataStreamEvent;
 class DataStream;
 class AIS_Target_Data;
 
+bool isSingleChart(ChartBase *chart);
+
 class  OCPNMessageDialog: public wxDialog
 {
     

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -963,6 +963,21 @@ wxString newPrivateFileName(wxString home_locn, const char *name, const char *wi
      return filePathAndName;
 }
 
+bool isSingleChart(ChartBase *chart)
+{
+   if (chart == nullptr)
+       return false;
+
+   // ..For each canvas...
+   for(unsigned int i=0 ; i < g_canvasArray.GetCount() ; i++){
+      ChartCanvas *cc = g_canvasArray.Item(i);
+      if(cc && cc->m_singleChart == chart){
+         return true;
+      }
+   }
+   return false;
+}
+
 
 // `Main program' equivalent, creating windows and returning main app frame
 //------------------------------------------------------------------------------

--- a/src/chartdb.cpp
+++ b/src/chartdb.cpp
@@ -69,9 +69,9 @@ extern bool         g_bopengl;
 extern s52plib      *ps52plib;
 extern ChartDB      *ChartData;
 
+
 bool G_FloatPtInPolygon(MyFlPoint *rgpts, int wnumpts, float x, float y) ;
 bool GetMemoryStatus(int *mem_total, int *mem_used);
-
 
 // ============================================================================
 // ChartStack implementation
@@ -1140,8 +1140,10 @@ CacheEntry *ChartDB::FindOldestDeleteCandidate( bool blog)
             {
                 CacheEntry *pce = (CacheEntry *)(pChartCache->Item(i));
                 if(pce->RecentTime < LRUTime && !pce->n_lock){
-                    LRUTime = pce->RecentTime;
-                    iOldest = i;
+                    if (!isSingleChart((ChartBase *)(pce->pChart))) {
+                       LRUTime = pce->RecentTime;
+                       iOldest = i;
+                    }
                 }
             }
             int dt = m_ticks - LRUTime;
@@ -1149,7 +1151,7 @@ CacheEntry *ChartDB::FindOldestDeleteCandidate( bool blog)
             CacheEntry *pce = (CacheEntry *)(pChartCache->Item(iOldest));
             ChartBase *pDeleteCandidate =  (ChartBase *)(pce->pChart);
                 
-            if( (!pce->n_lock) ){
+            if( !pce->n_lock &&  !isSingleChart(pDeleteCandidate)){
                 if(blog)
                     wxLogMessage(_T("Oldest unlocked cache index is %d, delta t is %d"), iOldest, dt);
                 
@@ -1525,8 +1527,8 @@ bool ChartDB::DeleteCacheChart(ChartBase *pDeleteCandidate)
     bool retval = false;
     
     if( wxMUTEX_NO_ERROR == m_cache_mutex.Lock() ){
-        
-
+       if(!isSingleChart(pDeleteCandidate))
+       {
             // Find the chart in the cache
             CacheEntry *pce = NULL;
             for(unsigned int i=0 ; i< pChartCache->GetCount() ; i++)
@@ -1548,7 +1550,7 @@ bool ChartDB::DeleteCacheChart(ChartBase *pDeleteCandidate)
                       retval = true;
                   }
             }
-      
+      }
       m_cache_mutex.Unlock();
     }
 


### PR DESCRIPTION
Hi,

This revert chartdb.cpp da82d3
Single charts aren't protected by cache reference counting but they can't
be removed from memory.

Quick and dirty fix for #1325 
Currently you can kill O by:
view the ship on screen in single chart mode with a raster chart displayed.
rebuild the texture cache.
once the displayed chart is rebuilt, reference is invalid.

You can do the same with two canvas:
select a single chart in one canvas
move a lot in the second, after a while the single chart will be evicted from the cache.

Regards
Didier