### PR TITLE
PluginPaths et. al.: Fix broken macos plugin datadir (#1751)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
        - run: ci/generic-upload.sh
    build-mingw:
      docker:
-         - image: fedora:29
+         - image: fedora:31
      environment:
        - OCPN_TARGET:  mingw
      steps:

--- a/ci/generic-build-mingw.sh
+++ b/ci/generic-build-mingw.sh
@@ -10,12 +10,6 @@ sudo dnf copr enable -y --nogpgcheck leamas/opencpn-mingw
 
 test -d /opencpn-ci && cd /opencpn-ci || :
 
-if [ -n "$CIRCLECI" ]; then
-    # horrible patch for circleci, does not work on travis despite same
-    # cmake version.
-    sed -i -e '/define NSIS_PACKEDVERSION/s/;!/!/'  NSIS.template.in.in
-fi
-
 sudo dnf builddep  -y mingw/fedora/opencpn-deps.spec
 rm -rf build; mkdir build; cd build
 cmake \

--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -1535,7 +1535,7 @@ wxString OCPNPlatform::GetPluginDataPath()
     }
     m_pluginDataPath = ExpandPaths(dirs, this);
     if (m_pluginDataPath != "") {
-        m_pluginDataPath += PATH_SEP;
+        m_pluginDataPath += ";";
     }
     m_pluginDataPath += GetPluginDir();
     if (m_pluginDataPath.EndsWith(wxFileName::GetPathSeparator())) {

--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -1528,6 +1528,11 @@ wxString OCPNPlatform::GetPluginDataPath()
     else if (osSystemId & wxOS_WINDOWS) {
         dirs = GetWinPluginBaseDir();
     }
+    else if (osSystemId & wxOS_MAC) {
+        dirs = "/Applications/OpenCPN.app/Contents/SharedSupport/plugins;";
+        dirs +=
+            "~/Library/Application Support/OpenCPN/Contents/SharedSupport/plugins";
+    }
     m_pluginDataPath = ExpandPaths(dirs, this);
     if (m_pluginDataPath != "") {
         m_pluginDataPath += PATH_SEP;


### PR DESCRIPTION
Add part  simply missing + a bugfix affecting macos plugins.

While on it, also update the mingw builder to resurrect these builds.

With these patches, I can see that at least the radar plugin locates it's data directory.