### PR TITLE
Remove g group index

### DIFF
--- a/src/ConfigMgr.cpp
+++ b/src/ConfigMgr.cpp
@@ -317,7 +317,6 @@ extern wxColour         g_colourTrackLineColour;
 extern wxString         g_default_wp_icon;
 
 extern ChartGroupArray  *g_pGroupArray;
-extern int              g_GroupIndex;
 
 extern bool             g_bDebugOGL;
 extern wxString         g_GPS_Ident;
@@ -1045,7 +1044,6 @@ bool ConfigMgr::SaveTemplate( wxString fileName)
     
     conf->Write( _T ( "InitialStackIndex" ), g_restore_stackindex );
     conf->Write( _T ( "InitialdBIndex" ), g_restore_dbindex );
-    conf->Write( _T ( "ActiveChartGroup" ), g_GroupIndex );
     
     conf->Write( _T ( "AnchorWatch1GUID" ), g_AW1GUID );
     conf->Write( _T ( "AnchorWatch2GUID" ), g_AW2GUID );
@@ -1413,8 +1411,6 @@ bool ConfigMgr::CheckTemplate( wxString fileName)
     
     CHECK_INT( _T ( "ShowFPS" ), &g_bShowFPS );
     
-    //Read( _T ( "ActiveChartGroup" ), &g_GroupIndex );
-
     CHECK_INT( _T( "NMEAAPBPrecision" ), &g_NMEAAPBPrecision );
     
     CHECK_STR( _T( "TalkerIdText" ), g_TalkerIdText );

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -7211,8 +7211,8 @@ void MyFrame::OnFrameTimer1( wxTimerEvent& event )
         int ut_index_max = ( ( g_unit_test_1 > 0 ) ? ( g_unit_test_1 - 1 ) : INT_MAX );
 
         if( ChartData ) {
-            if( g_GroupIndex > 0 ) {
-                while (ut_index < ChartData->GetChartTableEntries() && !ChartData->IsChartInGroup( ut_index, g_GroupIndex ) ) {
+            if( cc->m_groupIndex > 0 ) {
+                while (ut_index < ChartData->GetChartTableEntries() && !ChartData->IsChartInGroup( ut_index, cc->m_groupIndex ) ) {
                     ut_index++;
                 }
             }

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -522,7 +522,6 @@ bool                      g_bportable;
 bool                      g_bdisable_opengl;
 
 ChartGroupArray           *g_pGroupArray;
-int                       g_GroupIndex;
 
 wxString                  g_GPS_Ident;
 

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -365,7 +365,6 @@ extern wxString         g_default_wp_icon;
 extern wxString         g_default_routepoint_icon;
 
 extern ChartGroupArray  *g_pGroupArray;
-extern int              g_GroupIndex;
 
 extern bool             g_bDebugOGL;
 extern int              g_tcwin_scale;
@@ -870,8 +869,6 @@ int MyConfig::LoadMyConfigRaw( bool bAsTemplate )
     
     Read( _T ( "ShowFPS" ), &g_bShowFPS );
     
-    Read( _T ( "ActiveChartGroup" ), &g_GroupIndex );
-
     Read( _T( "NMEAAPBPrecision" ), &g_NMEAAPBPrecision );
     
     Read( _T( "TalkerIdText" ), &g_TalkerIdText );
@@ -2386,7 +2383,6 @@ void MyConfig::UpdateSettings()
 
     Write( _T ( "InitialStackIndex" ), g_restore_stackindex );
     Write( _T ( "InitialdBIndex" ), g_restore_dbindex );
-    Write( _T ( "ActiveChartGroup" ), g_GroupIndex );
 
     Write( _T( "NMEAAPBPrecision" ), g_NMEAAPBPrecision );
     


### PR DESCRIPTION
Hi,
With multiple canvas global g_Group_index variable isn't used anymore.
Fix a regression with -unit_test_2. (it'd only display charts in active group).

Regards,
Didier