### PR TITLE
Grib v5.0.x

### DIFF
--- a/plugins/grib_pi/src/GribReader.cpp
+++ b/plugins/grib_pi/src/GribReader.cpp
@@ -182,13 +182,15 @@ void GribReader::readAllGribRecords()
         if (firstdate== -1)
 	    firstdate = rec->getRecordCurrentDate();
 
-        if ((rec->getDataType()==GRB_PRESSURE && rec->getLevelType()==LV_MSL && rec->getLevelValue()==0)
-                    || ( RecordIsWind(rec) && rec->getLevelType()==LV_ABOV_GND && rec->getLevelValue()==10)
-                    || ( RecordIsWind(rec) && rec->getLevelType()==LV_ISOBARIC //wind at x hpa
-                    && (  rec->getLevelValue()==850
-			|| rec->getLevelValue()==700
-			|| rec->getLevelValue()==500
-			|| rec->getLevelValue()==300 ) ) )
+        if ((rec->getDataType()==GRB_PRESSURE && rec->getLevelValue()==0 &&
+                (rec->getLevelType()==LV_MSL || rec->getLevelType()==LV_GND_SURF)
+            )
+            || ( RecordIsWind(rec) && rec->getLevelType()==LV_ABOV_GND && rec->getLevelValue()==10)
+                || ( RecordIsWind(rec) && rec->getLevelType()==LV_ISOBARIC //wind at x hpa
+                    && (  rec->getLevelValue()==850 || rec->getLevelValue()==700
+			|| rec->getLevelValue()==500 || rec->getLevelValue()==300 
+                       ) 
+               ) )
             storeRecordInMap(rec);
 
         else if( (rec->getDataType()==GRB_WIND_GUST

--- a/plugins/grib_pi/src/GribReader.cpp
+++ b/plugins/grib_pi/src/GribReader.cpp
@@ -227,15 +227,21 @@ void GribReader::readAllGribRecords()
         else if( rec->getDataType() == GRB_HTSGW )               // Significant Wave Height
             storeRecordInMap(rec);
 
-        else if( rec->getDataType() == GRB_WVPER )               // Waves period
+        else if( rec->getDataType() == GRB_PER )                 // Combined Wind Waves and Swell period
             storeRecordInMap(rec);
 
-        else if( rec->getDataType() == GRB_WVDIR )               // Wind Wave Direction
+        else if( rec->getDataType() == GRB_DIR )                 // Combined Wind Waves and Swell Direction
             storeRecordInMap(rec);
 
-        else if( rec->getDataType() == GRB_WVHGT )               // Wave Height
+        else if( rec->getDataType() == GRB_WVHGT )               // Wind Wave Height
             storeRecordInMap(rec);
                 
+        else if( rec->getDataType() == GRB_WVPER )               // Wind Waves period
+            storeRecordInMap(rec);
+
+        else if( rec->getDataType() == GRB_WVDIR )               // Wind Waves Direction
+            storeRecordInMap(rec);
+
         else if( rec->getDataType() == GRB_CRAIN )               // Catagorical Rain  1/0
             storeRecordInMap(rec);
 
@@ -422,6 +428,8 @@ void  GribReader::copyMissingWaveRecords ()
 	copyMissingWaveRecords (GRB_HTSGW, LV_GND_SURF, 0);
 	copyMissingWaveRecords (GRB_WVDIR, LV_GND_SURF,0);
     copyMissingWaveRecords (GRB_WVPER, LV_GND_SURF,0);
+	copyMissingWaveRecords (GRB_DIR, LV_GND_SURF,0);
+    copyMissingWaveRecords (GRB_PER, LV_GND_SURF,0);
 }
 
 //---------------------------------------------------------------------------------

--- a/plugins/grib_pi/src/GribRecord.h
+++ b/plugins/grib_pi/src/GribRecord.h
@@ -77,6 +77,8 @@ Elément de base d'un fichier GRIB
 #define GRB_PERPW         108
 #define GRB_DIRSW         109
 #define GRB_PERSW         110
+#define GRB_PER           209
+#define GRB_DIR           210
 
 #define GRB_CRAIN         140   /* "Categorical rain", "yes=1;no=0" */
 #define GRB_FRZRAIN_CATEG 141   /* 1=yes 0=no */

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -1959,18 +1959,23 @@ GRIBFile::GRIBFile( const wxArrayString & file_names, bool CumRec, bool WaveRec,
                     if (m_GribRecordSetArray.Item( j ).m_GribRecordPtrArray[idx]) {
                         // already one
                         GribRecord *oRec = m_GribRecordSetArray.Item( j ).m_GribRecordPtrArray[idx];
-                        // we favor UV over DIR/SPEED
-                        if (polarWind) {
-                            if (oRec->getDataType() == GRB_WIND_VY || oRec->getDataType() == GRB_WIND_VX)
+                        if (idx == Idx_PRESSURE) {
+                            skip = (oRec->getLevelType() == LV_MSL);
+                        } 
+                        else {
+                            if (polarWind) {
+                                // we favor UV over DIR/SPEED
+                                if (oRec->getDataType() == GRB_WIND_VY || oRec->getDataType() == GRB_WIND_VX)
+                                    skip = true;
+                            }
+                            else if (polarCurrent) {
+                                if (oRec->getDataType() == GRB_UOGRD || oRec->getDataType() == GRB_VOGRD)
+                                    skip = true;
+                            }
+                            // favor average aka timeRange == 3 (HRRR subhourly subsets have both 3 and 0 records for winds)
+                            if (!skip && (oRec->getTimeRange() == 3)) {
                                 skip = true;
-                        }
-                        else if (polarCurrent) {
-                            if (oRec->getDataType() == GRB_UOGRD || oRec->getDataType() == GRB_VOGRD)
-                                skip = true;
-                        }
-                        // favor average aka timeRange == 3 (HRRR subhourly subsets have both 3 and 0 records for winds)
-                        if (!skip && (oRec->getTimeRange() == 3)) {
-                            skip = true;
+                            }
                         }
                     }
                     if (!skip) {

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -1963,12 +1963,12 @@ GRIBFile::GRIBFile( const wxArrayString & file_names, bool CumRec, bool WaveRec,
                             skip = (oRec->getLevelType() == LV_MSL);
                         } 
                         else {
+                            // we favor UV over DIR/SPEED
                             if (polarWind) {
-                                // we favor UV over DIR/SPEED
                                 if (oRec->getDataType() == GRB_WIND_VY || oRec->getDataType() == GRB_WIND_VX)
                                     skip = true;
                             }
-                            else if (polarCurrent) {
+                            if (polarCurrent) {
                                 if (oRec->getDataType() == GRB_UOGRD || oRec->getDataType() == GRB_VOGRD)
                                     skip = true;
                             }

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -1843,7 +1843,8 @@ GRIBFile::GRIBFile( const wxArrayString & file_names, bool CumRec, bool WaveRec,
     bool isOK(false);
     bool polarWind(false);
     bool polarCurrent(false);
-
+    bool sigWave(false);
+    bool sigH(false);
     //    Get the map of GribRecord vectors
     std::map<std::string, std::vector<GribRecord *>*> *p_map = m_pGribReader->getGribMap();
 
@@ -1903,7 +1904,18 @@ GRIBFile::GRIBFile( const wxArrayString & file_names, bool CumRec, bool WaveRec,
                         break;
                     case GRB_WIND_GUST: idx = Idx_WIND_GUST; break;
                     case GRB_PRESSURE: idx = Idx_PRESSURE;   break;
-                    case GRB_HTSGW:    idx = Idx_HTSIGW;  break;
+                    case GRB_HTSGW:
+                        sigH = true;
+                        idx = Idx_HTSIGW;
+                        break;
+                    case GRB_PER:
+                        sigWave = true;
+                        idx = Idx_WVPER;
+                        break;
+                    case GRB_DIR:
+                        sigWave = true;
+                        idx = Idx_WVDIR;
+                        break;
                     case GRB_WVHGT:    idx = Idx_HTSIGW;  break;                // Translation from NOAA WW3
                     case GRB_WVPER:    idx = Idx_WVPER;  break;
                     case GRB_WVDIR:    idx = Idx_WVDIR;   break;
@@ -1975,6 +1987,15 @@ GRIBFile::GRIBFile( const wxArrayString & file_names, bool CumRec, bool WaveRec,
                             // favor average aka timeRange == 3 (HRRR subhourly subsets have both 3 and 0 records for winds)
                             if (!skip && (oRec->getTimeRange() == 3)) {
                                 skip = true;
+                            }
+                            // we favor significant Wave other wind wave.
+                            if (sigH) {
+                                if (oRec->getDataType() == GRB_HTSGW)
+                                    skip = true;
+                            }
+                            if (sigWave) {
+                                if (oRec->getDataType() == GRB_DIR || oRec->getDataType() == GRB_PER)
+                                    skip = true;
                             }
                         }
                     }

--- a/plugins/grib_pi/src/GribV2Record.cpp
+++ b/plugins/grib_pi/src/GribV2Record.cpp
@@ -1014,6 +1014,8 @@ static zuchar GRBV2_TO_DATA(int productDiscipline, int dataCat, int dataNum)
                 case 4: ret= GRB_WVDIR; break; // Direction of Wind Waves
                 case 5: ret= GRB_WVHGT; break; // Significant Height of Wind Waves
                 case 6: ret= GRB_WVPER; break; // Mean Period of Wind Waves
+                case 14: ret= GRB_DIR; break;  // Direction of Combined Wind Waves and Swell
+                case 15: ret= GRB_PER; break;  // Mean Period of Combined Wind Waves and Swell
             }
             break;
 
@@ -1356,6 +1358,8 @@ void  GribV2Record::translateDataType()
             case GRB_HTSGW:
             case GRB_WVDIR:
             case GRB_WVPER:
+            case GRB_DIR:
+            case GRB_PER:
                 levelType  = LV_GND_SURF;
                 levelValue = 0;
                 break;

--- a/plugins/grib_pi/src/GribV2Record.cpp
+++ b/plugins/grib_pi/src/GribV2Record.cpp
@@ -1319,11 +1319,6 @@ void  GribV2Record::translateDataType()
 	}
     else if (idCenter==84 && idModel <= 5 && idGrid==0)
     {
-        // XXX Météo France AROME-01 is 
-		if ( getDataType()==GRB_PRESSURE && getLevelType()==LV_GND_SURF && getLevelValue()==0)
-		{
-			levelType  = LV_MSL;
-		} // missing enum for dataCenterModel
     }
 	
 	//------------------------


### PR DESCRIPTION
Hi,

- GRIB wave:
Opencpn display only one set of wave height direction and period for total sea (ie combined wind wave and swell), for this WW3 model is using significant height +  wind wave direction, MWAM model is using wave period and wave direction. Try to be smart and select the right set...

- thinko: it's not because wind is using polar than current can't, remove the 'else'

- Pressure, if there's only surface level don't fake it as MSL but display it as is.

Regards
Didier
