### PR TITLE
DashB. Add more guards to avoid viewing of HDM=999

### DIFF
--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -790,9 +790,11 @@ void dashboard_pi::SetNMEASentence( wxString &sentence )
 
                 }
                 if( mPriHeadingM >= 1 ) {
-                    mPriHeadingM = 1;
-                    mHdm = m_NMEA0183.Hdg.MagneticSensorHeadingDegrees;
-                    SendSentenceToAllInstruments( OCPN_DBP_STC_HDM, mHdm, _T("\u00B0") );
+                    if (m_NMEA0183.Hdg.MagneticSensorHeadingDegrees < 999.) {
+                        mPriHeadingM = 1;
+                        mHdm = m_NMEA0183.Hdg.MagneticSensorHeadingDegrees;
+                        SendSentenceToAllInstruments(OCPN_DBP_STC_HDM, mHdm, _T("\u00B0"));
+                    }
                 }
                 if( !std::isnan(m_NMEA0183.Hdg.MagneticSensorHeadingDegrees) )
                        mHDx_Watchdog = gps_watchdog_timeout_ticks;
@@ -817,9 +819,11 @@ void dashboard_pi::SetNMEASentence( wxString &sentence )
         else if( m_NMEA0183.LastSentenceIDReceived == _T("HDM") ) {
             if( m_NMEA0183.Parse() ) {
                 if( mPriHeadingM >= 2 ) {
-                    mPriHeadingM = 2;
-                    mHdm = m_NMEA0183.Hdm.DegreesMagnetic;
-                    SendSentenceToAllInstruments( OCPN_DBP_STC_HDM, mHdm, _T("\u00B0M") );
+                    if (m_NMEA0183.Hdm.DegreesMagnetic < 999.) {
+                        mPriHeadingM = 2;
+                        mHdm = m_NMEA0183.Hdm.DegreesMagnetic;
+                        SendSentenceToAllInstruments(OCPN_DBP_STC_HDM, mHdm, _T("\u00B0M"));
+                    }
                 }
                 if( !std::isnan(m_NMEA0183.Hdm.DegreesMagnetic) )
                     mHDx_Watchdog = gps_watchdog_timeout_ticks;
@@ -1091,9 +1095,11 @@ void dashboard_pi::SetNMEASentence( wxString &sentence )
                     }
                 }
                 if( mPriHeadingM >= 3 ) {
-                    mPriHeadingM = 3;
-                    SendSentenceToAllInstruments( OCPN_DBP_STC_HDM, m_NMEA0183.Vhw.DegreesMagnetic,
-                            _T("\u00B0M") );
+                    if (m_NMEA0183.Vhw.DegreesMagnetic < 999.) {
+                        mPriHeadingM = 3;
+                        SendSentenceToAllInstruments(OCPN_DBP_STC_HDM, m_NMEA0183.Vhw.DegreesMagnetic,
+                            _T("\u00B0M"));
+                    }
                 }
                 if( m_NMEA0183.Vhw.Knots < 999. ) {
                     SendSentenceToAllInstruments( OCPN_DBP_STC_STW, toUsrSpeed_Plugin( m_NMEA0183.Vhw.Knots, g_iDashSpeedUnit ),

--- a/plugins/dashboard_pi/src/wind.cpp
+++ b/plugins/dashboard_pi/src/wind.cpp
@@ -119,12 +119,12 @@ void DashboardInstrument_AppTrueWindAngle::SetData(int st, double data, wxString
 		m_MainValueAppUnit = unit;
 		m_MainValueOption1 = DIAL_POSITION_TOPLEFT;
 	}
-	else if (st == OCPN_DBP_STC_AWS && data < 200.0){
+	else if (st == OCPN_DBP_STC_AWS ){
 		m_ExtraValueApp = data;
 		m_ExtraValueAppUnit = unit;
 		m_ExtraValueOption1 = DIAL_POSITION_TOPRIGHT;
 	}
-	else if (st == OCPN_DBP_STC_TWS && data < 200.0){
+	else if (st == OCPN_DBP_STC_TWS ){
 		m_ExtraValueTrue = data;
 		m_ExtraValueTrueUnit = unit;
 		m_ExtraValueOption2 = DIAL_POSITION_BOTTOMRIGHT;


### PR DESCRIPTION
I've seen a heading equals 999 passing through in Dashboard. Also some forum notes seen about this.