### PR TITLE
Safe mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1612,7 +1612,7 @@ else ()
 endif ()
 
 if (MINGW)
-  target_link_libraries(${PACKAGE_NAME} PRIVATE psapi winmm setupapi)
+  target_link_libraries(${PACKAGE_NAME} PRIVATE psapi winmm setupapi ws2_32)
 endif ()
 
 # TODO dnl dnl Use OpenGL tesselator or Internal tesselator dnl

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -903,6 +903,7 @@ set(
   include/S57ObjectDesc.h
   include/S57QueryDialog.h
   include/S57Sector.h
+  include/safe_mode.h
   include/Select.h
   include/SelectItem.h
   include/SendToGpsDlg.h
@@ -1024,6 +1025,7 @@ set(
   src/RoutePropDlg.cpp
   src/RoutePropDlgImpl.cpp
   src/S57QueryDialog.cpp
+  src/safe_mode.cpp
   src/Select.cpp
   src/SelectItem.cpp
   src/SendToGpsDlg.cpp

--- a/include/safe_mode.h
+++ b/include/safe_mode.h
@@ -1,0 +1,31 @@
+/**
+ * Safe mode handling. 
+ *
+ * Administrate the safe mode state which is true if openpcn should run in
+ * safe mode without OpenGL, plugins, etc.
+ */
+
+#include <wx/window.h>
+
+#include "OCPNPlatform.h"
+#include "ocpn_utils.h"
+
+namespace safe_mode {
+
+bool get_mode();
+
+void set_mode(bool mode);
+
+
+/** 
+ * Check if the last start failed, possibly invoke user dialog and set 
+ * safe mode state.
+ */
+void check_last_start();
+ 
+
+/** Mark last run as successful. */
+void clear_check();
+
+
+} // namespace safe_mode

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -88,6 +88,7 @@
 #include "options.h"
 #include "AboutFrameImpl.h"
 #include "about.h"
+#include "safe_mode.h"
 #include "thumbwin.h"
 #include "tcmgr.h"
 #include "ais.h"
@@ -1109,6 +1110,7 @@ void MyApp::OnInitCmdLine( wxCmdLineParser& parser )
                         wxCMD_LINE_VAL_STRING,
                         wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE);
     parser.AddLongSwitch( "unit_test_2" );
+    parser.AddSwitch("safe_mode");
 }
 
 bool MyApp::OnCmdLineParsed( wxCmdLineParser& parser )
@@ -1129,6 +1131,7 @@ bool MyApp::OnCmdLineParsed( wxCmdLineParser& parser )
         if( g_unit_test_1 == 0 )
             g_unit_test_1 = -1;
     }
+    safe_mode::set_mode(parser.Found("safe_mode"));
 
     for (size_t paramNr=0; paramNr < parser.GetParamCount(); ++paramNr)
             g_params.push_back(parser.GetParam(paramNr));
@@ -1679,6 +1682,7 @@ bool MyApp::OnInit()
 #endif
 
     GpxDocument::SeedRandom();
+    safe_mode::set_mode(false);
     
     last_own_ship_sog_cog_calc_ts = wxInvalidDateTime;
 
@@ -1697,6 +1701,12 @@ bool MyApp::OnInit()
 
     // Instantiate the global OCPNPlatform class
     g_Platform = new OCPNPlatform;
+
+    // Check if last run failed, set up safe_mode.
+    if (!safe_mode::get_mode()) {
+        safe_mode::check_last_start();
+    }
+
 
 #ifndef __OCPN__ANDROID__
     //  On Windows
@@ -2689,6 +2699,7 @@ int MyApp::OnExit()
     delete m_checker;
 
     g_Platform->OnExit_2();
+    safe_mode::clear_check();
 
     return TRUE;
 }

--- a/src/download_mgr.cpp
+++ b/src/download_mgr.cpp
@@ -620,5 +620,6 @@ void GuiDownloader::showErrorDialog(const char* msg)
             text = text + "\nPlease check system log for more info.";
             dlg->SetMessage(text);
             dlg->ShowModal();
+            dlg->Destroy();
 }
 

--- a/src/easywsclient.cpp
+++ b/src/easywsclient.cpp
@@ -1,4 +1,8 @@
 
+#ifdef __MINGW32__
+#include <iostream>
+#endif
+
 #ifdef _WIN32
     #if defined(_MSC_VER) && !defined(_CRT_SECURE_NO_WARNINGS)
         #define _CRT_SECURE_NO_WARNINGS // _CRT_SECURE_NO_WARNINGS for sscanf errors in MSVC2013 Express
@@ -7,8 +11,8 @@
         #define WIN32_LEAN_AND_MEAN
     #endif
     #include <fcntl.h>
-    #include <WinSock2.h>
-    #include <WS2tcpip.h>
+    #include <winsock2.h>
+    #include <ws2tcpip.h>
     #pragma comment( lib, "ws2_32" )
     #include <stdio.h>
     #include <stdlib.h>
@@ -26,8 +30,8 @@
     #ifndef snprintf
         #define snprintf _snprintf_s
     #endif
-    #if _MSC_VER >=1600
-        // vs2010 or later
+    #if _MSC_VER >=1600 || defined(__MINGW32__)
+        // vs2010 or later, or mingw
         #include <stdint.h>
     #else
         typedef __int8 int8_t;
@@ -92,7 +96,11 @@ socket_t hostname_connect(const std::string& hostname, int port) {
     snprintf(sport, 16, "%d", port);
     if ((ret = getaddrinfo(hostname.c_str(), sport, &hints, &result)) != 0)
     {
+#ifdef __MINGW32__
+      std::cerr << "getaddrinfo" << gai_strerror(ret) << std::endl;
+#else
       fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(ret));
+#endif
       return 1;
     }
     for(p = result; p != NULL; p = p->ai_next)

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -94,6 +94,7 @@
 #include "multiplexer.h"
 #include "ocpn_utils.h"
 #include "piano.h"
+#include "safe_mode.h"
 #include "routeman.h"
 #include "FontMgr.h"
 #include "AIS_Decoder.h"
@@ -845,6 +846,11 @@ bool PlugInManager::LoadPlugInDirectory(const wxString& plugin_dir, bool load_en
         {
             wxLogMessage(wxString::Format(_T("    %s: %s"), _T("Incompatible plugin detected"), file_name.c_str()));
             OCPNMessageBox( NULL, wxString::Format(_("The plugin %s is not compatible with this version of OpenCPN, please get an updated version."), plugin_file.c_str()), wxString(_("OpenCPN Info")), wxICON_INFORMATION | wxOK, 10 );
+        }
+
+        // Safe mode? If so, refuse to load.
+        if (safe_mode::get_mode()) {
+            continue;
         }
             
         PlugInContainer *pic = NULL;

--- a/src/safe_mode.cpp
+++ b/src/safe_mode.cpp
@@ -10,6 +10,7 @@
 #include "safe_mode.h"
 
 extern OCPNPlatform*            g_Platform;
+extern bool                     g_bdisable_opengl;
 
 namespace safe_mode {
 
@@ -17,7 +18,11 @@ static bool safe_mode = false;
 
 bool get_mode() { return safe_mode; }
 
-void set_mode(bool mode) { safe_mode = mode; }
+void set_mode(bool mode)
+{
+    safe_mode = mode;
+    g_bdisable_opengl = g_bdisable_opengl || mode;
+}
 
 static const char* LAST_RUN_ERROR_MSG = \
     "The last opencpn run seems to have failed. Do you want to run\n"

--- a/src/safe_mode.cpp
+++ b/src/safe_mode.cpp
@@ -1,0 +1,73 @@
+#include <cstdio>
+#include <string>
+#include <fstream>
+
+#include <wx/dialog.h>
+
+#include "OCPNPlatform.h"
+#include "ocpn_utils.h"
+
+#include "safe_mode.h"
+
+extern OCPNPlatform*            g_Platform;
+
+namespace safe_mode {
+
+static bool safe_mode = false;
+
+bool get_mode() { return safe_mode; }
+
+void set_mode(bool mode) { safe_mode = mode; }
+
+static const char* LAST_RUN_ERROR_MSG = \
+    "The last opencpn run seems to have failed. Do you want to run\n"
+    "in safe mode without plugins and other possibly problematic\n"
+    "features?";
+
+
+#ifdef _WIN32
+static std::string SEP("\\");
+#else
+static std::string SEP("/");
+#endif
+
+
+static std::string check_file_path() 
+{
+    std::string path = g_Platform->GetPrivateDataDir().ToStdString();
+    path += SEP;
+    path += "startcheck.dat";
+    return path;
+}
+
+
+/** 
+ * Check if the last start failed, possibly invoke user dialog and set 
+ * safe mode state.
+ */
+void check_last_start()
+{
+    std::string path = g_Platform->GetPrivateDataDir().ToStdString();
+    path += SEP;
+    path += "start-check.dat";
+    if (ocpn::exists(path)) {
+        std::ofstream dest(path, std::ios::binary);
+        dest << "Internal opencpn use" << std::endl;
+        dest.close();
+        return;
+    }
+    auto dlg = new wxMessageDialog(0,  _(LAST_RUN_ERROR_MSG), "",
+                                   wxYES_NO | wxCENTRE | wxICON_QUESTION);
+    int reply = dlg->ShowModal();
+    safe_mode = reply == wxID_YES;
+    dlg->Destroy();
+}
+
+
+/** Mark last run as successful. */
+void clear_check()
+{
+    remove(check_file_path().c_str());
+}
+
+}  // namespace safe_mode

--- a/src/safe_mode.cpp
+++ b/src/safe_mode.cpp
@@ -47,10 +47,8 @@ static std::string check_file_path()
  */
 void check_last_start()
 {
-    std::string path = g_Platform->GetPrivateDataDir().ToStdString();
-    path += SEP;
-    path += "start-check.dat";
-    if (ocpn::exists(path)) {
+    std::string path = check_file_path();
+    if (!ocpn::exists(path)) {
         std::ofstream dest(path, std::ios::binary);
         dest << "Internal opencpn use" << std::endl;
         dest.close();


### PR DESCRIPTION

  - Add a new command line option `--safe_mode`.
  - Check if last opencpn run failed and offer user to run in safe mode if so.
  - In safe mode, disable plugin loading and OpenGL.

There are ideas to also block Connections in safe mode. This is not implemented.

This functionality might have affect how to eventually redesign plugin dialogs. 
