### PR TITLE
Avoid realtime prediction from anchored targets

### DIFF
--- a/src/ais.cpp
+++ b/src/ais.cpp
@@ -1479,7 +1479,9 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc, ViewPort& vp, ChartC
         dc.SetPen( target_pen );
 
         wxPoint Point = TargetPoint;
-        if (g_bDrawAISRealtime && (td->Class == AIS_CLASS_A || td->Class == AIS_CLASS_B )) {
+        if (g_bDrawAISRealtime && 
+            (td->Class == AIS_CLASS_A || td->Class == AIS_CLASS_B ) &&
+            td->SOG > g_ShowMoored_Kts) {
             wxDateTime now = wxDateTime::Now();
             now.MakeGMT();
             int target_age = now.GetTicks() - td->PositionReportTicks;


### PR DESCRIPTION
The AIS realtime prediction can surprisingly be triggered off by small movements at e.g. anchor. This patch uses the value at "Suppress anchored/moored targets, speed max (kn)" as a low limit condition for the realtime prediction function. 
The "Suppress anchored/moored...." function does not need to be checked. Only the value in the speed limit field is used.