### PR TITLE
Build a new bionic-gtk3 target linked to wxgtk3 (#1715)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,14 @@ matrix:
 
   - env:
     - OCPN_TARGET=bionic
+    - EXTRA_BUILD_OPTS="-DOCPN_FORCE_GTK3=OFF"
+    dist: bionic
+    compiler: gcc
+    script:
+    - "./ci/generic-build-debian.sh"
+  - env:
+    - OCPN_TARGET=bionic-gtk3
+    - EXTRA_BUILD_OPTS="-DOCPN_FORCE_GTK3=ON"
     dist: bionic
     compiler: gcc
     script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -548,7 +548,6 @@ set(PREFIX_LIB "${CMAKE_INSTALL_FULL_LIBDIR}")
 # Version handling
 #
 include(${CMAKE_SOURCE_DIR}/VERSION.cmake)
-include(TargetSetup)
 
 if (OCPN_CI_BUILD)
   include(Utils)
@@ -1635,6 +1634,11 @@ if (UNIX AND NOT APPLE)
   endif ()
 endif (UNIX AND NOT APPLE)
 
+# Finalize config.h setup and deploy it.
+include(TargetSetup)
+if ("${wxWidgets_LIBRARIES}" MATCHES "gtk3u" AND PKG_TARGET STREQUAL "ubuntu")
+  set(PKG_TARGET "${PKG_TARGET}-gtk3")
+endif ()
 configure_file(config.h.in ${CMAKE_BINARY_DIR}/include/config.h)
 include_directories(BEFORE "${CMAKE_BINARY_DIR}/include")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1105,12 +1105,9 @@ add_library(ocpn::opencpn ALIAS _opencpn)
 set_target_properties(
   ${PACKAGE_NAME}
   PROPERTIES
-    ENABLE_EXPORTS
-    1
-    OUTPUT_NAME
-    ${PACKAGE_NAME}
-    ARCHIVE_OUTPUT_DIRECTORY
-    ${CMAKE_CURRENT_BINARY_DIR}
+    ENABLE_EXPORTS 1
+    OUTPUT_NAME ${PACKAGE_NAME}
+    ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
 )
 
 target_include_directories(
@@ -1148,13 +1145,7 @@ if (DEFINED _wx_selected_config)
   if (_wx_selected_config MATCHES "androideabi-qt")
     message(STATUS "Building for wxQt-Android")
     message(STATUS "Qt_Base: " ${Qt_Base})
-    message(
-      STATUS
-        "wxQt_Base/Build: "
-        ${wxQt_Base}
-        "/"
-        ${wxQt_Build}
-    )
+    message(STATUS "wxQt_Base/Build:  ${wxQt_Base}/${wxQt_Build}")
     set(QT_ANDROID "ON")
   endif (_wx_selected_config MATCHES "androideabi-qt")
 endif (DEFINED _wx_selected_config)

--- a/ci/control
+++ b/ci/control
@@ -19,7 +19,9 @@ Build-Depends: debhelper (>= 9),
  libunarr-dev | base-files (<< 11),
  libwxgtk3.0-dev,
  libwxgtk3.0-0v5 | libwxgtk3.0-0,
+ libwxgtk3.0-gtk3-dev | base-files (<< 10),
  libwxgtk-webview3.0-dev | base-files (<< 11),
+ libwxgtk-webview3.0-gtk3-dev | base-files (<< 10),
  libwxsvg-dev | base-files (<< 11),
  portaudio19-dev
 

--- a/ci/generic-build-debian.sh
+++ b/ci/generic-build-debian.sh
@@ -26,8 +26,13 @@ if [ "$OCPN_TARGET" = "trusty"  -o "$OCPN_TARGET" = "xenial" ]; then \
     WEBVIEW_OPT="-DOCPN_USE_WEBVIEW:BOOL=OFF"
 fi
 
+if [[ "$EXTRA_BUILD_OPTS" == *OCPN_FORCE_GTK3=ON* ]]; then
+    sudo update-alternatives --set wx-config \
+        /usr/lib/*-linux-*/wx/config/gtk3-unicode-3.0
+fi
+
 rm -rf build && mkdir build && cd build
-cmake $WEBVIEW_OPT \
+cmake $WEBVIEW_OPT  $EXTRA_BUILD_OPTS\
     -DCMAKE_INSTALL_PREFIX=/usr \
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     -DOCPN_CI_BUILD:BOOL=ON \

--- a/ci/generic-upload.sh
+++ b/ci/generic-upload.sh
@@ -8,7 +8,7 @@ test -z "$TRAVIS_BUILD_DIR" || cd $TRAVIS_BUILD_DIR
 cd build
 
 case "$OCPN_TARGET" in
-    xenial|trusty|bionic) 
+    xenial|trusty|bionic*)
         for src in $(expand *.deb); do
             old=$(basename $src)
             new=$(echo $old | sed "s/opencpn/opencpn-${OCPN_TARGET}/")
@@ -39,9 +39,10 @@ if [ -z "$CLOUDSMITH_API_KEY" ]; then
 else
     echo 'Deploying to cloudsmith'
     set -x
-    if pyenv versions >/dev/null 2>&1; then   # circleci image
+    if pyenv versions >/dev/null 2>&1; then
         pyenv versions
         pyenv global $(pyenv versions | tail -1)
+        sudo -H python3 -m pip  install wheel
         sudo -H python3 -m pip install cloudsmith-cli
         pyenv rehash
     else


### PR DESCRIPTION
Patches adding a new build target named bionic-gtk3. Together with #1758 this should be the last bit in the overall echosystem.

The patches adds a build to travis. Here is also some bugfixes and cleanup in the generic-upload.sh script.

As a final part, the PKG_TARGET is adjusted on wxgtk3-based builds.

Only tested to the point that bionic-gtk3 builds starts. It doesn't list any plugins (there are no bionic-gtk3 plugin builds available).

This PR will (probably) have some conflicts with #1758. Depending on which is merged first, the other will need to be rebased.