### PR TITLE
Add "center on boat" option

### DIFF
--- a/include/CanvasOptions.h
+++ b/include/CanvasOptions.h
@@ -83,6 +83,7 @@ private:
     wxScrolledWindow *m_sWindow;
     
     wxCheckBox *pShowStatusBar, *pShowMenuBar, *pShowChartBar, *pShowCompassWin;
+    wxCheckBox *pBoatCenterButton;
     wxCheckBox *pPrintShowIcon, *pCDOOutlines, *pSDepthUnits, *pSDisplayGrid;
     wxCheckBox *pAutoAnchorMark, *pCDOQuilting, *pCBRaster, *pCBVector;
     wxCheckBox *pCBCM93, *pCBLookAhead, *pSkewComp, *pOpenGL, *pSmoothPanZoom;

--- a/include/chart1.h
+++ b/include/chart1.h
@@ -109,6 +109,7 @@ enum
     ID_STKDN,
     ID_ROUTE,
     ID_FOLLOW,
+    ID_BCENTER,
     ID_SETTINGS,
     ID_AIS,
     ID_ENC_TEXT,

--- a/include/chcanv.h
+++ b/include/chcanv.h
@@ -212,6 +212,7 @@ public:
       void ClearbFollow(void);
       void SetbFollow(void);
       void TogglebFollow( void );
+      void CenterBoat(void);
       void JumpToPosition( double lat, double lon, double scale );
       void SetFirstAuto( bool b_auto ){m_bFirstAuto = b_auto; }
       

--- a/include/options.h
+++ b/include/options.h
@@ -370,6 +370,7 @@ class options : private Uncopyable,
   // For general options
   wxScrolledWindow *pDisplayPanel;
   wxCheckBox *pShowStatusBar, *pShowMenuBar, *pShowChartBar, *pShowCompassWin;
+  wxCheckBox *pBoatCenterButton;
   wxCheckBox *pPrintShowIcon, *pCDOOutlines, *pSDepthUnits, *pSDisplayGrid;
   wxCheckBox *pAutoAnchorMark, *pCDOQuilting, *pCBRaster, *pCBVector;
   wxCheckBox *pCBCM93, *pCBLookAhead, *pSkewComp, *pOpenGL, *pSmoothPanZoom;

--- a/src/ConfigMgr.cpp
+++ b/src/ConfigMgr.cpp
@@ -414,6 +414,7 @@ extern bool             g_bShowCurrent;
 extern bool             g_benableUDPNullHeader;
 extern bool             g_bShowMenuBar;
 extern bool             g_bShowCompassWin;
+extern bool             g_BoatCenterButton;
 
 extern wxString         g_uiStyle;
 extern bool             g_useMUI;
@@ -1030,6 +1031,7 @@ bool ConfigMgr::SaveTemplate( wxString fileName)
     
     conf->Write( _T ( "Fullscreen" ), g_bFullscreen );
     conf->Write( _T ( "ShowCompassWindow" ), g_bShowCompassWin );
+    conf->Write( _T ( "BoatCenterButton" ), g_BoatCenterButton );
     conf->Write( _T ( "SetSystemTime" ), s_bSetSystemTime );
     conf->Write( _T ( "ShowGrid" ), g_bDisplayGrid );
     conf->Write( _T ( "PlayShipsBells" ), g_bPlayShipsBells );
@@ -1522,6 +1524,7 @@ bool ConfigMgr::CheckTemplate( wxString fileName)
 #endif
     CHECK_INT( _T ( "Fullscreen" ), &g_bFullscreen );
     CHECK_INT( _T ( "ShowCompassWindow" ), &g_bShowCompassWin );
+    CHECK_INT( _T ( "BoatCenterButton" ), &g_BoatCenterButton );
     CHECK_INT( _T ( "PlayShipsBells" ), &g_bPlayShipsBells );
     CHECK_INT( _T ( "SoundDeviceIndex" ), &g_iSoundDeviceIndex );
     CHECK_INT( _T ( "FullscreenToolbar" ), &g_bFullscreenToolbar );

--- a/src/MUIBar.cpp
+++ b/src/MUIBar.cpp
@@ -60,6 +60,7 @@ extern OCPNPlatform              *g_Platform;
 extern bool                      g_bEffects;
 extern ChartCanvas               *g_focusCanvas;
 extern ocpnStyle::StyleManager*   g_StyleManager;
+extern bool			 g_BoatCenterButton;
 
 //  Helper utilities
 static wxBitmap LoadSVG( const wxString filename, unsigned int width, unsigned int height )
@@ -729,8 +730,9 @@ void MUIBar::OnToolLeftClick(  wxCommandEvent& event )
 
         case ID_FOLLOW:
         {
-            wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED, event.GetId());
-            GetParent()->GetEventHandler()->AddPendingEvent( evt );
+	    wxCommandEvent evt(wxEVT_COMMAND_MENU_SELECTED,
+		g_BoatCenterButton ? ID_BCENTER : ID_FOLLOW);
+	    GetParent()->GetEventHandler()->AddPendingEvent( evt );
 
             if(g_focusCanvas)
                 g_focusCanvas->TriggerDeferredFocus();

--- a/src/canvasMenu.cpp
+++ b/src/canvasMenu.cpp
@@ -128,6 +128,7 @@ extern RouteList        *pRouteList;
 extern wxString         g_default_wp_icon;
 extern bool              g_btouch;
 extern bool             g_bBasicMenus;
+extern bool             g_BoatCenterButton;
 
 
 
@@ -143,6 +144,8 @@ enum
     ID_DEF_MENU_MOVE_BOAT_HERE,
     ID_DEF_MENU_GOTO_HERE,
     ID_DEF_MENU_GOTOPOSITION,
+    ID_DEF_MENU_BCENTER,
+    ID_DEF_MENU_FOLLOW,
 
     ID_WP_MENU_GOTO,
     ID_WP_MENU_DELPOINT,
@@ -418,8 +421,11 @@ if( !g_bBasicMenus && (nChartStack > 1 ) ) {
     if( !g_bBasicMenus && (!( g_pRouteMan->GetpActiveRoute() || ( seltype & SELTYPE_MARKPOINT )) ) )
         MenuAppend1( contextMenu, ID_DEF_MENU_GOTO_HERE, _( "Navigate To Here" ) );
 
-    if( !g_bBasicMenus)
+    if( !g_bBasicMenus) {
         MenuAppend1( contextMenu, ID_DEF_MENU_GOTOPOSITION, _("Center view") + _T("...") );
+        MenuAppend1( contextMenu, ID_DEF_MENU_BCENTER, _("Center on boat") + ( g_BoatCenterButton ? _T(" (F2)") : _T("") ) );
+        MenuAppend1( contextMenu, ID_DEF_MENU_FOLLOW, (parent->m_bFollow ? _("Disable Follow") : _("Enable follow") ) + ( g_BoatCenterButton ? _T("") : _T(" (F2)") ) );
+    }
 
     if( !g_bBasicMenus){
         if( !parent->m_bCourseUp )
@@ -1086,6 +1092,14 @@ void CanvasMenuHandler::PopupMenuHandler( wxCommandEvent& event )
         pGoToPositionDialog->CheckPasteBufferForPosition();
         pGoToPositionDialog->Show();
         break;
+
+    case ID_DEF_MENU_BCENTER:
+	parent->CenterBoat();
+	break;
+
+    case ID_DEF_MENU_FOLLOW:
+	parent->TogglebFollow();
+	break;
 
     case ID_WP_MENU_DELPOINT: {
         if( m_pFoundRoutePoint == pAnchorWatchPoint1 ) {

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -697,6 +697,7 @@ float                     g_toolbar_scalefactor;
 float                     g_compass_scalefactor;
 bool                      g_bShowMenuBar;
 bool                      g_bShowCompassWin;
+bool                      g_BoatCenterButton;
 
 bool                      g_benable_rotate;
 

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -5327,6 +5327,7 @@ void MyFrame::SetbFollow( ChartCanvas *cc )
     cc->m_bFollow = true;
 
     cc->SetCanvasToolbarItemState( ID_FOLLOW, true );
+    cc->UpdateFollowButtonState();
     SetMenubarItemState( ID_MENU_NAV_FOLLOW, true );
     
     #ifdef __OCPN__ANDROID__
@@ -5351,6 +5352,7 @@ void MyFrame::ClearbFollow( ChartCanvas *cc )
     cc->m_bFollow = false;
     cc->SetCanvasToolbarItemState(ID_FOLLOW, false );
     SetMenubarItemState( ID_MENU_NAV_FOLLOW, false );
+    cc->UpdateFollowButtonState();
 
     DoChartUpdate();
     cc->ReloadVP();

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -278,6 +278,7 @@ extern int              g_own_ship_sog_cog_calc_damp_sec;
 
 extern bool             g_bShowMenuBar;
 extern bool             g_bShowCompassWin;
+extern bool             g_BoatCenterButton;
 
 #ifdef USE_S57
 extern s52plib          *ps52plib;
@@ -593,6 +594,7 @@ int MyConfig::LoadMyConfig()
     
     g_bShowStatusBar = 1;
     g_bShowCompassWin = 1;
+    g_BoatCenterButton = 0;
     g_iSoundDeviceIndex = -1;
     g_bFullscreenToolbar = 1;
     g_bTransparentToolbar =  0;
@@ -931,6 +933,7 @@ int MyConfig::LoadMyConfigRaw( bool bAsTemplate )
 #endif
     Read( _T ( "Fullscreen" ), &g_bFullscreen );
     Read( _T ( "ShowCompassWindow" ), &g_bShowCompassWin );
+    Read( _T ( "BoatCenterButton" ), &g_BoatCenterButton );
     Read( _T ( "ShowGrid" ), &g_bDisplayGrid );
     Read( _T ( "PlayShipsBells" ), &g_bPlayShipsBells );
     Read( _T ( "SoundDeviceIndex" ), &g_iSoundDeviceIndex );
@@ -2269,6 +2272,7 @@ void MyConfig::UpdateSettings()
     
     Write( _T ( "Fullscreen" ), g_bFullscreen );
     Write( _T ( "ShowCompassWindow" ), g_bShowCompassWin );
+    Write( _T ( "BoatCenterButton" ), g_BoatCenterButton );
     Write( _T ( "SetSystemTime" ), s_bSetSystemTime );
     Write( _T ( "ShowGrid" ), g_bDisplayGrid );
     Write( _T ( "PlayShipsBells" ), g_bPlayShipsBells );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -300,6 +300,7 @@ options* g_pOptions;
 
 extern bool g_bShowMenuBar;
 extern bool g_bShowCompassWin;
+extern bool g_BoatCenterButton;
 
 extern bool g_btouch;
 extern bool g_bresponsive;
@@ -1153,6 +1154,7 @@ void options::Init(void) {
   pShowStatusBar = NULL;
   pShowMenuBar = NULL;
   pShowCompassWin = NULL;
+  pBoatCenterButton = NULL;
   pSelCtl = NULL;
   pActiveChartsList = NULL;
   ps57CtlListBox = NULL;
@@ -5289,6 +5291,11 @@ void options::CreatePanel_UI(size_t parent, int border_size, int group_item_spac
   pShowCompassWin->SetValue(FALSE);
   miscOptions->Add(pShowCompassWin, 0, wxALL, border_size);
 
+  pBoatCenterButton = new wxCheckBox(itemPanelFont, wxID_ANY,
+                                   _("Boat button is center"));
+  pBoatCenterButton->SetValue(FALSE);
+  miscOptions->Add(pBoatCenterButton, 0, wxALL, border_size);
+
   wxBoxSizer* pToolbarAutoHide = new wxBoxSizer(wxHORIZONTAL);
   miscOptions->Add(pToolbarAutoHide, 0, wxALL | wxEXPAND, group_item_spacing);
 
@@ -5867,6 +5874,7 @@ void options::SetInitialSettings(void) {
     pShowMenuBar->SetValue(g_bShowMenuBar);
 #endif
     pShowCompassWin->SetValue(g_bShowCompassWin);
+    pBoatCenterButton->SetValue(g_BoatCenterButton);
   }
 
   s.Printf(_T("%d"), g_COGAvgSec);
@@ -6903,6 +6911,7 @@ void options::OnApplyClick(wxCommandEvent& event) {
     g_bShowMenuBar = pShowMenuBar->GetValue();
 #endif
     g_bShowCompassWin = pShowCompassWin->GetValue();
+    g_BoatCenterButton = pBoatCenterButton->GetValue();
   }
 
   g_bShowChartBar = pShowChartBar->GetValue();


### PR DESCRIPTION
I have few use of follow mode (on small hardware it slows down the interface and consumes more power, especialy on vector charts with lots of objects - slow enouth that it takes more than 2 seconds to update display and process events). So, on daily use I end up clicking twice on the follow icon, or hitting twice F2 to just center on boat, and never leave follow mode on. But other crew members are not aware of it (and the delay updating the screen eventually makes them click several times).
To make use easier I implemented an option which, when enabled, turn F2 and the follow button to a simple "center on boat" function. I also added entries to the right-click canvas menu so that follow mode can still be activated when needed, even if the option "center on boat" is activated.

I'll take care of the french translations when this is merged.

Also this fixes a bug: a missing UpdateFollowButtonState() call from the main menu "auto follow".