### PR TITLE
Speedup o50

### DIFF
--- a/include/Quilt.h
+++ b/include/Quilt.h
@@ -230,7 +230,7 @@ public:
     int GetNomScaleMax(int scale, ChartTypeEnum type, ChartFamilyEnum family);
     
 private:
-    bool BuildExtendedChartStackAndCandidateArray(bool b_fullscreen, int ref_db_index, ViewPort &vp_in);
+    bool BuildExtendedChartStackAndCandidateArray(int ref_db_index, ViewPort &vp_in);
     int AdjustRefOnZoom( bool b_zin, ChartFamilyEnum family, ChartTypeEnum type, double proposed_scale_onscreen );
 
     bool DoRenderQuiltRegionViewOnDC( wxMemoryDC &dc, ViewPort &vp, OCPNRegion &chart_region );

--- a/include/TexFont.h
+++ b/include/TexFont.h
@@ -71,4 +71,7 @@ private:
     bool m_built;
     
 };
+
+TexFont *GetTexFont(wxFont *key);
+
 #endif  //guard

--- a/include/chartdbs.h
+++ b/include/chartdbs.h
@@ -220,8 +220,8 @@ struct ChartTableEntry
     float GetLatMax() const { return LatMax; }
     float GetLatMin() const { return LatMin; }
     int GetScale() const { return Scale; }
-    int GetChartType() const;
-    int GetChartFamily() const;
+    int GetChartType() const { return ChartType; }
+    int GetChartFamily() const { return ChartFamily; }
     int GetChartProjectionType() const { return ProjectionType; }
     float GetChartSkew() const { return Skew; }
 

--- a/include/glTexCache.h
+++ b/include/glTexCache.h
@@ -111,7 +111,7 @@ public:
 
     glTextureDescriptor *GetOrCreateTD(const wxRect &rect);
     bool BuildTexture(glTextureDescriptor *ptd, int base_level, const wxRect &rect);
-    bool PrepareTexture( int base_level, const wxRect &rect, ColorScheme color_scheme );
+    bool PrepareTexture( int base_level, const wxRect &rect, ColorScheme color_scheme, int mem_used );
     int GetTextureLevel( glTextureDescriptor *ptd, const wxRect &rect, int level,  ColorScheme color_scheme );
     bool UpdateCacheAllLevels( const wxRect &rect, ColorScheme color_scheme, unsigned char **compcomp_array, int *compcomp_size);
     bool IsLevelInCache( int level, const wxRect &rect, ColorScheme color_scheme );

--- a/include/ocpndc.h
+++ b/include/ocpndc.h
@@ -122,9 +122,6 @@ protected:
      wxColour m_textforegroundcolour;
      wxFont m_font;
 
-#ifdef ocpnUSE_GL     
-     TexFont m_texfont;
-#endif
      bool m_buseTex;
 
 #if  wxUSE_GRAPHICS_CONTEXT

--- a/src/Quilt.cpp
+++ b/src/Quilt.cpp
@@ -1244,10 +1244,11 @@ bool Quilt::BuildExtendedChartStackAndCandidateArray(int ref_db_index, ViewPort 
         
         const ChartTableEntry &cte = ChartData->GetChartTableEntry( i );
 
-        if( cte.GetChartType() == CHART_TYPE_CM93COMP ) continue;
-
         if( reference_family != cte.GetChartFamily() )
             continue;
+
+        if( cte.GetChartType() == CHART_TYPE_CM93COMP ) continue;
+
         
         const LLBBox &chart_box = cte.GetBBox();
         if( ( viewbox.IntersectOut( chart_box ) ) ) continue;

--- a/src/Quilt.cpp
+++ b/src/Quilt.cpp
@@ -785,7 +785,7 @@ void Quilt::AdjustQuiltVP( ViewPort &vp_last, ViewPort &vp_proposed )
         return;
 
 //      ChartBase *pRefChart = GetLargestScaleChart();
-    ChartBase *pRefChart = ChartData->OpenChartFromDB( m_refchart_dbIndex, FULL_INIT );
+    ChartBase *pRefChart = GetRefChart();
 
     if( pRefChart ) pRefChart->AdjustVP( vp_last, vp_proposed );
 }
@@ -793,15 +793,13 @@ void Quilt::AdjustQuiltVP( ViewPort &vp_last, ViewPort &vp_proposed )
 double Quilt::GetRefNativeScale()
 {
     double ret_val = 1.0;
-    if( ChartData ) {
-        ChartBase *pc = ChartData->OpenChartFromDB( m_refchart_dbIndex, FULL_INIT );
-        if( pc ) ret_val = pc->GetNativeScale();
-    }
+    ChartBase *pc = GetRefChart();
+    if( pc ) ret_val = pc->GetNativeScale();
 
     return ret_val;
 }
 
-int Quilt::GetNewRefChart( void )
+int Quilt::GetNewRefChart( )
 {
     //    Using the current quilt, select a useable reference chart
     //    Said chart will be in the extended (possibly full-screen) stack,
@@ -1452,10 +1450,9 @@ double Quilt::GetBestStartScale(int dbi_ref_hint, const ViewPort &vp_in)
 
 ChartBase *Quilt::GetRefChart()
 {
-    if(m_refchart_dbIndex >= 0 )
+    if(m_refchart_dbIndex >= 0 && ChartData)
         return ChartData->OpenChartFromDB( m_refchart_dbIndex, FULL_INIT );
-    else
-        return 0;
+    return nullptr;
 }
 
 void Quilt::UnlockQuilt()

--- a/src/Quilt.cpp
+++ b/src/Quilt.cpp
@@ -1044,9 +1044,9 @@ int Quilt::AdjustRefOnZoomIn( double proposed_scale_onscreen )
         }
 
     if(( -1 == m_refchart_dbIndex) && (m_zout_dbindex >= 0))
-        BuildExtendedChartStackAndCandidateArray(true, m_zout_dbindex, m_vp_quilt);
+        BuildExtendedChartStackAndCandidateArray(m_zout_dbindex, m_vp_quilt);
     else
-        BuildExtendedChartStackAndCandidateArray(true, m_refchart_dbIndex, m_vp_quilt);
+        BuildExtendedChartStackAndCandidateArray(m_refchart_dbIndex, m_vp_quilt);
     
 
 
@@ -1135,7 +1135,7 @@ LLRegion Quilt::GetHiliteRegion()
     return r;
 }
 
-bool Quilt::BuildExtendedChartStackAndCandidateArray(bool b_fullscreen, int ref_db_index, ViewPort &vp_in)
+bool Quilt::BuildExtendedChartStackAndCandidateArray(int ref_db_index, ViewPort &vp_in)
 {
     EmptyCandidateArray();
     m_extended_stack_array.clear();
@@ -1227,145 +1227,143 @@ bool Quilt::BuildExtendedChartStackAndCandidateArray(bool b_fullscreen, int ref_
 //             }
     }
 
-    if( b_fullscreen ) {
-        //    Search the entire database, potentially adding all charts
-        //    which intersect the ViewPort in any way
-        //    .AND. other requirements.
-        //    Again, skipping cm93 for now
-        int n_all_charts = ChartData->GetChartTableEntries();
+    //    Search the entire database, potentially adding all charts
+    //    which intersect the ViewPort in any way
+    //    .AND. other requirements.
+    //    Again, skipping cm93 for now
+    int n_all_charts = ChartData->GetChartTableEntries();
 
-        LLBBox viewbox = vp_local.GetBBox();
-        int sure_index = -1;
-        int sure_index_scale = 0;
+    LLBBox viewbox = vp_local.GetBBox();
+    int sure_index = -1;
+    int sure_index_scale = 0;
 
-        for( int i = 0; i < n_all_charts; i++ ) {
-            //    We can eliminate some charts immediately
-            //    Try to make these tests in some sensible order....
+    for( int i = 0; i < n_all_charts; i++ ) {
+        //    We can eliminate some charts immediately
+        //    Try to make these tests in some sensible order....
 
-            int groupIndex = m_parent->m_groupIndex;
-            if( ( groupIndex > 0 ) && ( !ChartData->IsChartInGroup( i, groupIndex ) ) ) continue;
-            
-            const ChartTableEntry &cte = ChartData->GetChartTableEntry( i );
+        int groupIndex = m_parent->m_groupIndex;
+        if( ( groupIndex > 0 ) && ( !ChartData->IsChartInGroup( i, groupIndex ) ) ) continue;
+        
+        const ChartTableEntry &cte = ChartData->GetChartTableEntry( i );
 
-            if( cte.GetChartType() == CHART_TYPE_CM93COMP ) continue;
+        if( cte.GetChartType() == CHART_TYPE_CM93COMP ) continue;
 
-            if( reference_family != cte.GetChartFamily() )
-                continue;
-            
-            const LLBBox &chart_box = cte.GetBBox();
-            if( ( viewbox.IntersectOut( chart_box ) ) ) continue;
+        if( reference_family != cte.GetChartFamily() )
+            continue;
+        
+        const LLBBox &chart_box = cte.GetBBox();
+        if( ( viewbox.IntersectOut( chart_box ) ) ) continue;
 
 
-            if( !m_bquiltanyproj && quilt_proj != cte.GetChartProjectionType() ) continue;
+        if( !m_bquiltanyproj && quilt_proj != cte.GetChartProjectionType() ) continue;
 
-            double skew_norm = cte.GetChartSkew();
-            if( skew_norm > 180. ) skew_norm -= 360.;
+        double skew_norm = cte.GetChartSkew();
+        if( skew_norm > 180. ) skew_norm -= 360.;
 
-             if( !m_bquiltskew && fabs( skew_norm ) > 1.0 )
-                continue;
+         if( !m_bquiltskew && fabs( skew_norm ) > 1.0 )
+            continue;
 
-            //    Calculate zoom factor for this chart
-            int candidate_chart_scale = cte.GetScale();
-            double chart_native_ppm = m_canvas_scale_factor / (double)candidate_chart_scale;
-            double zoom_factor = vp_in.view_scale_ppm / chart_native_ppm;
+        //    Calculate zoom factor for this chart
+        int candidate_chart_scale = cte.GetScale();
+        double chart_native_ppm = m_canvas_scale_factor / (double)candidate_chart_scale;
+        double zoom_factor = vp_in.view_scale_ppm / chart_native_ppm;
 
-            //  Try to guarantee that there is one chart added with scale larger than reference scale
-            //    Take note here, and keep track of the smallest scale chart that is larger scale than reference....
-            if( ! cte.Scale_ge( reference_scale) ) {
-                if( cte.Scale_gt( sure_index_scale ) ) {
-                    sure_index = i;
-                    sure_index_scale = candidate_chart_scale;
-                }
+        //  Try to guarantee that there is one chart added with scale larger than reference scale
+        //    Take note here, and keep track of the smallest scale chart that is larger scale than reference....
+        if( ! cte.Scale_ge( reference_scale) ) {
+            if( cte.Scale_gt( sure_index_scale ) ) {
+                sure_index = i;
+                sure_index_scale = candidate_chart_scale;
             }
+        }
 
-            //    At this point, the candidate is the right type, skew, and projection, and is on-screen somewhere....
-            //    Now  add the candidate if its scale is smaller than the reference scale, or is not excessively underzoomed.
+        //    At this point, the candidate is the right type, skew, and projection, and is on-screen somewhere....
+        //    Now  add the candidate if its scale is smaller than the reference scale, or is not excessively underzoomed.
 
-            if(  cte.Scale_ge( reference_scale) || ( zoom_factor > .2 ) ) {
-                bool b_add = true;
+        if(  cte.Scale_ge( reference_scale) || ( zoom_factor > .2 ) ) {
+            bool b_add = true;
 
-                //    Special case for S57 ENC
-                //    Add the chart only if the chart's fractional area exceeds n%
-                /* if( CHART_TYPE_S57 == reference_type ) { 
-                //Get the fractional area of this chart
-                    double chart_fractional_area = 0.;
-                    double quilt_area = vp_local.pix_width * vp_local.pix_height;
-                */
-                LLRegion cell_region = GetChartQuiltRegion( cte, vp_local );
+            //    Special case for S57 ENC
+            //    Add the chart only if the chart's fractional area exceeds n%
+            /* if( CHART_TYPE_S57 == reference_type ) { 
+            //Get the fractional area of this chart
+                double chart_fractional_area = 0.;
+                double quilt_area = vp_local.pix_width * vp_local.pix_height;
+            */
+            LLRegion cell_region = GetChartQuiltRegion( cte, vp_local );
 
-                // this is false if the chart has no actual overlap on screen
-                // or lots of NoCovr regions.  US3EC04.000 is a good example
-                // i.e the full bboxes overlap, but the actual vp intersect is null.
-                if( ! cell_region.Empty() ) {
-                    // Check to see if this chart is already in the stack array
-                    // by virtue of being under the Viewport center point....
-                    bool b_exists = false;
-                    for( unsigned int ir = 0; ir < m_extended_stack_array.size(); ir++ ) {
-                        if( i == m_extended_stack_array[ir] ) {
-                            b_exists = true;
-                            break;
-                        }
+            // this is false if the chart has no actual overlap on screen
+            // or lots of NoCovr regions.  US3EC04.000 is a good example
+            // i.e the full bboxes overlap, but the actual vp intersect is null.
+            if( ! cell_region.Empty() ) {
+                // Check to see if this chart is already in the stack array
+                // by virtue of being under the Viewport center point....
+                bool b_exists = false;
+                for( unsigned int ir = 0; ir < m_extended_stack_array.size(); ir++ ) {
+                    if( i == m_extended_stack_array[ir] ) {
+                        b_exists = true;
+                        break;
                     }
+                }
 
-                    if( !b_exists ) {
-                        //      Check to be sure that this chart has not already been added
-                        //    i.e. charts that have exactly the same file name and nearly the same mod time
-                        //    These charts can be in the database due to having the exact same chart in different directories,
-                        //    as may be desired for some grouping schemes
-                        bool b_noadd = false;
-                        ChartTableEntry *pn = ChartData->GetpChartTableEntry( i );
-                        for( unsigned int id = 0; id < m_extended_stack_array.size() ; id++ ) {
-                            if( m_extended_stack_array[id] != -1 ) {
-                                ChartTableEntry *pm = ChartData->GetpChartTableEntry( m_extended_stack_array[id] );
-                                if( pm->GetFileTime() && pn->GetFileTime()) {
-                                    if( labs(pm->GetFileTime() - pn->GetFileTime()) < 60 ) {           // simple test
-                                        if( pn->GetpFileName()->IsSameAs( *( pm->GetpFileName() ) ) )
-                                            b_noadd = true;
-                                    }
+                if( !b_exists ) {
+                    //      Check to be sure that this chart has not already been added
+                    //    i.e. charts that have exactly the same file name and nearly the same mod time
+                    //    These charts can be in the database due to having the exact same chart in different directories,
+                    //    as may be desired for some grouping schemes
+                    bool b_noadd = false;
+                    ChartTableEntry *pn = ChartData->GetpChartTableEntry( i );
+                    for( unsigned int id = 0; id < m_extended_stack_array.size() ; id++ ) {
+                        if( m_extended_stack_array[id] != -1 ) {
+                            ChartTableEntry *pm = ChartData->GetpChartTableEntry( m_extended_stack_array[id] );
+                            if( pm->GetFileTime() && pn->GetFileTime()) {
+                                if( labs(pm->GetFileTime() - pn->GetFileTime()) < 60 ) {           // simple test
+                                    if( pn->GetpFileName()->IsSameAs( *( pm->GetpFileName() ) ) )
+                                        b_noadd = true;
                                 }
                             }
                         }
+                    }
 
-                        if(!b_noadd) {
-                            m_extended_stack_array.push_back( i );
+                    if(!b_noadd) {
+                        m_extended_stack_array.push_back( i );
 
-                            QuiltCandidate *qcnew = new QuiltCandidate;
-                            qcnew->dbIndex = i;
-                            qcnew->SetScale ( candidate_chart_scale ); //ChartData->GetDBChartScale( i );
+                        QuiltCandidate *qcnew = new QuiltCandidate;
+                        qcnew->dbIndex = i;
+                        qcnew->SetScale ( candidate_chart_scale ); //ChartData->GetDBChartScale( i );
 
-                            m_pcandidate_array->push_back( qcnew );               // auto-sorted on scale
+                        m_pcandidate_array->push_back( qcnew );               // auto-sorted on scale
 
-                            b_need_resort = true;
-                        }
+                        b_need_resort = true;
                     }
                 }
             }
-        }               // for all charts
+        }
+    }               // for all charts
 
-        //    Check to be sure that at least one chart was added that is larger scale than reference scale
-        if( -1 != sure_index ) {
-            // check to see if it is already in
-            bool sure_exists = false;
-            for( unsigned int ir = 0; ir < m_extended_stack_array.size(); ir++ ) {
-                if( sure_index == m_extended_stack_array[ir] ) {
-                    sure_exists = true;
-                    break;
-                }
-            }
-
-            //    If not already added, do so now
-            if( !sure_exists ) {
-                m_extended_stack_array.push_back( sure_index );
-
-                QuiltCandidate *qcnew = new QuiltCandidate;
-                qcnew->dbIndex = sure_index;
-                qcnew->SetScale ( ChartData->GetDBChartScale( sure_index ) );
-                m_pcandidate_array->push_back( qcnew );               // auto-sorted on scale
-
-                b_need_resort = true;
+    //    Check to be sure that at least one chart was added that is larger scale than reference scale
+    if( -1 != sure_index ) {
+        // check to see if it is already in
+        bool sure_exists = false;
+        for( unsigned int ir = 0; ir < m_extended_stack_array.size(); ir++ ) {
+            if( sure_index == m_extended_stack_array[ir] ) {
+                sure_exists = true;
+                break;
             }
         }
-    }   // fullscreen
+
+        //    If not already added, do so now
+        if( !sure_exists ) {
+            m_extended_stack_array.push_back( sure_index );
+
+            QuiltCandidate *qcnew = new QuiltCandidate;
+            qcnew->dbIndex = sure_index;
+            qcnew->SetScale ( ChartData->GetDBChartScale( sure_index ) );
+            m_pcandidate_array->push_back( qcnew );               // auto-sorted on scale
+
+            b_need_resort = true;
+        }
+    }
 
     // Re sort the extended stack array on scale
     if( b_need_resort && m_extended_stack_array.size() > 1 ) {
@@ -1399,8 +1397,7 @@ double Quilt::GetBestStartScale(int dbi_ref_hint, const ViewPort &vp_in)
     double saved_vp_rotation = vp_local.rotation;                      // save a copy
     vp_local.SetRotationAngle( 0. );
 
-    bool bfull = vp_in.b_FullScreenQuilt;
-    BuildExtendedChartStackAndCandidateArray(bfull, tentative_ref_index, vp_local);
+    BuildExtendedChartStackAndCandidateArray(tentative_ref_index, vp_local);
 
     //  tentative choice might not be in the extended stack....
     bool bf = false;
@@ -1414,7 +1411,7 @@ double Quilt::GetBestStartScale(int dbi_ref_hint, const ViewPort &vp_in)
 
     if( !bf && m_pcandidate_array->GetCount() ) {
         tentative_ref_index = GetNewRefChart();
-        BuildExtendedChartStackAndCandidateArray(bfull, tentative_ref_index, vp_local);
+        BuildExtendedChartStackAndCandidateArray(tentative_ref_index, vp_local);
     }
 
     double proposed_scale_onscreen = vp_in.chart_scale;
@@ -1511,8 +1508,7 @@ bool Quilt::Compose( const ViewPort &vp_in )
 //    double saved_vp_rotation = vp_local.rotation;                      // save a copy
 //    vp_local.SetRotationAngle( 0. );
 
-    bool bfull = vp_in.b_FullScreenQuilt;
-    BuildExtendedChartStackAndCandidateArray(bfull, m_refchart_dbIndex, vp_local);
+    BuildExtendedChartStackAndCandidateArray(m_refchart_dbIndex, vp_local);
 
     //    It is possible that the reference chart is not really part of the visible quilt
     //    This can happen when the reference chart is panned
@@ -1543,15 +1539,15 @@ bool Quilt::Compose( const ViewPort &vp_in )
         int candidate_ref_index = GetNewRefChart();
         if(m_refchart_dbIndex != candidate_ref_index){
             m_refchart_dbIndex = candidate_ref_index;
-            BuildExtendedChartStackAndCandidateArray(bfull, m_refchart_dbIndex, vp_local);
+            BuildExtendedChartStackAndCandidateArray(m_refchart_dbIndex, vp_local);
         }
         //      There was no viable candidate of smaller scale than the "lost chart",
         //      so choose the smallest scale chart in the candidate list.
         else{
-            BuildExtendedChartStackAndCandidateArray(bfull, m_refchart_dbIndex, vp_local);
+            BuildExtendedChartStackAndCandidateArray(m_refchart_dbIndex, vp_local);
             if(m_pcandidate_array->GetCount()){
                 m_refchart_dbIndex = m_pcandidate_array->Item( m_pcandidate_array->GetCount() - 1 ) ->dbIndex;
-                BuildExtendedChartStackAndCandidateArray(bfull, m_refchart_dbIndex, vp_local);
+                BuildExtendedChartStackAndCandidateArray(m_refchart_dbIndex, vp_local);
             }
         }
     }
@@ -1563,7 +1559,7 @@ bool Quilt::Compose( const ViewPort &vp_in )
         for( unsigned int ir = 0; ir < m_extended_stack_array.size(); ir++ ) {
             if( m_lost_refchart_dbIndex == m_extended_stack_array[ir] ) {
                 m_refchart_dbIndex = m_lost_refchart_dbIndex;
-                BuildExtendedChartStackAndCandidateArray(bfull, m_refchart_dbIndex, vp_local);
+                BuildExtendedChartStackAndCandidateArray(m_refchart_dbIndex, vp_local);
                 m_lost_refchart_dbIndex = -1;
                 break;
             }

--- a/src/TexFont.cpp
+++ b/src/TexFont.cpp
@@ -31,6 +31,34 @@
 
 #include "TexFont.h"
 
+typedef struct {
+    wxFont  *key;
+    TexFont cache;
+} TexFontCache;
+
+#define TXF_CACHE 8
+static TexFontCache s_txf[TXF_CACHE];
+
+TexFont *GetTexFont(wxFont *pFont)
+{
+    // rebuild font if needed
+    TexFont *f_cache;
+    unsigned int i;
+    for (i = 0; i < TXF_CACHE && s_txf[i].key != nullptr; i++)
+    {
+        if (s_txf[i].key == pFont) {
+            return &s_txf[i].cache;
+        }
+    }
+    if (i == TXF_CACHE) {
+        i = rand() & (TXF_CACHE -1);
+    }
+    s_txf[i].key = pFont;
+    f_cache = &s_txf[i].cache;
+    f_cache->Build(*pFont);
+    return f_cache;
+}
+
 TexFont::TexFont( )
 {
     texobj = 0;

--- a/src/chartdbs.cpp
+++ b/src/chartdbs.cpp
@@ -49,7 +49,7 @@
 extern PlugInManager    *g_pi_manager;
 extern wxString         gWorldMapLocation;
 
-int s_dbVersion;                                //    Database version currently in use at runtime
+static int s_dbVersion;                         //    Database version currently in use at runtime
                                                 //  Needed for ChartTableEntry::GetChartType() only
                                                 //  TODO This can go away at opencpn Version 1.3.8 and above....
 ///////////////////////////////////////////////////////////////////////
@@ -64,7 +64,7 @@ bool FindMatchingFile(const wxString &theDir, const wxChar *theRegEx, int nameLe
 }
 
 
-ChartFamilyEnum GetChartFamily(int charttype)
+static ChartFamilyEnum GetChartFamily(int charttype)
 {
       ChartFamilyEnum cf;
 
@@ -409,13 +409,13 @@ bool ChartTableEntry::IsEqualTo(const ChartTableEntry &cte) const {
 
 ///////////////////////////////////////////////////////////////////////
 
-int ChartTableEntry::GetChartType() const
+static int convertChartType(int charttype)
 {
       //    Hackeroo here....
       //    dB version 14 had different ChartType Enum, patch it here
       if(s_dbVersion == 14)
       {
-            switch(ChartType)
+            switch(charttype)
             {
                   case 0: return CHART_TYPE_KAP;
                   case 1: return CHART_TYPE_GEO;
@@ -428,15 +428,14 @@ int ChartTableEntry::GetChartType() const
                   default: return CHART_TYPE_UNKNOWN;
             }
       }
-      else
-       return ChartType;
+      return charttype;
 }
 
-int ChartTableEntry::GetChartFamily() const
+static int convertChartFamily(int charttype, int chartfamily)
 {
     if(s_dbVersion < 18)
     {
-        switch(ChartType)
+        switch(charttype)
         {
             case CHART_TYPE_KAP:
             case CHART_TYPE_GEO:
@@ -451,11 +450,8 @@ int ChartTableEntry::GetChartFamily() const
                   return CHART_FAMILY_UNKNOWN;
       }
     }
-    else
-        return ChartFamily;
+    return chartfamily;
 }
-
-
 
 
 bool ChartTableEntry::Read(const ChartDatabase *pDb, wxInputStream &is)
@@ -785,6 +781,8 @@ bool ChartTableEntry::Read(const ChartDatabase *pDb, wxInputStream &is)
                 }
           }
     }
+    ChartFamily = convertChartFamily(ChartType, ChartFamily);
+    ChartType = convertChartType(ChartType);
 
     return true;
 }

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -6117,7 +6117,8 @@ void ChartCanvas::ScaleBarDraw( ocpnDC& dc )
             dist /= 2;
 
         wxString s = wxString::Format(_T("%g "), dist) + getUsrDistanceUnit( unit );
-        wxPen pen1 = wxPen( GetGlobalColor( _T ( "UBLCK" ) ), 3, wxPENSTYLE_SOLID );
+        wxColour black = GetGlobalColor( _T ( "UBLCK" ) );
+        wxPen pen1 = wxPen( black , 3, wxPENSTYLE_SOLID );
         double rotation = -VPoint.rotation;
 
         ll_gc_ll( blat, blon, rotation * 180 / PI + 90, fromUsrDistance(dist, unit), &tlat, &tlon );
@@ -6134,7 +6135,7 @@ void ChartCanvas::ScaleBarDraw( ocpnDC& dc )
         dc.DrawLine( x_origin + l1, y_origin, x_origin + l1, y_origin - 12);
 
         dc.SetFont( *m_pgridFont );
-        dc.SetTextForeground( GetGlobalColor( _T ( "UBLCK" ) ) );
+        dc.SetTextForeground( black );
         int w, h;
         dc.GetTextExtent(s, &w, &h);
         dc.DrawText( s, x_origin + l1/2 - w/2, y_origin - h - 1 );

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -3456,7 +3456,7 @@ void glChartCanvas::RenderGLAlertMessage()
 int n_render;
 void glChartCanvas::Render()
 {
-    if( !m_bsetup || !m_pParentCanvas->m_pQuilt ||
+    if( !m_bsetup ||
         ( m_pParentCanvas->VPoint.b_quilt && !m_pParentCanvas->m_pQuilt->IsComposed() ) ||
         ( !m_pParentCanvas->VPoint.b_quilt && !m_pParentCanvas->m_singleChart ) ) {
 #ifdef __WXGTK__  // for some reason in gtk, a swap is needed here to get an initial screen update

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -2673,6 +2673,12 @@ void glChartCanvas::RenderRasterChartRegionGL( ChartBase *chart, ViewPort &vp, L
 
     LLBBox box = region.GetBox();
     int numtiles;
+    int mem_used = 0;
+    if (g_memCacheLimit > 0) {
+        // GetMemoryStatus is slow on linux
+        GetMemoryStatus(0, &mem_used);
+    }
+
     glTexTile **tiles = pTexFact->GetTiles(numtiles);
     for(int i = 0; i<numtiles; i++) {
         glTexTile *tile = tiles[i];
@@ -2683,7 +2689,7 @@ void glChartCanvas::RenderRasterChartRegionGL( ChartBase *chart, ViewPort &vp, L
             if( bGLMemCrunch)
                 pTexFact->DeleteTexture( tile->rect );
         } else {
-            bool texture = pTexFact->PrepareTexture( base_level, tile->rect, global_color_scheme );
+            bool texture = pTexFact->PrepareTexture( base_level, tile->rect, global_color_scheme, mem_used );
             if(!texture) { // failed to load, draw red
                 glDisable(GL_TEXTURE_2D);
                 glColor3f(1, 0, 0);

--- a/src/glTexCache.cpp
+++ b/src/glTexCache.cpp
@@ -663,15 +663,17 @@ bool glTexFactory::PrepareTexture( int base_level, const wxRect &rect, ColorSche
     //   so there is no reason to save the bits forever.
     //   Of course, this means that if the texture is deleted elsewhere, then the bits will need to be
     //   regenerated.  The price to pay for memory limits....
-    
-    int mem_used;
-    GetMemoryStatus(0, &mem_used);
-    //    qDebug() << mem_used;
-    if((g_memCacheLimit > 0) && (mem_used > g_memCacheLimit * 7 / 10))
-        ptd->FreeMap();
+    if (g_memCacheLimit > 0) {
+        // GetMemoryStatus is slow on linux
+        int mem_used;
+        GetMemoryStatus(0, &mem_used);
+        //    qDebug() << mem_used;
+        if(mem_used > g_memCacheLimit * 7 / 10)
+            ptd->FreeMap();
 
-    if((g_memCacheLimit > 0) && (mem_used > g_memCacheLimit * 9 / 10))
-        ptd->FreeAll();
+        if(mem_used > g_memCacheLimit * 9 / 10)
+            ptd->FreeAll();
+    }
 
 //    g_Platform->HideBusySpinner();
     

--- a/src/glTexCache.cpp
+++ b/src/glTexCache.cpp
@@ -73,7 +73,6 @@ extern int              g_uncompressed_tile_size;
 
 extern PFNGLCOMPRESSEDTEXIMAGE2DPROC s_glCompressedTexImage2D;
 extern PFNGLGENERATEMIPMAPEXTPROC          s_glGenerateMipmap;
-extern bool GetMemoryStatus( int *mem_total, int *mem_used );
 
 extern wxString CompressedCachePath(wxString path);
 extern glTextureManager   *g_glTextureManager;
@@ -629,7 +628,7 @@ bool glTexFactory::BuildTexture(glTextureDescriptor *ptd, int base_level, const 
     return true;
 }
 
-bool glTexFactory::PrepareTexture( int base_level, const wxRect &rect, ColorScheme color_scheme )
+bool glTexFactory::PrepareTexture( int base_level, const wxRect &rect, ColorScheme color_scheme, int mem_used )
 {    
     glTextureDescriptor *ptd = NULL;
 
@@ -665,9 +664,6 @@ bool glTexFactory::PrepareTexture( int base_level, const wxRect &rect, ColorSche
     //   regenerated.  The price to pay for memory limits....
     if (g_memCacheLimit > 0) {
         // GetMemoryStatus is slow on linux
-        int mem_used;
-        GetMemoryStatus(0, &mem_used);
-        //    qDebug() << mem_used;
         if(mem_used > g_memCacheLimit * 7 / 10)
             ptd->FreeMap();
 

--- a/src/glTextureManager.cpp
+++ b/src/glTextureManager.cpp
@@ -1278,7 +1278,7 @@ bool glTextureManager::TextureCrunch(double factor)
  
                 if( cc->GetVP().b_quilt )          // quilted
                 {
-                        if( cc->m_pQuilt && cc->m_pQuilt->IsComposed() &&
+                        if( cc->m_pQuilt->IsComposed() &&
                             !cc->m_pQuilt->IsChartInQuilt( chart_full_path ) ) {
                             ptf->DeleteSomeTextures( g_GLOptions.m_iTextureMemorySize * 1024 * 1024 * factor *hysteresis);
                             }
@@ -1339,7 +1339,7 @@ bool glTextureManager::FactoryCrunch(double factor)
                 
                 if( cc->GetVP().b_quilt )          // quilted
                 {
-                    if( cc->m_pQuilt && cc->m_pQuilt->IsComposed() &&
+                    if( cc->m_pQuilt->IsComposed() &&
                         !cc->m_pQuilt->IsChartInQuilt( chart_full_path ) ) {
                 
                         int lru = ptf->GetLRUTime();

--- a/src/ocpndc.cpp
+++ b/src/ocpndc.cpp
@@ -1032,9 +1032,9 @@ void ocpnDC::DrawText( const wxString &text, wxCoord x, wxCoord y )
         wxCoord h = 0;
 
         if(m_buseTex){
-        
-            m_texfont.Build( m_font );      // make sure the font is ready
-            m_texfont.GetTextExtent(text, &w, &h);
+            TexFont *texfont = GetTexFont( &m_font );
+
+            texfont->GetTextExtent(text, &w, &h);
             
             if( w && h ) {
                 
@@ -1050,7 +1050,7 @@ void ocpnDC::DrawText( const wxString &text, wxCoord x, wxCoord y )
                             m_textforegroundcolour.Blue() );
                 
 
-                m_texfont.RenderString(text);
+                texfont->RenderString(text);
                 glPopMatrix();
 
                 glDisable( GL_TEXTURE_2D );
@@ -1173,8 +1173,9 @@ void ocpnDC::GetTextExtent( const wxString &string, wxCoord *w, wxCoord *h, wxCo
 
         if(m_buseTex){
   #ifdef ocpnUSE_GL       
-        m_texfont.Build( f );      // make sure the font is ready
-        m_texfont.GetTextExtent(string, w, h);
+        TexFont *texfont = GetTexFont(&f);
+
+        texfont->GetTextExtent(string, w, h);
   #else        
         wxMemoryDC temp_dc;
         temp_dc.GetTextExtent( string, w, h, descent, externalLeading, &f );

--- a/src/s52plib.cpp
+++ b/src/s52plib.cpp
@@ -75,17 +75,6 @@ void PLIBDrawGLThickLine( float x1, float y1, float x2, float y2, wxPen pen, boo
 
 void LoadS57Config();
 
-#ifdef ocpnUSE_GL
-typedef struct {
-    TexFont cache;
-    wxFont  *key;
-} TexFontCache;
-
-#define TXF_CACHE 8
-static TexFontCache s_txf[TXF_CACHE];
-#endif
-
-
 //    Implement all lists
 #include <wx/listimpl.cpp>
 WX_DEFINE_LIST( TextObjList );
@@ -1296,18 +1285,6 @@ void s52plib::FlushSymbolCaches( void )
     }
     m_CARC_DL_hashmap.clear();
     
-    // Flush all texFonts
-    TexFont *f_cache = 0;
-    unsigned int i;
-    for (i = 0; i < TXF_CACHE; i++)
-    {
-        if (s_txf[i].key != 0) {
-            f_cache = &s_txf[i].cache;
-            f_cache->Delete();
-            s_txf[i].key = 0;
-        }
-    }
-    
 #endif
 }
 
@@ -2064,28 +2041,7 @@ bool s52plib::RenderText( wxDC *pdc, S52_TextC *ptext, int x, int y, wxRect *pRe
         }
         
         else {                                          // render using cached texture glyphs
-            // rebuild font if needed
-            TexFont *f_cache = 0;
-            unsigned int i;
-            for (i = 0; i < TXF_CACHE; i++)
-            {
-                if (s_txf[i].key == ptext->pFont) {
-                    f_cache = &s_txf[i].cache;
-                    break;
-                }
-                if (s_txf[i].key == 0) {
-                    break;
-                }
-            }
-            if (i == TXF_CACHE) {
-                i = rand() & (TXF_CACHE -1);
-            }
-            if (f_cache == 0) {
-                s_txf[i].key = ptext->pFont;
-                f_cache = &s_txf[i].cache;
-                f_cache->Build(*ptext->pFont);
-            }
-            
+            TexFont *f_cache = GetTexFont(ptext->pFont);
             int w, h;
             f_cache->GetTextExtent(ptext->frmtd, &w, &h);
             


### PR DESCRIPTION
Hi,
callgrind and linux perf analysis.

On linux both getmemory and are slow
when profiling zooming with opengl:
- 10% of instructions were in scale text rendering. ==> use cache for all font textures not only s57 charts.
- 20% of instructions were in getmemory ==> only check once per chart not every textures.


Then perf output first line was getChartType ==> convert database values once when loading it not on every get, but I have a lot of charts.

Regards
Didier
