### PR TITLE
Draw route points if they are visible in GL mode same as non GL

### DIFF
--- a/src/Route.cpp
+++ b/src/Route.cpp
@@ -472,9 +472,9 @@ void Route::DrawGLLines( ViewPort &vp, ocpnDC *dc, ChartCanvas *canvas )
 void Route::DrawGL( ViewPort &vp, ChartCanvas *canvas )
 {
 #ifdef ocpnUSE_GL
-    if( pRoutePointList->empty() || !m_bVisible ) return;
+    if( pRoutePointList->empty() ) return;
 
-    if(!vp.GetBBox().IntersectOut(GetBBox()))
+    if(!vp.GetBBox().IntersectOut(GetBBox()) && m_bVisible)
         DrawGLRouteLines(vp, canvas);
 
     /*  Route points  */


### PR DESCRIPTION
I got tired of adding all the patches to every PR just so the CI builds would complete without errors. This PR will build even though CI doesn't think so.