### PR TITLE
PluginPaths.cpp: Fix broken windows data path (#1566).

### DIFF
--- a/src/PluginPaths.cpp
+++ b/src/PluginPaths.cpp
@@ -56,7 +56,7 @@ void PluginPaths::initWindowsPaths()
         g_Platform->GetWinPluginBaseDir().ToStdString();
     m_userLibdir = winPluginBaseDir + "\\plugins";
     m_userBindir = winPluginBaseDir + "\\plugins";
-    m_userDatadir = winPluginBaseDir;
+    m_userDatadir = winPluginBaseDir + "\\plugins";
     m_unknownPathDir = winPluginBaseDir + "\\unknown-prefix";
 
     m_libdirs.push_back(m_userLibdir);


### PR DESCRIPTION
Closes: #1566

Untested, the chocolatey servers are down. However, it's already broken so it shouldn't get worse. Looks good to me, though.