### PR TITLE
Correct route legs drawing when creating long leg routes in touch mode

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -9569,8 +9569,6 @@ void ChartCanvas::RenderRouteLegs( ocpnDC &dc )
         if(route){
             int np = route->GetnPoints();
             if(np){
-                if(g_btouch && (np > 1))
-                    np --;
                 RoutePoint rp = route->GetPoint(np);
                 render_lat = rp.m_lat;
                 render_lon = rp.m_lon;


### PR DESCRIPTION
When creating a multi long leg route in touch mode the drawing is very curious and the length calculation is wrong. I don't know what was the purpose of this small part of code and I didn't find any other effect except destroying the the drawing and the lenght calculation
JP
