### PR TITLE
Ci upload

### DIFF
--- a/ci/appveyor-upload.sh
+++ b/ci/appveyor-upload.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-REPO="david-register/opencpn-unstable"
+REPO=${CLOUDSMITH_REPO:-"david-register/opencpn-unstable"}
 
 if [ -z "$CLOUDSMITH_API_KEY" ]; then
     echo 'Cannot deploy to cloudsmith: missing $CLOUDSMITH_API_KEY'

--- a/ci/generic-build-debian.sh
+++ b/ci/generic-build-debian.sh
@@ -3,6 +3,14 @@
 #
 # Build the Travis Debian artifacts
 #
+
+
+# https://askubuntu.com/questions/793182/update-not-working-on-ubuntu-14-04-4-lts
+if [ "$OCPN_TARGET" = "trusty" ]; then
+     sudo apt-key adv \
+         --keyserver keyserver.ubuntu.com --recv-keys 6B05F25D762E3157
+fi
+
 set -xe
 sudo apt-get -qq update
 sudo apt-get install -q devscripts equivs

--- a/ci/generic-upload.sh
+++ b/ci/generic-upload.sh
@@ -2,7 +2,7 @@
 
 expand() { for arg in "$@"; do test -f $arg && echo $arg; done }
 
-REPO="david-register/opencpn-unstable"
+REPO=${CLOUDSMITH_REPO:-"david-register/opencpn-unstable"}
 
 test -z "$TRAVIS_BUILD_DIR" || cd $TRAVIS_BUILD_DIR
 cd build

--- a/ci/generic-upload.sh
+++ b/ci/generic-upload.sh
@@ -42,7 +42,7 @@ else
     if pyenv versions >/dev/null 2>&1; then   # circleci image
         pyenv versions
         pyenv global $(pyenv versions | tail -1)
-        sudo -H python -m pip install cloudsmith-cli
+        sudo -H python3 -m pip install cloudsmith-cli
         pyenv rehash
     else
         # Assuming builders have installed python3 + pip

--- a/src/NetworkDataStream.cpp
+++ b/src/NetworkDataStream.cpp
@@ -29,6 +29,13 @@
  ***************************************************************************
  *
  */
+#ifdef __MINGW32__
+#undef IPV6STRICT    // mingw FTBS fix:  missing struct ip_mreq
+#include <ws2tcpip.h>
+#include <windows.h>
+#endif
+
+
 #include "wx/wxprec.h"
 
 #ifndef  WX_PRECOMP

--- a/src/SignalKDataStream.cpp
+++ b/src/SignalKDataStream.cpp
@@ -1,6 +1,12 @@
 //
 // Created by balp on 2018-07-28.
 //
+
+#ifdef __MINGW32__
+#undef IPV6STRICT    // mingw FTBS fix:  missing struct ip_mreq
+#include <windows.h>
+#endif
+
 #include "zeroconf.hpp"
 
 #include "wx/wxprec.h"


### PR DESCRIPTION
Fix #1579 so that trusty builds are uploaded.

While we are on it, also fix the mingw FTBS problems introduced lately.

This PR also makes it possible for developers to use an alternative cloudsmith deployment repo using the environment variable CLOUDSMITH_REPO (defaults to david-register/opencpn).

EDIT: defaults to david-register/opencpn-unstable

See: #1536