### PR TITLE
One signalK include file did not identify WIN32 build

### DIFF
--- a/include/zeroconf-detail.hpp
+++ b/include/zeroconf-detail.hpp
@@ -11,6 +11,11 @@
 #include <memory>
 #include <chrono>
 
+#if (defined(_WIN32) || defined(__WIN32__)) && \
+     !defined(WIN32)
+#define WIN32
+#endif
+
 #ifdef WIN32
 #define WIN32_LEAN_AND_MEAN
 #include <winsock2.h>


### PR DESCRIPTION
I had to patch one header file to build under Windows.  Would not build without this fix.  I have not checked every single files for a similar issue but don't think any others have the problem.