### PR TITLE
wxWidgets Allert warning.

### DIFF
--- a/src/AIS_Target_Data.cpp
+++ b/src/AIS_Target_Data.cpp
@@ -493,7 +493,7 @@ wxString AIS_Target_Data::BuildQueryResult( void )
 
         now.MakeGMT();
         int target_age = now.GetTicks() - PositionReportTicks;
-        wxLogMessage(wxString::Format(_T("** PositionReportTicks %d %d %d"),
+        wxLogMessage(wxString::Format(_T("** PositionReportTicks %ld %ld %d"),
                                       now.GetTicks(), PositionReportTicks, target_age));
 
         html << vertSpacer


### PR DESCRIPTION
Opening an AIS object properties dialog was giving an wxwidgets allert warning. Easy fix.

`ASSERT INFO:
/usr/include/wx-3.0/wx/strvararg.h(456): assert "(argtype & (wxFormatStringSpecifier<T>::value)) == argtype" failed in wxArgNormalizer(): format specifier doesn't match argument type

BACKTRACE:
[1] wxString wxString::Format<long, long, int>(wxFormatString const&, long, long, int)
[2] AIS_Target_Data::BuildQueryResult()`