### PR TITLE
Redirecting messages from stderr to LOG_INFO for options.cpp

### DIFF
--- a/src/options.cpp
+++ b/src/options.cpp
@@ -8036,8 +8036,8 @@ compress(lzma_stream *strm, FILE *infile, FILE *outfile)
                                    infile);
 
             if (ferror(infile)) {
-                LOG_INFO ("Read error: %s\i", errno);
-                      //  strerror(errno));
+                LOG_INFO ("Read error: %i\n", errno);
+                      //  strerror(errno)); /* fro testing not for merging */
                 return false;
             }
 
@@ -8078,8 +8078,8 @@ compress(lzma_stream *strm, FILE *infile, FILE *outfile)
 
             if (fwrite(outbuf, 1, write_size, outfile)
                 != write_size) {
-                LOG_INFO ("Read error: %s\i", errno);
-                      //  strerror(errno));
+                LOG_INFO ("Read error: %i\n", errno);
+                      //  strerror(errno)); /* fro testing not for merging */
                 return false;
             }
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -23,6 +23,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 #include <memory>
+#include "logger.h"
 
 #ifdef __linux__
 #include <unistd.h>
@@ -8035,7 +8036,7 @@ compress(lzma_stream *strm, FILE *infile, FILE *outfile)
                                    infile);
 
             if (ferror(infile)) {
-                fprintf(stderr, "Read error: %s\n",
+                LOG_INFO ("Read error: %s\n",
                         strerror(errno));
                 return false;
             }
@@ -8077,7 +8078,7 @@ compress(lzma_stream *strm, FILE *infile, FILE *outfile)
 
             if (fwrite(outbuf, 1, write_size, outfile)
                 != write_size) {
-                fprintf(stderr, "Write error: %s\n",
+                LOG_INFO ("Write error: %s\n",
                         strerror(errno));
                 return false;
             }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -23,7 +23,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 #include <memory>
-#include "logger.h"
+#include "logger.h" /**/
 
 #ifdef __linux__
 #include <unistd.h>

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -23,7 +23,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 #include <memory>
-#include "logger.h" /**/
+#include "logger.h" 
 
 #ifdef __linux__
 #include <unistd.h>
@@ -8036,8 +8036,8 @@ compress(lzma_stream *strm, FILE *infile, FILE *outfile)
                                    infile);
 
             if (ferror(infile)) {
-                LOG_INFO ("Read error: %s\n",
-                        strerror(errno));
+                LOG_INFO ("Read error: %s\i", errno);
+                      //  strerror(errno));
                 return false;
             }
 
@@ -8078,8 +8078,8 @@ compress(lzma_stream *strm, FILE *infile, FILE *outfile)
 
             if (fwrite(outbuf, 1, write_size, outfile)
                 != write_size) {
-                LOG_INFO ("Write error: %s\n",
-                        strerror(errno));
+                LOG_INFO ("Read error: %s\i", errno);
+                      //  strerror(errno));
                 return false;
             }
 


### PR DESCRIPTION
Just to see how it works I made some arbitrary commits for the implementation of logger.

I just searched in src for the most hits on stderr and replaced the most obvious.
Choice of replacement from fprintf(stderr, ..) with LOG_INFO( .. ) is mostly arbitrary.

Feel free to reject / ignore
