### PR TITLE
Increase precision on XTE. Add ZeroXTE() to pluginmanager

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -684,6 +684,8 @@ extern "C"  DECL_EXP bool AddLocaleCatalog( wxString catalog );
 
 extern "C"  DECL_EXP void PushNMEABuffer( wxString str );
 
+extern "C"  DECL_EXP void ZeroXTE();
+
 extern  DECL_EXP wxXmlDocument GetChartDatabaseEntryXML(int dbIndex, bool b_getGeom);
 
 extern  DECL_EXP bool UpdateChartDBInplace(wxArrayString dir_array,

--- a/libs/nmea0183/src/xte.cpp
+++ b/libs/nmea0183/src/xte.cpp
@@ -126,7 +126,16 @@ bool XTE::Write( SENTENCE& sentence )
 
    sentence += IsLoranBlinkOK;
    sentence += IsLoranCCycleLockOK;
-   sentence += CrossTrackErrorDistance;
+
+
+  // sentence += CrossTrackErrorDistance;
+  // use special version for XTE to increase precision
+   wxString temp_string;
+   temp_string.Printf(_T("%.5f"), CrossTrackErrorDistance);
+   sentence += temp_string;
+
+
+
 
    if(DirectionToSteer == Left)
        sentence += _T("L");

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -2869,6 +2869,12 @@ void PushNMEABuffer( wxString buf )
     g_pMUX->AddPendingEvent( event );
 }
 
+void ZeroXTE() {
+  if (g_pRouteMan){
+  g_pRouteMan->ZeroCurrentXTEToActivePoint();
+  }
+}
+
 wxXmlDocument GetChartDatabaseEntryXML(int dbIndex, bool b_getGeom)
 {
 


### PR DESCRIPTION
Needed for new route following plugin: AutoTrackRaymarine_pi

Remote control and following of complex routes for Raymarine Evolution pilots. Steering on XTE requires more precision than the current 3 decimals. (Re)Starting a route requires zero XTE for decent behavior.