### PR TITLE
Object query improvements

### DIFF
--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -5426,29 +5426,31 @@ wxString s57chart::CreateObjDescriptions( ListOfObjRazRules* rule_list )
                         ts.Empty();                        
                         if ( m ) ts =  wxDateTime::GetMonthName(dt.GetMonth());                        
                         if ( d ) ts.Append( wxString::Format(wxT(" %d"), dt.GetDay()) );
-                        if( dt.GetYear()>0 ) ts.Append( wxString::Format(wxT(",  %Y"), dt.GetYear() ) );
+                        if( dt.GetYear()>0 ) ts.Append( wxString::Format(wxT(",  %i"), dt.GetYear() ) );
                         if ( curAttrName == _T("PEREND")) ts = _("Period ends: ") + ts + wxT("  (")+ value + wxT(")");
-                        if ( curAttrName == _T("PERSTA")) ts = _("Period starts: ") + ts + wxT("  (")+ value + wxT(")"); 
+                        if ( curAttrName == _T("PERSTA")) ts = _("Period starts: ") + ts + wxT("  (")+ value + wxT(")");
+                        if ( curAttrName == _T("DATEND")) ts = _("Date ending: ") + ts + wxT("  (")+ value + wxT(")");
+                        if ( curAttrName == _T("DATSTA")) ts = _("Date starting: ") + ts + wxT("  (")+ value + wxT(")");
                         value= ts;
                     }    
                 }
-                if ( curAttrName == _T("TS_TSP")){
+                if ( curAttrName == _T("TS_TSP")){ //Tidal current applet
                     wxArrayString as;
-                    wxString ts;
+                    wxString ts, ts1;
                     wxStringTokenizer tk(value,  wxT(","));
-                    while ( tk.HasMoreTokens() )
-                        as.Add( tk.GetNextToken() );
-                    if (as.Count() > 14){
-                        ts= _T("Tidal Streams referred to<br>HW at <b>");
-                        ts.Append(as[1]).Append(_T("</b><br><table >"));
-                        size_t j=2;
-                        while( j < as.Count()-2 ){
-                            ts.Append(_T("<tr><td>")).Append( wxString::Format(wxT("%i"), (int)j/2 - 7)).Append(_T("</td><td>")).Append(as[j+1]).Append(_T("&#176</td><td>")).Append(as[j+2]).Append(_T("</td></tr>"));
-                            j=j+2;                        
-                        }
+                    ts = tk.GetNextToken(); //we don't show this part (the TT entry number)'
+                    ts1 = tk.GetNextToken(); //Now has the tidal reference port name'
+                    ts =  _T("Tidal Streams referred to<br><b>");
+                    ts.Append(tk.GetNextToken()).Append(_T("</b> at <b>")).Append(ts1);
+                    ts.Append(/*tk.GetNextToken()).Append(*/_T("</b><br><table >"))  ;
+                    int i = -6;
+                    while ( tk.HasMoreTokens() ){ // fill the current table
+                        ts.Append(_T("<tr><td>")).Append( wxString::Format(wxT("%i"),i)).Append(_T("</td><td>"))
+                            .Append(tk.GetNextToken()).Append(_T("&#176</td><td>")).Append(tk.GetNextToken()).Append(_T("</td></tr>")); 
+                        i++;
+                    }   
                         ts.Append(_T("</table>"));
                         value = ts;
-                    }
                 }
                     
                 if( isLight ) {

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -5404,7 +5404,34 @@ wxString s57chart::CreateObjDescriptions( ListOfObjRazRules* rule_list )
                             else
                                 value = value + _T("&nbsp;&nbsp;<font color=\"red\">[ ") + _("this file is not available") + _T(" ]</font>");
                         }
-                    }                    
+                    }
+                AttrNamesFiles = _T("DATEND,DATSTA,PEREND,PERSTA"); //AttrNames with date info
+                if ( AttrNamesFiles.Find( curAttrName) != wxNOT_FOUND ) {
+                    bool d = true;
+                    bool m = true;
+                    wxString ts = value;
+
+                    ts.Replace(wxT("--"),wxT("0000"));//make a valid year entry if not available
+                    if( ts.Length() < 5){ //(no month set)
+                        m = false;
+                        ts.Append(wxT("01") ); // so we add a fictive month to get a valid date
+                    }
+                    if( ts.Length() < 7){ //(no day set)
+                        d=false;
+                        ts.Append(wxT("01") ); // so we add a fictive day to get a valid date
+                    }
+                    wxString::const_iterator end;
+                    wxDateTime dt;
+                    if( dt.ParseFormat( ts, "%Y%m%d", &end ) ){
+                        ts.Empty();                        
+                        if ( m ) ts =  wxDateTime::GetMonthName(dt.GetMonth());                        
+                        if ( d ) ts.Append( wxString::Format(wxT(" %d"), dt.GetDay()) );
+                        if( dt.GetYear()>0 ) ts.Append( wxString::Format(wxT(",  %Y"), dt.GetYear() ) );
+                        if ( curAttrName == _T("PEREND")) ts = _("Period ends: ") + ts + wxT("  (")+ value + wxT(")");
+                        if ( curAttrName == _T("PERSTA")) ts = _("Period starts: ") + ts + wxT("  (")+ value + wxT(")"); 
+                        value= ts;
+                    }    
+                } 
                     
                 if( isLight ) {
                     assert( curLight != nullptr);

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -5431,7 +5431,25 @@ wxString s57chart::CreateObjDescriptions( ListOfObjRazRules* rule_list )
                         if ( curAttrName == _T("PERSTA")) ts = _("Period starts: ") + ts + wxT("  (")+ value + wxT(")"); 
                         value= ts;
                     }    
-                } 
+                }
+                if ( curAttrName == _T("TS_TSP")){
+                    wxArrayString as;
+                    wxString ts;
+                    wxStringTokenizer tk(value,  wxT(","));
+                    while ( tk.HasMoreTokens() )
+                        as.Add( tk.GetNextToken() );
+                    if (as.Count() > 14){
+                        ts= _T("Tidal Streams referred to<br>HW at <b>");
+                        ts.Append(as[1]).Append(_T("</b><br><table >"));
+                        size_t j=2;
+                        while( j < as.Count()-2 ){
+                            ts.Append(_T("<tr><td>")).Append( wxString::Format(wxT("%i"), (int)j/2 - 7)).Append(_T("</td><td>")).Append(as[j+1]).Append(_T("&#176</td><td>")).Append(as[j+2]).Append(_T("</td></tr>"));
+                            j=j+2;                        
+                        }
+                        ts.Append(_T("</table>"));
+                        value = ts;
+                    }
+                }
                     
                 if( isLight ) {
                     assert( curLight != nullptr);


### PR DESCRIPTION
Some extra eye candy in the Object query.
First a more readable date, and second a far more readable tidal stream panel.
In the pictures left as-is, and to the right as after the commit.
![Screenshot_20190926_175938](https://user-images.githubusercontent.com/2668258/65705556-fc06f800-e088-11e9-90ee-7358a10b20e1.png)
![Screenshot_20190926_175832](https://user-images.githubusercontent.com/2668258/65705559-fd382500-e088-11e9-9ef1-9cc5d376c21f.png)

