### PR TITLE
Master 1355: Fixes for #1355

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -577,6 +577,21 @@ IF(NOT QT_ANDROID)
   ENDIF(MSYS)
   INCLUDE(${wxWidgets_USE_FILE})
 
+  # As of cmake 3.11.2, these libraries are missing in list despite that
+  # we looked for them. This is a nasty fix which might fail miserably.
+  # Assumption: All builds using GTK uses unicode and wxWidgets 3.0
+  IF(GTK2_FOUND)
+    list(APPEND wxWidgets_LIBRARIES -lwx_gtk2u_aui-3.0)
+    if (OPENGL_FOUND)
+      list(APPEND wxWidgets_LIBRARIES -lwx_gtk2u_gl-3.0)
+    endif()
+  ELSEIF(GTK3_FOUND)
+    list(APPEND wxWidgets_LIBRARIES -lwx_gtk3u_aui-3.0)
+    if (OPENGL_FOUND)
+      list(APPEND wxWidgets_LIBRARIES -lwx_gtk3u_gl-3.0)
+    endif()
+  ENDIF ()
+
   MESSAGE (STATUS "Found wxWidgets..." )
   MESSAGE (STATUS " wxWidgets Include: ${wxWidgets_INCLUDE_DIRS}")
   MESSAGE (STATUS " wxWidgets Libraries: ${wxWidgets_LIBRARIES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -924,9 +924,9 @@ ENDIF(DEFINED _wx_selected_config)
 
 
 IF((_wx_selected_config MATCHES "qt-armv7"))
-  SET(wxWidgets_USE_LIBS base core xml html adv aui)
+  SET(wxWidgets_FIND_COMPONENTS base core xml html adv aui)
 ELSE()
-  SET(wxWidgets_USE_LIBS net xml html adv aui core base webview)
+  SET(wxWidgets_FIND_COMPONENTS net xml html adv aui core base webview)
 ENDIF()
 
 IF (ARCH MATCHES "arm*" AND (NOT QT_ANDROID) )
@@ -943,7 +943,7 @@ IF (ARCH MATCHES "arm*" AND (NOT QT_ANDROID) )
 ENDIF()
 
 IF (OPENGLES_FOUND)
-  SET(wxWidgets_USE_LIBS ${wxWidgets_USE_LIBS} gl )
+  list(APPEND wxwidgets_FIND_COMPONENTS gl)
 ENDIF ()
 
 IF ((NOT OPENGLES_FOUND) AND (NOT QT_ANDROID))
@@ -954,7 +954,7 @@ IF ((NOT OPENGLES_FOUND) AND (NOT QT_ANDROID))
   ENDIF(USE_GL)
 
   IF(OPENGL_FOUND)
-    SET(wxWidgets_USE_LIBS gl ${wxWidgets_USE_LIBS} )
+    list(APPEND wxwidgets_FIND_COMPONENTS gl)
     target_include_directories(${PACKAGE_NAME} PRIVATE ${OPENGL_INCLUDE_DIR})
 
     MESSAGE (STATUS "Found OpenGL...." )
@@ -1014,7 +1014,7 @@ IF(NOT QT_ANDROID)
     message(STATUS "Found wxWidgets webview add-on")
     target_compile_definitions(${PACKAGE_NAME} PRIVATE -DOCPN_USE_WEBVIEW)
   else ()
-    list(REMOVE_ITEM wxWidgets_USE_LIBS webview)
+    list(REMOVE_ITEM wxWidgets_FIND_COMPONENTS webview)
     message(STATUS "Could not find wxWidgets webview add-on")
     FIND_PACKAGE(wxWidgets REQUIRED)
   endif ()
@@ -1232,7 +1232,7 @@ IF (ARCH MATCHES "arm*" AND (NOT QT_ANDROID) )
     SET(OPENGLES_FOUND "YES")
     SET(OPENGL_FOUND "YES")
 
-    # SET(wxWidgets_USE_LIBS ${wxWidgets_USE_LIBS} gl )
+    # SET(wxWidgets_FIND_COMPONENTS ${wxWidgets_FIND_COMPONENTS} gl )
     add_subdirectory(libs/glshim)
 
     SET(OPENGL_LIBRARIES "GL_static" "EGL" "X11" "drm"  )
@@ -1267,7 +1267,7 @@ IF(QT_ANDROID)
   SET(OPENGLES_FOUND "YES")
   SET(OPENGL_FOUND "YES")
 
-  # SET(wxWidgets_USE_LIBS ${wxWidgets_USE_LIBS} gl )
+  # SET(wxWidgets_FIND_COMPONENTS ${wxWidgets_FIND_COMPONENTS} gl )
   add_subdirectory(libs/glshim)
 ENDIF(QT_ANDROID)
 

--- a/include/AboutFrame.h
+++ b/include/AboutFrame.h
@@ -25,7 +25,7 @@
 #include <wx/hyperlink.h>
 #include <wx/scrolwin.h>
 #include <wx/html/htmlwin.h>
-#ifdef OCPN_USE_WEBVIEW
+#if wxUSE_WEBVIEW
 #include <wx/webview.h>
 #endif
 #include <wx/panel.h>
@@ -60,10 +60,10 @@ class AboutFrame : public wxFrame
 		wxHyperlinkCtrl* m_hyperlinkIniFile;
 		wxHtmlWindow* m_htmlWinAuthors;
 		wxHtmlWindow* m_htmlWinLicense;
-#ifdef OCPN_USE_WEBVIEW
+#if wxUSE_WEBVIEW
 		wxWebView* m_htmlWinHelp;
 #else
-        wxHtmlWindow* m_htmlWinHelp;
+                wxHtmlWindow* m_htmlWinHelp;
 #endif
 		wxPanel* m_panelMainLinks;
 		wxHyperlinkCtrl* m_hyperlinkWebsite;

--- a/include/AboutFrameImpl.h
+++ b/include/AboutFrameImpl.h
@@ -40,7 +40,7 @@ protected:
     void OnLinkLicense( wxHyperlinkEvent& event );
     void OnLinkAuthors( wxHyperlinkEvent& event );
     void AboutFrameOnActivate( wxActivateEvent& event );
-#ifdef OCPN_USE_WEBVIEW
+#if wxUSE_WEBVIEW
     void m_btnBackOnButtonClick( wxCommandEvent& event ) { m_htmlWinHelp->GoBack(); m_btnBack->Enable(m_htmlWinHelp->CanGoBack()); }
 #else
     void m_btnBackOnButtonClick( wxCommandEvent& event ) { m_htmlWinHelp->HistoryBack(); m_btnBack->Enable(m_htmlWinHelp->HistoryCanBack()); }

--- a/src/AboutFrame.cpp
+++ b/src/AboutFrame.cpp
@@ -142,10 +142,10 @@ AboutFrame::AboutFrame( wxWindow* parent, wxWindowID id, const wxString& title, 
 	m_htmlWinLicense = new wxHtmlWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHW_SCROLLBAR_AUTO );
 	bSizerContent->Add( m_htmlWinLicense, 1, wxALL|wxEXPAND, 5 );
 
-#ifdef OCPN_USE_WEBVIEW
-    m_htmlWinHelp = wxWebView::New( this, wxID_ANY );
+#if wxUSE_WEBVIEW
+	m_htmlWinHelp = wxWebView::New( this, wxID_ANY );
 #else
-    m_htmlWinHelp = new wxHtmlWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHW_SCROLLBAR_AUTO );
+	m_htmlWinHelp = new wxHtmlWindow( this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxHW_SCROLLBAR_AUTO );
 #endif
 	bSizerContent->Add( m_htmlWinHelp, 1, wxALL|wxEXPAND, 5 );
 

--- a/src/AboutFrameImpl.cpp
+++ b/src/AboutFrameImpl.cpp
@@ -55,7 +55,7 @@ AboutFrameImpl::AboutFrameImpl( wxWindow* parent, wxWindowID id, const wxString&
     wxBitmap logo(wxString::Format("%s/opencpn.png", g_Platform->GetSharedDataDir().c_str()), wxBITMAP_TYPE_ANY);
 
     m_hyperlinkHelp->SetURL(wxString::Format("file://%sdoc/help_en_US.html", g_Platform->GetSharedDataDir().c_str()));
-#ifdef OCPN_USE_WEBVIEW
+#if wxUSE_WEBVIEW
     m_htmlWinHelp->LoadURL(wxString::Format("file://%sdoc/help_en_US.html", g_Platform->GetSharedDataDir().c_str()));
 #else
     m_htmlWinHelp->LoadFile(wxString::Format("%s/doc/help_en_US.html", g_Platform->GetSharedDataDir().c_str()));
@@ -92,7 +92,7 @@ void AboutFrameImpl::OnLinkHelp( wxHyperlinkEvent& event )
         m_htmlWinHelp->Show();
         m_scrolledWindowAbout->Hide();
         m_btnBack->Show();
-#ifdef OCPN_USE_WEBVIEW
+#if wxUSE_WEBVIEW
         m_btnBack->Enable(m_htmlWinHelp->CanGoBack());
 #else
         m_btnBack->Enable(m_htmlWinHelp->HistoryCanBack());


### PR DESCRIPTION
It turns out that #1355 is a can of worms:

  - The obvious rebasing error, handled by *s/wxWidgets_USE_LIBS/wxWidgets_FIND_COMPONENTS/*
  - Using `#ifdef OCPN_USE_WEBVIEW` instead of the correct `#if wxUSE_WEBVIEW`
  - In what looks like a cmake bug, the wxWidgets libraries does not contain the aui and gl libs despite that these was successfulle configured using wxWidgets_FIND_COMPONENTS.

The patch for the last problem is non-trivial, reviews welcome! That said. this is a pretty urgent PR