### PR TITLE
use "sudo" in install instructions, fix typo in docu

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -29,8 +29,8 @@ with the following wxWidgets hosts:
 
 Fro Debian Sid, package to install:
 
-         apt install libwxgtk-webview3.0-gtk3-dev libgtk-3-dev libbz2-dev exif libarchive-dev libsndfile1-dev portaudio19-dev
-         apt install cmake gettext sqlite3 libsqlite3-dev libcurl4-openssl-dev libtinyxml-dev libexif-dev liblzma-dev liblz4-dev
+         sudo apt install libwxgtk-webview3.0-gtk3-dev libgtk-3-dev libbz2-dev exif libarchive-dev libsndfile1-dev portaudio19-dev
+         sudo apt install cmake gettext sqlite3 libsqlite3-dev libcurl4-openssl-dev libtinyxml-dev libexif-dev liblzma-dev liblz4-dev
 
 ------------------------
 Build OpenCPN 
@@ -43,11 +43,9 @@ Opencpn uses the cmake system, so...
         cd build
         cmake ../
 
-        make
+        make -j 4
 
-        su, <password>
-
-        make install	
+        sudo make install
 
 
 

--- a/data/doc/toolbar_buttons/tides_and_currents.html
+++ b/data/doc/toolbar_buttons/tides_and_currents.html
@@ -284,11 +284,11 @@ Please note that OpenCPN differs from <strong>XTide</strong> results, in very sm
 </p>
 
 <p>
-There is currently has a problem when multiple <strong>.tcd</strong> files are loaded. The reference station may be incorrectly identified. In practical navigation only one <strong>.tcd</strong> file is needed at any given time, depending on which side of the Atlantic you are navigating.
+OpenCPN currently has a problem when multiple <strong>.tcd</strong> files are loaded. The reference station may be incorrectly identified. In practical navigation only one <strong>.tcd</strong> file is needed at any given time, depending on which side of the Atlantic you are navigating.
 </p>
 
 <p>
-A number of different datasets are available on the Internet, with vastly greater coverage. Some of these datasets are quite old, and they also contains glitches and errors, many of which have been corrected in the OpenCPN default dataset.
+A number of different datasets are available on the Internet, with vastly greater coverage. Some of these datasets are quite old, and they also contain glitches and errors, many of which have been corrected in the OpenCPN default dataset.
 </p>
 
 <p>


### PR DESCRIPTION
sudo is best for all ubuntu users.

And docu mini-fix.

best regards,

Florian La Roche
