### PR TITLE
Relicense opencpn.appdata.xml CC0-1.0 -> gpl-2+ (#1490).

### DIFF
--- a/data/opencpn.appdata.xml
+++ b/data/opencpn.appdata.xml
@@ -2,7 +2,7 @@
 <!-- Copyright 2018 Alec Leamas <leamas@nowhere.net> -->
 <component type="desktop">
   <id>opencpn.desktop</id>
-  <metadata_license>CC0-1.0</metadata_license>
+  <metadata_license>gpl-2+</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>OpenCPN</name>
   <summary>A concise Chartplotter and Navigation software</summary>


### PR DESCRIPTION
The CC0-1.0 license was an oversight from my side. I have the
copyright and is thus free to relicense this file. Using the
overall gpl-2+ license simplifies license handling downstream.

Closes: #1490

This is cleanup targeting next downstream Debian release.