### PR TITLE
Check also version in compatibliity check (#1681)

### DIFF
--- a/include/PluginHandler.h
+++ b/include/PluginHandler.h
@@ -122,13 +122,12 @@ class PluginHandler {
 	/** Uninstall an installed plugin. */
         bool uninstall(const std::string plugin);
 
-        std::string getLastErrorMsg() { return last_error_msg; }
 
         CatalogData *GetCatalogData(){ return &catalogData; }
         
     protected:
 	/** Initiats the handler and set up LD_LIBRARY_PATH. */
-        PluginHandler() { m_sOsLike = ""; }
+        PluginHandler() {}
 
     private:
         std::string metadataPath;
@@ -140,38 +139,6 @@ class PluginHandler {
                             std::string& filelist);
         bool extractTarball(const std::string path, std::string& filelist);
         bool archive_check(int r, const char* msg, struct archive* a);
-
-        wxString m_sOsLike;
-        void find_compat_target(const std::string& plugin_target)
-        {
-            if (m_sOsLike != "") {
-                return;
-            }
-            if (getenv("OPENCPN_COMPAT_TARGET") != 0) {
-                // Undocumented test hook.
-                m_sOsLike = getenv("OPENCPN_COMPAT_TARGET");
-                return;
-            }
-            if (plugin_target != "ubuntu") {
-                return;
-            }
-            wxFile file("/etc/os-release");
-            if(!file.IsOpened()) {
-                return;
-            }
-            wxString l_InString;
-            if(file.ReadAll(&l_InString)) {
-                // Find OS_LIKE in string
-                int l_nPos = l_InString.Find("ID_LIKE=");
-                if(l_nPos != wxNOT_FOUND) {
-                    l_nPos += 8;
-                    int l_nEnd = l_InString.find('\n', l_nPos);
-                    m_sOsLike.append(l_InString.SubString(l_nPos, l_nEnd - 1));
-                }
-            }
-            file.Close();
-        }
-
 };
 
 

--- a/include/PluginHandler.h
+++ b/include/PluginHandler.h
@@ -56,6 +56,8 @@
 #ifndef PLUGIN_HANDLER_H__
 #define PLUGIN_HANDLER_H__
 
+#include "config.h"
+
 #include <string>
 #include <memory>
 #include <vector>
@@ -86,6 +88,12 @@ class PluginHandler {
 
         /** Return path to file containing version for given plugin. */
         static std::string versionPath(std::string name);
+
+        /** Return true if given plugin is loadable on given os/version. */
+        static bool isCompatible(const PluginMetadata& metadata,
+                                 const char* os = PKG_TARGET,
+                                 const char* os_version = PKG_TARGET_VERSION);
+         
 
         /** Check if given plugin can be installed/updated. */
         bool isPluginWritable(std::string name);

--- a/include/PluginHandler.h
+++ b/include/PluginHandler.h
@@ -122,6 +122,7 @@ class PluginHandler {
 	/** Uninstall an installed plugin. */
         bool uninstall(const std::string plugin);
 
+        std::string getLastErrorMsg() { return last_error_msg; }
 
         CatalogData *GetCatalogData(){ return &catalogData; }
         

--- a/include/PluginHandler.h
+++ b/include/PluginHandler.h
@@ -66,16 +66,26 @@
 
 #include "catalog_parser.h"
 
-//  Some useful static functions
-extern bool isRegularFile(const char* path);
-extern std::string fileListPath(std::string name);
-extern std::string versionPath(std::string name);
-extern void cleanup(const std::string& filelist, const std::string& plugname);
+bool isRegularFile(const char* path);
+
+
+
+
 
 class PluginHandler {
 
     public:
         static PluginHandler* getInstance();
+
+        /** Cleanup failed installation attempt using filelist for plugin. */
+        static void
+            cleanup(const std::string& filelist, const std::string& plugname);
+
+        /** Return path to installation manifest for given plugin. */
+        static std::string fileListPath(std::string name);
+
+        /** Return path to file containing version for given plugin. */
+        static std::string versionPath(std::string name);
 
         /** Check if given plugin can be installed/updated. */
         bool isPluginWritable(std::string name);

--- a/include/ocpn_utils.h
+++ b/include/ocpn_utils.h
@@ -40,6 +40,10 @@ std::string trim(std::string s);
 
 std::string join(std::vector<std::string> v, char c);
 
+std::string tolower(const std::string& s);
+
+std::vector<std::string> split(const char* s, const std::string& delimiter);
+
 bool exists(const std::string& path);
 
 void mkdir(const std::string path);

--- a/src/PluginHandler.cpp
+++ b/src/PluginHandler.cpp
@@ -179,7 +179,7 @@ bool PluginHandler::isCompatible(const PluginMetadata& metadata,
         }
     }
     else if (g_compatOS != "") {
-        // CompatOS set in opencpn.conf/.ini file.
+        // CompatOS and CompatOsVersion in opencpn.conf/.ini file.
         compatOS = g_compatOS;
         if (g_compatOsVersion != ""){
             compatOsVersion = g_compatOsVersion;
@@ -787,10 +787,10 @@ bool PluginHandler::uninstall(const std::string plugin_name)
 
 std::vector<PluginMetadata> PluginHandler::getAvailableUniquePlugins()
 {
-               /** Compare two PluginMetadata objects, a named c++ requirement. */
+    /** Compare two PluginMetadata objects, a named c++ requirement. */
     struct metadata_compare{
         bool operator() (const PluginMetadata& lhs,
-                                 const PluginMetadata& rhs) const
+                         const PluginMetadata& rhs) const
         {
             return lhs.key() < rhs.key();
         }
@@ -803,13 +803,9 @@ std::vector<PluginMetadata> PluginHandler::getAvailableUniquePlugins()
         unique_plugins.insert(plugin);
     }
     for (auto plugin: unique_plugins) {
-        if (plugin.target != PKG_TARGET) {
-            find_compat_target(plugin.target);
-            if (plugin.target != m_sOsLike)
-                continue;
+        if (PluginHandler::isCompatible(plugin)) {
+            returnArray.push_back(plugin);
         }
-        returnArray.push_back(plugin);
     }
-    
     return returnArray;
 }

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -204,6 +204,10 @@ bool                      g_bFirstRun;
 bool                      g_bUpgradeInProcess;
 
 bool                      g_bPauseTest;
+
+wxString                  g_compatOS;
+wxString                  g_compatOsVersion;
+
 int                       g_unit_test_1;
 int                       g_unit_test_2;
 bool                      g_start_fullscreen;

--- a/src/download_mgr.cpp
+++ b/src/download_mgr.cpp
@@ -449,10 +449,8 @@ class OcpnScrolledWindow : public wxScrolledWindow
                 unique_plugins.insert(plugin);
             }
             for (auto plugin: unique_plugins) {
-                if (plugin.target != PKG_TARGET) {
-                    find_compat_target(plugin.target);
-                    if (plugin.target != m_sOsLike)
-                        continue;
+                if (!PluginHandler::isCompatible(plugin)) {
+                    continue;
                 }
                 grid->Add(new PluginIconPanel(this, plugin.name), flags.Expand());
                 auto buttons = new CandidateButtonsPanel(this, &plugin);

--- a/src/download_mgr.cpp
+++ b/src/download_mgr.cpp
@@ -413,8 +413,7 @@ class OcpnScrolledWindow : public wxScrolledWindow
     public:
         OcpnScrolledWindow(wxWindow* parent)
             :wxScrolledWindow(parent),
-            m_grid(new wxFlexGridSizer(3, 0, 0)),
-            m_sOsLike("")
+            m_grid(new wxFlexGridSizer(3, 0, 0))
         {
             auto box = new wxBoxSizer(wxVERTICAL);
             populateGrid(m_grid);
@@ -476,36 +475,6 @@ class OcpnScrolledWindow : public wxScrolledWindow
 
     private:
         wxFlexGridSizer* m_grid;
-        wxString m_sOsLike;
-        void find_compat_target(const std::string& plugin_target)
-        {
-            if (m_sOsLike != "") {
-                return;
-            }
-            if (getenv("OPENCPN_COMPAT_TARGET") != 0) {
-                // Undocumented test hook.
-                m_sOsLike = getenv("OPENCPN_COMPAT_TARGET");
-                return;
-            }
-            if (plugin_target != "ubuntu") {
-                return;
-            }
-            wxFile file("/etc/os-release");
-            if(!file.IsOpened()) {
-                return;
-            }
-            wxString l_InString;
-            if(file.ReadAll(&l_InString)) {
-                // Find OS_LIKE in string
-                int l_nPos = l_InString.Find("ID_LIKE=");
-                if(l_nPos != wxNOT_FOUND) {
-                    l_nPos += 8;
-                    int l_nEnd = l_InString.find('\n', l_nPos);
-                    m_sOsLike.append(l_InString.SubString(l_nPos, l_nEnd - 1));
-                }
-            }
-            file.Close();
-        }
 };
 
 }  // namespace download_mgr

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -444,6 +444,9 @@ extern int              g_route_prop_x, g_route_prop_y;
 extern int              g_route_prop_sx, g_route_prop_sy;
 extern int              g_AndroidVersionCode;
 
+extern wxString         g_compatOS;
+extern wxString         g_compatOsVersion;
+
 wxString                g_gpx_path;
 bool                    g_bLayersLoaded;
 bool                    g_bShowMuiZoomButtons = true;
@@ -754,6 +757,8 @@ int MyConfig::LoadMyConfigRaw( bool bAsTemplate )
     SetPath( _T ( "/Settings" ) );    
     
     Read( _T ( "LastAppliedTemplate" ), &g_lastAppliedTemplateGUID );
+    Read( _T ( "CompatOS" ), &g_compatOS );
+    Read( _T ( "CompatOsVersion" ), &g_compatOsVersion );
     
     // Some undocumented values
     Read( _T ( "ConfigVersionString" ), &g_config_version_string );
@@ -2251,7 +2256,8 @@ void MyConfig::UpdateSettings()
     SetPath( _T ( "/Settings" ) );
 
     Write( _T ( "LastAppliedTemplate" ), g_lastAppliedTemplateGUID );
-    
+    Write( _T ( "CompatOS" ), g_compatOS);
+    Write( _T ( "CompatOsVersion" ), g_compatOsVersion);
     Write( _T ( "ConfigVersionString" ), g_config_version_string );
 #ifdef SYSTEM_SOUND_CMD
     if ( wxIsEmpty( g_CmdSoundString ) )

--- a/src/ocpn_utils.cpp
+++ b/src/ocpn_utils.cpp
@@ -53,18 +53,20 @@ bool startswith(const std::string& str, const std::string& prefix)
 }
 
 
-/** split s on first occurrence of delim, or return s in first result. */
-static std::vector<std::string> split(const std::string& s, const std::string& delim)
+std::vector<std::string> split(const char* token_string,
+                               const std::string& delimiter)
 {
-    std::vector<std::string> result;
-    size_t pos = s.find(delim);
-    if (pos == std::string::npos) {
-        result.push_back(s);
-        return result;
+    std::vector<std::string> tokens;
+    std::string s = std::string(token_string);
+    size_t pos = 0;
+    std::string token;
+    while ((pos = s.find(delimiter)) != std::string::npos) {
+        token = s.substr(0, pos);
+        tokens.push_back(token);
+        s.erase(0, pos + delimiter.length());
     }
-    result.push_back(s.substr(0, pos));
-    result.push_back(s.substr(pos + delim.length()));
-    return result;
+    tokens.push_back(s);
+    return tokens;
 }
 
 
@@ -126,6 +128,13 @@ std::string join(std::vector<std::string> v, char c)
             s += c;
         }
     }
+    return s;
+}
+
+std::string tolower(const std::string& input)
+{
+    std::string s(input);
+    std::transform(s.begin(), s.end(), s.begin(), ::tolower);
     return s;
 }
 

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -485,7 +485,8 @@ void pluginUtilHandler::OnPluginUtilAction( wxCommandEvent& event )
 
             
             // Provisional error check
-            std::string manifestPath = fileListPath(g_actionPIC->m_ManagedMetadata.name);
+            std::string manifestPath =
+                PluginHandler::fileListPath(g_actionPIC->m_ManagedMetadata.name);
             if(isRegularFile(manifestPath.c_str())) {
 
                 // dynamically deactivate the legacy plugin, making way for the upgrade.
@@ -499,9 +500,10 @@ void pluginUtilHandler::OnPluginUtilAction( wxCommandEvent& event )
                 //  Reload all plugins, which will bring in the new, managed version.
                 g_pi_manager->LoadAllPlugIns( false );
             }
-            else
-                cleanup(manifestPath, g_actionPIC->m_ManagedMetadata.name);
-
+            else {
+                PluginHandler::cleanup(manifestPath,
+                                       g_actionPIC->m_ManagedMetadata.name);
+            }
             g_pi_manager->GetListPanelPtr()->ReloadPluginPanels(g_pi_manager->GetPlugInArray());
             g_pi_manager->GetListPanelPtr()->SelectByName(name);
 
@@ -529,10 +531,11 @@ void pluginUtilHandler::OnPluginUtilAction( wxCommandEvent& event )
             downloader->run(gFrame/*g_pi_manager->GetListPanelPtr()*/);
             
             // Provisional error check
-             std::string manifestPath = fileListPath(metaSave.name);
+             std::string manifestPath =
+                 PluginHandler::fileListPath(metaSave.name);
              if(!isRegularFile(manifestPath.c_str())) {
                  wxLogMessage("Installation of %s failed",  metaSave.name.c_str());
-                 cleanup(manifestPath, metaSave.name);
+                 PluginHandler::cleanup(manifestPath, metaSave.name);
              }
 
              //  Reload all plugins, which will bring in the action results.
@@ -552,10 +555,11 @@ void pluginUtilHandler::OnPluginUtilAction( wxCommandEvent& event )
             downloader->run(g_pi_manager->GetListPanelPtr());
             
             // Provisional error check
-             std::string manifestPath = fileListPath(metaSave.name);
+             std::string manifestPath =
+                 PluginHandler::fileListPath(metaSave.name);
              if(!isRegularFile(manifestPath.c_str())) {
                  wxLogMessage("Installation of %s failed",  metaSave.name.c_str());
-                 cleanup(manifestPath, metaSave.name);
+                 PluginHandler::cleanup(manifestPath, metaSave.name);
              }
 
             //  Reload all plugins, which will bring in the action results.
@@ -1312,11 +1316,11 @@ void PlugInManager::UpdateManagedPlugins()
         // Match found, so merge the info and determine the plugin status        
         else{
             // If the managed plugin is installed, the fileList (manifest) will be present
-            if(isRegularFile(fileListPath(plugin.name).c_str())) {
+            if (isRegularFile(PluginHandler::fileListPath(plugin.name).c_str())) {
                 
                 // Get the installed version from the manifest
                 std::string installed;
-                std::string path = versionPath(plugin.name);
+                std::string path = PluginHandler::versionPath(plugin.name);
                 if (path != "" && wxFileName::IsFileReadable(path)) {
                     std::ifstream stream;
                     stream.open(path, std::ifstream::in);
@@ -1861,7 +1865,7 @@ bool PlugInManager::CheckPluginCompatibility(wxString plugin_file)
     fclose(f);
 #endif
 #endif // __WXGTK__
-    wxLogMessage("PLugin is compatible: %s", b_compat ? "true" : "false");
+    wxLogMessage("Plugin is compatible: %s", b_compat ? "true" : "false");
     return b_compat;
 }
 
@@ -5258,6 +5262,7 @@ void PluginListPanel::MoveDown( PluginPanel *pi )
     m_parent->Layout();
     Refresh(false);
 }
+
 
 static bool canUninstall(std::string name)
 {


### PR DESCRIPTION
Check not only operating system but also version before deeming a plugin as compatible (that is, loadable).

The previous code which basically checked for Mint and used Ubuntu in this case case been removed, mostly because it wasn't possible to determine the version to use this way.

New code checks that operating system and operating system version are compatible with the  plugin by comparing the configuration constants  PKG_TARGET and  PKG_TARGET_VERSION with plugin metadata.

There are two ways to override the default checks:

   - By setting compatOS and compatOsVersion in the configuration file manually (there is yet
     no GUI). This overrides the PKG_TARGET\* variables.

  - By setting the OPENCPN_COMPAT_VERSION environment  variable. This is used like
    OS:VERSION for example Ubuntu:16.04


Closes: #1681