### PR TITLE
Master-1364: Collateral damage after #1298 (#1364)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
 # ---------------------------------------------------------------------------
-# Author:      Dave Register DEB config from: antonm - Anton Martchukov
-# <anton@martchukov.com> Update:      sethdart (Jean-Eudes Onfray) with parts
-# from balp (Anders Arnholm)
+# Author:      Dave Register DEB 
+# config from: antonm - Anton Martchukov <anton@martchukov.com> 
+# Update:      sethdart (Jean-Eudes Onfray) 
+#                 with parts from balp (Anders Arnholm)
 # ***************************************************************************
 # - Copyright (C) 2010 by David S. Register                               *
 # - This program is free software; you can redistribute it and/or modify  *
@@ -72,38 +73,31 @@ Documentation:
 
 
 Tidal/current and GSHHS wallpaper
-  - OCPN_BUNDLE_TCDATA (boolean) includes tide/current harmonics data in package
+  - OCPN_BUNDLE_TCDATA (boolean) includes tide/current harmonics data in
+    package.
   - BUNDLE_GSHHS (NONE,MIN,[CRUDE],LOW,INTERMEDIATE,HIGH,FULL) governs the
     wallpaper map used as last resort and world overview.
 
 To build for android, use something like:
-    $cmake -DUSE_GARMINHOST=OFF -D_wx_selected_config=androideabi-qt
+    $cmake -DUSE_GARMINHOST=OFF
+        -D_wx_selected_config=androideabi-qt
         -DCMAKE_TOOLCHAIN_FILE=../buildandroid/build_android.cmake
-        -DwxQt_Build=build_android_53 -DwxQt_Base=/home/dsr/Projects/wxqt/wxWidgets
-        -DQt_Base /home/dsr/Qt/5.3) ..
+        -DwxQt_Build=build_android_53
+       	-DwxQt_Base=/home/dsr/Projects/wxqt/wxWidgets
+        -DQt_Base /home/dsr/Qt/5.3)
+        ..
+
+Silent/Verbose builds:
+    cmake's handling of these issues is underwhelming. On most platforms the
+    builds are by default silent. Use 'make VERBOSE=1' to make a verbose
+    build. The cmake option OCPN_VERBOSE is supposed to handle this, but is
+    buggy on at least Linux.
 
 #]]
 #[[
 TODO:
 - Profiling opt
 - test with Win & OSX
-- GNU install paths
-- Use list() instead of set() -OK
-- Rework options, naming conventions. - OK
-- Review TinyXML handling  - OK
-- Drop PACKAGE_DEPS: - OK
-- Test (rework?) wxWidgets GLU handling. OK
-- Unbundle jasper.  OK
-- Better USE_BUNDLED_LIBS option (list)  OK
-- Fix link libraries name (tinyxml:: > ocpn::) OK
-- Fix 3.1 requirement overall OK
-- Silent build mode. OK
-- Move final linking ahead of install section. OK
-- Separate gpsd configuration OK
-- Separate ffmpeg configuration OK
-- Review Mingw package generation. OK
-- Drop -s linker flag OK
-- Make missing sound libs info instead of warnings. OK
 USE_GLU_TESS
 USE_GLU_DLL
 I also find it deficient in some areas. For instance, I cannot make it

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,10 +89,9 @@ To build for android, use something like:
 
 Silent/Verbose builds:
     cmake's handling of these issues is underwhelming. On most platforms the
-    builds are by default silent. Use 'make VERBOSE=1' to make a verbose
-    build. The cmake option OCPN_VERBOSE is supposed to handle this, but is
-    buggy on at least Linux.
-
+    builds are by default verbose. Use 'cmake OCPN_VERBOSE=OFF' to make 
+    a silent build. The OCPN_VERBOSE value can be overridden using
+    'make VERBOSE=1' or 'make -s'
 #]]
 #[[
 TODO:
@@ -120,9 +119,9 @@ set(OpenGL_GL_PREFERENCE "LEGACY")
 
 project(OpenCPN)
 
-option(OCPN_VERBOSE "Verbose build output" ON)
-
-set(CMAKE_VERBOSE_MAKEFILE ${OCPN_VERBOSE})
+if (NOT DEFINED OCPN_VERBOSE OR OCPN_VERBOSE)
+  set(CMAKE_VERBOSE_MAKEFILE ON)
+endif ()
 
 message(STATUS "cmake version: ${CMAKE_VERSION}")
 
@@ -187,6 +186,8 @@ else (APPLE OR WIN32)
   bundle_tcdata_opt("OFF")
   bundle_gshhs_opt("NONE")
 endif (APPLE OR WIN32)
+
+option(OCPN_VERBOSE "Make verbose builds"  ON)
 
 set(OCPN_PACKAGE_RELEASE "1" CACHE STRING "Package release number")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1116,6 +1116,7 @@ if (UNIX)
     find_package(X11)
     if (X11_FOUND AND NOT APPLE)
       target_link_libraries(${PACKAGE_NAME} PRIVATE ${X11_LIBRARIES})
+      set(OCPN_HAVE_X11 ON)   # => config.h
     endif ()
     if (NOT APPLE)
       # TinyXML from Homebrew is not good enough for our GpxDocument needs We

--- a/config.h.in
+++ b/config.h.in
@@ -18,7 +18,7 @@
 
 #cmakedefine USE_GARMINHOST
 
-#cmakedefine ocpnUSE_NEWSERIAL
+#cmakedefine OCPN_USE_NEWSERIAL
 
 // Enable dark mode on modern MacOS.
 #cmakedefine OCPN_USE_DARKMODE

--- a/include/OCP_DataStreamInput_Thread.h
+++ b/include/OCP_DataStreamInput_Thread.h
@@ -43,7 +43,7 @@
 
 #include "dsPortType.h"
 
-#ifdef ocpnUSE_NEWSERIAL
+#ifdef OCPN_USE_NEWSERIAL
 #include "serial/serial.h"
 #endif
 
@@ -116,7 +116,7 @@ public:
 
 
 private:
-#ifdef ocpnUSE_NEWSERIAL
+#ifdef OCPN_USE_NEWSERIAL
     serial::Serial m_serial;
     void ThreadMessage(const wxString &msg);
     bool OpenComPortPhysical(const wxString &com_name, int baud_rate);

--- a/include/macutils.h
+++ b/include/macutils.h
@@ -26,7 +26,7 @@
 
 #ifdef __WXOSX__
 
-#ifndef ocpnUSE_NEWSERIAL
+#ifndef OCPN_USE_NEWSERIAL
 #define MAX_SERIAL_PORTS 10
 
 extern "C" int FindSerialPortNames(char** pNames, int iMaxNames) ;

--- a/src/OCP_DataStreamInput_Thread.cpp
+++ b/src/OCP_DataStreamInput_Thread.cpp
@@ -103,7 +103,7 @@ void OCP_DataStreamInput_Thread::OnExit(void)
 {
 }
 
-#ifdef ocpnUSE_NEWSERIAL
+#ifdef OCPN_USE_NEWSERIAL
 
 size_t OCP_DataStreamInput_Thread::WriteComPortPhysical(char *msg)
 {
@@ -320,7 +320,7 @@ thread_exit:
     
     return 0;
 }
-#else //ocpnUSE_NEWSERIAL
+#else //OCPN_USE_NEWSERIAL
 
 //      Sadly, the thread itself must implement the underlying OS serial port
 //      in a very machine specific way....
@@ -1321,5 +1321,5 @@ bool OCP_DataStreamInput_Thread::CheckComPortPhysical(int port_descriptor)
 }
 
 #endif            // __WXMSW__
-#endif //ocpnUSE_NEWSERIAL
+#endif //OCPN_USE_NEWSERIAL
 

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -163,7 +163,7 @@
 #include "DarkMode.h"
 #endif
 
-#ifdef ocpnUSE_NEWSERIAL
+#ifdef OCPN_USE_NEWSERIAL
 #include "serial/serial.h"
 #endif
 
@@ -10572,7 +10572,7 @@ DEFINE_GUID(GUID_CLASS_COMPORT, 0x86e0d1e0L, 0x8089, 0x11d0, 0x9c, 0xe4, 0x08, 0
 wxArrayString *EnumerateSerialPorts( void )
 {
     wxArrayString *preturn = new wxArrayString;
-#ifdef ocpnUSE_NEWSERIAL
+#ifdef OCPN_USE_NEWSERIAL
     std::vector<serial::PortInfo> ports = serial::list_ports();
     for(std::vector<serial::PortInfo>::iterator it = ports.begin(); it != ports.end(); ++it) {
         wxString port((*it).port);
@@ -11011,7 +11011,7 @@ wxArrayString *EnumerateSerialPorts( void )
 #endif
 
 #endif      //__WXMSW__
-#endif //ocpnUSE_NEWSERIAL
+#endif //OCPN_USE_NEWSERIAL
     return preturn;
 }
 

--- a/src/macutils.c
+++ b/src/macutils.c
@@ -55,7 +55,7 @@
 
 #include "config.h"
 
-#ifndef ocpnUSE_NEWSERIAL
+#ifndef OCPN_USE_NEWSERIAL
 // Returns an iterator across all known serial ports. Caller is responsible for
 // releasing the iterator when iteration is complete.
 static kern_return_t FindSerialPorts(io_iterator_t *matchingServices)


### PR DESCRIPTION
Fixes for #1364.
@nohal:  verbose builds: We simply disagree, but you are the maintainer. Case closed.
@did-g: Thanks for good catches!

EDIT: One lesson from this: it's much easier to review config.h than looking for what's defined on the command line in the build logs. So, let's stick to config.h for  new configuration variables.