### PR TITLE
Debian downstream packaging fixes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -772,6 +772,32 @@ if (NOT QT_ANDROID)
   message(STATUS " Revised wxWidgets Libraries: ${wxWidgets_LIBRARIES}")
 endif (NOT QT_ANDROID)
 
+# Handle #1500: Force NDEBUG on gtk3 for wxwidgets < 3.2 (all builds)
+if (GTK3_FOUND)
+  set( _VERSPROG [=[
+    #include <stdio.h>
+    #include <wx/version.h>
+    int main(int argc, char**argv) { 
+      printf("%d\\n", wxMAJOR_VERSION * 10 + wxMINOR_VERSION);
+    }
+  ]=])
+  execute_process(
+    COMMAND "/bin/sh" "-c" "echo '${_VERSPROG}' > wx-32.c"
+    COMMAND "/bin/sh" "-c" "cc $(wx-config --cflags) wx-32.c"
+    COMMAND "./a.out"
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+    OUTPUT_VARIABLE _WX_VERSION
+    ERROR_VARIABLE _WX_ERRORS
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  if(NOT "${_WX_ERRORS}" STREQUAL "")
+    message(FATAL_ERROR "Cannot run wxWidgets  version test (!)")
+  elseif ("${_WX_VERSION}" LESS 32)
+    add_definitions("-DNDEBUG")
+    message(STATUS "Forcing -NDEBUG on gtk3 build (#1500).")
+  endif ()
+endif ()
+
 IF(QT_ANDROID)
   SET( wxWidgets_LIBRARIES
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -611,9 +611,9 @@ endif (OCPN_BUNDLE_DOCS MATCHES "ON")
 #
 # Linux: set up GTK (wxWidgets prerequisite).
 #
-#if (NOT WIN32 AND NOT APPLE AND NOT QT_ANDROID)
-#  include(OcpnFindGtk)
-#endif ()
+if (NOT WIN32 AND NOT APPLE AND NOT QT_ANDROID)
+  include(OcpnFindGtk)
+endif ()
 
 # set a build flag for arm architecture, to catch any rPI runtime changes
 # required
@@ -1181,8 +1181,8 @@ target_link_libraries(${PACKAGE_NAME} PRIVATE ssl::sha1)
 # Linux: set up GTK
 #
 if (NOT WIN32 AND NOT APPLE AND NOT QT_ANDROID)
-#  include(OcpnFindGtk)
-#  target_link_libraries(${PACKAGE_NAME} PRIVATE ocpn::gtk)
+  include(OcpnFindGtk)
+  target_link_libraries(${PACKAGE_NAME} PRIVATE ocpn::gtk)
 endif (NOT WIN32 AND NOT APPLE AND NOT QT_ANDROID)
 
 # Search for opengles, short of running a program to test the speed of

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,14 +179,16 @@ endmacro (BUNDLE_GSHHS_OPT)
 # sense values from the commandline (due to cmake inability to distinguish
 # between not set and set to FALSE): cmake -DOCPN_BUNDLE_DOCS=BLAH
 # -DOCPN_BUNDLE_TCDATA=BLAH 
+
+# Bundle tcdata and gshhs by default also on linux, to keep the defaults
+# close to the official Debian package.
+bundle_gshhs_opt("ON")
+bundle_tcdata_opt("ON")
+
 if (APPLE OR WIN32)
   bundle_docs_opt("ON")
-  bundle_tcdata_opt("ON")
-  bundle_gshhs_opt("ON")
 else (APPLE OR WIN32)
   bundle_docs_opt("OFF")
-  bundle_tcdata_opt("OFF")
-  bundle_gshhs_opt("OFF")
 endif (APPLE OR WIN32)
 
 

--- a/libs/iso8211/src/ddffield.cpp
+++ b/libs/iso8211/src/ddffield.cpp
@@ -83,7 +83,7 @@
  * New
  *
  */
-
+#include <algorithm>
 #include "iso8211.h"
 #include "gdal/cpl_conv.h"
 
@@ -133,7 +133,7 @@ void DDFField::Dump( FILE * fp )
     fprintf( fp, "      Data = \n" );
     
     int il = 0;
-    for( int i = 0; i < MIN(nDataSize,1000); i++ )
+    for( int i = 0; i < std::min(nDataSize,1000); i++ )
     {
         //if( pachData[i] < 32 || pachData[i] > 126 )
             fprintf( fp, "\\%02X", ((unsigned char *) pachData)[i] );

--- a/libs/iso8211/src/ddfsubfielddefn.cpp
+++ b/libs/iso8211/src/ddfsubfielddefn.cpp
@@ -73,6 +73,7 @@
  *
  */
 
+#include <algorithm>
 #include "gdal/cpl_conv.h"
 #include "iso8211.h"
 
@@ -781,7 +782,7 @@ void DDFSubfieldDefn::DumpData( const char * pachData, int nMaxBytes,
         GByte   *pabyBString = (GByte *) ExtractStringData( pachData, nMaxBytes, &nBytes );
 
         fprintf( fp, "      Subfield `%s' = 0x", pszName );
-        for( i = 0; i < MIN(nBytes,24); i++ )
+        for( i = 0; i < std::min(nBytes,24); i++ )
             fprintf( fp, "%02X", pabyBString[i] );
 
         if( nBytes > 24 )

--- a/libs/libtess2/Source/CustomArray.cpp
+++ b/libs/libtess2/Source/CustomArray.cpp
@@ -50,7 +50,9 @@ CustomArray::CustomArray(const char* filename) :  mCollapsed(null), mAddresses(n
 	FILE* fp = fopen(filename, "rb");
 	if(fp)
 	{
-		fread(mCurrentCell->Item.Addy, StartSize, 1, fp);
+		if (fread(mCurrentCell->Item.Addy, StartSize, 1, fp)) { 
+                    // Ignore 
+                };
 		fclose(fp);
 	}
 

--- a/libs/wxservdisc/CMakeLists.txt
+++ b/libs/wxservdisc/CMakeLists.txt
@@ -15,6 +15,9 @@ add_library(ocpn::wxservdisc ALIAS WXSERVDISC)
 
 set_property(TARGET WXSERVDISC PROPERTY COMPILE_FLAGS "${OBJ_VISIBILITY}")
 target_include_directories(WXSERVDISC PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(WXSERVDISC PRIVATE -Wno-pointer-sign -Wno-parentheses)
+endif ()
 
 if (WIN32)
   target_link_libraries(WXSERVDISC PRIVATE ws2_32)

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -1317,8 +1317,8 @@ void dashboard_pi::SetNMEASentence( wxString &sentence )
                 for (int i = 0; i<m_NMEA0183.Xdr.TransducerCnt; i++) {
                     xdrdata = m_NMEA0183.Xdr.TransducerInfo[i].MeasurementData;
                     // XDR Airtemp
-                    if (m_NMEA0183.Xdr.TransducerInfo[i].TransducerType == _T("C") &&
-                        m_NMEA0183.Xdr.TransducerInfo[i].TransducerName == _T("TempAir") ||
+                    if ((m_NMEA0183.Xdr.TransducerInfo[i].TransducerType == _T("C") &&
+                        m_NMEA0183.Xdr.TransducerInfo[i].TransducerName == _T("TempAir")) ||
                         m_NMEA0183.Xdr.TransducerInfo[i].TransducerName == _T("ENV_OUTAIR_T") ||
                         m_NMEA0183.Xdr.TransducerInfo[i].TransducerName == _T("ENV_OUTSIDE_T")) {
                         if (mPriATMP >= 2) {

--- a/src/GarminProtocolHandler.cpp
+++ b/src/GarminProtocolHandler.cpp
@@ -976,7 +976,7 @@ GARMIN_USB_Thread::~GARMIN_USB_Thread()
 
 void *GARMIN_USB_Thread::Entry()
 {
-    garmin_usb_packet iresp;
+    garmin_usb_packet iresp = {0};
     int n_short_read = 0;
     m_receive_state = rs_fromintr;
 

--- a/src/OCPNRegion.cpp
+++ b/src/OCPNRegion.cpp
@@ -3283,7 +3283,7 @@ else gdk_region_intersect (a,b)
      OScanLineList *pSLL;     /* current scanLineList    */
      OGdkPoint *pts;          /* output buffer           */
      OEdgeTableEntry *pPrevAET;        /* ptr to previous AET     */
-     OEdgeTable ET;                    /* header node for ET      */
+     OEdgeTable ET = {0};              /* header node for ET      */
      OEdgeTableEntry AET;              /* header node for AET     */
      OEdgeTableEntry *pETEs;           /* EdgeTableEntries pool   */
      OScanLineListBlock SLLBlock;      /* header for scanlinelist */

--- a/src/ais.cpp
+++ b/src/ais.cpp
@@ -1744,7 +1744,7 @@ static void AISDrawTarget( AIS_Target_Data *td, ocpnDC& dc, ViewPort& vp, ChartC
         //  create vector of x-y points
         int TrackLength = td->m_ptrack->GetCount();
         int TrackPointCount;
-        wxPoint *TrackPoints;
+        wxPoint *TrackPoints = 0;
         if (TrackLength > 1) {
             TrackPoints = new wxPoint[TrackLength];
             wxAISTargetTrackListNode *node = td->m_ptrack->GetFirst();

--- a/src/bbox.cpp
+++ b/src/bbox.cpp
@@ -166,8 +166,8 @@ OVERLAP wxBoundingBox::Intersect(const wxBoundingBox &other, double Marge) const
 {
     assert (m_validbbox == TRUE);
 
-    // other boundingbox must exist
-    assert (&other);
+    // other boundingbox exists, it is a reference:
+    // assert (&other);
 
     if (((m_minx - Marge) > (other.m_maxx + Marge)) ||
          ((m_maxx + Marge) < (other.m_minx - Marge)) ||

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -8229,7 +8229,9 @@ GetMemoryStatus( int *mem_total, int *mem_used )
         FILE* file = fopen ( "/proc/self/statm", "r");
         if ( file )
         {
-            fscanf( file, "%d", mem_used);
+            if (fscanf( file, "%d", mem_used) != 1) {
+                wxLogWarning("Cannot parse /proc/self/statm (!)");
+            }
             *mem_used *= 4; // XXX assume 4K page
             fclose( file );
         }

--- a/src/concanv.cpp
+++ b/src/concanv.cpp
@@ -394,7 +394,7 @@ void ConsoleCanvas::UpdateRouteData()
 
                 wxString tttg_s;
                 wxTimeSpan tttg_span;
-                float tttg_sec;
+                float tttg_sec = 0.0;
                 if( speed > 0. )
                 {
                     tttg_sec = ( trng / gSog ) * 3600.;

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -5520,38 +5520,38 @@ void glChartCanvas::FastZoom(float factor, float cp_x, float cp_y, float post_x,
 //     }
 //    else
     {
-    m_nStep = 20; 
-    m_nTotal = 100;
-    
-    m_nStep = 10; 
-    m_nTotal = 40;
-    
-    m_nRun = 0;
-    
-    float perStep = m_nStep / m_nTotal;
-    
- 
-    if(zoomTimer.IsRunning()){
-        m_offsetxStep = (m_fbo_offsetx - m_runoffsetx) * perStep;
-        m_offsetyStep = (m_fbo_offsety - m_runoffsety) * perStep;
-        m_swidthStep = (m_fbo_swidth - m_runswidth) * perStep;
-        m_sheightStep = (m_fbo_sheight - m_runsheight) * perStep;
+        m_nStep = 20; 
+        m_nTotal = 100;
         
-    }
-    else{
-        m_offsetxStep = (m_fbo_offsetx - m_lastfbo_offsetx) * perStep;
-        m_offsetyStep = (m_fbo_offsety - m_lastfbo_offsety) * perStep;
-        m_swidthStep = (m_fbo_swidth - m_lastfbo_swidth) * perStep;
-        m_sheightStep = (m_fbo_sheight - m_lastfbo_sheight) * perStep;
-
-        m_runoffsetx = m_lastfbo_offsetx;
-        m_runoffsety = m_lastfbo_offsety;
-        m_runswidth = m_lastfbo_swidth;
-        m_runsheight = m_lastfbo_sheight;
-    }
-
-    if(!zoomTimer.IsRunning())
-        zoomTimer.Start(m_nStep);
+        m_nStep = 10; 
+        m_nTotal = 40;
+        
+        m_nRun = 0;
+        
+        float perStep = m_nStep / m_nTotal;
+        
+     
+        if(zoomTimer.IsRunning()){
+            m_offsetxStep = (m_fbo_offsetx - m_runoffsetx) * perStep;
+            m_offsetyStep = (m_fbo_offsety - m_runoffsety) * perStep;
+            m_swidthStep = (m_fbo_swidth - m_runswidth) * perStep;
+            m_sheightStep = (m_fbo_sheight - m_runsheight) * perStep;
+            
+        }
+        else{
+            m_offsetxStep = (m_fbo_offsetx - m_lastfbo_offsetx) * perStep;
+            m_offsetyStep = (m_fbo_offsety - m_lastfbo_offsety) * perStep;
+            m_swidthStep = (m_fbo_swidth - m_lastfbo_swidth) * perStep;
+            m_sheightStep = (m_fbo_sheight - m_lastfbo_sheight) * perStep;
+    
+            m_runoffsetx = m_lastfbo_offsetx;
+            m_runoffsety = m_lastfbo_offsety;
+            m_runswidth = m_lastfbo_swidth;
+            m_runsheight = m_lastfbo_sheight;
+        }
+    
+        if(!zoomTimer.IsRunning())
+            zoomTimer.Start(m_nStep);
         m_zoomFinal = false;
     }
 }

--- a/src/tcmgr.cpp
+++ b/src/tcmgr.cpp
@@ -4515,7 +4515,7 @@ static NV_BOOL read_tide_db_header ()
     NV_INT32            temp_int;
     NV_CHAR             varin[ONELINER_LENGTH], *info;
     NV_U_INT32          utemp, i, j, pos, size, key_count;
-    NV_U_BYTE           *buf, checksum_c[4];
+    NV_U_BYTE           *buf, checksum_c[5];
     TIDE_RECORD         rec;
 
     if (!fp) {


### PR DESCRIPTION
A bunch of patches from the downstream Debian packaging. Notably linking issues as discussed in #1889 and also gshhs bundling as discussed in #1875. EDIT: #1750.

The latter drops the configuration option completely, always bundling the crude data.
EDIT: the latter just sets the defaults to bundling gshhs and tcdata.

The rest should be trivial. some bugfix and a bunch of fixed warnings -- it now builds cleanly on sid.

Note: All of these patches have been applied to the downstream packaging branch. Accepted or not, they can still be simple downstream patches. This also means that they can be cherry-picked, should you want to.

Also note: the downstream package is by no means set in stone. It can be modified, we are still on a beta cycle.

Closes: #1889