### PR TITLE
PluginPaths: Don't add extra /opencpn to path (#1535).

### DIFF
--- a/src/PluginPaths.cpp
+++ b/src/PluginPaths.cpp
@@ -104,13 +104,13 @@ void PluginPaths::initLinuxPaths()
     const string platform_dir = g_Platform->GetPluginDir().ToStdString();
     const char* const envdirs = getenv("OPENCPN_PLUGIN_DIRS");
     string dirlist = envdirs ? envdirs : OCPN_LINUX_LOAD_PATH;
-    if (envdirs == 0 && dirlist.find(platform_dir) == string::npos) {
-        dirlist = dirlist + ":" + platform_dir;
-    }
     m_libdirs = split(dirlist, ':');
     for (auto& dir: m_libdirs) {
         dir += "/opencpn";
         dir = expand(dir);
+    }
+    if (envdirs == 0 && dirlist.find(platform_dir) == string::npos) {
+        m_libdirs.push_back(expand(platform_dir));
     }
     m_bindirs = m_libdirs;
     for (auto& dir: m_bindirs) {


### PR DESCRIPTION
Closes: #1535.