### PR TITLE
Fix broken source tarball generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ ci/opencpn_rsa
 src/opencpn.rc
 .DS_Store
 NSIS.template.in
+version?git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2486,12 +2486,12 @@ set(CPACK_SOURCE_GENERATOR "TGZ")
 
 # The following components are regex's to match anywhere (unless anchored) in
 # absolute path + filename to find files or directories to be excluded from
-# source tarball.
+# source tarball created by 'make package_source'.
 set(
   CPACK_SOURCE_IGNORE_FILES
+  "\\\\.flatpak-builder*"
   "\\\\.git*"
-  "^${CMAKE_CURRENT_SOURCE_DIR}/build*"
-  "^${CPACK_PACKAGE_INSTALL_DIRECTORY}/*"
+  "${CMAKE_BINARY_DIR}*"
 )
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2767,6 +2767,9 @@ if (MSVC)
   )
 endif (MSVC)
 
+# Repack tarball using tar if available
+include(dist_target)
+
 # uninstall target
 if(NOT TARGET uninstall)
     configure_file(

--- a/cmake/dist_target.cmake
+++ b/cmake/dist_target.cmake
@@ -1,0 +1,67 @@
+#
+# Add a custom 'dist' target. At a minimum, it performs
+# 'make package_source'. If a tar command is found the
+# source tarball is repacked to avoid incompatibilities
+# with cmake's tar (#1849)
+#
+#
+# Usage:
+#    file(GLOB DIST_TARBALL opencpn*.tar.*)
+#    include(dist_target)
+#
+#    The DIST_TARBALL file is the file to repack, defaults to
+#    build/ *.tar.* (the definition could usually be omitted).
+#
+# Sets global DIST_TARBALL if not already defined.
+
+file(WRITE ${CMAKE_BINARY_DIR}/gitcheck.sh
+    "
+    if output=$(git status --porcelain) && [ -z \"$output\" ]; then
+        echo 'Git status: clean'
+    else 
+        echo 'WARNING: git status not clean' >&2
+    fi"
+)
+add_custom_target(gitcheck 
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_SOURCE_DIR}/cmake/gitcheck.cmake
+)
+if (GIT_STATUS)
+   message(FATAL_ERROR "Git repository is not clean. Aborting")
+else ()
+   message(STATUS "Git status: clean")
+endif ()
+
+find_program(TAR NAMES tar)
+if (TAR)
+    if (NOT TARBALL)
+        file(GLOB TARBALL ${CMAKE_BINARY_DIR}/*.tar.*)
+    endif()
+    file(WRITE ${CMAKE_BINARY_DIR}/repack.sh
+      "
+      tmpdir=repack.$$ 
+      rm -rf $tmpdir && mkdir repack.$$ 
+      tar -C $tmpdir -xf $1
+      tar -C $tmpdir -cjf $1 .
+      rm -rf $tmpdir"
+    )
+    add_custom_target(repack 
+        COMMAND bash repack.sh ${TARBALL}
+        COMMENT "Repacking ${TARBALL} using external tar(1)"
+    )
+else ()
+    add_custom_target(repack 
+        COMMAND bash :
+        COMMENT "Cannot repack (no tar found)"
+    )
+endif ()
+
+
+add_custom_target(dist 
+    COMMAND ${CMAKE_MAKE_PROGRAM} gitcheck
+    COMMAND ${CMAKE_COMMAND} 
+        -D SOURCE_DIR=${CMAKE_SOURCE_DIR}
+        -P ${CMAKE_SOURCE_DIR}/cmake/version_git.cmake
+    COMMAND ${CMAKE_MAKE_PROGRAM} package_source
+    COMMAND ${CMAKE_MAKE_PROGRAM} repack
+    COMMAND ${CMAKE_COMMAND} -E  remove ${CMAKE_SOURCE_DIR}/git-version
+)

--- a/cmake/gitcheck.cmake
+++ b/cmake/gitcheck.cmake
@@ -1,0 +1,16 @@
+#
+#  dist_target helper
+#
+execute_process(
+    COMMAND git status --porcelain
+    OUTPUT_VARIABLE GIT_STATUS
+    ERROR_VARIABLE GIT_STATUS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if (GIT_STATUS)
+   message(FATAL_ERROR "Git repository is not clean. Aborting")
+else ()
+   message(STATUS "Git status: clean")
+endif ()
+
+

--- a/cmake/version_git.cmake
+++ b/cmake/version_git.cmake
@@ -1,0 +1,25 @@
+#
+# Helper for dist_target.cmake
+#
+
+execute_process(
+    COMMAND git rev-parse --short HEAD 
+    OUTPUT_VARIABLE  GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+execute_process(
+    COMMAND git tag --contains HEAD 
+    OUTPUT_VARIABLE  GIT_TAG
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+execute_process(
+    COMMAND git log --pretty=format:%cd --date=iso -1
+    OUTPUT_VARIABLE GIT_DATE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+message(STATUS "Creating ${SOURCE_DIR}/git-version")
+configure_file(
+    "${SOURCE_DIR}/cmake/version_git.in"
+    "${SOURCE_DIR}/git-version"
+    IMMEDIATE @ONLY
+)

--- a/cmake/version_git.in
+++ b/cmake/version_git.in
@@ -1,0 +1,3 @@
+git_tag="@GIT_TAG@"
+git_date="@GIT_DATE@"
+git_hash="@GIT_HASH@"

--- a/flatpak/.gitignore
+++ b/flatpak/.gitignore
@@ -1,7 +1,2 @@
-.flatpak-builder
-*.key
 plugin
 gpg
-app
-repo/repo
-website


### PR DESCRIPTION
This PR resolves #1872, rectifying the empty tarballs created by `make package_source`. It also adds the usual `make dist` target.  The latter warns if git status isn't  clean. It also adds some info on the git commit in the source tarball, a trick somewhat messy to do when relying on git-archive.

Closes: #1872 

EDIT: this could  be postponed to next cycle without problems, should the beta imminent.