### PR TITLE
Set EnableRolloverBlock on first time use when not a touch screen

### DIFF
--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -618,6 +618,11 @@ void OCPNPlatform::Initialize_3( void )
     if(bAndroid){
         g_btouch = true;
     }
+
+    if (g_bFirstRun || g_bUpgradeInProcess) {
+        if (!g_bRollover)  //Not explicit set before
+            g_bRollover = g_btouch ? false : true;
+    }
 }
 
 //  Called from MyApp() just before end of MyApp::OnInit()


### PR DESCRIPTION
Compare Issue 1628 and more. Will set the option true when not on a touch screen. Or leave it set if the user has explicit set it also on the touch screen.