### PR TITLE
Version: Extend plugin version info API  + display extended version info

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -844,6 +844,7 @@ set(
   include/ocpn_pixel.h
   include/OCPNPlatform.h
   include/ocpn_plugin.h
+  include/semantic_vers.h
   include/OCPNRegion.h
   include/ocpn_types.h
   include/options.h
@@ -952,6 +953,7 @@ set(
   src/ocpndc.cpp
   src/OCPNListCtrl.cpp
   src/ocpn_pixel.cpp
+  src/semantic_vers.cpp
   src/OCPNPlatform.cpp
   src/OCPNRegion.cpp
   src/options.cpp

--- a/ci/travis-build-osx.sh
+++ b/ci/travis-build-osx.sh
@@ -8,7 +8,7 @@
 set -xe
 
 set -o pipefail
-for pkg in cairo cmake libexif wget xz; do
+for pkg in cairo cmake libexif python3 wget xz; do
     brew list $pkg 2>/dev/null | head -10 || brew install $pkg
 done
 

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -567,6 +567,9 @@ public:
      */
     virtual int GetPlugInVersionPatch();
 
+    /** Post-release version part, extends the semver spec. */
+    virtual int GetPlugInVersionPost();
+
     /** Pre-release tag version part, see GetPlugInVersionPatch() */
     virtual const char* GetPlugInVersionPre();
 

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -66,7 +66,7 @@ class wxGLContext;
 //    PlugIns conforming to API Version less then the most modern will also
 //    be correctly supported.
 #define API_VERSION_MAJOR           1
-#define API_VERSION_MINOR           16
+#define API_VERSION_MINOR           17
 
 //    Fwd Definitions
 class       wxFileConfig;
@@ -557,6 +557,22 @@ public:
 
 };
 
+class DECL_EXP opencpn_plugin_117 : public opencpn_plugin_116
+{
+public:
+    opencpn_plugin_117(void *pmgr);
+    /*
+     * Forms a semantic version together with GetPlugInVersionMajor() and
+     * GetPlugInVersionMinor(), see https://semver.org/
+     */
+    virtual int GetPlugInVersionPatch();
+
+    /** Pre-release tag version part, see GetPlugInVersionPatch() */
+    virtual const char* GetPlugInVersionPre();
+
+    /** Build version part  see GetPlugInVersionPatch(). */
+    virtual const char* GetPlugInVersionBuild();
+};
 //------------------------------------------------------------------
 //      Route and Waypoint PlugIn support
 //

--- a/include/pluginmanager.h
+++ b/include/pluginmanager.h
@@ -44,6 +44,7 @@
 #include "chartimg.h"
 
 #include "s57chart.h"               // for Object list
+#include "semantic_vers.h"
 
 //For widgets...
 #include "wx/hyperlink.h"
@@ -168,6 +169,12 @@ class PlugInContainer
             int               m_version_major;
             int               m_version_minor;
             wxBitmap         *m_bitmap;
+            /** 
+             * Return version from plugin API. Older pre-117 plugins just
+             * support major and minor version, newer plugins have
+             * complete semantic version data.
+             */
+            SemanticVersion   GetVersion();
 
 };
 

--- a/include/semantic_vers.h
+++ b/include/semantic_vers.h
@@ -1,0 +1,77 @@
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ *
+ ***************************************************************************
+ *   Copyright (C) 2019 Alec Leamas                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ */
+
+#ifndef SEMANTIC_VERSION_H_GUARD
+#define SEMANTIC_VERSION_H_GUARD
+
+#include "config.h"
+#include <sstream>
+
+#undef major                // walk around gnu's major() and minor() macros.
+#undef minor
+
+
+/**
+ * Versions are simplified semantic versioning: major.minor.revision-tag+build
+ * for example 1.2.6+1-alfa+deadbee. The values major, minor and revision should
+ * be integers. The tag is a pre-release marker, the build is build info.
+ *
+ * Parsing and comparing follows the spec besides the pre-release tag which 
+ * is sorted strictly lexically (no dotted parts support).
+ *
+ * See: https://semver.org/
+ */
+struct SemanticVersion
+{
+    int major;
+    int minor;
+    int patch;
+    std::string pre;    // Pre-release tag like alfa
+    std::string build;  // Build info
+
+    /** Construct a "0.0.0" version. */ 
+    SemanticVersion();
+
+    /** Parse a version string, sets major == -1 on errors. */
+    SemanticVersion(std::string version_release);
+
+    SemanticVersion(int major, int minor, int rev = 0,
+                    std::string pre = "",  std::string build = "");
+
+    bool operator <  (const SemanticVersion& other);
+    bool operator == (const SemanticVersion& other);
+    bool operator >  (const SemanticVersion& other);
+    bool operator <= (const SemanticVersion& other);
+    bool operator >= (const SemanticVersion& other);
+    bool operator != (const SemanticVersion& other);
+
+    /** Return printable representation. */
+    std::string to_string();
+};
+
+/** Dump version string. */
+std::ostream& operator << (std::ostream& s, const SemanticVersion& v);
+
+
+#endif  // SEMANTIC_VERSION_H_GUARD

--- a/include/semantic_vers.h
+++ b/include/semantic_vers.h
@@ -38,7 +38,7 @@
  * be integers. The tag is a pre-release marker, the build is build info.
  *
  * Parsing and comparing follows the spec besides the pre-release tag which 
- * is sorted strictly lexically (no dotted parts support).
+ * is sorted strictly lexically (no dotted parts or numeric ordering support).
  *
  * See: https://semver.org/
  */

--- a/include/semantic_vers.h
+++ b/include/semantic_vers.h
@@ -53,15 +53,12 @@ struct SemanticVersion
     int major;
     int minor;
     int patch;
-    int post;           // Post-release number e. g., at downstream.
+    int post;           // Post-release number e. g., downstream packaging.
     std::string pre;    // Pre-release tag like alfa.
     std::string build;  // Build info
 
-    /** Construct a "0.0.0" version. */
+    /** Construct a "0.0.0.0" version. */
     SemanticVersion();
-
-    /** Parse a version string, sets major == -1 on errors. */
-    SemanticVersion(std::string version_release);
 
     SemanticVersion(int major, int minor, int rev = 0, int post = 0,
                     std::string pre = "",  std::string build = "");
@@ -75,6 +72,9 @@ struct SemanticVersion
 
     /** Return printable representation. */
     std::string to_string();
+
+    /** Parse a version string, sets major == -1 on errors. */
+    static SemanticVersion parse(std::string s);
 };
 
 /** Dump version string. */

--- a/include/semantic_vers.h
+++ b/include/semantic_vers.h
@@ -33,12 +33,18 @@
 
 
 /**
- * Versions are simplified semantic versioning: major.minor.revision-tag+build
- * for example 1.2.6+1-alfa+deadbee. The values major, minor and revision should
- * be integers. The tag is a pre-release marker, the build is build info.
+ * Versions uses a modified semantic versioning scheme:
+ * major.minor.revision.post-tag+build.
+ * for example 1.2.6.1-alfa+deadbee. The values major, minor, revision
+ * and post should be integers. The tag is a pre-release marker, the build
+ * part is build info.
  *
- * Parsing and comparing follows the spec besides the pre-release tag which 
- * is sorted strictly lexically (no dotted parts or numeric ordering support).
+ * Parsing and comparing follows the spec besides
+ *   -  the pre-release tag which is sorted strictly lexically
+ *      (no dotted parts or numeric ordering support).
+ *
+ *   -  The post part which is post-release number, typically used in
+ *      downstream releases.
  *
  * See: https://semver.org/
  */
@@ -47,16 +53,17 @@ struct SemanticVersion
     int major;
     int minor;
     int patch;
-    std::string pre;    // Pre-release tag like alfa
+    int post;           // Post-release number e. g., at downstream.
+    std::string pre;    // Pre-release tag like alfa.
     std::string build;  // Build info
 
-    /** Construct a "0.0.0" version. */ 
+    /** Construct a "0.0.0" version. */
     SemanticVersion();
 
     /** Parse a version string, sets major == -1 on errors. */
     SemanticVersion(std::string version_release);
 
-    SemanticVersion(int major, int minor, int rev = 0,
+    SemanticVersion(int major, int minor, int rev = 0, int post = 0,
                     std::string pre = "",  std::string build = "");
 
     bool operator <  (const SemanticVersion& other);

--- a/src/AboutFrame.cpp
+++ b/src/AboutFrame.cpp
@@ -4,8 +4,10 @@
 //
 // PLEASE DO *NOT* EDIT THIS FILE!
 ///////////////////////////////////////////////////////////////////////////
+#include <sstream>
 
 #include "AboutFrame.h"
+#include "ocpn_plugin.h"
 
 ///////////////////////////////////////////////////////////////////////////
 
@@ -127,9 +129,14 @@ AboutFrame::AboutFrame( wxWindow* parent, wxWindowID id, const wxString& title, 
 
 	bSizerIniFile->Add( m_hyperlinkIniFile, 0, wxALL, 5 );
 
-
 	bSizerAbout->Add( bSizerIniFile, 1, wxEXPAND, 5 );
 
+	auto bApiInfo = new wxBoxSizer( wxHORIZONTAL );
+	std::ostringstream api_os;
+	api_os << _("Plugin API: ") << API_VERSION_MAJOR * 100 + API_VERSION_MINOR;
+	auto API_info = new wxStaticText( m_scrolledWindowAbout, wxID_ANY, api_os.str() );
+	bApiInfo->Add(API_info, 0, wxALL, 5 );
+	bSizerAbout->Add( bApiInfo, 1, wxEXPAND, 5 );
 
 	m_scrolledWindowAbout->SetSizer( bSizerAbout );
 	m_scrolledWindowAbout->Layout();

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -310,6 +310,7 @@ SemanticVersion PlugInContainer::GetVersion()
         return SemanticVersion(plugin_117->GetPlugInVersionMajor(),
                                plugin_117->GetPlugInVersionMinor(),
                                plugin_117->GetPlugInVersionPatch(),
+                               plugin_117->GetPlugInVersionPost(),
                                plugin_117->GetPlugInVersionPre(),
                                plugin_117->GetPlugInVersionBuild());
     }
@@ -4109,6 +4110,8 @@ opencpn_plugin_117::opencpn_plugin_117(void *pmgr)
 {}
 
 int opencpn_plugin_117::GetPlugInVersionPatch() { return 0; };
+
+int opencpn_plugin_117::GetPlugInVersionPost() { return 0; };
 
 const char* opencpn_plugin_117::GetPlugInVersionPre() { return ""; };
 

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -50,6 +50,11 @@
 #include <fcntl.h>
 #include <errno.h>
 
+#include <cstdio>
+#include <string>
+#include <sstream>
+#include <iostream>
+
 #ifdef ocpnUSE_SVG
 #include <wxSVG/svg.h>
 #endif // ocpnUSE_SVG
@@ -4365,6 +4370,8 @@ void PluginPanel::OnPluginSelected( wxMouseEvent &event )
 void PluginPanel::SetSelected( bool selected )
 {
     m_bSelected = selected;
+    std::ostringstream version;
+    version << m_pPlugin->GetVersion();
     if (selected)
     {
         SetBackgroundColour(GetGlobalColor(_T("DILG1")));
@@ -4376,6 +4383,9 @@ void PluginPanel::SetSelected( bool selected )
         // Some Android devices (e.g. Kyocera) have trouble with  wxBitmapButton...
         m_pButtonsUpDown->Show(false);
 #endif        
+        std::ostringstream os(m_pVersion->GetLabel().ToStdString());
+        version <<  _(" -- requires API version ")  << m_pPlugin->m_api_version;
+        m_pVersion->SetLabel(version.str());
         Layout();
         //FitInside();
     }
@@ -4389,6 +4399,7 @@ void PluginPanel::SetSelected( bool selected )
         m_pButtons->Show(true);
 #endif        
         m_pButtonsUpDown->Show(false);
+        m_pVersion->SetLabel(version.str());
         Layout();
         //FitInside();
     }

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -4312,8 +4312,8 @@ PluginPanel::PluginPanel(PluginListPanel *parent, wxWindowID id, const wxPoint &
     font.SetWeight(wxFONTWEIGHT_BOLD);
     m_pName->SetFont(font);
     itemBoxSizer03->Add(m_pName, 0, wxEXPAND|wxALL, 5);
-    m_pVersion = new wxStaticText( this, wxID_ANY,
-                                   wxString::Format(_T("%d.%d"), m_pPlugin->m_version_major, m_pPlugin->m_version_minor) );
+
+    m_pVersion = new wxStaticText( this, wxID_ANY, p_plugin->GetVersion().to_string() );
     itemBoxSizer03->Add(m_pVersion, 0, wxEXPAND|wxALL, 5);
     m_pVersion->Connect(wxEVT_LEFT_DOWN, wxMouseEventHandler( PluginPanel::OnPluginSelected ), NULL, this);
     m_pDescription = new wxStaticText( this, wxID_ANY, m_pPlugin->m_short_description );

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -50,6 +50,7 @@
 #include <fcntl.h>
 #include <errno.h>
 
+#include <algorithm>
 #include <cstdio>
 #include <string>
 #include <sstream>

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -4373,8 +4373,7 @@ void PluginPanel::SetSelected( bool selected )
     m_bSelected = selected;
     std::ostringstream version;
     version << m_pPlugin->GetVersion();
-    if (selected)
-    {
+    if (selected) {
         SetBackgroundColour(GetGlobalColor(_T("DILG1")));
         m_pDescription->SetLabel( m_pPlugin->m_long_description );
         m_pButtons->Show(true);
@@ -4386,12 +4385,8 @@ void PluginPanel::SetSelected( bool selected )
 #endif        
         std::ostringstream os(m_pVersion->GetLabel().ToStdString());
         version <<  _(" -- requires API version ")  << m_pPlugin->m_api_version;
-        m_pVersion->SetLabel(version.str());
-        Layout();
-        //FitInside();
     }
-    else
-    {
+    else {
         SetBackgroundColour(GetGlobalColor(_T("DILG0")));
         m_pDescription->SetLabel( m_pPlugin->m_short_description );
 #ifndef __WXQT__
@@ -4406,6 +4401,11 @@ void PluginPanel::SetSelected( bool selected )
     }
     Refresh(true);
     
+    m_pButtons->Show(selected);   // FIXME: Check show button logic
+    m_pButtonsUpDown->Show(selected);
+    m_pVersion->SetLabel(version.str());
+    Layout();
+    //FitInside();
 #ifdef __WXOSX__
     if( wxPlatformInfo::Get().CheckOSVersion(10, 14) ) {
         wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -297,6 +297,22 @@ ViewPort CreateCompatibleViewport( const PlugIn_ViewPort &pivp)
     return vp;
 }
 
+SemanticVersion PlugInContainer::GetVersion() 
+{
+    auto plugin_117 = dynamic_cast<opencpn_plugin_117*>(m_pplugin);
+    if (plugin_117) {
+        return SemanticVersion(plugin_117->GetPlugInVersionMajor(),
+                               plugin_117->GetPlugInVersionMinor(),
+                               plugin_117->GetPlugInVersionPatch(),
+                               plugin_117->GetPlugInVersionPre(),
+                               plugin_117->GetPlugInVersionBuild());
+    }
+    else {
+        return SemanticVersion(m_pplugin->GetAPIVersionMajor(),
+                               m_pplugin->GetAPIVersionMinor());
+    }
+
+}
 
 //------------------------------------------------------------------------------
 //    NMEA Event Implementation
@@ -4080,6 +4096,18 @@ void opencpn_plugin_116::PrepareContextMenu( int canvasIndex)
 {
     return;
 }
+
+//    Opencpn_Plugin_117 Implementation
+opencpn_plugin_117::opencpn_plugin_117(void *pmgr)
+    :opencpn_plugin_116(pmgr)
+{}
+
+int opencpn_plugin_117::GetPlugInVersionPatch() { return 0; };
+
+const char* opencpn_plugin_117::GetPlugInVersionPre() { return ""; };
+
+const char* opencpn_plugin_117::GetPlugInVersionBuild() { return ""; };
+
 
 //          Helper and interface classes
 

--- a/src/semantic_vers.cpp
+++ b/src/semantic_vers.cpp
@@ -36,7 +36,7 @@
 #undef minor
 
 SemanticVersion::SemanticVersion()
-    :major(0), minor(0), patch(0), pre(""), build("")
+    :major(0), minor(0), patch(0), post(0), pre(""), build("")
 {}
 
 
@@ -54,19 +54,20 @@ SemanticVersion::SemanticVersion(std::string s)
         pre = s.substr(pos + 1);
         s = s.substr(0, pos);
     }
-    int r = sscanf(s.c_str(), "%d.%d.%d", &major, &minor, &patch);
+    int r = sscanf(s.c_str(), "%d.%d.%d.%d", &major, &minor, &patch, &post);
     if (r < 2) {
         major = -1;
     }
 }
 
 
-SemanticVersion::SemanticVersion(
-    int major, int minor, int patch, std::string pre, std::string build)
+SemanticVersion::SemanticVersion(int major, int minor, int patch, int post,
+                                 std::string pre, std::string build)
 {
     this->major = major;
     this->minor = minor;
     this->patch = patch;
+    this->post = post;
     this->pre = pre;
     this->build = build;
 }
@@ -76,6 +77,7 @@ bool SemanticVersion::operator < (const SemanticVersion& other)
     if (major != other.major) return major < other.major;
     if (minor != other.minor) return minor < other.minor;
     if (patch != other.patch) return patch < other.patch;
+    if (post != other.post) return post < other.post;
     return pre < other.pre;
 }
 
@@ -84,6 +86,7 @@ bool SemanticVersion::operator == (const SemanticVersion& other)
     return major == other.major
         && minor == other.minor
         && patch == other.patch
+        && post == other.post
         && pre == other.pre;
 }
 
@@ -110,6 +113,9 @@ bool SemanticVersion::operator != (const SemanticVersion& other)
 std::ostream& operator << (std::ostream& s, const SemanticVersion& v)
 {
     s << v.major << '.' << v.minor << '.' << v.patch;
+    if (v.post != 0) {
+        s << '.' << v.post;
+    }
     if (v.pre != "" ) { 
         s << '-' << v.pre;
     }

--- a/src/semantic_vers.cpp
+++ b/src/semantic_vers.cpp
@@ -44,7 +44,7 @@ SemanticVersion::SemanticVersion(std::string s)
     :SemanticVersion()
 {
     using namespace std;
-    int pos = s.find('+');
+    size_t pos = s.find('+');
     if (pos != string::npos) {
         build = s.substr(pos + 1);
         s = s.substr(0, pos);

--- a/src/semantic_vers.cpp
+++ b/src/semantic_vers.cpp
@@ -1,0 +1,133 @@
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ *
+ ***************************************************************************
+ *   Copyright (C) 2019 Alec Leamas                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ */
+
+
+#include "config.h"
+
+#include <cstdio>
+#include <string>
+#include <sstream>
+
+#include "semantic_vers.h"
+
+#undef major                // walk around gnu's major() and minor() macros.
+#undef minor
+
+SemanticVersion::SemanticVersion()
+    :major(0), minor(0), patch(0), pre(""), build("")
+{}
+
+
+SemanticVersion::SemanticVersion(std::string s)
+    :SemanticVersion()
+{
+    using namespace std;
+    int pos = s.find('+');
+    if (pos != string::npos) {
+        build = s.substr(pos + 1);
+        s = s.substr(0, pos);
+    }
+    pos = s.find('-');
+    if (pos != string::npos) {
+        pre = s.substr(pos + 1);
+        s = s.substr(0, pos);
+    }
+    int r = sscanf(s.c_str(), "%d.%d.%d", &major, &minor, &patch);
+    if (r < 2) {
+        major = -1;
+    }
+}
+
+
+SemanticVersion::SemanticVersion(
+    int major, int minor, int patch, std::string pre, std::string build)
+{
+    this->major = major;
+    this->minor = minor;
+    this->patch = patch;
+    this->pre = pre;
+    this->build = build;
+}
+
+bool SemanticVersion::operator < (const SemanticVersion& other)
+{
+    if (major < other.major) return true;
+    if (major > other.major) return false;
+    if (minor < other.minor) return true;
+    if (minor > other.minor) return false;
+    if (patch < other.patch) return true;
+    if (patch > other.patch) return false;
+    int len = std::min(pre.length(), other.pre.length());
+    if (pre.substr(0, len) != other.pre.substr(0, len)) {
+        return pre.substr(0, len) < other.pre.substr(0, len);
+    }
+    return pre.length() > other.pre.length();
+}
+
+bool SemanticVersion::operator == (const SemanticVersion& other)
+{
+    return major == other.major
+        && minor == other.minor
+        && patch == other.patch
+        && pre == other.pre;
+}
+
+bool SemanticVersion::operator > (const SemanticVersion& other)
+{
+    return !(*this == other) && !(*this < other);
+}
+
+bool SemanticVersion::operator <= (const SemanticVersion& other)
+{
+    return (*this == other) || (*this < other);
+}
+
+bool SemanticVersion::operator >= (const SemanticVersion& other)
+{
+    return (*this == other) || (*this > other);
+}
+
+bool SemanticVersion::operator != (const SemanticVersion& other)
+{
+    return !(*this == other);
+}
+
+std::ostream& operator << (std::ostream& s, const SemanticVersion& v)
+{
+    s << v.major << '.' << v.minor << '.' << v.patch;
+    if (v.pre != "" ) { 
+        s << '-' << v.pre;
+    }
+    if (v.build != "" ) { 
+        s << '+' << v.build;
+    }
+    return s;
+}
+
+std::string SemanticVersion::to_string()
+{
+    std::ostringstream os;
+    os << *this;
+    return os.str();
+}

--- a/src/semantic_vers.cpp
+++ b/src/semantic_vers.cpp
@@ -73,17 +73,11 @@ SemanticVersion::SemanticVersion(
 
 bool SemanticVersion::operator < (const SemanticVersion& other)
 {
-    if (major < other.major) return true;
-    if (major > other.major) return false;
-    if (minor < other.minor) return true;
-    if (minor > other.minor) return false;
-    if (patch < other.patch) return true;
-    if (patch > other.patch) return false;
-    int len = std::min(pre.length(), other.pre.length());
-    if (pre.substr(0, len) != other.pre.substr(0, len)) {
-        return pre.substr(0, len) < other.pre.substr(0, len);
-    }
-    return pre.length() > other.pre.length();
+    if (major != other.major) return major < other.major;
+    if (minor != other.minor) return minor < other.minor;
+    if (patch != other.patch) return patch < other.patch;
+    if (pre != other.pre) return pre < other.pre;
+    return false;
 }
 
 bool SemanticVersion::operator == (const SemanticVersion& other)

--- a/src/semantic_vers.cpp
+++ b/src/semantic_vers.cpp
@@ -35,30 +35,33 @@
 #undef major                // walk around gnu's major() and minor() macros.
 #undef minor
 
-SemanticVersion::SemanticVersion()
-    :major(0), minor(0), patch(0), post(0), pre(""), build("")
-{}
-
-
-SemanticVersion::SemanticVersion(std::string s)
-    :SemanticVersion()
+SemanticVersion SemanticVersion::parse(std::string s)
 {
     using namespace std;
+
+    SemanticVersion vers;
     size_t pos = s.find('+');
     if (pos != string::npos) {
-        build = s.substr(pos + 1);
+        vers.build = s.substr(pos + 1);
         s = s.substr(0, pos);
     }
     pos = s.find('-');
     if (pos != string::npos) {
-        pre = s.substr(pos + 1);
+        vers.pre = s.substr(pos + 1);
         s = s.substr(0, pos);
     }
-    int r = sscanf(s.c_str(), "%d.%d.%d.%d", &major, &minor, &patch, &post);
+    int r = sscanf(s.c_str(), "%d.%d.%d.%d",
+                   &vers.major, &vers.minor, &vers.patch, &vers.post);
     if (r < 2) {
-        major = -1;
+        vers.major = -1;
     }
+    return vers;
 }
+
+
+SemanticVersion::SemanticVersion()
+    :major(0), minor(0), patch(0), post(0), pre(""), build("")
+{}
 
 
 SemanticVersion::SemanticVersion(int major, int minor, int patch, int post,

--- a/src/semantic_vers.cpp
+++ b/src/semantic_vers.cpp
@@ -76,8 +76,7 @@ bool SemanticVersion::operator < (const SemanticVersion& other)
     if (major != other.major) return major < other.major;
     if (minor != other.minor) return minor < other.minor;
     if (patch != other.patch) return patch < other.patch;
-    if (pre != other.pre) return pre < other.pre;
-    return false;
+    return pre < other.pre;
 }
 
 bool SemanticVersion::operator == (const SemanticVersion& other)

--- a/src/semantic_vers.cpp
+++ b/src/semantic_vers.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 
+#include <algorithm>
 #include <cstdio>
 #include <string>
 #include <sstream>

--- a/src/testvers.cpp
+++ b/src/testvers.cpp
@@ -1,0 +1,31 @@
+#include "semantic_vers.h"
+#include <iostream>
+
+// c++   -I../include -I../build/include  testvers.cpp semantic_vers.cpp
+// a.out 1.4.6 7.8.9+deadbee
+
+
+int main(int argc, char** argv) 
+{
+    SemanticVersion v1;
+    SemanticVersion v2;
+    if (argc > 1) {
+        SemanticVersion tmp(argv[1]);
+        v1 = tmp;
+        std::cout << "First version: " << v1 << "\n";
+    }
+    if (argc > 2) {
+        SemanticVersion tmp(argv[2]);
+        v2 = tmp;
+        std::cout << "Second version: " << v2 << "\n";
+    }
+    else {
+        exit(0);
+    }
+    std::cout << "1 > 2" << " " << ( v1 > v2 ? "True" : "False") << "\n";
+    std::cout << "1 < 2" << " " << ( v1 < v2 ? "True" : "False") << "\n";
+    std::cout << "1 == 2" << " " << ( v1 == v2 ? "True" : "False") << "\n";
+    std::cout << "1 != 2" << " " << ( v1 != v2 ? "True" : "False") << "\n";
+    std::cout << "1 <= 2" << " " << ( v1 <= v2 ? "True" : "False") << "\n";
+    std::cout << "1 >= 2" << " " << ( v1 >= v2 ? "True" : "False") << "\n";
+}

--- a/src/testvers.cpp
+++ b/src/testvers.cpp
@@ -10,12 +10,12 @@ int main(int argc, char** argv)
     SemanticVersion v1;
     SemanticVersion v2;
     if (argc > 1) {
-        SemanticVersion tmp(argv[1]);
+        auto tmp = SemanticVersion::parse(argv[1]);
         v1 = tmp;
         std::cout << "First version: " << v1 << "\n";
     }
     if (argc > 2) {
-        SemanticVersion tmp(argv[2]);
+        auto tmp = SemanticVersion::parse(argv[2]);
         v2 = tmp;
         std::cout << "Second version: " << v2 << "\n";
     }


### PR DESCRIPTION
Add some new attributes to the plugin API to establish a full plugin semantic version. Displays the complete plugin version and also makes the plugin API version visible in both Options | Plugins and About.

The PR closes #1443 and also handles IMHO still valid aspects of #1445.

This PR is not fully coordinated with #1457. Depending on which is merged first there is some rebasing to do.