### PR TITLE
	modified:   LLRegion.cpp

### DIFF
--- a/src/LLRegion.cpp
+++ b/src/LLRegion.cpp
@@ -30,6 +30,7 @@
 #include <math.h>
 
 #include "LLRegion.h"
+#include "logger.h"
 
 static inline double cross(const contour_pt &v1, const contour_pt &v2)
 {
@@ -307,8 +308,7 @@ static void /*APIENTRY*/ LLerrorCallback(GLenum errorCode)
 {
     const GLubyte *estring;
     estring = gluErrorString(errorCode);
-    fprintf (stderr, "Tessellation Error: %s\n", estring);
-    wxLogMessage( _T("Tessellation Error: %s"), (char *)estring );
+    LOG_INFO ("Tessellation Error: %s\n", estring);
     //exit (0);
 }
 


### PR DESCRIPTION
Last one of the rewrites to include Log_Info in favor of a write to stderr.

One liner, no real advantage except more consistent information to the logfile.
Only here 2 lines of code were changed to one.