### PR TITLE
Fix incorrect placement of Window menu on macOS

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -5687,8 +5687,13 @@ void MyFrame::RegisterGlobalMenuItems()
     tools_menu->AppendSeparator();
     tools_menu->Append( wxID_PREFERENCES, _menuText(_("Options") + _T("..."), _T("Ctrl-,")) );
 #endif
-
     m_pMenuBar->Append( tools_menu, _("&Tools") );
+
+#ifdef __WXOSX__
+    wxMenu* window_menu = new wxMenu();
+    m_pMenuBar->Append( window_menu, _("&Window") );
+#endif
+
     wxMenu* help_menu = new wxMenu();
     help_menu->Append( wxID_ABOUT, _("About OpenCPN") );
     help_menu->Append( wxID_HELP, _("OpenCPN Help") );


### PR DESCRIPTION
Fixes #1411 by manually adding an empty "Window" menu to the default menubar on macOS.