### PR TITLE
Grib add current polar record type.

### DIFF
--- a/plugins/grib_pi/src/GribReader.cpp
+++ b/plugins/grib_pi/src/GribReader.cpp
@@ -107,6 +107,12 @@ static bool RecordIsWind(GribRecord *rec)
          rec->getDataType()==GRB_WIND_DIR || rec->getDataType()==GRB_WIND_SPEED;
 }
 
+static bool RecordIsCurrent(GribRecord *rec)
+{
+  return rec->getDataType()==GRB_UOGRD || rec->getDataType()==GRB_VOGRD ||
+         rec->getDataType()==GRB_CUR_DIR || rec->getDataType()==GRB_CUR_SPEED;
+}
+
 void GribReader::readAllGribRecords()
 {
     //--------------------------------------------------------
@@ -234,7 +240,7 @@ void GribReader::readAllGribRecords()
         else if ((rec->getDataType()==GRB_WTMP) && (rec->getLevelType()==LV_GND_SURF) && (rec->getLevelValue()==0))
             storeRecordInMap(rec);                             // rtofs Water Temp + translated gfs Water Temp  
 
-        else if( (rec->getDataType()==GRB_UOGRD || rec->getDataType()==GRB_VOGRD))          // rtofs model sea current current
+        else if( RecordIsCurrent(rec))          // rtofs model sea current current
             storeRecordInMap(rec);
 
         else if(rec->getDataType() == GRB_CAPE && rec->getLevelType()==LV_GND_SURF && rec->getLevelValue()==0) //Potential energy

--- a/plugins/grib_pi/src/GribRecord.cpp
+++ b/plugins/grib_pi/src/GribRecord.cpp
@@ -359,8 +359,14 @@ void GribRecord::Polar2UV(GribRecord *pDIR, GribRecord *pSPEED)
                 pSPEED->data[i] = -speed * cos ( dir *M_PI/180.);
             }
         }
-        pDIR->dataType = GRB_WIND_VX;
-        pSPEED->dataType = GRB_WIND_VY;
+        if (pDIR->dataType == GRB_WIND_DIR) {
+            pDIR->dataType = GRB_WIND_VX;
+            pSPEED->dataType = GRB_WIND_VY;
+        }
+        else {
+            pDIR->dataType = GRB_UOGRD;
+            pSPEED->dataType = GRB_VOGRD;
+        }
     }
 }
 

--- a/plugins/grib_pi/src/GribV2Record.cpp
+++ b/plugins/grib_pi/src/GribV2Record.cpp
@@ -1019,10 +1019,8 @@ static zuchar GRBV2_TO_DATA(int productDiscipline, int dataCat, int dataNum)
 
         case 1: // Currents 
             switch (dataNum) {
-            #if 0
                 case 0: ret = GRB_CUR_DIR; break;
                 case 1: ret = GRB_CUR_SPEED; break;
-            #endif
                 case 2: ret = GRB_UOGRD; break; // DATA_TO_GRBV2[DATA_CURRENT_VX] = grb2DataType(10,1,2);
                 case 3: ret = GRB_VOGRD; break; // DATA_TO_GRBV2[DATA_CURRENT_VY] = grb2DataType(10,1,3);
             }


### PR DESCRIPTION
Hi,
Backport grib current polar record to v5.0.x.
Not exactly a bug fix but it's a small patch.

For the summer I put on a site some very high resolution current / wind/ wave grib files. 
Using polar coordinates reduce their size, and if there's a v5.1 release in May/June it'd be great to have it in.


Regards
Didier