### PR TITLE
Adjust color scheme toggle function

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -5040,11 +5040,16 @@ void MyFrame::ToggleChartBar( ChartCanvas *cc)
 
 void MyFrame::ToggleColorScheme()
 {
+    static bool lastIsNight;
     ColorScheme s = GetColorScheme();
     int is = (int) s;
     is++;
+    if (lastIsNight && is == 3)         // Back from step 3
+        { is = 1; lastIsNight = false; }//      Goto to Day
+    if (lastIsNight) is = 2;            // Back to Dusk on step 3
+    if ( is == 3 ) lastIsNight = true;  // Step 2 Night
     s = (ColorScheme) is;
-    if( s == N_COLOR_SCHEMES ) s = GLOBAL_COLOR_SCHEME_RGB;
+    if (s == N_COLOR_SCHEMES) s = GLOBAL_COLOR_SCHEME_RGB;
 
     SetAndApplyColorScheme( s );
 }

--- a/src/compass.cpp
+++ b/src/compass.cpp
@@ -144,8 +144,8 @@ bool ocpnCompass::MouseEvent( wxMouseEvent& event )
 
 void ocpnCompass::SetColorScheme( ColorScheme cs )
 {
-    UpdateStatus( true );
     m_cs = cs;
+    UpdateStatus( true );
 }
 
 void ocpnCompass::UpdateStatus( bool bnew )


### PR DESCRIPTION
When a user want to toggle Color scheme, by a tools click or F5, a common request would be:
 On evening one toggle to dusk.
 It's getting darker, toggle to night.
 Morning to come. Toggle to leave darkest night scheme but Ooops. Day light on screen!
 Would have expected dusk again until the sun is up and the last toggle for this night.
 
 Present toggle scheme:
 Init 		 : GLOBAL_COLOR_SCHEME_DAY
 first click : GLOBAL_COLOR_SCHEME_DUSK
 second click: GLOBAL_COLOR_SCHEME_NIGHT
 third click : GLOBAL_COLOR_SCHEME_RGB  (This is a day scheme on chart but dimmed compass.)
 fourth click: GLOBAL_COLOR_SCHEME_DAY  
 Bug: Compass is always "one step behind"
 
 After the patch: 
 Init 		 : GLOBAL_COLOR_SCHEME_DAY
 first click : GLOBAL_COLOR_SCHEME_DUSK
 second click: GLOBAL_COLOR_SCHEME_NIGHT
 third click : GLOBAL_COLOR_SCHEME_DUSK
 fourth click: GLOBAL_COLOR_SCHEME_DAY  
 Compass is also corrected to be on phase.

I don't understand why GLOBAL_COLOR_SCHEME_RGB have been used here so please check for any foolishness from my side.
Now when compass is on phase we could go to Scheme RGB on fourth click but then on next time use it takes two clicks from RGB to Day to Dusk.