### PR TITLE
Fix forcing of wxWidgets version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -704,8 +704,8 @@ if (NOT QT_ANDROID)
   set(wxWidgets_USE_UNIVERSAL OFF)
   set(wxWidgets_USE_STATIC OFF)
 
-  if (WXWIDGETS_FORCE_VERSION)
-    set(wxWidgets_CONFIG_OPTIONS --version=${WXWIDGETS_FORCE_VERSION})
+  if (OCPN_WXWIDGETS_FORCE_VERSION)
+      set (wxWidgets_CONFIG_OPTIONS --version=${OCPN_WXWIDGETS_FORCE_VERSION})
   endif ()
 
   if (MSVC)


### PR DESCRIPTION
Allows setting of wxWidgets version for compile when more than one version is installed in Linux. 