### PR TITLE
DB: Omit residual values on Instrument_Dial at watchdog timeout.

### DIFF
--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -212,7 +212,7 @@ wxString getInstrumentCaption( unsigned int id )
             return _("Depth");
         case ID_DBP_D_DPT:
             return _("Depth");
-	case ID_DBP_D_MDA:
+        case ID_DBP_D_MDA:
             return _("Barometric pressure");
         case ID_DBP_I_MDA:
             return _("Barometric pressure");

--- a/plugins/dashboard_pi/src/dial.cpp
+++ b/plugins/dashboard_pi/src/dial.cpp
@@ -98,9 +98,7 @@ wxSize DashboardInstrument_Dial::GetSize( int orient, wxSize hint )
 }
 
 void DashboardInstrument_Dial::SetData(int st, double data, wxString unit)
-{
-      if (std::isnan(data))
-          return;
+{      
       if (st == m_MainValueCap)
       {
             m_MainValue = data;


### PR DESCRIPTION
Dial is used for Speedometer, Barometer etc.