### PR TITLE
chart1: Test for crash after checking another instance (#1797).

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -1783,7 +1783,7 @@ bool MyApp::OnInit()
             return false;               // exit quietly
         }
     }
-#endif
+#endif  // __OCPN__ANDROID__
 
     // Check if last run failed, set up safe_mode.
     if (!safe_mode::get_mode()) {

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -1728,11 +1728,6 @@ bool MyApp::OnInit()
     // Instantiate the global OCPNPlatform class
     g_Platform = new OCPNPlatform;
 
-    // Check if last run failed, set up safe_mode.
-    if (!safe_mode::get_mode()) {
-        safe_mode::check_last_start();
-    }
-
 
 #ifndef __OCPN__ANDROID__
     //  On Windows
@@ -1789,6 +1784,11 @@ bool MyApp::OnInit()
         }
     }
 #endif
+
+    // Check if last run failed, set up safe_mode.
+    if (!safe_mode::get_mode()) {
+        safe_mode::check_last_start();
+    }
 
     //  Perform first stage initialization
     OCPNPlatform::Initialize_1( );


### PR DESCRIPTION
I honestly don't remember why I placed the check for  previous crash
before checking if another instance is running. This patch puts the
crash check after the duplicate instance check, solving #1797, possibly
causing other headaches which I don't foresee.