### PR TITLE
Ui: Refactoring and clean-up

### DIFF
--- a/include/catalog_mgr.h
+++ b/include/catalog_mgr.h
@@ -27,18 +27,29 @@
 #define CATALOG_MGR_H__
 
 #include <wx/dialog.h>
+#include <wx/frame.h>
 #include <wx/window.h>
 
 /** Catalog handler GUI.  */
-class CatalogDialog: public wxDialog
+class AdvancedCatalogDialog: public wxFrame
 {
     public:
 
         /**
-         * Ctor. Simple reflects whether to just install the last catalog
-         * or invoke the advanced dialog instead. 
+         * Invoke the advanced catalog dialog after a status check.
          */
-        CatalogDialog(wxWindow* parent, bool simple);
+        AdvancedCatalogDialog(wxWindow* parent);
 };
+
+class SimpleCatalogDialog: public wxDialog
+{
+    public:
+
+        /**
+         * Perform a simple catalog update without options.
+         */
+        SimpleCatalogDialog(wxWindow* parent);
+};
+
 
 #endif // CATALOG_MGR_H__

--- a/include/download_mgr.h
+++ b/include/download_mgr.h
@@ -36,8 +36,6 @@ class PluginDownloadDialog: public wxDialog
 
         wxWindow* GetRealParent() { return  m_parent; }
 
-    private:
-        wxWindow* m_parent;
 };
 
 #endif // DOWNLOAD_MGR_H__

--- a/include/download_mgr.h
+++ b/include/download_mgr.h
@@ -29,6 +29,9 @@
 #include <wx/dialog.h>
 #include <wx/window.h>
 
+// Accepted by PluginDownloadDialog, reloads plugin list.
+wxDECLARE_EVENT(EVT_PLUGINS_RELOAD, wxCommandEvent);
+
 class PluginDownloadDialog: public wxDialog
 {
     public:

--- a/src/catalog_mgr.cpp
+++ b/src/catalog_mgr.cpp
@@ -316,11 +316,11 @@ class CatalogUpdate: public wxDialog, Helpers
                 std::string message;
                 if (status != CatalogHandler::ServerStatus::OK) {
                     message = "Cannot download data form url";
-                } 
+                }
                 status = handler->ParseCatalog(xml.str(), true);
                 if (status != CatalogHandler::ServerStatus::OK) {
                     message = "Cannot parse downloaded data";
-                } 
+                }
                 if (message != "") {
                     wxMessageBox(message,
                                  "catalog update problem",
@@ -330,7 +330,7 @@ class CatalogUpdate: public wxDialog, Helpers
                     UpdateVersions();
                 }
             }
- 
+
             std::string GetPrivateCatalogPath()
             {
                 auto plugin_handler = PluginHandler::getInstance();

--- a/src/catalog_mgr.cpp
+++ b/src/catalog_mgr.cpp
@@ -294,7 +294,7 @@ class CatalogUpdate: public wxDialog, Helpers
                 UpdateVersion(grid, data, 5);
                 data = CatalogHandler::getInstance()->LatestCatalogData();
                 UpdateVersion(grid, data, 9);
-                Refresh();
+                Refresh(true);
                 Update();
             }
 

--- a/src/catalog_mgr.cpp
+++ b/src/catalog_mgr.cpp
@@ -129,7 +129,7 @@ class CatalogUpdate: public wxDialog, Helpers
             sizer->Add(m_url_box, flags);
             sizer->Add(new wxStaticLine(this), flags);
 
-            auto done = makeButton("Done");
+            auto done = makeButton(_("Done"));
             sizer->Add(done, wxSizerFlags().Border().Right());
             done->Bind(wxEVT_COMMAND_BUTTON_CLICKED, [=] (wxCommandEvent e) {
                 EndModal(wxID_OK);
@@ -139,20 +139,18 @@ class CatalogUpdate: public wxDialog, Helpers
             });
             toggleUrlEdit();
 
-
-            SetSizer(sizer);
-            auto size = getWindowSize();
-            size.SetHeight(1);
-            SetMinClientSize(size);
-
             Bind(wxEVT_CLOSE_WINDOW, [=](wxCloseEvent& e) {
                 EndModal(wxID_OK);
                 wxCommandEvent cmd_evt(CATALOG_DLG_CLOSE);
                 wxPostEvent(GetParent(), cmd_evt);
                 e.Skip();
             });
-            parent->Hide();
 
+            SetSizer(sizer);
+            auto size = getWindowSize();
+            size.SetHeight(1);
+            SetMinClientSize(size);
+            parent->Hide();
             Fit();
             ShowModal();
         }
@@ -191,6 +189,7 @@ class CatalogUpdate: public wxDialog, Helpers
             m_advanced->SetLabelMarkup(m_show_edit ? HIDE : ADVANCED);
             Fit();
         }
+
         /** The Url Status line at top */
         struct UrlStatus: public wxPanel, public Helpers
         {
@@ -210,7 +209,6 @@ class CatalogUpdate: public wxDialog, Helpers
                 Show();
             }
         };
-
 
         /**
          * Active catalog: The current active, the default and latest
@@ -300,7 +298,6 @@ class CatalogUpdate: public wxDialog, Helpers
 
             std::string GetDefaultCatalogPath()
             {
-                auto plugin_handler = PluginHandler::getInstance();
                 std::string path
                     = g_Platform->GetSharedDataDir().ToStdString();
                 path += SEP ;
@@ -315,15 +312,15 @@ class CatalogUpdate: public wxDialog, Helpers
                 auto status = handler->DownloadCatalog(&xml);
                 std::string message;
                 if (status != CatalogHandler::ServerStatus::OK) {
-                    message = "Cannot download data form url";
+                    message = _("Cannot download data from url");
                 }
                 status = handler->ParseCatalog(xml.str(), true);
                 if (status != CatalogHandler::ServerStatus::OK) {
-                    message = "Cannot parse downloaded data";
+                    message = _("Cannot parse downloaded data");
                 }
                 if (message != "") {
                     wxMessageBox(message,
-                                 "catalog update problem",
+                                 _("Catalog update problem"),
                                  wxICON_ERROR);
                 }
                 else {
@@ -334,10 +331,9 @@ class CatalogUpdate: public wxDialog, Helpers
             std::string GetPrivateCatalogPath()
             {
                 auto plugin_handler = PluginHandler::getInstance();
-                std::string path
-                    = g_Platform->GetPrivateDataDir().ToStdString();
-                path += SEP ;
-                path += "ocpn-plugins.xml";
+                std::string path =
+                    g_Platform->GetPrivateDataDir().ToStdString();
+                path += SEP + "ocpn-plugins.xml";
                 return path;
             }
 
@@ -358,7 +354,6 @@ class CatalogUpdate: public wxDialog, Helpers
                catalog->ClearCatalogData();
                UpdateVersions();
             }
-
         };
 
         /** The buttons below custom url: Use Default and Update. */
@@ -394,8 +389,7 @@ class CatalogUpdate: public wxDialog, Helpers
 
             void useDefaultUrl()
             {
-                auto handler = CatalogHandler::getInstance();
-                auto url = handler->GetDefaultUrl();
+                auto url = CatalogHandler::getInstance()->GetDefaultUrl();
                 m_parent->m_url_edit->setText(url);
             }
 
@@ -413,7 +407,6 @@ class CatalogUpdate: public wxDialog, Helpers
 
             ActiveCatalogGrid* m_catalog_grid;
             CatalogUpdate* m_parent;
-
         };
 
 
@@ -459,7 +452,6 @@ class CatalogUpdate: public wxDialog, Helpers
             std::string m_active_channel;
             ActiveCatalogGrid* m_catalog_grid;
         };
-
 
 
         /** Custom url edit control, a text line. */
@@ -517,7 +509,6 @@ class CatalogLoad: public wxPanel, public Helpers
         CatalogLoad(wxWindow* parent, bool use_latest = false)
             :wxPanel(parent), Helpers(this), m_simple(use_latest)
         {
-
             auto sizer = new wxBoxSizer(wxVERTICAL);
             auto flags = wxSizerFlags().Expand().Border() ;
             m_grid = new DialogGrid(this);
@@ -561,7 +552,7 @@ class CatalogLoad: public wxPanel, public Helpers
         {
             m_grid->CellDone(ev, 5);
             if (m_simple) {
-                std::string message = "Catalog updated";
+                std::string message =_("Catalog updated").ToStdString();
                 std::string path =
                     g_Platform->GetPrivateDataDir().ToStdString();
                 path += SEP;
@@ -587,7 +578,6 @@ class CatalogLoad: public wxPanel, public Helpers
                 CatalogData catalog_data;
                 auto handler = CatalogHandler::getInstance();
                 catalog_data = handler->LatestCatalogData();
-                wxLogMessage("Running CatalogUpdate.");
                 new CatalogUpdate(this);
             }
         }
@@ -626,7 +616,7 @@ class CatalogLoad: public wxPanel, public Helpers
             }
         }
 
-        /** grid with  Server is Reachable..., Check channel... etc. */
+        /** Grid with  Server is Reachable..., Check channel... etc. */
         struct DialogGrid: public wxPanel, public Helpers
         {
             DialogGrid(wxWindow* parent): wxPanel(parent), Helpers(this)
@@ -655,7 +645,7 @@ class CatalogLoad: public wxPanel, public Helpers
             /* Update status values in grid. */
             void CellDone(const wxCommandEvent& event, size_t index)
             {
-                wxLogMessage("CellDone: event %d", event.GetInt());
+                //wxLogMessage("CellDone: event %d", event.GetInt());
                 auto cell = GetSizer()->GetItem(index)->GetWindow();
                 auto code = static_cast<catalog_status>(event.GetInt());
                 if (code == catalog_status::OK) {
@@ -721,11 +711,8 @@ AdvancedCatalogDialog::AdvancedCatalogDialog(wxWindow* parent)
     auto vbox = new wxBoxSizer(wxHORIZONTAL);
     vbox->Add(new catalog_mgr::CatalogLoad(this, false),
               wxSizerFlags(1).Expand());
-    Bind(wxEVT_CLOSE_WINDOW, [=](wxCloseEvent& e) { Destroy(); });
-    Bind(CATALOG_DLG_CLOSE, [this](wxCommandEvent& ev) {
-            wxLogMessage("CLOSING: CatalogLoad");
-            Destroy();
-    });
+    Bind(wxEVT_CLOSE_WINDOW, [this](wxCloseEvent& e) { Destroy(); });
+    Bind(CATALOG_DLG_CLOSE, [this](wxCommandEvent& ev) { Destroy(); });
     SetSizer(vbox);
 
     Fit();

--- a/src/download_mgr.cpp
+++ b/src/download_mgr.cpp
@@ -217,11 +217,6 @@ class PluginIconPanel: public wxPanel
             Bind(wxEVT_PAINT, &PluginIconPanel::OnPaint, this);
         }
 
-        ~PluginIconPanel()
-        {
-            Unbind(wxEVT_PAINT, &PluginIconPanel::OnPaint, this);
-        }
-
         void OnPaint(wxPaintEvent& event)
         {
             auto size = GetClientSize();
@@ -383,12 +378,6 @@ class InstallButton: public wxPanel
             Bind(wxEVT_COMMAND_BUTTON_CLICKED, &InstallButton::OnClick, this);
         }
 
-        ~InstallButton()
-        {
-            Unbind(wxEVT_COMMAND_BUTTON_CLICKED,
-                   &InstallButton::OnClick, this);
-        }
-
         void OnClick(wxCommandEvent& event) {
             if (m_remove) {
                 wxLogMessage("Uninstalling %s", m_metadata.name.c_str());
@@ -456,12 +445,6 @@ class WebsiteButton: public wxPanel
             SetSizer(vbox);
             Bind(wxEVT_COMMAND_BUTTON_CLICKED,
                  [=](wxCommandEvent&) {wxLaunchDefaultBrowser(m_url);});
-        }
-
-        ~WebsiteButton()
-        {
-            Unbind(wxEVT_COMMAND_BUTTON_CLICKED,
-                   [=](wxCommandEvent&) {wxLaunchDefaultBrowser(m_url);});
         }
 
     protected:
@@ -532,12 +515,6 @@ class PluginTextPanel: public wxPanel
 
             m_more->Bind(wxEVT_LEFT_DOWN, &PluginTextPanel::OnClick, this);
             m_descr->Bind(wxEVT_LEFT_DOWN, &PluginTextPanel::OnClick, this);
-        }
-
-        ~PluginTextPanel()
-        {
-            m_more->Unbind(wxEVT_LEFT_DOWN, &PluginTextPanel::OnClick, this);
-            m_descr->Unbind(wxEVT_LEFT_DOWN, &PluginTextPanel::OnClick, this);
         }
 
         void OnClick(wxMouseEvent& event)

--- a/src/download_mgr.cpp
+++ b/src/download_mgr.cpp
@@ -645,8 +645,12 @@ class OcpnScrolledWindow : public wxScrolledWindow
 
         void Reload()
         {
+            Hide();
             m_grid->Clear();
             populateGrid(m_grid);
+            Layout();
+            Show();
+            Refresh(true);
         }
 
     private:

--- a/src/download_mgr.cpp
+++ b/src/download_mgr.cpp
@@ -576,7 +576,7 @@ class MainButtonsPanel: public wxPanel
                 :wxButton(parent, wxID_ANY, _("Update plugin catalog"))
             {
                 Bind(wxEVT_COMMAND_BUTTON_CLICKED,
-                   [=](wxCommandEvent&) {new CatalogDialog(GetParent(), true);
+                   [=](wxCommandEvent&) {new CatalogDialog(this, true);
                 });
             }
         
@@ -591,7 +591,7 @@ class MainButtonsPanel: public wxPanel
                 :wxButton(parent, wxID_ANY, _("Advanced catalog update..."))
             {
                  Bind(wxEVT_COMMAND_BUTTON_CLICKED, [=](wxCommandEvent&) {
-                      new CatalogDialog(GetParent(), false);
+                      new CatalogDialog(this, false);
                  });
             }
         

--- a/src/download_mgr.cpp
+++ b/src/download_mgr.cpp
@@ -54,6 +54,9 @@ extern wxImage LoadSVGIcon( wxString filename, int width, int height );
 #undef major                // walk around gnu's major() and minor() macros.
 #undef minor
 
+// Main window reload event
+wxDEFINE_EVENT(EVT_PLUGINS_RELOAD, wxCommandEvent);
+
 namespace download_mgr {
 
 /**
@@ -608,11 +611,13 @@ class OcpnScrolledWindow : public wxScrolledWindow
             :wxScrolledWindow(parent),
             m_grid(new wxFlexGridSizer(3, 0, 0))
         {
-            populateGrid(m_grid);
             auto box = new wxBoxSizer(wxVERTICAL);
+            populateGrid(m_grid);
             box->Add(m_grid, wxSizerFlags().Proportion(1).Expand());
             auto button_panel = new MainButtonsPanel(this, parent);
             box->Add(button_panel, wxSizerFlags().Right().Border().Expand());
+            Bind(EVT_PLUGINS_RELOAD, [&](wxCommandEvent& ev) { Reload(); });
+
             SetSizer(box);
             FitInside();
             // TODO: Compute size using wxWindow::GetEffectiveMinSize()

--- a/src/download_mgr.cpp
+++ b/src/download_mgr.cpp
@@ -576,7 +576,7 @@ class MainButtonsPanel: public wxPanel
                 :wxButton(parent, wxID_ANY, _("Update plugin catalog"))
             {
                 Bind(wxEVT_COMMAND_BUTTON_CLICKED,
-                   [=](wxCommandEvent&) {new CatalogDialog(this, true);
+                   [=](wxCommandEvent&) {new SimpleCatalogDialog(this);
                 });
             }
         
@@ -591,7 +591,7 @@ class MainButtonsPanel: public wxPanel
                 :wxButton(parent, wxID_ANY, _("Advanced catalog update..."))
             {
                  Bind(wxEVT_COMMAND_BUTTON_CLICKED, [=](wxCommandEvent&) {
-                      new CatalogDialog(this, false);
+                      new AdvancedCatalogDialog(this);
                  });
             }
         


### PR DESCRIPTION
The ui  still needs overall changes before actual bugs can be handled. Here are some:

  - Refactor the initial catalog window to two separate ones (advanced/simple).
  - Make some parts a little more dynamic.
  - Clean up parenthood mess (again...)
  - Various cleanup and minor fixes.