### PR TITLE
Flatpak 1852

### DIFF
--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -1487,6 +1487,15 @@ wxString &OCPNPlatform::GetPrivateDataDir()
         
 #ifdef __WXMSW__
         m_PrivateDataDir = GetHomeDir();                     // should be {Documents and Settings}\......
+#elif defined FLATPAK
+        // ~/.var/app/org.opencpn.OpenCPN/config
+        const char* config_home = getenv("XDG_CONFIG_HOME");
+        if (!config_home {
+            config_home = std::string(getenv("HOME"))
+                + "/.var/app/org.opencpn.OpenCPN/config";
+        }
+        m_PrivateDataDir = std::string(config_home) + "/opencpn";
+
 #elif defined __WXOSX__
         m_PrivateDataDir = std_path.GetUserConfigDir();     // should be ~/Library/Preferences
         appendOSDirSlash(&m_PrivateDataDir);

--- a/src/PluginHandler.cpp
+++ b/src/PluginHandler.cpp
@@ -49,15 +49,16 @@ typedef __LA_INT64_T la_int64_t;      //  "older" libarchive versions support
 #undef Yield                 // from win.h, conflicts with mingw headers
 #endif
 
-#include "Downloader.h"
-#include "OCPNPlatform.h"
-#include "PluginHandler.h"
-#include "PluginPaths.h"
-#include "pluginmanager.h"
-#include "navutil.h"
-#include "ocpn_utils.h"
 #include "catalog_parser.h"
 #include "catalog_handler.h"
+#include "Downloader.h"
+#include "logger.h"
+#include "navutil.h"
+#include "OCPNPlatform.h"
+#include "ocpn_utils.h"
+#include "PluginHandler.h"
+#include "pluginmanager.h"
+#include "PluginPaths.h"
 
 #ifdef _WIN32
 static std::string SEP("\\");
@@ -527,8 +528,7 @@ static void entry_set_install_path(struct archive_entry* entry,
     }
     const std::string dest = archive_entry_pathname(entry);
     if(dest.size()){
-        std::cout << "Installing " << src << " into " << dest << std::endl;
-        wxLogMessage( _T("Installing ") + wxString(src.c_str()) + _T(" into ") + wxString(dest.c_str()));
+        DEBUG_LOG << "Installing " << src << " into " << dest << std::endl;
     }
 }
 
@@ -869,7 +869,7 @@ bool PluginHandler::installPlugin(PluginMetadata plugin)
     path = std::string(fname);
     std::ofstream stream;
     stream.open(path.c_str(), std::ios::out|std::ios::binary|std::ios::trunc);
-    std::cout << "Downloading: " << plugin.name << std::endl;
+    DEBUG_LOG << "Downloading: " << plugin.name << std::endl;
     auto downloader = Downloader(plugin.tarball_url);
     downloader.download(&stream);
 

--- a/src/PluginHandler.cpp
+++ b/src/PluginHandler.cpp
@@ -390,6 +390,9 @@ static void flatpak_entry_set_install_path(struct archive_entry* entry,
         archive_entry_set_pathname(entry, "");
         return;
     }
+    if (ocpn::startswith(path, "./")) {
+        path = path.substr(2);
+    }
     int slashpos = path.find_first_of('/', 1);
     string prefix = path.substr(0, slashpos);
     path = path.substr(prefix.size() + 1);
@@ -418,11 +421,11 @@ static void linux_entry_set_install_path(struct archive_entry* entry,
         archive_entry_set_pathname(entry, "");
         return;
     }
-    
+
     int slashpos = path.find_first_of('/', 1);
     if(ocpn::startswith(path, "./"))
         slashpos = path.find_first_of('/', 2);  // skip the './'
-        
+
     string prefix = path.substr(0, slashpos);
     path = path.substr(prefix.size() + 1);
     if (ocpn::startswith(path, "usr/")) {


### PR DESCRIPTION
The discussion in #1852 reveals three things which needs to be fixed in the flatpak builds:
  - Plugin installer cannot handle a ./ prefix paths.
  - Plugin installer still has some logging to stdout.
  - Using the same configuration directory for "traditional" installations and flatpaked  carries too many risks.

Here is three commits trying to cope with this. The change of configuration directory is perhaps the most important one.