### PR TITLE
Mingw build error fix (see #1469)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2287,8 +2287,9 @@ endif ()
 # Prepare CPACK configuration (MINGW)
 #
 if (MINGW)
-  set(CMD "sed -e 's|/TRIMLEFT||' -e '/!define NSIS_PACKEDVERSION/s/^;//' \
-    NSIS.template.in.in >build/NSIS.template.in")
+  set(
+    CMD "sed -e 's|/TRIMLEFT||' NSIS.template.in.in >build/NSIS.template.in"
+  )
   file(GENERATE OUTPUT ${CMAKE_BINARY_DIR}/fix-NSIS.sh CONTENT "${CMD}")
   add_custom_target(
     NSIS_config ALL

--- a/ci/travis-build-mingw.sh
+++ b/ci/travis-build-mingw.sh
@@ -16,16 +16,16 @@ echo "DOCKER_OPTS=\"-H tcp://127.0.0.1:2375 -H $DOCKER_SOCK -s devicemapper\"" \
     | sudo tee /etc/default/docker > /dev/null
 sudo service docker restart;
 sleep 5;
-sudo docker pull fedora:29;
+sudo docker pull fedora:30;
 
 docker run --privileged -d -ti -e "container=docker"  \
     -v /sys/fs/cgroup:/sys/fs/cgroup \
     -v $(pwd):/opencpn-ci:rw \
-    fedora:29   /usr/sbin/init
+    fedora:30   /usr/sbin/init
 DOCKER_CONTAINER_ID=$(docker ps | grep fedora | awk '{print $1}')
 docker logs $DOCKER_CONTAINER_ID
 docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -xec \
-    "bash -xe /opencpn-ci/ci/docker-build-mingw.sh 29;
+    "bash -xe /opencpn-ci/ci/docker-build-mingw.sh 30;
          echo -ne \"------\nEND OPENCPN-CI BUILD\n\";"
 docker ps -a
 docker stop $DOCKER_CONTAINER_ID

--- a/ci/travis-build-mingw.sh
+++ b/ci/travis-build-mingw.sh
@@ -16,16 +16,16 @@ echo "DOCKER_OPTS=\"-H tcp://127.0.0.1:2375 -H $DOCKER_SOCK -s devicemapper\"" \
     | sudo tee /etc/default/docker > /dev/null
 sudo service docker restart;
 sleep 5;
-sudo docker pull fedora:30;
+sudo docker pull fedora:31;
 
 docker run --privileged -d -ti -e "container=docker"  \
     -v /sys/fs/cgroup:/sys/fs/cgroup \
     -v $(pwd):/opencpn-ci:rw \
-    fedora:30   /usr/sbin/init
+    fedora:31   /usr/sbin/init
 DOCKER_CONTAINER_ID=$(docker ps | grep fedora | awk '{print $1}')
 docker logs $DOCKER_CONTAINER_ID
 docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -xec \
-    "bash -xe /opencpn-ci/ci/docker-build-mingw.sh 30;
+    "bash -xe /opencpn-ci/ci/docker-build-mingw.sh 31;
          echo -ne \"------\nEND OPENCPN-CI BUILD\n\";"
 docker ps -a
 docker stop $DOCKER_CONTAINER_ID

--- a/include/datastream.h
+++ b/include/datastream.h
@@ -32,6 +32,11 @@
 #ifndef __DATASTREAM_H__
 #define __DATASTREAM_H__
 
+#ifdef __MINGW32__
+#undef IPV6STRICT    // mingw FTBS fix:  missing struct ip_mreq
+#include <windows.h>
+#endif
+
 #include "wx/wxprec.h"
 
 #ifndef  WX_PRECOMP

--- a/include/options.h
+++ b/include/options.h
@@ -26,6 +26,11 @@
 #ifndef _OPTIONS_H_
 #define _OPTIONS_H_
 
+#ifdef __MINGW32__
+#undef IPV6STRICT    // mingw FTBS fix:  missing struct ip_mreq
+#include <windows.h>
+#endif
+
 #include <wx/listbook.h>
 #include <wx/dirctrl.h>
 #include <wx/spinctrl.h>

--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -22,6 +22,11 @@
  ***************************************************************************
  */
 
+#ifdef __MINGW32__
+#undef IPV6STRICT    // mingw FTBS fix:  missing struct ip_mreq
+#include <windows.h>
+#endif
+
 #include "wx/tokenzr.h"
 
 #include "SoundFactory.h"

--- a/src/ConfigMgr.cpp
+++ b/src/ConfigMgr.cpp
@@ -21,6 +21,11 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 
+#ifdef __MINGW32__
+#undef IPV6STRICT    // mingw FTBS fix:  missing struct ip_mreq
+#include <windows.h>
+#endif
+
 #include <wx/tokenzr.h>
 
 #include "config.h"

--- a/src/ConnectionParams.cpp
+++ b/src/ConnectionParams.cpp
@@ -21,6 +21,11 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 
+#ifdef __MINGW32__
+#undef IPV6STRICT    // mingw FTBS fix:  missing struct ip_mreq
+#include <windows.h>
+#endif
+
 #include <wx/tokenzr.h>
 #include <wx/intl.h>
 

--- a/src/DetailSlider.cpp
+++ b/src/DetailSlider.cpp
@@ -22,6 +22,11 @@
  ***************************************************************************
  */
 
+#ifdef __MINGW32__
+#undef IPV6STRICT    // mingw FTBS fix:  missing struct ip_mreq
+#include <windows.h>
+#endif
+
 #include "wx/wxprec.h"
 
 #include <wx/slider.h>

--- a/src/ais.cpp
+++ b/src/ais.cpp
@@ -24,6 +24,11 @@
  ***************************************************************************
  */
 
+#ifdef __MINGW32__
+#undef IPV6STRICT    // mingw FTBS fix:  missing struct ip_mreq
+#include <windows.h>
+#endif
+
 #include "wx/wx.h"
 #include "wx/tokenzr.h"
 #include "wx/datetime.h"

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -23,6 +23,12 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 #include <memory>
+
+#ifdef __MINGW32__
+#undef IPV6STRICT    // mingw FTBS fix:  missing struct ip_mreq
+#include <windows.h>
+#endif
+
 #include "wx/wxprec.h"
 
 #ifndef  WX_PRECOMP

--- a/src/datastream.cpp
+++ b/src/datastream.cpp
@@ -29,6 +29,13 @@
  ***************************************************************************
  *
  */
+
+#ifdef __MINGW32__
+#undef IPV6STRICT    // mingw FTBS fix:  missing struct ip_mreq
+#include <windows.h>
+#include <ws2tcpip.h>
+#endif
+
 #include "wx/wxprec.h"
 
 #ifndef  WX_PRECOMP

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -25,6 +25,11 @@
 
 #include "wx/wxprec.h"
 
+#ifdef __MINGW32__
+#undef IPV6STRICT    // mingw FTBS fix:  missing struct ip_mreq
+#include <windows.h>
+#endif
+
 #ifndef  WX_PRECOMP
 #include "wx/wx.h"
 #endif //precompiled headers

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -28,6 +28,11 @@
 #include <unistd.h>
 #endif
 
+#ifdef __MINGW32__
+#undef IPV6STRICT    // mingw FTBS fix:  missing struct ip_mreq
+#include <windows.h>
+#endif
+
 // For compilers that support precompilation, includes "wx/wx.h".
 #include "wx/wxprec.h"
 

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -25,6 +25,11 @@
 
 #include <config.h>
 
+#ifdef __MINGW32__
+#undef IPV6STRICT    // mingw FTBS fix:  missing struct ip_mreq
+#include <windows.h>
+#endif
+
 #include <typeinfo>
 #ifdef __linux__
 #include <wordexp.h>


### PR DESCRIPTION
Fixes mingw build errors as described in #1469, but in a slightly more long-term solution (f30)

F30 will be EOL around late spring -20. By then we need to have some kind of decision if/how the mingw builds should be used. It is possible to get a more long-term solution by moving to centos, but this will require rebuilding a lot of packages.