### PR TITLE
Fix uninitialized Fix_Time bug and accept valid GPS time with decimal…

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -9145,9 +9145,9 @@ void MyFrame::PostProcessNMEA( bool pos_valid, bool cog_sog_valid, const wxStrin
 #ifdef ocpnUPDATE_SYSTEM_TIME
 //      Use the fix time to update the local system clock, only once per session
     if( ( sfixtime.Len() ) && s_bSetSystemTime && ( m_bTimeIsSet == false ) ) {
-        wxDateTime Fix_Time;
+        wxDateTime Fix_Time( wxDateTime::Now() );
 
-        if( 6 == sfixtime.Len() )                   // perfectly recognised format?
+        if( 6 == sfixtime.Len() || 6 == sfixtime.find('.') )                   // perfectly recognised format?
                 {
             wxString a;
             long b;


### PR DESCRIPTION
Fix_Time variable was not initialized before first use.
GPS time sometimes contains decimal point at position 6.