### PR TITLE
Improve UI colours and macOS dark mode support

### DIFF
--- a/src/ConnectionParams.cpp
+++ b/src/ConnectionParams.cpp
@@ -368,14 +368,12 @@ void ConnectionParamsPanel::SetSelected( bool selected )
     }
     
 #ifdef __WXOSX__
-    if( wxPlatformInfo::Get().CheckOSVersion(10, 14) ) {
-        wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
-        if( bg.Red() < 128 ) {
-            if(selected) {
-                m_boxColour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
-            } else {
-                m_boxColour = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
-            }
+    if (wxPlatformInfo::Get().CheckOSVersion(10, 14)) {
+        // On macOS 10.14+ we use the native colours, which automatically adjust in Dark Mode.
+        if (selected) {
+            m_boxColour = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT);
+        } else {
+            m_boxColour = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
         }
     }
 #endif

--- a/src/DarkMode.h
+++ b/src/DarkMode.h
@@ -23,9 +23,8 @@
  */
 
 #include "wx/wxprec.h"
-
-
 #include "wx/osx/private.h"
 
-void applyDarkAppearanceToWindow(NSWindow *window, bool vibrant = false, bool flat = false, bool subviews = false);
+void setAppLevelDarkMode(bool enabled = true);
 
+void setWindowLevelDarkMode(NSWindow *window, bool enabled = true);

--- a/src/DarkMode.mm
+++ b/src/DarkMode.mm
@@ -24,40 +24,16 @@
 
 #import "DarkMode.h"
 
-void updateDarkModeStateForTreeStartingAtView(__kindof NSView *rootView, bool vibrant = false)
+void setAppLevelDarkMode(bool enabled)
 {
-    for (NSView *view in rootView.subviews) {
-        if( vibrant ) {
-            view.appearance = [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark];
-        }
-        if ([view isKindOfClass:[NSVisualEffectView class]]) {
-            [(NSVisualEffectView *)view setMaterial:NSVisualEffectMaterialDark];
-        }
-        
-        if ([view isKindOfClass:[NSClipView class]] ||
-            [view isKindOfClass:[NSScrollView class]] ||
-            [view isKindOfClass:[NSMatrix class]] ||
-            [view isKindOfClass:[NSTextView class]] ||
-            [view isKindOfClass:NSClassFromString(@"TBrowserTableView")] ||
-            [view isKindOfClass:NSClassFromString(@"TIconView")]) {
-            [view performSelector:@selector(setBackgroundColor:) withObject:[NSColor colorWithCalibratedWhite:0.1 alpha:1.0]];
-        }
-        
-        if (view.subviews.count > 0)
-            updateDarkModeStateForTreeStartingAtView(view, vibrant);
+    if (@available(macOS 10.14, *)) {
+        NSAppearance *appearance = (enabled ? [NSAppearance appearanceNamed:NSAppearanceNameDarkAqua] : nil);
+        [[NSApplication sharedApplication] setAppearance:appearance];
     }
 }
 
-void applyDarkAppearanceToWindow (NSWindow *window, bool vibrant, bool flat, bool subviews)
+void setWindowLevelDarkMode(NSWindow *window, bool enabled)
 {
-    if( vibrant ) {
-        [window setAppearance:[NSAppearance appearanceNamed:NSAppearanceNameVibrantDark]];
-    }
-    if( flat ) {
-        window.titlebarAppearsTransparent = true; // gives it "flat" look
-    }
-    [window setBackgroundColor:[NSColor blackColor]];
-    if( subviews ) {
-        updateDarkModeStateForTreeStartingAtView(window.contentView, vibrant);
-    }
+    NSAppearance *appearance = (enabled ? [NSAppearance appearanceNamed:NSAppearanceNameVibrantDark] : nil);
+    [window setAppearance: appearance];
 }

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -2996,6 +2996,16 @@ void MyFrame::SetAndApplyColorScheme( ColorScheme cs )
             break;
     }
 
+#if defined(__WXOSX__) && defined(OCPN_USE_DARKMODE)
+    bool darkMode = (cs == GLOBAL_COLOR_SCHEME_DUSK || cs == GLOBAL_COLOR_SCHEME_NIGHT || g_bDarkDecorations);
+
+    if (wxPlatformInfo::Get().CheckOSVersion(10, 14)) {
+        setAppLevelDarkMode(darkMode);
+    }
+    else if (wxPlatformInfo::Get().CheckOSVersion(10, 12)) {
+        setWindowLevelDarkMode(MacGetTopLevelWindowRef(), darkMode);
+    }
+#endif
 
     g_pauidockart->SetMetric(wxAUI_DOCKART_GRADIENT_TYPE, wxAUI_GRADIENT_NONE);
         
@@ -3142,15 +3152,6 @@ void MyFrame::SetAndApplyColorScheme( ColorScheme cs )
     }
     
     if( g_pi_manager ) g_pi_manager->SetColorSchemeForAllPlugIns( cs );
-
-#if defined(__WXOSX__) && defined(OCPN_USE_DARKMODE)
-    if( (osMajor >= 10) && (osMinor >= 12) ){
-        if( g_bDarkDecorations ) {
-            applyDarkAppearanceToWindow(MacGetTopLevelWindowRef(), true);
-        }
-    }
-#endif
-
 }
 
 void MyFrame::ApplyGlobalColorSchemetoStatusBar( void )

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -2933,7 +2933,7 @@ void options::CreatePanel_Ownship(size_t parent, int border_size,
 
   dispOwnShipCalcOptionsGrid->Add(pSogCogFromLLDampInterval, 0, wxALIGN_RIGHT | wxALL, group_item_spacing);
 
-  DimeControl(itemPanelShip);
+  // DimeControl(itemPanelShip);
 }
 
 void options::CreatePanel_Routes(size_t parent, int border_size,
@@ -3193,7 +3193,7 @@ void options::CreatePanel_Routes(size_t parent, int border_size,
        }
    }
   
-  DimeControl(itemPanelRoutes);
+  // DimeControl(itemPanelRoutes);
 }
 
 void options::CreatePanel_ChartsLoad(size_t parent, int border_size,


### PR DESCRIPTION
Improves UI colours for dialogs etc cross-platform, especially on macOS.

- The most-improved platform is macOS 10.14+, where native light and dark modes are now used unmodified.
- Older macOS versions are also much improved.
- Windows 10 is improved, but still far from perfect.

Fixes #1412 – although I would like to do more work on this at some point, potentially fully reworking `DimeControl` and the colour-changing logic in general.