### PR TITLE
ci: Update macos build deps handling (Closes: #1432).

### DIFF
--- a/ci/travis-build-mingw.sh
+++ b/ci/travis-build-mingw.sh
@@ -16,16 +16,16 @@ echo "DOCKER_OPTS=\"-H tcp://127.0.0.1:2375 -H $DOCKER_SOCK -s devicemapper\"" \
     | sudo tee /etc/default/docker > /dev/null
 sudo service docker restart;
 sleep 5;
-sudo docker pull fedora:28;
+sudo docker pull fedora:29;
 
 docker run --privileged -d -ti -e "container=docker"  \
     -v /sys/fs/cgroup:/sys/fs/cgroup \
     -v $(pwd):/opencpn-ci:rw \
-    fedora:28   /usr/sbin/init
+    fedora:29   /usr/sbin/init
 DOCKER_CONTAINER_ID=$(docker ps | grep fedora | awk '{print $1}')
 docker logs $DOCKER_CONTAINER_ID
 docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -xec \
-    "bash -xe /opencpn-ci/ci/docker-build-mingw.sh 28;
+    "bash -xe /opencpn-ci/ci/docker-build-mingw.sh 29;
          echo -ne \"------\nEND OPENCPN-CI BUILD\n\";"
 docker ps -a
 docker stop $DOCKER_CONTAINER_ID

--- a/ci/travis-build-osx.sh
+++ b/ci/travis-build-osx.sh
@@ -7,10 +7,10 @@
 # bailout on errors and echo commands
 set -xe
 
-brew install libexif
-brew upgrade cairo
-xz --version || brew install xz
-python3 --version || brew install python
+
+for pkg in cairo cmake libexif wget xz; do
+    brew list $pkg || brew install $pkg
+done
 
 export MACOSX_DEPLOYMENT_TARGET=10.9
 # We need to build own libarchive

--- a/ci/travis-build-osx.sh
+++ b/ci/travis-build-osx.sh
@@ -7,14 +7,14 @@
 # bailout on errors and echo commands
 set -xe
 
-
+set -o pipefail
 for pkg in cairo cmake libexif wget xz; do
-    brew list $pkg || brew install $pkg
+    brew list $pkg 2>/dev/null | head -10 || brew install $pkg
 done
 
 export MACOSX_DEPLOYMENT_TARGET=10.9
 # We need to build own libarchive
-wget https://libarchive.org/downloads/libarchive-3.3.3.tar.gz
+wget -q https://libarchive.org/downloads/libarchive-3.3.3.tar.gz
 tar zxf libarchive-3.3.3.tar.gz
 cd libarchive-3.3.3
 ./configure --without-lzo2 --without-nettle --without-xml2 --without-openssl --with-expat
@@ -22,7 +22,7 @@ make
 make install
 cd ..
 
-wget http://opencpn.navnux.org/build_deps/wx312_opencpn50_macos109.tar.xz
+wget -q http://opencpn.navnux.org/build_deps/wx312_opencpn50_macos109.tar.xz
 tar xJf wx312_opencpn50_macos109.tar.xz -C /tmp
 export PATH="/usr/local/opt/gettext/bin:$PATH"
 echo 'export PATH="/usr/local/opt/gettext/bin:$PATH"' >> ~/.bash_profile


### PR DESCRIPTION
Oddly, on macos brew fails if trying to install an already installed package. Use a generic mechanism to only install package if it's not already on host, and make the list of build deps somewhat more compltete.