### PR TITLE
Handle Pango >=1.44 Harfbuz dep (Closes: #1453).

### DIFF
--- a/ci/travis-build-mingw.sh
+++ b/ci/travis-build-mingw.sh
@@ -16,16 +16,16 @@ echo "DOCKER_OPTS=\"-H tcp://127.0.0.1:2375 -H $DOCKER_SOCK -s devicemapper\"" \
     | sudo tee /etc/default/docker > /dev/null
 sudo service docker restart;
 sleep 5;
-sudo docker pull fedora:28;
+sudo docker pull fedora:29;
 
 docker run --privileged -d -ti -e "container=docker"  \
     -v /sys/fs/cgroup:/sys/fs/cgroup \
     -v $(pwd):/opencpn-ci:rw \
-    fedora:28   /usr/sbin/init
+    fedora:29   /usr/sbin/init
 DOCKER_CONTAINER_ID=$(docker ps | grep fedora | awk '{print $1}')
 docker logs $DOCKER_CONTAINER_ID
 docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -xec \
-    "bash -xe /opencpn-ci/ci/docker-build-mingw.sh 28;
+    "bash -xe /opencpn-ci/ci/docker-build-mingw.sh 29;
          echo -ne \"------\nEND OPENCPN-CI BUILD\n\";"
 docker ps -a
 docker stop $DOCKER_CONTAINER_ID

--- a/ci/travis-build-osx.sh
+++ b/ci/travis-build-osx.sh
@@ -7,14 +7,14 @@
 # bailout on errors and echo commands
 set -xe
 
-brew install libexif
-brew upgrade cairo
-xz --version || brew install xz
-python3 --version || brew install python
+set -o pipefail
+for pkg in cairo cmake libexif wget xz; do
+    brew list $pkg 2>/dev/null | head -10 || brew install $pkg
+done
 
 export MACOSX_DEPLOYMENT_TARGET=10.9
 # We need to build own libarchive
-wget https://libarchive.org/downloads/libarchive-3.3.3.tar.gz
+wget -q https://libarchive.org/downloads/libarchive-3.3.3.tar.gz
 tar zxf libarchive-3.3.3.tar.gz
 cd libarchive-3.3.3
 ./configure --without-lzo2 --without-nettle --without-xml2 --without-openssl --with-expat
@@ -22,7 +22,7 @@ make
 make install
 cd ..
 
-wget http://opencpn.navnux.org/build_deps/wx312_opencpn50_macos109.tar.xz
+wget -q http://opencpn.navnux.org/build_deps/wx312_opencpn50_macos109.tar.xz
 tar xJf wx312_opencpn50_macos109.tar.xz -C /tmp
 export PATH="/usr/local/opt/gettext/bin:$PATH"
 echo 'export PATH="/usr/local/opt/gettext/bin:$PATH"' >> ~/.bash_profile

--- a/cmake/FindHarfBuzz.cmake
+++ b/cmake/FindHarfBuzz.cmake
@@ -1,0 +1,78 @@
+# https://github.com/SFTtech/openage/blob/master/buildsystem/modules/FindHarfBuzz.cmake
+# Copyright 2015-2016 the openage authors. See copying.md for legal info.
+
+# FindHarfBuzz
+# ---------
+#
+# Locate HarfBuzz, the awesome text shaping library.
+#
+# The module defines the following variables:
+#
+# ::
+#
+#    HarfBuzz_FOUND - Found HarfBuzz library
+#    HarfBuzz_INCLUDE_DIRS - HarfBuzz include directories
+#    HarfBuzz_LIBRARIES - The libraries needed to use HarfBuzz
+#    HarfBuzz_VERSION_STRING - the version of HarfBuzz found
+#
+# Example Usage:
+#
+# ::
+#
+#     find_package(HarfBuzz REQUIRED)
+#     include_directories(${HarfBuzz_INCLUDE_DIRS})
+#
+# ::
+#
+#     add_executable(foo foo.cc)
+#     target_link_libraries(foo ${HarfBuzz_LIBRARIES})
+
+find_path(HarfBuzz_INCLUDE_DIR harfbuzz/hb.h
+	HINTS $ENV{HARFBUZZ_DIR}
+	PATHS
+		/usr/include
+		/usr/local/include
+		/sw/include
+		/opt/local/include
+		/usr/freeware/include
+)
+
+find_library(HarfBuzz_LIBRARY
+	NAMES harfbuzz libharfbuzz
+	HINTS $ENV{HARFBUZZ_DIR}
+	PATH_SUFFIXES lib64 lib
+	PATHS
+		/usr/lib
+		/usr/local/lib
+		/sw
+		/usr/freeware
+)
+
+if(HarfBuzz_INCLUDE_DIR)
+	set(HarfBuzz_VERSION_FILE "${HarfBuzz_INCLUDE_DIR}/harfbuzz/hb-version.h")
+	if(EXISTS "${HarfBuzz_VERSION_FILE}")
+		file(STRINGS "${HarfBuzz_VERSION_FILE}" hb_version_str
+		     REGEX "^#define[\t ]+HB_VERSION_STRING[\t ]+\".*\"")
+
+		string(REGEX REPLACE "^#define[\t ]+HB_VERSION_STRING[\t ]+\"([^\"]*)\".*" "\\1"
+		       HarfBuzz_VERSION_STRING "${hb_version_str}")
+		unset(hb_version_str)
+	endif()
+	unset(HarfBuzz_VERSION_FILE)
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(HarfBuzz
+	FOUND_VAR HarfBuzz_FOUND
+	REQUIRED_VARS HarfBuzz_LIBRARY HarfBuzz_INCLUDE_DIR
+	VERSION_VAR HarfBuzz_VERSION_STRING
+)
+
+if(HarfBuzz_FOUND)
+	set(HarfBuzz_INCLUDE_DIRS ${HarfBuzz_INCLUDE_DIR})
+        # pango has evil include <hb.h> instead of regular <harfbuzz/hb.h>:
+        list (APPEND HarfBuzz_INCLUDE_DIRS "${HarfBuzz_INCLUDE_DIR}/harfbuzz")
+	set(HarfBuzz_LIBRARIES "${HarfBuzz_LIBRARY}")
+endif()
+
+mark_as_advanced(HarfBuzz_INCLUDE_DIR HarfBuzz_LIBRARY)

--- a/cmake/FindPANGO.cmake
+++ b/cmake/FindPANGO.cmake
@@ -1,0 +1,91 @@
+# FindPango.cmake
+# <https://github.com/nemequ/gnome-cmake>
+#
+# CMake support for Pango.
+#
+# If pango is found create the linkable ocpn::pango interface library
+# carrying headers, libraries and compilation flags.
+# On a sidenote also sets PANGO_FOUND and PANGO_VERSION.
+#
+# License:
+#
+#   Copyright (c) 2016 Evan Nemerson <evan@nemerson.com>
+#   Copyright (c) 2019 Alec Leamas
+#
+#   Permission is hereby granted, free of charge, to any person
+#   obtaining a copy of this software and associated documentation
+#   files (the "Software"), to deal in the Software without
+#   restriction, including without limitation the rights to use, copy,
+#   modify, merge, publish, distribute, sublicense, and/or sell copies
+#   of the Software, and to permit persons to whom the Software is
+#   furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be
+#   included in all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+#   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+#   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+#   NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+#   HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+#   WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+#   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+#   DEALINGS IN THE SOFTWARE.
+
+if (TARGET ocpn::pango)
+    return ()
+endif ()
+
+find_package(PkgConfig)
+if(PKG_CONFIG_FOUND)
+    pkg_search_module(PANGO_PKG pango)
+endif()
+
+
+find_library(PANGO_LIBRARIES pango-1.0 HINTS ${PANGO_PKG_LIBRARY_DIRS})
+set(PANGO pango-1.0)
+
+if(PANGO_LIBRARIES AND NOT PANGO_FOUND)
+  add_library(_PANGO INTERFACE)
+  target_link_libraries(_PANGO INTERFACE "${PANGO_LIBRARIES}")
+  target_compile_options(_PANGO INTERFACE "${PANGO_PKG_CFLAGS_OTHER}")
+
+  find_path(PANGO_INCLUDE_DIR "pango/pango.h"
+      HINTS ${PANGO_PKG_INCLUDE_DIRS})
+  if(PANGO_INCLUDE_DIR)
+    file(STRINGS "${PANGO_INCLUDE_DIR}/pango/pango-features.h"
+       PANGO_MAJOR_VERSION REGEX
+       "^#define PANGO_VERSION_MAJOR +\\(?([0-9]+)\\)?$")
+    string(REGEX REPLACE
+       "^#define PANGO_VERSION_MAJOR \\(?([0-9]+)\\)?" "\\1"
+       PANGO_MAJOR_VERSION "${PANGO_MAJOR_VERSION}")
+    file(STRINGS "${PANGO_INCLUDE_DIR}/pango/pango-features.h"
+       PANGO_MINOR_VERSION REGEX
+       "^#define PANGO_VERSION_MINOR +\\(?([0-9]+)\\)?$")
+    string(REGEX REPLACE
+       "^#define PANGO_VERSION_MINOR \\(?([0-9]+)\\)?" "\\1"
+       PANGO_MINOR_VERSION "${PANGO_MINOR_VERSION}")
+    file(STRINGS "${PANGO_INCLUDE_DIR}/pango/pango-features.h"
+       PANGO_MICRO_VERSION REGEX
+       "^#define PANGO_VERSION_MICRO +\\(?([0-9]+)\\)?$")
+    string(REGEX REPLACE
+       "^#define PANGO_VERSION_MICRO \\(?([0-9]+)\\)?" "\\1"
+       PANGO_MICRO_VERSION "${PANGO_MICRO_VERSION}")
+    set(
+      PANGO_VERSION
+      "${PANGO_MAJOR_VERSION}.${PANGO_MINOR_VERSION}.${PANGO_MICRO_VERSION}")
+    unset(PANGO_MAJOR_VERSION)
+    unset(PANGO_MINOR_VERSION)
+    unset(PANGO_MICRO_VERSION)
+
+    target_include_directories(_PANGO INTERFACE ${PANGO_INCLUDE_DIR})
+    if (PANGO_VERSION VERSION_GREATER_EQUAL "1.44")
+      find_package(HarfBuzz REQUIRED)
+      target_include_directories(_PANGO INTERFACE ${HarfBuzz_INCLUDE_DIRS})
+      target_link_libraries(_PANGO INTERFACE ${HarfBuzz_LIBRARIES})
+    endif()
+  endif()
+  add_library(ocpn::pango ALIAS _PANGO)
+endif()
+
+unset(PANGO_DEPS_FOUND_VARS)

--- a/cmake/FindPANGO.cmake
+++ b/cmake/FindPANGO.cmake
@@ -5,7 +5,7 @@
 #
 # If pango is found create the linkable ocpn::pango interface library
 # carrying headers, libraries and compilation flags.
-# On a sidenote also sets PANGO_FOUND and PANGO_VERSION.
+# On a sidenote also sets PANGO_FOUND.
 #
 # License:
 #
@@ -87,5 +87,11 @@ if(PANGO_LIBRARIES AND NOT PANGO_FOUND)
   endif()
   add_library(ocpn::pango ALIAS _PANGO)
 endif()
+
+mark_as_advanced(PANGO_INCLUDE_DIR PANGO_LIBRARIES PANGO_VERSION)
+find_package_handle_standard_args(PANGO
+    REQUIRED_VARS PANGO_INCLUDE_DIR PANGO_LIBRARIES
+    VERSION_VAR PANGO_VERSION
+)
 
 unset(PANGO_DEPS_FOUND_VARS)

--- a/cmake/OcpnFindCairo.cmake
+++ b/cmake/OcpnFindCairo.cmake
@@ -54,14 +54,13 @@ if (NOT CAIRO_FOUND)
   message(FATAL_ERROR "Cairo component required, but not found!")
 endif ()
 
+add_library(_CAIRO INTERFACE)
 # Some systems (e.g ARMHF RPI2) require some extra libraries
 # This is not exactly a general solution, but probably harmless where
 # not needed.
 if (NOT APPLE AND NOT WIN32)
-  find_library(
-    PANGOCAIRO_LIBRARY
-    NAMES pangocairo-1.0 PATHS ${LINUX_LIB_PATHS}
-  )
+  find_package(PANGO REQUIRED)
+  target_link_libraries(_CAIRO INTERFACE ocpn::pango)
   find_library(PANGOFT2_LIBRARY NAMES pangoft2-1.0 PATHS ${LINUX_LIB_PATHS})
   find_library(PANGOXFT_LIBRARY NAMES pangoxft-1.0 PATHS ${LINUX_LIB_PATHS})
   find_library(
@@ -69,26 +68,25 @@ if (NOT APPLE AND NOT WIN32)
     NAMES gdk_pixbuf-2.0 PATHS ${LINUX_LIB_PATHS}
   )
   find_package_handle_standard_args("CAIRO_EXTRAS" DEFAULT_MSG
-    PANGOCAIRO_LIBRARY PANGOFT2_LIBRARY PANGOXFT_LIBRARY GDK_PIXBUF_LIBRARY
+    PANGOFT2_LIBRARY PANGOXFT_LIBRARY GDK_PIXBUF_LIBRARY
   )
 endif ()
 
 if (CAIRO_EXTRAS_FOUND)
   set(CAIRO_LIBRARIES ${CAIRO_LIBRARIES}
-    ${PANGOCAIRO_LIBRARY}
     ${PANGOFT2_LIBRARY} ${PANGOXFT_LIBRARY}
     ${GDK_PIXBUF_LIBRARY}
   )
 endif ()
-add_library(_CAIRO INTERFACE)
 target_link_libraries(_CAIRO INTERFACE ${CAIRO_LIBRARIES})
 
 target_include_directories(_CAIRO INTERFACE ${CAIRO_INCLUDE_DIRS})
 if (APPLE)
   target_include_directories(_CAIRO INTERFACE ${CAIRO_INCLUDE_DIRS}/..)
 endif ()
-if (PANGOCAIRO_INCLUDE_DIRS)
-  target_include_directories(_CAIRO INTERFACE ${PANGOCAIRO_INCLUDE_DIRS})
+if (HarfBuzz_FOUND)
+    target_include_directories(_CAIRO INTERFACE ${HarfBuzz_INCLUDE_DIRS})
+    target_link_libraries(_CAIRO INTERFACE ${Harfbuzz_LIBRARIES})
 endif ()
 
 add_library(ocpn::cairo ALIAS _CAIRO)

--- a/libs/wxsvg/CMakeLists.txt
+++ b/libs/wxsvg/CMakeLists.txt
@@ -104,21 +104,21 @@ if (NOT wxWidgets_INCLUDE_DIRS)
 
     include(FindPkgConfig)
     pkg_search_module(GLIB2 glib-2.0)
-    pkg_search_module(EXPAT expat)
     pkg_search_module(CAIRO cairo libcairo)
-    pkg_search_module(PANGO pango libpango)
+    find_package(EXPAT REQUIRED)
+    find_package(PANGO REQUIRED)
+    target_link_libraries(WXSVG_CAIRO PRIVATE ocpn::pango)
 endif (NOT wxWidgets_INCLUDE_DIRS)
 add_library(WXSVG_CAIRO INTERFACE)
+
 target_include_directories(WXSVG_CAIRO INTERFACE
     ${CAIRO_INCLUDE_DIRS}
     ${EXPAT_INCLUDE_DIRS}
-    ${PANGO_INCLUDE_DIRS}
     ${GLIB2_INCLUDE_DIRS}
 )
 target_link_libraries(WXSVG_CAIRO INTERFACE
     ${CAIRO_LIBRARIES}
     ${EXPAT_LIBRARIES}
-    ${PANGO_LIBRARIES}
     ${GLIB2_LIBRARIES}
 )
 add_library(wxsvg::cairo ALIAS WXSVG_CAIRO)
@@ -138,6 +138,9 @@ if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang|AppleClang")
     )
 endif()
 target_link_libraries(WXSVG PRIVATE ocpn::expat wxsvg::cairo)
+if (TARGET ocpn::pango)
+    target_link_libraries(WXSVG PRIVATE ocpn::pango)
+endif ()
 if (TARGET ocpn::gtk)
   target_link_libraries(WXSVG PRIVATE ocpn::gtk)
 endif ()

--- a/plugins/grib_pi/CMakeLists.txt
+++ b/plugins/grib_pi/CMakeLists.txt
@@ -252,6 +252,8 @@ ENDIF(APPLE)
 if  (NOT WIN32 AND NOT APPLE AND NOT QT_ANDROID)
   include(OcpnFindGtk)
   target_link_libraries(${PACKAGE_NAME} PRIVATE ocpn::gtk)
+  find_package(PANGO REQUIRED)
+  target_link_libraries(${PACKAGE_NAME} PRIVATE ocpn::pango)
 endif ()
 
 IF(UNIX AND NOT APPLE AND NOT QT_ANDROID)


### PR DESCRIPTION
Recent pango libraries (1.44+) has a harfbuzz dependency.  Add a
new FindPango and FindHarfBuzz cmake finders and use them as
appropriate.

Tested on fedora 31 with pango-1.42.4-2

EDIT: For reference: closes #1453