### PR TITLE
Add a "Lock North up" option.

### DIFF
--- a/include/CanvasOptions.h
+++ b/include/CanvasOptions.h
@@ -85,7 +85,7 @@ private:
     wxCheckBox *pShowStatusBar, *pShowMenuBar, *pShowChartBar, *pShowCompassWin;
     wxCheckBox *pPrintShowIcon, *pCDOOutlines, *pSDepthUnits, *pSDisplayGrid;
     wxCheckBox *pAutoAnchorMark, *pCDOQuilting, *pCBRaster, *pCBVector;
-    wxCheckBox *pCBCM93, *pCBLookAhead, *pSkewComp, *pOpenGL, *pSmoothPanZoom;
+    wxCheckBox *pCBCM93, *pCBLookAhead, *pSkewComp, *pNorthLock, *pOpenGL, *pSmoothPanZoom;
     wxCheckBox *pFullScreenQuilt, *pMobile, *pResponsive, *pOverzoomEmphasis;
     wxCheckBox *pOZScaleVector, *pToolbarAutoHideCB, *pInlandEcdis, *pDarkDecorations;
     wxTextCtrl *pCOGUPUpdateSecs, *m_pText_OSCOG_Predictor, *pScreenMM;

--- a/include/options.h
+++ b/include/options.h
@@ -196,7 +196,8 @@ enum {
   ID_SCREENCONFIG1,
   ID_SCREENCONFIG2,
   ID_CONFIGEDIT_OK,
-  ID_CONFIGEDIT_CANCEL
+  ID_CONFIGEDIT_CANCEL,
+  ID_NORTHLOCKBOX
 };
 
 /* Define an int bit field for dialog return value
@@ -372,7 +373,7 @@ class options : private Uncopyable,
   wxCheckBox *pShowStatusBar, *pShowMenuBar, *pShowChartBar, *pShowCompassWin;
   wxCheckBox *pPrintShowIcon, *pCDOOutlines, *pSDepthUnits, *pSDisplayGrid;
   wxCheckBox *pAutoAnchorMark, *pCDOQuilting, *pCBRaster, *pCBVector;
-  wxCheckBox *pCBCM93, *pCBLookAhead, *pSkewComp, *pOpenGL, *pSmoothPanZoom;
+  wxCheckBox *pCBCM93, *pCBLookAhead, *pSkewComp, *pNorthLock, *pOpenGL, *pSmoothPanZoom;
   wxCheckBox *pFullScreenQuilt, *pMobile, *pResponsive, *pOverzoomEmphasis;
   wxCheckBox *pOZScaleVector, *pToolbarAutoHideCB, *pInlandEcdis, *pDarkDecorations;
   wxTextCtrl *pCOGUPUpdateSecs, *m_pText_OSCOG_Predictor, *pScreenMM;

--- a/src/ConfigMgr.cpp
+++ b/src/ConfigMgr.cpp
@@ -129,6 +129,7 @@ extern bool             g_bPermanentMOBIcon;
 extern bool             g_bShowDepthUnits;
 extern bool             g_bAutoAnchorMark;
 extern bool             g_bskew_comp;
+extern bool             g_bnorth_lock;
 extern bool             g_bopengl;
 extern bool             g_bdisable_opengl;
 extern bool             g_bSoftwareGL;
@@ -1059,6 +1060,7 @@ bool ConfigMgr::SaveTemplate( wxString fileName)
     conf->Write( _T ( "ShowCM93DetailSlider" ), g_bShowDetailSlider );
     
     conf->Write( _T ( "SkewToNorthUp" ), g_bskew_comp );
+    conf->Write( _T ( "LockNorthUp" ), g_bnorth_lock );
     
     conf->Write( _T ( "ZoomDetailFactor" ), g_chart_zoom_modifier );
     conf->Write( _T ( "ZoomDetailFactorVector" ), g_chart_zoom_modifier_vector );
@@ -1461,6 +1463,7 @@ bool ConfigMgr::CheckTemplate( wxString fileName)
     CHECK_INT( _T ( "COGUPAvgSeconds" ), &g_COGAvgSec );
     //CHECK_INT( _T ( "LookAheadMode" ), &g_bLookAhead );
     //CHECK_INT( _T ( "SkewToNorthUp" ), &g_bskew_comp );
+    //CHECK_INT( _T ( "LockNorthUp" ), &g_bnorth_lock );
     CHECK_INT( _T ( "OpenGL" ), &g_bopengl );
     CHECK_INT( _T ( "SoftwareGL" ), &g_bSoftwareGL );
     

--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -219,6 +219,7 @@ extern double                   g_PlanSpeed;
 extern bool                     g_bFullScreenQuilt;
 extern bool                     g_bQuiltEnable;
 extern bool                     g_bskew_comp;
+extern bool                     g_bnorth_lock;
 
 extern bool                     g_bopengl;
 extern bool                     g_btouch;
@@ -982,6 +983,7 @@ void OCPNPlatform::SetDefaultOptions( void )
     g_bFullScreenQuilt = true;
     g_bQuiltEnable = true;
     g_bskew_comp = false;
+    g_bnorth_lock = false;
     g_bShowAreaNotices = false;
     g_bDrawAISSize = false;
     g_bShowAISName = false;

--- a/src/androidUTIL.cpp
+++ b/src/androidUTIL.cpp
@@ -90,6 +90,7 @@ extern bool             g_bShowOutlines;
 extern bool             g_bShowChartBar;
 extern bool             g_bShowDepthUnits;
 extern bool             g_bskew_comp;
+extern bool             g_bnorth_lock;
 extern bool             g_bopengl;
 extern bool             g_bsmoothpanzoom;
 extern bool             g_bShowMag;

--- a/src/canvasMenu.cpp
+++ b/src/canvasMenu.cpp
@@ -94,6 +94,7 @@ extern bool             g_bShowAreaNotices;
 extern bool             bGPSValid;
 extern Routeman         *g_pRouteMan;
 extern bool             g_bskew_comp;
+extern bool             g_bnorth_lock;
 extern double           gLat, gLon, gSog, gCog, vLat, vLon;
 extern MyFrame          *gFrame;
 extern ChartGroupArray  *g_pGroupArray;
@@ -421,7 +422,7 @@ if( !g_bBasicMenus && (nChartStack > 1 ) ) {
     if( !g_bBasicMenus)
         MenuAppend1( contextMenu, ID_DEF_MENU_GOTOPOSITION, _("Center view") + _T("...") );
 
-    if( !g_bBasicMenus){
+    if( !g_bBasicMenus && ! g_bnorth_lock){
         if( !parent->m_bCourseUp )
             MenuAppend1( contextMenu, ID_DEF_MENU_COGUP, _("Course Up Mode") );
         else {

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -472,6 +472,7 @@ int                       g_COGAvgSec = 15; // COG average period (sec.) for Cou
 double                    g_COGAvg;
 bool                      g_bLookAhead;
 bool                      g_bskew_comp;
+bool                      g_bnorth_lock;
 bool                      g_bopengl;
 bool                      g_bSoftwareGL;
 bool                      g_bShowFPS;
@@ -5618,6 +5619,8 @@ void MyFrame::UpdateGlobalMenuItems()
     m_pMenuBar->FindItem( ID_MENU_NAV_FOLLOW )->Check( GetPrimaryCanvas()->m_bFollow );
     m_pMenuBar->FindItem( ID_MENU_CHART_NORTHUP )->Check( !GetPrimaryCanvas()->m_bCourseUp );
     m_pMenuBar->FindItem( ID_MENU_CHART_COGUP )->Check( GetPrimaryCanvas()->m_bCourseUp );
+    m_pMenuBar->Enable( ID_MENU_CHART_NORTHUP, !g_bnorth_lock);
+    m_pMenuBar->Enable( ID_MENU_CHART_COGUP, !g_bnorth_lock);
     m_pMenuBar->FindItem( ID_MENU_NAV_TRACK )->Check( g_bTrackActive );
     m_pMenuBar->FindItem( ID_MENU_CHART_OUTLINES )->Check( g_bShowOutlines );
     m_pMenuBar->FindItem( ID_MENU_CHART_QUILTING )->Check( g_bQuiltEnable );
@@ -5673,6 +5676,8 @@ void MyFrame::UpdateGlobalMenuItems( ChartCanvas *cc)
     m_pMenuBar->FindItem( ID_MENU_NAV_FOLLOW )->Check( cc->m_bFollow );
     m_pMenuBar->FindItem( ID_MENU_CHART_NORTHUP )->Check( !cc->m_bCourseUp );
     m_pMenuBar->FindItem( ID_MENU_CHART_COGUP )->Check( cc->m_bCourseUp );
+    m_pMenuBar->Enable( ID_MENU_CHART_NORTHUP, !g_bnorth_lock);
+    m_pMenuBar->Enable( ID_MENU_CHART_COGUP, !g_bnorth_lock);
     m_pMenuBar->FindItem( ID_MENU_NAV_TRACK )->Check( g_bTrackActive );
     m_pMenuBar->FindItem( ID_MENU_CHART_OUTLINES )->Check( cc->GetShowOutlines() );
     m_pMenuBar->FindItem( ID_MENU_CHART_QUILTING )->Check( cc->GetQuiltMode() );
@@ -9419,6 +9424,8 @@ void MyFrame::applySettingsString( wxString settings)
         else if(token.StartsWith( _T("prefs_navmode"))){
             bool bPrevMode = g_bCourseUp;
             bool new_val = val.IsSameAs(_T("Course Up"));
+	    if ( g_bnorth_lock)
+		new_val = false;
             if(bPrevMode != new_val)
                 ToggleCourseUp(GetPrimaryCanvas());
         }

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -364,6 +364,8 @@ extern ChartCanvas      *g_overlayCanvas;
 extern float            g_toolbar_scalefactor;
 extern SENCThreadManager *g_SencThreadManager;
 
+extern bool             g_bnorth_lock;
+
 // "Curtain" mode parameters
 wxDialog                *g_pcurtain;
 
@@ -1081,7 +1083,8 @@ void ChartCanvas::ApplyCanvasConfig(canvasConfig *pcc)
     m_encShowBuoyLabels = pcc->bShowENCBuoyLabels;
     m_encShowLights = pcc->bShowENCLights;
     
-    m_bCourseUp = pcc->bCourseUp;
+    if (! g_bnorth_lock) 
+	    m_bCourseUp = pcc->bCourseUp;
     m_bLookAhead = pcc->bLookahead;
     
     m_singleChart = NULL;
@@ -3295,6 +3298,8 @@ void ChartCanvas::ToggleLookahead( )
 void ChartCanvas::ToggleCourseUp( )
 {
     m_bCourseUp = !m_bCourseUp;
+    if (g_bnorth_lock)
+	m_bCourseUp = false;
     
     if( m_bCourseUp ) {
         //    Stuff the COGAvg table in case COGUp is selected

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -142,6 +142,7 @@ extern bool             g_bPermanentMOBIcon;
 extern bool             g_bShowDepthUnits;
 extern bool             g_bAutoAnchorMark;
 extern bool             g_bskew_comp;
+extern bool             g_bnorth_lock;
 extern bool             g_bopengl;
 extern bool             g_bdisable_opengl;
 extern bool             g_bSoftwareGL;
@@ -860,6 +861,7 @@ int MyConfig::LoadMyConfigRaw( bool bAsTemplate )
     Read( _T ( "COGUPAvgSeconds" ), &g_COGAvgSec );
     Read( _T ( "LookAheadMode" ), &g_bLookAhead );
     Read( _T ( "SkewToNorthUp" ), &g_bskew_comp );
+    Read( _T ( "LockNorthUp" ), &g_bnorth_lock );
     
     Read( _T ( "ShowFPS" ), &g_bShowFPS );
     
@@ -2302,6 +2304,7 @@ void MyConfig::UpdateSettings()
     Write( _T ( "ShowCM93DetailSlider" ), g_bShowDetailSlider );
 
     Write( _T ( "SkewToNorthUp" ), g_bskew_comp );
+    Write( _T ( "LockNorthUp" ), g_bnorth_lock );
     Write( _T ( "OpenGL" ), g_bopengl );
     Write( _T ( "SoftwareGL" ), g_bSoftwareGL );
     Write( _T ( "ShowFPS" ), g_bShowFPS );

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -128,6 +128,7 @@ extern bool g_bShowOutlines;
 extern bool g_bShowChartBar;
 extern bool g_bShowDepthUnits;
 extern bool g_bskew_comp;
+extern bool g_bnorth_lock;
 extern bool g_bopengl;
 extern bool g_bsmoothpanzoom;
 extern bool g_bShowTrue, g_bShowMag;
@@ -3572,6 +3573,10 @@ void options::CreatePanel_Advanced(size_t parent, int border_size,
                                _("De-skew Raster Charts"));
     boxCharts->Add(pSkewComp, inputFlags);
 
+    pNorthLock = new wxCheckBox(m_ChartDisplayPage, ID_NORTHLOCKBOX,
+                               _("Lock North-up mode"));
+    boxCharts->Add(pNorthLock, inputFlags);
+
 //     pFullScreenQuilt = new wxCheckBox(m_ChartDisplayPage, ID_FULLSCREENQUILT,
 //                                       _("Disable Full Screen Quilting"));
 //     boxCharts->Add(pFullScreenQuilt, inputFlags);
@@ -3728,6 +3733,10 @@ void options::CreatePanel_Advanced(size_t parent, int border_size,
     pSkewComp = new wxCheckBox(m_ChartDisplayPage, ID_SKEWCOMPBOX,
                                _("Show Skewed Raster Charts as North-Up"));
     boxCharts->Add(pSkewComp, verticleInputFlags);
+
+    pNorthLock = new wxCheckBox(m_ChartDisplayPage, ID_NORTHLOCKBOX,
+                               _("Lock North-up mode"));
+    boxCharts->Add(pNorthLock, verticleInputFlags);
 
 //     pFullScreenQuilt = new wxCheckBox(m_ChartDisplayPage, ID_FULLSCREENQUILT,
 //                                       _("Disable Full Screen Quilting"));
@@ -5877,6 +5886,7 @@ void options::SetInitialSettings(void) {
 //  if(pFullScreenQuilt) pFullScreenQuilt->SetValue(!g_bFullScreenQuilt);
   if(pSDepthUnits) pSDepthUnits->SetValue(g_bShowDepthUnits);
   if(pSkewComp) pSkewComp->SetValue(g_bskew_comp);
+  if(pNorthLock) pNorthLock->SetValue(g_bnorth_lock);
   pMobile->SetValue(g_btouch);
   pResponsive->SetValue(g_bresponsive);
   //pOverzoomEmphasis->SetValue(!g_fog_overzoom);
@@ -7044,6 +7054,9 @@ void options::OnApplyClick(wxCommandEvent& event) {
 
   if(pSDepthUnits) g_bShowDepthUnits = pSDepthUnits->GetValue();
   g_bskew_comp = pSkewComp->GetValue();
+  g_bnorth_lock = pNorthLock->GetValue();
+  if (g_bnorth_lock)
+	gFrame->GetPrimaryCanvas()->ToggleCourseUp();
   g_btouch = pMobile->GetValue();
   g_bresponsive = pResponsive->GetValue();
   


### PR DESCRIPTION
Course up mode it computationally intensive on vector charts (maybe more than with raster ? I didn't try ...). On my (small) harware, this causes the interface to freese for several seconds and eventually cause NMEA messages to be lost (also, it makes it hard to
go back to north up mode).
I don't use course up, but ended in this mode accidentally by clicking the compass icon or
selecting the wrong menu entry (it's easy to do bad mouse actions in rough sailing conditions). Other crew members couldn't make sense of the display in course up, and I was quite confused too until I understood what happened.

So I added a "lock north up" option to disable all ways to turn on course up, especially the compass icon. I don't want to disable the compass/gps status windows because the GPS status is valuable information.

I'll take care of the french translations when this is merged.