### PR TITLE
build: Clean up cmake architecture detection (#1488).

### DIFF
--- a/cmake/GetArch.cmake
+++ b/cmake/GetArch.cmake
@@ -2,88 +2,43 @@
 # Set ARCH and LIB_INSTALL_DIR  and PACKAGE_RECS in parent 
 # using cmake probes and various heuristics.
 
-#Red Hat:   /etc/redhat-release
-#Slackware: /etc/slackware-version
-#Slamd64:   /etc/slamd64-version
+#Red Hat:/etc/redhat-release
 #Gentoo: /etc/gentoo-release
 #Ubuntu: /etc/debian_version
+#Suse:   /etc/suse-release or /etc/SuSE-release
 
 # Based on code from nohal
 function(GetArch)
-    if (NOT WIN32)
+  if (NOT WIN32)
     # default
-    set (ARCH "i386")
+    set (ARCH "x86_64")
     set (LIB_INSTALL_DIR "lib")
+    if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
+      if (CMAKE_SIZEOF_VOID_P MATCHES "8")
+        set (ARCH "arm64")
+      else ()
+        set (ARCH "armhf")
+      endif ()
+    else (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
+      set (ARCH ${CMAKE_SYSTEM_PROCESSOR})
+    endif ()
     if (EXISTS /etc/debian_version)
       set (PACKAGE_FORMAT "DEB")
       set (PACKAGE_RECS "xcalib,xdg-utils")
       set (LIB_INSTALL_DIR "lib")
-      if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-        if (CMAKE_SIZEOF_VOID_P MATCHES "8")
-          set (ARCH "arm64")
-        else ()
-          set (ARCH "armhf")
-        endif ()
-      else (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-        if (CMAKE_SIZEOF_VOID_P MATCHES "8")
-          set (ARCH "amd64")
-        else ()
-          set (ARCH "i386")
-        endif ()
-      endif (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
       set(TENTATIVE_PREFIX "/usr/local")
-    endif (EXISTS /etc/debian_version)
-    if (EXISTS /etc/redhat-release)
-      set (PACKAGE_FORMAT "TBZ2")
-      if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-        if (CMAKE_SIZEOF_VOID_P MATCHES "8")
-          set (ARCH "aarch64")
-        else ()
-          set (ARCH "armhf")
-        endif ()
-      else (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-        if (CMAKE_SIZEOF_VOID_P MATCHES "8")
-          set (ARCH "x86_64")
-          set (LIB_INSTALL_DIR "lib64")
-        else ()
-          set (ARCH "i386")
-          set (LIB_INSTALL_DIR "lib")
-        endif ()
-      endif (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-    endif (EXISTS /etc/redhat-release)
-    if (EXISTS /etc/suse-release OR EXISTS /etc/SuSE-release)
-      set (PACKAGE_FORMAT "TBZ2")
-      if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-        if (CMAKE_SIZEOF_VOID_P MATCHES "8")
-          set (ARCH "aarch64")
-        else ()
-          set (ARCH "armhf")
-        endif ()
-      else (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-        if (cMAKE_SIZEOF_VOID_P MATCHES "8")
-          set (ARCH "x86_64")
-          set (LIB_INSTALL_DIR "lib")
-          # In recent openSUSE versions (as of 2016), lib64 is mostly 
-          # used when there are both 32-bit and 64-bit versions, although 
-          # not limited to that. This CMake variable only affects the location
-          # of OpenCPN plugins at installation time, and nothing more than that.
-          # At run time, the plugin directory is determined by 
-          # wxStandardPaths::GetPluginsDir(), which returns "lib", so this can 
-          # be considered canonical.
-        else ()
-          set (ARCH "i386")
-          set (LIB_INSTALL_DIR "lib")
-        endif ()
-      endif (CMAKE_SYSTEM_PROCESSOR MATCHES "arm*")
-    endif (EXISTS /etc/suse-release OR EXISTS /etc/SuSE-release)
-    if (EXISTS /etc/gentoo-release)
+    elseif (EXISTS /etc/redhat-release)
+      set (LIB_INSTALL_DIR "lib64")
+      if (ARCH STREQUAL "arm64")
+        set (ARCH "aarch64")
+      endif()
+    elseif (EXISTS /etc/suse-release OR EXISTS /etc/SuSE-release)
+      if (ARCH STREQUAL "arm64")
+         set (ARCH "aarch64")
+      endif()
+    elseif (EXISTS /etc/gentoo-release)
       set (LIB_INSTALL_DIR "lib${LIB_SUFFIX}")
     endif ()
-    if (APPLE)
-      if (CMAKE_SIZEOF_VOID_P MATCHES "8")
-        set(ARCH "x86_64")
-      endif ()
-    endif (APPLE)
   else (NOT WIN32)
     # On WIN32 probably CMAKE_SIZEOF_VOID_P EQUAL 8, but we don't use it at all now...
     set (ARCH "i386")


### PR DESCRIPTION
Clean up current mess in cmake/GetArch, making *make install* work better one more platforms.

Closes: #1488