### PR TITLE
Bugfix for buffer overflow in AIS_Decoder::Decode

### DIFF
--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -893,7 +893,7 @@ AIS_Error AIS_Decoder::Decode( const wxString& str )
         token = tkz.GetNextToken(); //11) Target name
         if ( token == wxEmptyString )
             token = wxString::Format( _T("ARPA %d"), arpa_tgt_num );
-        int len = token.Length();
+        int len = wxMin(token.Length(),20);
         strncpy( arpa_name_str, token.mb_str(), len );
         arpa_name_str[len] = 0;
         arpa_status = tkz.GetNextToken(); //12) Target Status
@@ -955,7 +955,7 @@ AIS_Error AIS_Decoder::Decode( const wxString& str )
         token = tkz.GetNextToken(); //4) Target name
         if ( token == wxEmptyString )
             token = wxString::Format( _T("ARPA %d"), arpa_tgt_num );
-        int len = token.Length();
+        int len = wxMin(token.Length(),20);
         strncpy( arpa_name_str, token.mb_str(), len );
         arpa_name_str[len] = 0;
         token = tkz.GetNextToken(); //5) UTC of data
@@ -1011,7 +1011,7 @@ AIS_Error AIS_Decoder::Decode( const wxString& str )
         if( token.Mid( 0, 1 ).Contains( _T("W") ) == true || token.Mid( 0, 1 ).Contains( _T("w") ) == true )
             aprs_lon = 0. - aprs_lon;
         token = tkz.GetNextToken(); //5) Target name
-        int len = token.Length();
+        int len = wxMin(token.Length(),20);
         int i, hash = 0;
         strncpy( aprs_name_str, token.mb_str(), len );
         aprs_name_str[len] = 0;


### PR DESCRIPTION
This is a fix for a buffer overflow which can occur in the AIS_Decoder:Decode function if the NMEA sentence is malformed. For more details see issues #1738.