### PR TITLE
Correction for API116. Calling RenderOverlay() and RenderGLOverlay() …

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -138,6 +138,16 @@ class PlugIn_ViewPort
             bool     bValid;                 // This VP is valid
 };
 
+class Plugin_Active_Leg_Info
+{
+public:
+  double xte;               // Negative value means steer Left
+  double btw;
+  double dtw;
+  wxString wp_name;         // Name of destination waypoint for active leg
+  bool arrival;             // True when within arrival circle
+};
+
 class PlugIn_Position_Fix
 {
    public:
@@ -556,6 +566,14 @@ public:
     virtual bool RenderOverlayMultiCanvas(wxDC &dc, PlugIn_ViewPort *vp, int canvasIndex);
     virtual void PrepareContextMenu( int canvasIndex);
 
+};
+
+class DECL_EXP opencpn_plugin_117 : public opencpn_plugin_116
+{
+public:
+  opencpn_plugin_117(void *pmgr);
+  virtual ~opencpn_plugin_117();
+  virtual void SetActiveLegInfo(Plugin_Active_Leg_Info &leg_info);
 };
 
 //------------------------------------------------------------------
@@ -1336,5 +1354,9 @@ enum SDDMFORMAT
 };
 
 extern DECL_EXP int GetLatLonFormat(void);
+
+// API 1.17
+extern "C"  DECL_EXP void ZeroXTE();
+
 
 #endif //_PLUGIN_H_

--- a/include/ocpn_types.h
+++ b/include/ocpn_types.h
@@ -110,4 +110,13 @@ typedef struct {
     int    nSats;
 } GenericPosDatEx;
 
+//    A collection of active leg Data structure
+typedef struct {
+  double xte;               // Negative value means steer Left
+  double btw;
+  double dtw;
+  wxString wp_name;         // Name of destination waypoint for active leg;
+  bool arrival;
+} ActiveLegDat;
+
 #endif

--- a/include/pluginmanager.h
+++ b/include/pluginmanager.h
@@ -288,6 +288,7 @@ public:
 
       void SendNMEASentenceToAllPlugIns(const wxString &sentence);
       void SendPositionFixToAllPlugIns(GenericPosDatEx *ppos);
+      void SendActiveLegInfoToAllPlugIns(ActiveLegDat *infos);
       void SendAISSentenceToAllPlugIns(const wxString &sentence);
       void SendJSONMessageToAllPlugins(const wxString &message_id, wxJSONValue v);
       void SendMessageToAllPlugins(const wxString &message_id, const wxString &message_body);

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -642,6 +642,7 @@ bool PlugInManager::CallLateInit(void)
             case 114:
             case 115:
             case 116:
+            case 117:
                 if(pic->m_cap_flag & WANTS_LATE_INIT) {
                     wxString msg(_T("PlugInManager: Calling LateInit PlugIn: "));
                     msg += pic->m_plugin_file;
@@ -675,8 +676,9 @@ void PlugInManager::SendVectorChartObjectInfo(const wxString &chart, const wxStr
                 case 112:
                 case 113:
                 case 114:
-		case 115:
+                case 115:
                 case 116:
+                case 117:
                 {
                     opencpn_plugin_112 *ppi = dynamic_cast<opencpn_plugin_112 *>(pic->m_pplugin);
                     if(ppi)
@@ -1448,6 +1450,10 @@ PlugInContainer *PlugInManager::LoadPlugIn(wxString plugin_file)
     case 116:
         pic->m_pplugin = dynamic_cast<opencpn_plugin_116*>(plug_in);
         break;
+
+    case 117:
+      pic->m_pplugin = dynamic_cast<opencpn_plugin_117*>(plug_in);
+      break;
         
     default:
         break;
@@ -1521,6 +1527,7 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &v
                             break;
                         }
                         case 116:
+                        case 117:
                         {
                             opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                             if (ppi) {
@@ -1585,6 +1592,7 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &v
                             break;
                         }
                         case 116:
+                        case 117:
                         {
                             opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                             if (ppi) {
@@ -1658,6 +1666,7 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, cons
                         break;
                     }
                     case 116:
+                    case 117:
                     {
                         opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                         if (ppi) {
@@ -1695,7 +1704,8 @@ bool PlugInManager::SendMouseEventToPlugins( wxMouseEvent &event)
                     case 113:
                     case 114:
                     case 115:
-                    case 116:    
+                    case 116:
+                    case 117:
                     {
                         opencpn_plugin_112 *ppi = dynamic_cast<opencpn_plugin_112*>(pic->m_pplugin);
                         if(ppi)
@@ -1728,7 +1738,8 @@ bool PlugInManager::SendKeyEventToPlugins( wxKeyEvent &event)
                         case 113:
                         case 114:
                         case 115:
-                        case 116:    
+                        case 116:
+                        case 117:
                         {
                             opencpn_plugin_113 *ppi = dynamic_cast<opencpn_plugin_113*>(pic->m_pplugin);
                             if(ppi && ppi->KeyboardEventHook( event ))
@@ -1791,7 +1802,8 @@ void NotifySetupOptionsPlugin( PlugInContainer *pic )
             case 113:
             case 114:
             case 115:
-            case 116:    
+            case 116:
+            case 117:
             {
                 opencpn_plugin_19 *ppi = dynamic_cast<opencpn_plugin_19 *>(pic->m_pplugin);
                 if(ppi) {
@@ -1973,6 +1985,7 @@ void PlugInManager::SendMessageToAllPlugins(const wxString &message_id, const wx
                 case 114:
                 case 115:
                 case 116:
+                case 117:
                 {
                     opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                     if(ppi)
@@ -2000,6 +2013,48 @@ void PlugInManager::SendAISSentenceToAllPlugIns(const wxString &sentence)
                 pic->m_pplugin->SetAISSentence(decouple_sentence);
         }
     }
+}
+
+void PlugInManager::SendActiveLegInfoToAllPlugIns(ActiveLegDat *leg_info)
+{
+  Plugin_Active_Leg_Info leg;
+  leg.btw = leg_info->btw;
+  leg.dtw = leg_info->dtw;
+  leg.wp_name = leg_info->wp_name;
+  leg.xte = leg_info->xte;
+  leg.arrival = leg_info->arrival;
+  for (unsigned int i = 0; i < plugin_array.GetCount(); i++)
+  {
+    PlugInContainer *pic = plugin_array[i];
+    if (pic->m_bEnabled && pic->m_bInitState)
+    {
+      if (pic->m_cap_flag & WANTS_NMEA_EVENTS)
+      {
+        switch (pic->m_api_version)
+        {
+        case 108:
+        case 109:
+        case 110:
+        case 111:
+        case 112:
+        case 113:
+        case 114:
+        case 115:
+        case 116:
+          break;
+        case 117:
+        {
+          opencpn_plugin_117 *ppi = dynamic_cast<opencpn_plugin_117 *>(pic->m_pplugin);
+          if (ppi)
+            ppi->SetActiveLegInfo(leg);
+          break;
+        }
+        default:
+          break;
+        }
+      }
+    }
+  }
 }
 
 void PlugInManager::SendPositionFixToAllPlugIns(GenericPosDatEx *ppos)
@@ -2054,6 +2109,7 @@ void PlugInManager::SendPositionFixToAllPlugIns(GenericPosDatEx *ppos)
                 case 114:
                 case 115:
                 case 116:
+                case 117:
                 {
                     opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                     if(ppi)
@@ -2102,6 +2158,7 @@ void PlugInManager::PrepareAllPluginContextMenus()
                 switch(pic->m_api_version)
                 {
                     case 116:
+                    case 117:
                     {
                         opencpn_plugin_116 *ppi = dynamic_cast<opencpn_plugin_116 *>(pic->m_pplugin);
                         if(ppi)
@@ -3807,6 +3864,8 @@ PlugInManager created this base class");
 void opencpn_plugin::SetPositionFix(PlugIn_Position_Fix &pfix)
 {}
 
+
+
 void opencpn_plugin::SetNMEASentence(wxString &sentence)
 {}
 
@@ -4057,6 +4116,20 @@ bool opencpn_plugin_116::RenderOverlayMultiCanvas(wxDC &dc, PlugIn_ViewPort *vp,
 void opencpn_plugin_116::PrepareContextMenu( int canvasIndex)
 {
     return;
+}
+
+//    Opencpn_Plugin_117 Implementation
+opencpn_plugin_117::opencpn_plugin_117(void *pmgr)
+  : opencpn_plugin_116(pmgr)
+{
+}
+
+opencpn_plugin_117::~opencpn_plugin_117(void)
+{
+}
+
+void opencpn_plugin_117::SetActiveLegInfo(Plugin_Active_Leg_Info &leg_info)
+{
 }
 
 //          Helper and interface classes
@@ -6948,4 +7021,12 @@ int GetCanvasCount( )
 int GetLatLonFormat()
 {
     return g_iSDMMFormat;
+}
+
+/* API 1.17 */
+
+void ZeroXTE() {
+  if (g_pRouteMan) {
+    g_pRouteMan->ZeroCurrentXTEToActivePoint();
+  }
 }

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -1522,6 +1522,10 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &v
                         }
                         case 116:
                         {
+                            opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
+                            if (ppi) {
+                              ppi->RenderOverlay(*pdc, &pivp);
+                            }
                             opencpn_plugin_116 *ppi116 = dynamic_cast<opencpn_plugin_116 *>(pic->m_pplugin);
                             if (ppi116) 
                                 ppi116->RenderOverlayMultiCanvas(*pdc, &pivp, canvasIndex);
@@ -1582,6 +1586,10 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &v
                         }
                         case 116:
                         {
+                            opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
+                            if (ppi) {
+                                b_rendered = ppi->RenderOverlay(*pdc, &pivp);
+                            }
                             opencpn_plugin_116 *ppi116 = dynamic_cast<opencpn_plugin_116 *>(pic->m_pplugin);
                             if (ppi116) 
                                 b_rendered = ppi116->RenderOverlayMultiCanvas(*pdc, &pivp, g_canvasConfig);
@@ -1651,6 +1659,10 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, cons
                     }
                     case 116:
                     {
+                        opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
+                        if (ppi) {
+                            ppi->RenderGLOverlay(pcontext, &pivp);
+                        }
                         opencpn_plugin_116 *ppi116 = dynamic_cast<opencpn_plugin_116 *>(pic->m_pplugin);
                         if (ppi116) {
                             ppi116->RenderGLOverlayMultiCanvas(pcontext, &pivp, canvasIndex);

--- a/src/routeman.cpp
+++ b/src/routeman.cpp
@@ -628,6 +628,21 @@ bool Routeman::UpdateAutopilot()
    double r_Sog(0.0), r_Cog(0.0);
    if (!std::isnan(gSog)) r_Sog = gSog;
    if (!std::isnan(gCog)) r_Cog = gCog;
+
+   // Send active leg info directly to plugins with full precision
+
+   ActiveLegDat leg_info;
+   leg_info.btw = CurrentBrgToActivePoint;
+   leg_info.dtw = CurrentRngToActivePoint;
+   leg_info.xte = CurrentXTEToActivePoint;
+   if (XTEDir < 0) {
+     leg_info.xte = -leg_info.xte;    // direction to steer Left -> negative XTE
+   }
+   leg_info.wp_name = pActivePoint->GetName().Truncate(6);
+   leg_info.arrival = m_bArrival;
+
+   g_pi_manager->SendActiveLegInfoToAllPlugIns(&leg_info);
+
     //RMB
         {
 


### PR DESCRIPTION
In API116 RenderOverlay() and RenderGLOverlay() were replaced with RenderOverlayMultiCanvas() and RenderGLOverlayMultiCanvas(). However in API116 the original functions RenderOverlay() and RenderGLOverlay() were not called anymore. Until now this has not been an issue, users of API116 are using the MultiCanvas versions. This could be a problem. Therefore support of the original RenderOverlay() and RenderGLOverlay() should be continued in API116.