### PR TITLE
Use the right directory for libsound include

### DIFF
--- a/libs/sound/CMakeLists.txt
+++ b/libs/sound/CMakeLists.txt
@@ -47,6 +47,6 @@ target_include_directories(SOUND
     PUBLIC 
         ${CMAKE_CURRENT_SOURCE_DIR}/include
     PRIVATE 
-        ${CMAKE_CURRENT_SOURCE_DIR}/../../build/include
+        ${CMAKE_BINARY_DIR}/include
         ${wxWidgets_INCLUDE_DIRS}
 )


### PR DESCRIPTION
Hi,
Naming output directory 'build' is not mandatory and CMAKE_BINARY_DIR is used for generating config.h

Regards
Didier