### PR TITLE
Clear plugin list cleanly

### DIFF
--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -5208,6 +5208,7 @@ void PluginListPanel::Clear()
         if (count > numChildren)
             break;
     }
+    wxASSERT(count == numChildren);
     m_pitemBoxSizer01->Clear();
     m_PluginItems.Clear();
 

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -5198,13 +5198,15 @@ PluginListPanel::PluginListPanel(wxWindow *parent, wxWindowID id,
  */
 void PluginListPanel::Clear()
 {
-    for (auto it = GetChildren().GetFirst(); it; it = it->GetNext()) {
-        if (dynamic_cast<PluginPanel*>(it->GetData())) {
-            it->GetData()->Destroy();
-        }
-        else if (dynamic_cast<wxStaticLine*>(it->GetData())) {
-            it->GetData()->Destroy();
-        }
+    int count = 0;
+    int numChildren = GetChildren().GetCount();
+    while (auto it = GetChildren().GetFirst()) {
+        count = count + 1;
+        auto pData = it->GetData();
+        if (pData)
+            pData->Destroy();
+        if (count > numChildren)
+            break;
     }
     m_pitemBoxSizer01->Clear();
     m_PluginItems.Clear();


### PR DESCRIPTION
@bdbcat 

I hope this works on all platforms.  I added a "get out of jail" step in case it should try to become an infinite loop as a defensive measure.