### PR TITLE
fix "break;" statement for lost connections

### DIFF
--- a/src/NetworkDataStream.cpp
+++ b/src/NetworkDataStream.cpp
@@ -368,9 +368,8 @@ void NetworkDataStream::OnSocketEvent(wxSocketEvent& event)
 
                 GetSocketThreadWatchdogTimer()->Stop();
                 GetSocketTimer()->Start(retry_time, wxTIMER_ONE_SHOT);     // Schedule a re-connect attempt
-
-                break;
             }
+            break;
         }
 
         case wxSOCKET_CONNECTION :


### PR DESCRIPTION
This looks like a misplaced "break;" statement.

Can someone who sees strange items with lost connections try out this patch?

best regards,

Florian La Roche
