### PR TITLE
Fix Plugin Loading on Arch Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,7 +254,7 @@ endif ()
 
 if (NOT WIN32 AND NOT APPLE AND NOT QT_ANDROID)
     if (EXISTS "/usr/lib64")
-        set(_LIBDIRS "~/.local/lib:/usr/local/lib64:/usr/lib64")
+        set(_LIBDIRS "~/.local/lib:/usr/local/lib64:/usr/lib64:/usr/local/lib:/usr/lib")
     elseif (EXISTS "/usr/lib/arm-linux-gnueabihf") 
         set(_LIBDIRS "~/.local/lib:/usr/local/lib:/usr/lib/arm-linux-gnueabihf:/usr/lib")
     else ()


### PR DESCRIPTION
This fixes loading old manually installed plugins on Arch Linux.

Perhaps this also helps #1541

First I was wrongly accusing PI manager, now I notice some machines have an innocent /usr/lib64 symlink which breaks old plugin loading on OpenCPN built on those machines. 