### PR TITLE
chart1: TimedHTMLMessageDialog: Fix timeout return (#1705).

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -12471,7 +12471,7 @@ void OCPN_TimedHTMLMessageDialog::OnClose( wxCloseEvent& event )
 void OCPN_TimedHTMLMessageDialog::OnTimer(wxTimerEvent &evt)
 {
     if(IsModal())
-        EndModal( wxID_YES );
+        EndModal( m_style & wxNO_DEFAULT ? wxID_NO :  wxID_YES );
     else
         Hide();
 }


### PR DESCRIPTION
There seems to be no usage  of wxNO_DEFAULT related to
TimedHTMLMessageDialog besides the new safe_mode code. So it
seems safe to apply this patch.
