### PR TITLE
Route first eta

### DIFF
--- a/src/Route.cpp
+++ b/src/Route.cpp
@@ -1001,7 +1001,7 @@ void Route::UpdateSegmentDistance( RoutePoint *prp0, RoutePoint *prp, double pla
             prp0->m_manual_etd = false;
             if( prp0->GetETA().IsValid() ) {
                 prp0->m_seg_etd = prp0->GetETA();
-            } else {
+            } else if (!prp0->GetETD().IsValid()) {
                 prp0->m_seg_etd = m_PlannedDeparture + wxTimeSpan(0, 0, m_route_time);
             }
         }


### PR DESCRIPTION
Hi,

First leg has no ETA but a valid ETD, update distance must use this ETD otherwise it adds its own route time to its departure time, a bit fragile though.

Fix issue https://github.com/OpenCPN/OpenCPN/issues/1362

Regards
Didier
