### PR TITLE
safe-mode: Make no default, add timeout (#1705).

### DIFF
--- a/src/safe_mode.cpp
+++ b/src/safe_mode.cpp
@@ -3,6 +3,8 @@
 #include <fstream>
 
 #include <wx/dialog.h>
+#include <wx/filename.h>
+#include <wx/sizer.h>
 
 #include "OCPNPlatform.h"
 #include "ocpn_utils.h"
@@ -12,23 +14,15 @@
 extern OCPNPlatform*            g_Platform;
 extern bool                     g_bdisable_opengl;
 
+extern wxImage LoadSVGIcon(wxString filename, int width, int height);
+
+
 namespace safe_mode {
 
-static bool safe_mode = false;
-
-bool get_mode() { return safe_mode; }
-
-void set_mode(bool mode)
-{
-    safe_mode = mode;
-    g_bdisable_opengl = g_bdisable_opengl || mode;
-}
-
 static const char* LAST_RUN_ERROR_MSG = \
-    "The last opencpn run seems to have failed. Do you want to run\n"
+    _("The last opencpn run seems to have failed. Do you want to run\n"
     "in safe mode without plugins and other possibly problematic\n"
-    "features?";
-
+    "features?\n");
 
 #ifdef _WIN32
 static std::string SEP("\\");
@@ -37,7 +31,13 @@ static std::string SEP("/");
 #endif
 
 
-static std::string check_file_path() 
+static const int TIMEOUT_SECONDS = 15;
+
+
+static bool safe_mode = false;
+
+
+static std::string check_file_path()
 {
     std::string path = g_Platform->GetPrivateDataDir().ToStdString();
     path += SEP;
@@ -46,8 +46,87 @@ static std::string check_file_path()
 }
 
 
+static void LoadIcon(const char* plugin_name, wxBitmap& bitmap, int size=32)
+{
+    wxFileName path(g_Platform->GetSharedDataDir(), plugin_name);
+    path.AppendDir("uidata");
+    path.AppendDir("markicons");
+    bool ok = false;
+    path.SetExt("svg");
+    if (path.IsFileReadable()) {
+        wxImage img = LoadSVGIcon(path.GetFullPath(), size, size);
+        bitmap = wxBitmap(img);
+        ok = bitmap.IsOk();
+    }
+    if (!ok) {
+        wxLogMessage("Cannot load Symbol-Question-Black.svg icon");
+    }
+}
+
+
+class SafeModeDialog: public wxDialog
+{
+
+    public:
+        SafeModeDialog() :
+            wxDialog(0, wxID_ANY, "Safe restart") 
+        {
+            timer.Bind(wxEVT_TIMER, [&](wxTimerEvent) { EndModal(wxID_NO); });
+            timer.StartOnce(TIMEOUT_SECONDS * 1000);
+
+            wxBitmap bitmap;
+            LoadIcon("Symbol-Question-Black.svg", bitmap, 64);
+            auto static_bitmap = new wxStaticBitmap(this, wxID_ANY, bitmap);
+
+            auto hbox = new wxBoxSizer(wxHORIZONTAL);
+            hbox->Add(static_bitmap);
+            hbox->Add(new wxStaticText(this, wxID_ANY,  LAST_RUN_ERROR_MSG),
+                      wxSizerFlags().Expand());
+
+            auto no_btn = new wxButton(this, wxID_NO);
+            no_btn->SetFocus();
+            no_btn->Bind(wxEVT_COMMAND_BUTTON_CLICKED,
+                         [&](wxCommandEvent&) { EndModal(wxID_NO); } );
+
+            auto yes_btn = new wxButton(this, wxID_YES);
+            yes_btn->Bind(wxEVT_COMMAND_BUTTON_CLICKED,
+                          [&](wxCommandEvent&) { EndModal(wxID_YES); } );
+
+            auto buttons = new wxStdDialogButtonSizer();
+            buttons->Add(no_btn, wxSizerFlags().Border());
+            buttons->Add(yes_btn, wxSizerFlags().Border());
+
+            auto vbox = new wxBoxSizer(wxVERTICAL);
+            vbox->Add(hbox);
+            vbox->Add(buttons);
+
+            SetSizer(vbox);
+            auto size = GetTextExtent(
+                "in safe mode without plugins and other possibly problematic");
+            SetMinClientSize(wxSize(size.GetWidth() * 12 / 10,
+                             size.GetHeight() * 8));
+            SetMaxClientSize(wxSize(-1, size.GetHeight() * 8));
+            Layout();
+            Show();
+        };
+
+    private:
+        wxTimer timer;
+};
+
+
+void set_mode(bool mode)
+{
+    safe_mode = mode;
+    g_bdisable_opengl = g_bdisable_opengl || mode;
+}
+
+
+bool get_mode() { return safe_mode; }
+
+
 /** 
- * Check if the last start failed, possibly invoke user dialog and set 
+ * Check if the last start failed, possibly invoke user dialog and set
  * safe mode state.
  */
 void check_last_start()
@@ -59,8 +138,7 @@ void check_last_start()
         dest.close();
         return;
     }
-    auto dlg = new wxMessageDialog(0,  _(LAST_RUN_ERROR_MSG), "",
-                                   wxYES_NO | wxCENTRE | wxICON_QUESTION);
+    auto dlg = new SafeModeDialog();
     int reply = dlg->ShowModal();
     safe_mode = reply == wxID_YES;
     dlg->Destroy();
@@ -72,5 +150,6 @@ void clear_check()
 {
     remove(check_file_path().c_str());
 }
+
 
 }  // namespace safe_mode

--- a/src/safe_mode.cpp
+++ b/src/safe_mode.cpp
@@ -8,6 +8,7 @@
 
 #include "OCPNPlatform.h"
 #include "ocpn_utils.h"
+#include "chart1.h"
 
 #include "safe_mode.h"
 
@@ -45,76 +46,6 @@ static std::string check_file_path()
     return path;
 }
 
-
-static void LoadIcon(const char* plugin_name, wxBitmap& bitmap, int size=32)
-{
-    wxFileName path(g_Platform->GetSharedDataDir(), plugin_name);
-    path.AppendDir("uidata");
-    path.AppendDir("markicons");
-    bool ok = false;
-    path.SetExt("svg");
-    if (path.IsFileReadable()) {
-        wxImage img = LoadSVGIcon(path.GetFullPath(), size, size);
-        bitmap = wxBitmap(img);
-        ok = bitmap.IsOk();
-    }
-    if (!ok) {
-        wxLogMessage("Cannot load Symbol-Question-Black.svg icon");
-    }
-}
-
-
-class SafeModeDialog: public wxDialog
-{
-
-    public:
-        SafeModeDialog() :
-            wxDialog(0, wxID_ANY, "Safe restart") 
-        {
-            timer.Bind(wxEVT_TIMER, [&](wxTimerEvent) { EndModal(wxID_NO); });
-            timer.StartOnce(TIMEOUT_SECONDS * 1000);
-
-            wxBitmap bitmap;
-            LoadIcon("Symbol-Question-Black.svg", bitmap, 64);
-            auto static_bitmap = new wxStaticBitmap(this, wxID_ANY, bitmap);
-
-            auto hbox = new wxBoxSizer(wxHORIZONTAL);
-            hbox->Add(static_bitmap);
-            hbox->Add(new wxStaticText(this, wxID_ANY,  LAST_RUN_ERROR_MSG),
-                      wxSizerFlags().Expand());
-
-            auto no_btn = new wxButton(this, wxID_NO);
-            no_btn->SetFocus();
-            no_btn->Bind(wxEVT_COMMAND_BUTTON_CLICKED,
-                         [&](wxCommandEvent&) { EndModal(wxID_NO); } );
-
-            auto yes_btn = new wxButton(this, wxID_YES);
-            yes_btn->Bind(wxEVT_COMMAND_BUTTON_CLICKED,
-                          [&](wxCommandEvent&) { EndModal(wxID_YES); } );
-
-            auto buttons = new wxStdDialogButtonSizer();
-            buttons->Add(no_btn, wxSizerFlags().Border());
-            buttons->Add(yes_btn, wxSizerFlags().Border());
-
-            auto vbox = new wxBoxSizer(wxVERTICAL);
-            vbox->Add(hbox);
-            vbox->Add(buttons);
-
-            SetSizer(vbox);
-            auto size = GetTextExtent(
-                "in safe mode without plugins and other possibly problematic");
-            SetMinClientSize(wxSize(size.GetWidth() * 12 / 10,
-                             size.GetHeight() * 8));
-            SetMaxClientSize(wxSize(-1, size.GetHeight() * 8));
-            Layout();
-            Show();
-        };
-
-    private:
-        wxTimer timer;
-};
-
-
 void set_mode(bool mode)
 {
     safe_mode = mode;
@@ -138,7 +69,14 @@ void check_last_start()
         dest.close();
         return;
     }
-    auto dlg = new SafeModeDialog();
+    long style = wxYES | wxNO | wxNO_DEFAULT | wxICON_QUESTION;
+    auto dlg = new OCPN_TimedHTMLMessageDialog(0,
+                                               LAST_RUN_ERROR_MSG,
+                                               _("Safe restart"),
+                                               TIMEOUT_SECONDS,
+                                               style,
+                                               false,
+                                               wxDefaultPosition);
     int reply = dlg->ShowModal();
     safe_mode = reply == wxID_YES;
     dlg->Destroy();


### PR DESCRIPTION
Make No the default option, so users just clicking don't are surprised
by missing plugins etc.

Add a timeout to the dialog for use-cases where it's hard/impossible to
click buttons.

The latter become messy since the standard wxMessageDialog cannot handle
timeouts. Thus the dialog is rewritten as a basic wxDialog. It certainly
looks worse than the standard dialog, but it does support timeouts.