### PR TITLE
Fix for incorrectly scaled vector ship shape

### DIFF
--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -2726,29 +2726,29 @@ void glChartCanvas::ShipDraw(ocpnDC& dc)
                 dc.SetPen( ppPen );
                 dc.SetBrush( ppBrush );
 
-                shipPoints[0].x = 0; shipPoints[0].y = -28;
-                shipPoints[1].x = 11; shipPoints[1].y = -28;
-                shipPoints[2].x = 11; shipPoints[2].y = 42;
-                shipPoints[3].x = 0; shipPoints[3].y = 42;
-                dc.DrawPolygon( 4, shipPoints, lShipMidPoint.x, lShipMidPoint.y, scale_factor_x, icon_rad - PI/2 );
+                shipPoints[0].x = 0*scale_factor_x; shipPoints[0].y = -28*scale_factor_y;
+                shipPoints[1].x = 11*scale_factor_x; shipPoints[1].y = -28*scale_factor_y;
+                shipPoints[2].x = 11*scale_factor_x; shipPoints[2].y = 42*scale_factor_y;
+                shipPoints[3].x = 0*scale_factor_x; shipPoints[3].y = 42*scale_factor_y;
+                dc.DrawPolygon( 4, shipPoints, lShipMidPoint.x, lShipMidPoint.y, 1, icon_rad - PI/2 );
                 
-                shipPoints[0].x = 0; shipPoints[0].y = -42;
-                shipPoints[1].x = 5; shipPoints[1].y = -42;
-                shipPoints[2].x = 11; shipPoints[2].y = -28;
-                shipPoints[3].x = 0; shipPoints[3].y = -28;
-                dc.DrawPolygon( 4, shipPoints, lShipMidPoint.x, lShipMidPoint.y, scale_factor_x, icon_rad - PI/2 );
+                shipPoints[0].x = 0*scale_factor_x; shipPoints[0].y = -42*scale_factor_y;
+                shipPoints[1].x = 5*scale_factor_x; shipPoints[1].y = -42*scale_factor_y;
+                shipPoints[2].x = 11*scale_factor_x; shipPoints[2].y = -28*scale_factor_y;
+                shipPoints[3].x = 0*scale_factor_x; shipPoints[3].y = -28*scale_factor_y;
+                dc.DrawPolygon( 4, shipPoints, lShipMidPoint.x, lShipMidPoint.y, 1, icon_rad - PI/2 );
                 
-                shipPoints[0].x = 0; shipPoints[0].y = -28;
-                shipPoints[1].x = -11; shipPoints[1].y = -28;
-                shipPoints[2].x = -11; shipPoints[2].y = 42;
-                shipPoints[3].x = 0; shipPoints[3].y = 42;
-                dc.DrawPolygon( 4, shipPoints, lShipMidPoint.x, lShipMidPoint.y, scale_factor_x, icon_rad - PI/2 );
+                shipPoints[0].x = 0*scale_factor_x; shipPoints[0].y = -28*scale_factor_y;
+                shipPoints[1].x = -11*scale_factor_x; shipPoints[1].y = -28*scale_factor_y;
+                shipPoints[2].x = -11*scale_factor_x; shipPoints[2].y = 42*scale_factor_y;
+                shipPoints[3].x = 0*scale_factor_x; shipPoints[3].y = 42*scale_factor_y;
+                dc.DrawPolygon( 4, shipPoints, lShipMidPoint.x, lShipMidPoint.y, 1, icon_rad - PI/2 );
 
-                shipPoints[0].x = 0; shipPoints[0].y = -42;
-                shipPoints[1].x = -5; shipPoints[1].y = -42;
-                shipPoints[2].x = -11; shipPoints[2].y = -28;
-                shipPoints[3].x = 0; shipPoints[3].y = -28;
-                dc.DrawPolygon( 4, shipPoints, lShipMidPoint.x, lShipMidPoint.y, scale_factor_x, icon_rad - PI/2 );
+                shipPoints[0].x = 0*scale_factor_x; shipPoints[0].y = -42*scale_factor_y;
+                shipPoints[1].x = -5*scale_factor_x; shipPoints[1].y = -42*scale_factor_y;
+                shipPoints[2].x = -11*scale_factor_x; shipPoints[2].y = -28*scale_factor_y;
+                shipPoints[3].x = 0*scale_factor_x; shipPoints[3].y = -28*scale_factor_y;
+                dc.DrawPolygon( 4, shipPoints, lShipMidPoint.x, lShipMidPoint.y, 1, icon_rad - PI/2 );
  
                 // draw with cross
                 double p1x = -11 * scale_factor_x;
@@ -2763,8 +2763,8 @@ void glChartCanvas::ShipDraw(ocpnDC& dc)
 
                 p1x = 0;
                 p2x = 0;
-                p1y = -42 * scale_factor_x;
-                p2y =  42 * scale_factor_x;
+                p1y = -42 * scale_factor_y;
+                p2y =  42 * scale_factor_y;
                 p1xr = ((p1x) * cos(icon_rad - PI/2)) - ((p1y) * sin(icon_rad - PI/2));
                 p2xr = ((p2x) * cos(icon_rad - PI/2)) - ((p2y) * sin(icon_rad - PI/2));
                 p1yr = ((p1y) * cos(icon_rad - PI/2)) + ((p1x) * sin(icon_rad - PI/2));


### PR DESCRIPTION
This is a proposed fix for a scaling issue in the real scale vector ship display described in issue #1895 .  It looks like only a scaling of the x scale factor was being applied in the polygons.  This led to the ship being proportional to its breadth but not respecting its length.  Scaling is applied in this PR to each point of the polygon before polygon creation.  It also applies to the points of the line cross.