### PR TITLE
Add active leg data functions to API117:

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -164,6 +164,16 @@ class PlugIn_Position_Fix_Ex
             int    nSats;
 };
 
+class Plugin_Active_Leg_Info
+{
+public:
+  double Xte;               // Left side of the track -> negative XTE
+  double Btw;
+  double Dtw;
+  wxString wp_name;         // Name of destination waypoint for active leg
+  bool arrival;             // True when within arrival circle
+};
+
 //    Describe AIS Alarm state
 enum plugin_ais_alarm_type
 {
@@ -575,6 +585,9 @@ public:
 
     /** Build version part  see GetPlugInVersionPatch(). */
     virtual const char* GetPlugInVersionBuild();
+
+    /*Provide active leg data to plugins*/
+    virtual void SetActiveLegInfo(Plugin_Active_Leg_Info &leg_info);
 };
 //------------------------------------------------------------------
 //      Route and Waypoint PlugIn support
@@ -1366,5 +1379,8 @@ enum SDDMFORMAT
 };
 
 extern DECL_EXP int GetLatLonFormat(void);
+
+// API 1.17
+extern "C"  DECL_EXP void ZeroXTE();
 
 #endif //_PLUGIN_H_

--- a/include/ocpn_types.h
+++ b/include/ocpn_types.h
@@ -110,4 +110,13 @@ typedef struct {
     int    nSats;
 } GenericPosDatEx;
 
+//    A collection of active leg Data structure
+typedef struct {
+  double Xte;               // Left side of the track -> negative XTE
+  double Btw;
+  double Dtw;
+  wxString wp_name;         // Name of destination waypoint for active leg;
+  bool arrival;
+} ActiveLegDat;
+
 #endif

--- a/include/pluginmanager.h
+++ b/include/pluginmanager.h
@@ -295,6 +295,7 @@ public:
 
       void SendNMEASentenceToAllPlugIns(const wxString &sentence);
       void SendPositionFixToAllPlugIns(GenericPosDatEx *ppos);
+      void SendActiveLegInfoToAllPlugIns(ActiveLegDat *infos);
       void SendAISSentenceToAllPlugIns(const wxString &sentence);
       void SendJSONMessageToAllPlugins(const wxString &message_id, wxJSONValue v);
       void SendMessageToAllPlugins(const wxString &message_id, const wxString &message_body);

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -689,6 +689,7 @@ bool PlugInManager::CallLateInit(void)
             case 114:
             case 115:
             case 116:
+            case 117:
                 if(pic->m_cap_flag & WANTS_LATE_INIT) {
                     wxString msg(_T("PlugInManager: Calling LateInit PlugIn: "));
                     msg += pic->m_plugin_file;
@@ -722,8 +723,9 @@ void PlugInManager::SendVectorChartObjectInfo(const wxString &chart, const wxStr
                 case 112:
                 case 113:
                 case 114:
-		case 115:
+                case 115:
                 case 116:
+                case 117:
                 {
                     opencpn_plugin_112 *ppi = dynamic_cast<opencpn_plugin_112 *>(pic->m_pplugin);
                     if(ppi)
@@ -1500,6 +1502,7 @@ PlugInContainer *PlugInManager::LoadPlugIn(wxString plugin_file)
         break;
         
     case 116:
+    case 117:
         pic->m_pplugin = dynamic_cast<opencpn_plugin_116*>(plug_in);
         break;
         
@@ -1575,6 +1578,7 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &v
                             break;
                         }
                         case 116:
+                        case 117:
                         {
                             opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                             if (ppi) {
@@ -1639,6 +1643,7 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &v
                             break;
                         }
                         case 116:
+                        case 117:
                         {
                             opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                             if (ppi) {
@@ -1712,6 +1717,7 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns( wxGLContext *pcontext, cons
                         break;
                     }
                     case 116:
+                    case 117:
                     {
                         opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                         if (ppi) {
@@ -1749,7 +1755,8 @@ bool PlugInManager::SendMouseEventToPlugins( wxMouseEvent &event)
                     case 113:
                     case 114:
                     case 115:
-                    case 116:    
+                    case 116:
+                    case 117:
                     {
                         opencpn_plugin_112 *ppi = dynamic_cast<opencpn_plugin_112*>(pic->m_pplugin);
                         if(ppi)
@@ -1782,7 +1789,8 @@ bool PlugInManager::SendKeyEventToPlugins( wxKeyEvent &event)
                         case 113:
                         case 114:
                         case 115:
-                        case 116:    
+                        case 116: 
+                        case 117:
                         {
                             opencpn_plugin_113 *ppi = dynamic_cast<opencpn_plugin_113*>(pic->m_pplugin);
                             if(ppi && ppi->KeyboardEventHook( event ))
@@ -1846,6 +1854,7 @@ void NotifySetupOptionsPlugin( PlugInContainer *pic )
             case 114:
             case 115:
             case 116:    
+            case 117:
             {
                 opencpn_plugin_19 *ppi = dynamic_cast<opencpn_plugin_19 *>(pic->m_pplugin);
                 if(ppi) {
@@ -2027,6 +2036,7 @@ void PlugInManager::SendMessageToAllPlugins(const wxString &message_id, const wx
                 case 114:
                 case 115:
                 case 116:
+                case 117:
                 {
                     opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                     if(ppi)
@@ -2108,6 +2118,7 @@ void PlugInManager::SendPositionFixToAllPlugIns(GenericPosDatEx *ppos)
                 case 114:
                 case 115:
                 case 116:
+                case 117:
                 {
                     opencpn_plugin_18 *ppi = dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
                     if(ppi)
@@ -2120,6 +2131,48 @@ void PlugInManager::SendPositionFixToAllPlugIns(GenericPosDatEx *ppos)
             }
         }
     }
+}
+
+void PlugInManager::SendActiveLegInfoToAllPlugIns(ActiveLegDat *leg_info)
+{
+  Plugin_Active_Leg_Info leg;
+  leg.Btw = leg_info->Btw;
+  leg.Dtw = leg_info->Dtw;
+  leg.wp_name = leg_info->wp_name;
+  leg.Xte = leg_info->Xte;
+  leg.arrival = leg_info->arrival;
+  for (unsigned int i = 0; i < plugin_array.GetCount(); i++)
+  {
+    PlugInContainer *pic = plugin_array[i];
+    if (pic->m_bEnabled && pic->m_bInitState)
+    {
+      if (pic->m_cap_flag & WANTS_NMEA_EVENTS)
+      {
+        switch (pic->m_api_version)
+        {
+        case 108:
+        case 109:
+        case 110:
+        case 111:
+        case 112:
+        case 113:
+        case 114:
+        case 115:
+        case 116:
+          break;
+        case 117:
+        {
+          opencpn_plugin_117 *ppi = dynamic_cast<opencpn_plugin_117 *>(pic->m_pplugin);
+          if (ppi)
+            ppi->SetActiveLegInfo(leg);
+          break;
+        }
+        default:
+          break;
+        }
+      }
+    }
+  }
 }
 
 void PlugInManager::SendResizeEventToAllPlugIns(int x, int y)
@@ -2156,6 +2209,7 @@ void PlugInManager::PrepareAllPluginContextMenus()
                 switch(pic->m_api_version)
                 {
                     case 116:
+                    case 117:
                     {
                         opencpn_plugin_116 *ppi = dynamic_cast<opencpn_plugin_116 *>(pic->m_pplugin);
                         if(ppi)
@@ -4128,6 +4182,9 @@ int opencpn_plugin_117::GetPlugInVersionPost() { return 0; };
 const char* opencpn_plugin_117::GetPlugInVersionPre() { return ""; };
 
 const char* opencpn_plugin_117::GetPlugInVersionBuild() { return ""; };
+
+void opencpn_plugin_117::SetActiveLegInfo(Plugin_Active_Leg_Info &leg_info)
+{}
 
 
 //          Helper and interface classes
@@ -7092,4 +7149,12 @@ wxRect GetMasterToolbarRect()
         return g_MainToolbar->GetRect();
     else
         return wxRect(0,0,1,1);
+}
+
+/* API 1.17 */
+
+void ZeroXTE() {
+  if (g_pRouteMan) {
+    g_pRouteMan->ZeroCurrentXTEToActivePoint();
+  }
 }

--- a/src/routeman.cpp
+++ b/src/routeman.cpp
@@ -644,6 +644,20 @@ bool Routeman::UpdateAutopilot()
    double r_Sog(0.0), r_Cog(0.0);
    if (!std::isnan(gSog)) r_Sog = gSog;
    if (!std::isnan(gCog)) r_Cog = gCog;
+
+   // Send active leg info directly to plugins
+
+   ActiveLegDat leg_info;
+   leg_info.Btw = CurrentBrgToActivePoint;
+   leg_info.Dtw = CurrentRngToActivePoint;
+   leg_info.Xte = CurrentXTEToActivePoint;
+   if (XTEDir < 0) {
+     leg_info.Xte = -leg_info.Xte;    // Left side of the track -> negative XTE
+   }
+   leg_info.wp_name = pActivePoint->GetName().Truncate(6);
+   leg_info.arrival = m_bArrival;
+   g_pi_manager->SendActiveLegInfoToAllPlugIns(&leg_info);
+
     //RMB
         {
 


### PR DESCRIPTION
   - SetActiveLegInfo() : directly send active leg info to plugin without loss of precision.
   - ZeroXTE() : set XTE to zero from plugin, same as from context menu.

These functions are meant for a route following plugin, that controls an autopilot. With these functions the plugin has direct access with full precision to the active leg data, without having to do all calculations again. A plugin using this info can continue to use the OpenCPN active route window and context menu. The XTE in NMEA0183 is rounded off to 0.001 nm. To exactly follow a route a XTE a better precision is required.
This PR replaces PR #1506 (closed)