### PR TITLE
code cleanup for the Windows/Apple builds

### DIFF
--- a/include/dychart.h
+++ b/include/dychart.h
@@ -85,6 +85,7 @@
 #ifdef __MSVC__
 //    __MSVC__ randomly does not link snprintf, or _snprintf
 //    Replace it with a local version, code is in cutil.c
+#undef snprintf
 #define snprintf mysnprintf
 #endif
 

--- a/libs/serial/src/serial.cc
+++ b/libs/serial/src/serial.cc
@@ -6,7 +6,9 @@
 #endif
 
 #if defined (__MINGW32__) || ( defined(__NetBSD__) && defined(__GNUC__) )
+#ifndef alloca
 # define alloca __builtin_alloca
+#endif
 #endif
 
 #include "serial/serial.h"

--- a/plugins/dashboard_pi/src/dial.cpp
+++ b/plugins/dashboard_pi/src/dial.cpp
@@ -99,12 +99,12 @@ wxSize DashboardInstrument_Dial::GetSize( int orient, wxSize hint )
 
 void DashboardInstrument_Dial::SetData(int st, double data, wxString unit)
 {
-      if ( (st == m_MainValueCap))
+      if (st == m_MainValueCap)
       {
             m_MainValue = data;
             m_MainValueUnit = unit;
       }
-      else if ( (st == m_ExtraValueCap))
+      else if (st == m_ExtraValueCap)
       {
             m_ExtraValue = data;
             m_ExtraValueUnit = unit;

--- a/plugins/grib_pi/CMakeLists.txt
+++ b/plugins/grib_pi/CMakeLists.txt
@@ -262,7 +262,7 @@ target_link_libraries(${PACKAGE_NAME} PRIVATE ${OPENCPN_LINK_TARGET} )
 
 IF( APPLE )
     target_compile_options(${PACKAGE_NAME} PRIVATE
-        "-Wall -Wno-unused" "-fexceptions"
+        "-Wall" "-Wno-unused" "-fexceptions"
         "-Wno-overloaded-virtual"
         "-Wno-deprecated" "-Wno-deprecated-declarations"
         "-D_WCHAR_H_CPLUSPLUS_98_CONFORMANCE_"

--- a/plugins/wmm_pi/CMakeLists.txt
+++ b/plugins/wmm_pi/CMakeLists.txt
@@ -108,7 +108,7 @@ ENDIF(WIN32)
 
 IF( APPLE )
     target_compile_options(${PACKAGE_NAME} PRIVATE
-        "-Wall -Wno-unused" "-fexceptions"
+        "-Wall" "-Wno-unused" "-fexceptions"
         "-Wno-overloaded-virtual"
         "-Wno-deprecated" "-Wno-deprecated-declarations"
         "-Wno-unknown-pragmas"


### PR DESCRIPTION
Looking at the automatic Windows/Apple builds, the following cleanup
patches reduce warnings in the build logs.

best regards,

Florian La Roche
