### PR TITLE
missing "break;"

### DIFF
--- a/src/canvasMenu.cpp
+++ b/src/canvasMenu.cpp
@@ -970,6 +970,7 @@ void CanvasMenuHandler::PopupMenuHandler( wxCommandEvent& event )
 
     case ID_DEF_MENU_SCALE_IN:
         parent->DoCanvasStackDelta( -1 );
+	break;
 
     case ID_DEF_MENU_SCALE_OUT:
         parent->DoCanvasStackDelta( 1 );


### PR DESCRIPTION
One more missing "break;" in the current source.