### PR TITLE
Correct a 180 degrees bearing error.

### DIFF
--- a/include/georef.h
+++ b/include/georef.h
@@ -150,7 +150,7 @@ extern "C" double DistLoxodrome(double slat, double slon, double dlat, double dl
 extern "C" int GetDatumIndex(const char *str);
 extern "C" void MolodenskyTransform (double lat, double lon, double *to_lat, double *to_lon, int from_datum_index, int to_datum_index);
 
-extern "C" void DistanceBearingMercator(double lat0, double lon0, double lat1, double lon1, double *brg, double *dist);
+extern "C" void DistanceBearingMercator(double lat1, double lon1, double lat0, double lon0, double *brg, double *dist);
 
 extern "C" int Georef_Calculate_Coefficients(struct GeoRef *cp, int nlin_lon);
 extern "C" int Georef_Calculate_Coefficients_Proj(struct GeoRef *cp);

--- a/src/georef.cpp
+++ b/src/georef.cpp
@@ -1186,7 +1186,7 @@ void ll_gc_ll_reverse(double lat1, double lon1, double lat2, double lon2,
     // For small distances do an ordinary mercator calc. (To prevent return of nan's )
     if ((fabs(lon2-lon1)<0.1) &&  (fabs(lat2-lat1)<0.1)) 
     {
-        DistanceBearingMercator( lat1, lon1, lat2, lon2, bearing, dist);
+        DistanceBearingMercator( lat2, lon2, lat1, lon1, bearing, dist);
         return;
     }
     else{
@@ -1412,7 +1412,7 @@ double DistGreatCircle(double slat, double slon, double dlat, double dlon)
 }
 
 
-void DistanceBearingMercator(double lat0, double lon0, double lat1, double lon1, double *brg, double *dist)
+void DistanceBearingMercator(double lat1, double lon1, double lat0, double lon0, double *brg, double *dist)
 {
     //Calculate bearing and distance between two points
     double latm = (lat0 + lat1)/2 * DEGREE; //median of latitude


### PR DESCRIPTION
While improving the algorithm for mercator course and distance, I didn't notice the difference in sequence of arguments between the greatcircle and the mercator function. (For greatcircle it is first lat/lon departure then lat/lon destination, and for the mercator first destination then departure. Grr)

The result is a bearing/course which is 180 degrees of.

