### PR TITLE
Fix missing menu shortcuts with Scaled Graphics enabled

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -5539,8 +5539,9 @@ void MyFrame::ApplyGlobalSettings( bool bnewtoolbar )
 wxString _menuText( wxString name, wxString shortcut ) {
     wxString menutext;
     menutext << name;
-    if(!g_bresponsive)
-        menutext << _T("\t") << shortcut;
+#ifndef __OCPN__ANDROID__
+    menutext << _T("\t") << shortcut;
+#endif
     return menutext;
 }
 


### PR DESCRIPTION
Instead of disabling menu shortcuts if `g_bresponsive` is true, only disable them on Android.

I believe this fix is appropriate. See #1414 for further discussion.

Fixes #1414 
