### PR TITLE
Correct Crash when creating long legs routes with touch option set

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -8046,7 +8046,9 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
                         << _("Would you like include the Great Circle routing points for this leg?");
                         
                         #ifndef __WXOSX__
+                        m_FinishRouteOnKillFocus = false;
                         int answer = OCPNMessageBox( this, msg, _("OpenCPN Route Create"), wxYES_NO | wxNO_DEFAULT );
+                        m_FinishRouteOnKillFocus = true;
                         #else
                         int answer = wxID_NO;
                         #endif


### PR DESCRIPTION
Both under Linux Mint and Windows 10 when I create a route with very long legs and
whether I click YES or NOT to the great circle asking window, I get a crash.