### PR TITLE
remove "-fno-strict-aliasing" for most of the code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -422,10 +422,9 @@ if (NOT WIN32 AND NOT APPLE)
   if (NOT OCPN_PEDANTIC)
     add_compile_options(
       "-Wno-unused"
+      "-Wno-deprecated-declarations"
       "-fexceptions"
       "-rdynamic"
-      "-fno-strict-aliasing"
-      "-Wno-deprecated-declarations"
     )
   endif ()
   if (CMAKE_BUILD_TYPE MATCHES "Debug")
@@ -445,7 +444,6 @@ if (MINGW)
       "-Wno-unused"
       "-Wno-cpp"
       "-fexceptions"
-      "-fno-strict-aliasing"
     )
   endif ()
   add_definitions("-DPSAPI_VERSION=1")
@@ -459,7 +457,6 @@ if (APPLE)
       "-Wno-unused"
       "-fexceptions"
       "-Wno-overloaded-virtual"
-      "-fno-strict-aliasing"
       "-Wno-deprecated"
       "-Wno-deprecated-declarations"
       "-Wno-unknown-pragmas"

--- a/libs/glu/CMakeLists.txt
+++ b/libs/glu/CMakeLists.txt
@@ -14,7 +14,7 @@ link_directories(${CMAKE_LIBRARY_OUTPUT_DIRECTORY})
 
 IF (NOT WIN32 AND NOT APPLE)
   ADD_DEFINITIONS( "-Wall -Wno-unused -fexceptions -rdynamic" )
-  ADD_DEFINITIONS( " -g -fno-strict-aliasing -O2")
+  ADD_DEFINITIONS( " -g -O2")
 ENDIF(NOT WIN32 AND NOT APPLE)
 
 IF(QT_ANDROID)

--- a/libs/iso8211/CMakeLists.txt
+++ b/libs/iso8211/CMakeLists.txt
@@ -25,3 +25,5 @@ set_property(TARGET ISO8211 PROPERTY COMPILE_FLAGS "${OBJ_VISIBILITY}")
 target_include_directories(ISO8211 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(ISO8211 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../../include)
 target_include_directories(ISO8211 PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../gdal/include)
+ADD_DEFINITIONS( "-fno-strict-aliasing" )
+

--- a/libs/libtess2/CMakeLists.txt
+++ b/libs/libtess2/CMakeLists.txt
@@ -10,7 +10,7 @@ SET(CMAKE_VERBOSE_MAKEFILE ON)
 
 IF(NOT WIN32 AND NOT APPLE )
     #  ADD_COMPILE_OPTIONS( "-Wall" "-Wno-unused" "-fexceptions" "-rdynamic" )
-    #  ADD_COMPILE_OPTIONS( " -g" "-fno-strict-aliasing" "-O2")
+    #  ADD_COMPILE_OPTIONS( " -g" "-O2")
 ENDIF(NOT WIN32 AND NOT APPLE)
 
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")

--- a/plugins/wmm_pi/cmake/PluginConfigure.cmake
+++ b/plugins/wmm_pi/cmake/PluginConfigure.cmake
@@ -36,7 +36,7 @@ INCLUDE_DIRECTORIES(${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src)
 
 #  IF NOT DEBUGGING CFLAGS="-O2 -march=native"
 IF(NOT MSVC)
-    ADD_COMPILE_OPTIONS( "-fvisibility=hidden" )
+    ADD_COMPILE_OPTIONS( "-fvisibility=hidden" "-fno-strict-aliasing" )
  IF(PROFILING)
      ADD_COMPILE_OPTIONS(
          "-Wall" "-g" "-fprofile-arcs" "-ftest-coverage" "-fexceptions")


### PR DESCRIPTION
"-fno-strict-aliasing" does reduce the compiler optimizations quite a bit. The compiler outputs
warnings if it does see coding problems and strict-aliasing should not be enabled.
The "wmm_pi" plugin does give such warnings, so "-fno-strict-aliasing" is added to the
options of this plugin. The rest of the code is now run with full optimizations.

This patch aims at more compiler optimizations, so can of course be a stability problem.

best regards,

Florian La Roche
