### PR TITLE
Options AutoHide. Fix checkbox ID mix up

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -5282,7 +5282,7 @@ void options::CreatePanel_UI(size_t parent, int border_size, int group_item_spac
   wxBoxSizer* pToolbarAutoHide = new wxBoxSizer(wxHORIZONTAL);
   miscOptions->Add(pToolbarAutoHide, 0, wxALL | wxEXPAND, group_item_spacing);
 
-  pToolbarAutoHideCB = new wxCheckBox(itemPanelFont, ID_REPONSIVEBOX,
+  pToolbarAutoHideCB = new wxCheckBox(itemPanelFont, wxID_ANY,
                                       _("Enable Toolbar auto-hide"));
   pToolbarAutoHide->Add(pToolbarAutoHideCB, 0, wxALL, group_item_spacing);
 


### PR DESCRIPTION
I don't know when this bug was introduced. Saw it first time after today's master fetch:
The AutoHide checkbox was given an ID for no reason(?) and the ID was mixed up with another control and created the bug as of the shot below. (The "extra" autohide was not responsive)
![bild](https://user-images.githubusercontent.com/7202854/70422823-aaa5bc80-1a6c-11ea-8f9b-20bbe55c5407.png)
After fix:
![bild](https://user-images.githubusercontent.com/7202854/70422867-babd9c00-1a6c-11ea-9305-d22530be561c.png)

