### PR TITLE
Fix for NMEA loop to resend to it self.

### DIFF
--- a/src/multiplexer.cpp
+++ b/src/multiplexer.cpp
@@ -330,7 +330,7 @@ void Multiplexer::OnEvtStream(OCPN_DataStreamEvent& event)
             {
                 DataStream* s = m_pdatastreams->Item(i);
                 if ( s->IsOk() ) {
-                    if((s->GetConnectionType() == SERIAL)  || (s->GetPort() != port)) {
+                    if((s->GetConnectionType() == SERIAL || s->GetConnectionType()==NETWORK)  && (s->GetPort() != port)) {
                         if ( s->GetIoSelect() == DS_TYPE_INPUT_OUTPUT || s->GetIoSelect() == DS_TYPE_OUTPUT ) {
                             bool bout_filter = true;
 


### PR DESCRIPTION
I have recently installed a NMEA hardware HUB in my boat. After some debugging I realized that O was sending back received sentences from the hardware HUB - starting an infinite loop. However, due to limited buffer sizes the NMEA bus survives but I really have problems with sentences that disappears. 

I did not have time to figure out the full potential of the Multiplexer in O but from my point of view this is not a good behavior. Suggest a correction to fix this problem and also enable Multiplexing to networks.

/fredrik
