### PR TITLE
add missing "break;" for plugin-manager

### DIFF
--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -1863,6 +1863,7 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns( ocpnDC &dc, const ViewPort &v
                             opencpn_plugin_116 *ppi116 = dynamic_cast<opencpn_plugin_116 *>(pic->m_pplugin);
                             if (ppi116) 
                                 b_rendered = ppi116->RenderOverlayMultiCanvas(*pdc, &pivp, g_canvasConfig);
+			    break;
                         }
                         default:
                         {


### PR DESCRIPTION
This looks like another missing "break;" statement for OpenGL-enabled plugins of O.

best regards,

Florian La Roche
