### PR TITLE
catalog_parser: Rewrite meta-url code using real recursion.

### DIFF
--- a/include/catalog_handler.h
+++ b/include/catalog_handler.h
@@ -118,6 +118,7 @@ class CatalogHandler {
         CatalogHandler();
 
         void LoadCatalogData(const std::string& path, CatalogData& data);
+        ServerStatus DoParseCatalog(const std::string xml, catalog_ctx* ctx);
 
         const char* const GET_BRANCHES_PATH =
             "/repos/OpenCPN/plugins/branches";

--- a/include/catalog_parser.h
+++ b/include/catalog_parser.h
@@ -59,14 +59,19 @@ struct PluginMetadata {
     std::string target_version;
     std::string info_url;
     std::string meta_url;
-    
+
     bool openSource;
 
     bool readonly;                // Can plugin be removed?
     int ix;                       // Index in list of installed or available.
     void clear() { *this = PluginMetadata(); }
+    std::string key() const
+    {
+       return std::string(name) + version + release + target + target_version;
+    }
+
+
     PluginMetadata() :  readonly(true), ix(-1) {}
-    bool IsSameAs( PluginMetadata *other );
 };
 
 
@@ -74,13 +79,19 @@ struct PluginMetadata {
  * The result from parsing the xml catalog i. e., ocpn-plugins.xml.
  */
 struct catalog_ctx {
+    // list of plugins parsed
     std::vector<PluginMetadata> plugins;
+
+    // list meta-urls found when parsing last plugin.
+    std::vector<std::string> meta_urls;
+
     std::string version;
     std::string date;
 
     // Internal data used while parsing, undefined on exit.
-    std::unique_ptr<PluginMetadata> plugin;    
+    std::unique_ptr<PluginMetadata> plugin;
     std::string buff;
+    std::string meta_url;
     int depth;
     catalog_ctx(): depth(0) {}
 };

--- a/src/catalog_handler.cpp
+++ b/src/catalog_handler.cpp
@@ -134,6 +134,8 @@ catalog_status CatalogHandler::DownloadCatalog(std::string& filePath)
     return status;
 }
 
+
+
 catalog_status CatalogHandler::DownloadCatalog(std::string& filePath, std::string url)
 {
     if (filePath == "") {
@@ -151,20 +153,34 @@ catalog_status CatalogHandler::DownloadCatalog(std::string& filePath, std::strin
     return status;
 }
 
+catalog_status CatalogHandler::DoParseCatalog(const std::string xml,
+                                              catalog_ctx* ctx)
+{
+    bool ok = ::ParseCatalog(xml, ctx);
+    while (ok && ctx->meta_urls.size() > 0) {
+        std::ostringstream xml;
+        std::string url = ctx->meta_urls.back();
+        ctx->meta_urls.pop_back();
+        DownloadCatalog(&xml, url);
+        ok = DoParseCatalog(xml.str(), ctx) == ServerStatus::OK;
+    }
+    if (!ok){
+       wxLogWarning("Cannot parse xml starting with: %s",
+                    xml.substr(0,60).c_str());
+    }
+    return ok ? ServerStatus::OK : ServerStatus::XML_ERROR;
+}
 
 catalog_status CatalogHandler::ParseCatalog(const std::string xml, bool latest)
 {
     catalog_ctx ctx;
-    bool ok = ::ParseCatalog(xml, &ctx);
-    if (ok && latest) {
+    auto status = DoParseCatalog(xml, &ctx);
+    if (status == ServerStatus::OK && latest) {
         this->latest_data.version = ctx.version;
         this->latest_data.date = ctx.date;
         this->latest_data.undef = false;
-        return ServerStatus::OK;
     }
-    wxLogWarning("Cannot parse xml starting with: %s", xml.substr(0,60).c_str());
-    return ok ? ServerStatus::OK : ServerStatus::XML_ERROR;
-
+    return status;
 }
 
 
@@ -227,7 +243,8 @@ CatalogHandler::LoadCatalogData(const std::string& path, CatalogData& data)
                         std::istreambuf_iterator<char>());
         file.close();
         catalog_ctx ctx;
-        if (::ParseCatalog(xml, &ctx)) {
+        auto status = DoParseCatalog(xml, &ctx);
+        if (status == ServerStatus::OK) {
             data.version = ctx.version;
             data.date = ctx.date;
             data.undef = false;


### PR DESCRIPTION
  - Use standard containers to drop duplicates
  - Add undocumented OPENCPN_COMPAT_TARGET environment variable
    test hook.
  - Simplify (again) catalog_parser, move the recursive mechanics to catalog_handler.

For me, this is in a better shape. Show scrollbars where it should, at least on windows and linux.

macOS has an extremely annoying bug where the advanced catalog window disappears when it gets the focus(!). Need someone who understands macOS to cope with this; a working build chain shouldn't hurt either. However, this is *not* blocking, testing can proceed despite this by clicking the (invisible) window..