### PR TITLE
Check reasonably Barometer pressure due to Pa-hPa mismatch in SignalK.

### DIFF
--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -1567,7 +1567,7 @@ void dashboard_pi::updateSKItem(wxJSONValue &item, wxString &sfixtime) {
         else if (update_path == _T("environment.water.temperature")) {
             if (mPriWTP >= 1) {
                 double m_wtemp = KELVIN2C(value.AsDouble());
-                if (m_wtemp > -60 && m_wtemp < 200 && !isnan(m_wtemp)) {
+                if (m_wtemp > -60 && m_wtemp < 200 && !std::isnan(m_wtemp)) {
                     mPriWTP = 1;
                     SendSentenceToAllInstruments(OCPN_DBP_STC_TMP, m_wtemp, "C");
                     mWTP_Watchdog = no_nav_watchdog_timeout_ticks;
@@ -1613,7 +1613,7 @@ void dashboard_pi::updateSKItem(wxJSONValue &item, wxString &sfixtime) {
         else if (update_path == _T("environment.outside.temperature")) { //TODO check path: MTA/XDR N/A in SignK. 
             if (mPriATMP >= 1) {
                 double m_airtemp = KELVIN2C(value.AsDouble());
-                if (m_airtemp > -60 && m_airtemp < 200 && !isnan(m_airtemp)) {
+                if (m_airtemp > -60 && m_airtemp < 200 && !std::isnan(m_airtemp)) {
                     mPriATMP = 1;
                     SendSentenceToAllInstruments(OCPN_DBP_STC_ATMP, m_airtemp, "C");
                     mATMP_Watchdog = no_nav_watchdog_timeout_ticks;

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -3572,9 +3572,9 @@ void DashboardWindow::SetInstrumentList( wxArrayInt list )
                case ID_DBP_D_MDA: //barometric pressure
                 instrument = new DashboardInstrument_Speedometer( this, wxID_ANY,
                         getInstrumentCaption( id ), OCPN_DBP_STC_MDA, 938, 1088 );
-                ( (DashboardInstrument_Dial *) instrument )->SetOptionLabel( 10,
+                ( (DashboardInstrument_Dial *) instrument )->SetOptionLabel( 15,
                         DIAL_LABEL_HORIZONTAL );
-                ( (DashboardInstrument_Dial *) instrument )->SetOptionMarker( 5,
+                ( (DashboardInstrument_Dial *) instrument )->SetOptionMarker( 7.5,
                         DIAL_MARKER_SIMPLE, 1 );
                 ( (DashboardInstrument_Dial *) instrument )->SetOptionMainValue( _T("%5.1f"),
                         DIAL_POSITION_INSIDE );

--- a/plugins/dashboard_pi/src/dashboard_pi.h
+++ b/plugins/dashboard_pi/src/dashboard_pi.h
@@ -77,10 +77,11 @@ class DashboardInstrumentContainer;
 #define DASHBOARD_TOOL_POSITION -1          // Request default positioning of toolbar tool
 
 #define gps_watchdog_timeout_ticks  10
-
+#define no_nav_watchdog_timeout_ticks 40    // SignalK motor & environ instr defaults 30 sec
 #define GEODESIC_RAD2DEG(r) ((r)*(180.0/M_PI))
 #define MS2KNOTS(r) ((r)*(1.9438444924406))
 #define KELVIN2C(r) ((r)-(273.13))
+#define PA2HPA(r) ((r)/(100))
 
 #define wxFontPickerCtrl OCPNFontButton
 class OCPNFontButton;


### PR DESCRIPTION
- Check reasonably temperature values. Null is sometimes passed through SignalK
- Decreased number of decimals for Baro pressure
- Adjust Barometer gauge scale to show 1013 hPa as middle position.
- Implemented new 40 sec watchdog to prepare for non nautical data from SignalK. (Often defaults to 30 sec)