### PR TITLE
Flatpak fixes (again)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2207,13 +2207,10 @@ if (NOT APPLE)
       DESTINATION ${PREFIX_DATA}/icons/hicolor/scalable/apps
     )
     install(FILES data/opencpn.desktop DESTINATION ${PREFIX_DATA}/applications)
-    install(DIRECTORY DESTINATION ${PREFIX_DATA}/metainfo)
     install(
-       FILES ${CMAKE_BINARY_DIR}/opencpn.appdata.xml
-       DESTINATION ${PREFIX_DATA}/metainfo
-       RENAME opencpn.metainfo.xml
+      FILES ${CMAKE_BINARY_DIR}/opencpn.appdata.xml
+      DESTINATION ${PREFIX_DATA}/metainfo
     )
-
     install(FILES opencpn.1 DESTINATION ${PREFIX_DATA}/man/man1)
   endif (UNIX)
 

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -12,11 +12,6 @@ set -xe
 sudo apt-key adv \
     --keyserver keyserver.ubuntu.com --recv-keys 78BD65473CB3BD13
 
-sudo apt-get -qq update
-if [ -z "$CIRCLE_BUILD_NUM" ]; then
-    sudo apt install -y docker docker.io
-fi
-
 DOCKER_SOCK="unix:///var/run/docker.sock"
 
 echo "DOCKER_OPTS=\"-H tcp://127.0.0.1:2375 -H $DOCKER_SOCK -s devicemapper\"" \

--- a/ci/generic-build-flatpak.sh
+++ b/ci/generic-build-flatpak.sh
@@ -20,7 +20,7 @@ sudo dnf clean all
 
 # Install required packages
 su -c "dnf install -y -q sudo dnf-plugins-core"
-sudo dnf install -q -y flatpak-builder ccrypt make rsync gnupg2
+sudo dnf install -q -y appstream flatpak-builder ccrypt make rsync gnupg2 
 
 test -d /opencpn-ci && cd /opencpn-ci || :
 
@@ -71,4 +71,5 @@ flatpak remote-add --user opencpn $PWD/website/opencpn.flatpakrepo
 flatpak update --appstream opencpn
 flatpak remote-ls opencpn
 
-
+# Validate the appstream data:
+appstreamcli validate app/files/share/appdata/org.opencpn.OpenCPN.appdata.xml

--- a/ci/generic-build-flatpak.sh
+++ b/ci/generic-build-flatpak.sh
@@ -49,6 +49,12 @@ make -f ../flatpak/Makefile install
 make GPG_HOMEDIR=opencpn-gpg -f ../flatpak/Makefile sign
 rm -rf gpg.tar.gz opencpn-gpg
 
+# Debug: show version in local repo.
+flatpak remote-add  \
+    --user --gpg-import=website/opencpn.key local $PWD/website/repo
+flatpak update --appstream local
+flatpak remote-ls local
+
 # Deploy website/ to deployment server.
 ccat --envvar FLATPAK_KEY ../ci/amazon-ec2.pem.cpt > amazon-ec2.pem
 chmod 400 amazon-ec2.pem
@@ -59,3 +65,10 @@ rm -f ../ci/amazon-ec2.pem
 
 # Restore the patched file so the caching works.
 git checkout ../flatpak/org.opencpn.OpenCPN.yaml
+
+# Debug: show version in remote repo.
+flatpak remote-add --user opencpn $PWD/website/opencpn.flatpakrepo
+flatpak update --appstream opencpn
+flatpak remote-ls opencpn
+
+

--- a/data/opencpn.appdata.xml.in
+++ b/data/opencpn.appdata.xml.in
@@ -1,12 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2018 Alec Leamas <leamas@nowhere.net> -->
 <component type="desktop">
-  <id>opencpn.desktop</id>
-  <metadata_license>gpl-2+</metadata_license>
+  <id>org.opencpn.OpenCPN</id>
+  <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <name>OpenCPN</name>
   <summary>A concise Chartplotter and Navigation software</summary>
   <summary xml:lang="sv">Kartplotter och navigationsprogram</summary>
+  <provides>
+    <binary>opencpn</binary>
+  </provides>
+  <launchable type="desktop-id">org.opencpn.OpenCPN.desktop</launchable>
   <description>
     <p>
       A cross-platform ship-borne GUI navigation application made
@@ -28,21 +32,6 @@
       at the same site.
     </p>
   </description>
-  <description xml:lang="sv">
-    <p> Plattformsoberoende navigationsprogram som stödjer: </p>
-    <ul>
-      <li> GPS/GPDS positionsdata </li>
-      <li> Presentation av BSB rasterkort. </li>
-      <li> Presentation av S57 och CM93 vektorkort </li>
-      <li> AIS-data </li>
-      <li> Rutter och girpunkter för att styra autopilot </li>
-    </ul>
-    <p>
-      Ytterligare sjökort kan laddas ner från projektets webbplats
-      opencpn.org. Här finns också ytterligare tillägg till programmet, bl
-      a under länken "Download".
-    </p>
-   </description>
   <releases>
     <release version="@PACKAGE_VERSION@" date="@VERSION_DATE@">
       <description>
@@ -52,9 +41,8 @@
   </releases>
   <screenshots>
     <screenshot type="default">
-      <image>
-        https://upload.wikimedia.org/wikipedia/commons/c/cd/Opencpn-screenshot.png
-      </image>
+      <caption>Main window</caption>
+      <image>https://en.wikipedia.org/wiki/OpenCPN#/media/File:OCPN_5_0.jpg</image>
     </screenshot>
   </screenshots>
   <url type="homepage">https://opencpn.org/</url>

--- a/flatpak/Makefile
+++ b/flatpak/Makefile
@@ -23,7 +23,7 @@ build:
 	flatpak install -y --user --reinstall \
 	    $(CURDIR)/repo org.opencpn.OpenCPN
 
-install:
+install: .phony
 	rm -rf $(DESTDIR); mkdir $(DESTDIR)
 	cp ../flatpak/repo/*flat* ../flatpak/repo/index.html $(DESTDIR)
 	cp -ar repo $(DESTDIR)

--- a/flatpak/Makefile
+++ b/flatpak/Makefile
@@ -56,6 +56,7 @@ repourl:
 
 publish:
 	rsync -a  --info=stats --rsh="$(RSYNC_RSH)" $(DESTDIR)/ \
+	    --delete-after \
 	    $(RSYNC_HOST):/var/www/ocpn-flatpak/website
 
 .phony:

--- a/flatpak/org.opencpn.OpenCPN.yaml
+++ b/flatpak/org.opencpn.OpenCPN.yaml
@@ -79,7 +79,8 @@ modules:
       build-options:
           cxxflags: -DFLATPAK
           cflags: -DFLATPAK
-          env: {BUILD_NUMBER: "0"}
+          env:
+            BUILD_NUMBER: "0"
       post-install:
           - install -d /app/extensions
           - sed -i '/^Exec=/s/=.*/=opencpn.sh/' /app/share/applications/opencpn.desktop

--- a/org.opencpn.OpenCPN.yaml
+++ b/org.opencpn.OpenCPN.yaml
@@ -6,8 +6,7 @@
 # (at your option) any later version.
 #
 
-# This manifest is used to build development snapshots (including
-# nightly builds) of the flatpak package.
+# This manifest is used to build the official flathub package. 
 
 
 app-id: org.opencpn.OpenCPN
@@ -90,7 +89,8 @@ modules:
           - install -Dm 755 ../data/opencpn.sh /app/bin/opencpn.sh
       sources:
           - type: git
-            url: ..
-            branch: master
+            url: https://github.com/OpenCPN/OpenCPN.git
+            # tag: 5.1.511-Beta
+            commit: c3b67169f
           - type: patch
-            path: ../flatpak/src/0008-flatpak-Add-a-shell-wrapper.patch
+            path: flatpak/src/0008-flatpak-Add-a-shell-wrapper.patch


### PR DESCRIPTION
Some fixes to the flatpak toolchain + #1908 which I thought was merged when https://github.com/OpenCPN/OpenCPN/pull/1910 was merged. However, this PR contained 0 (zero) commits, so something went terribly wrong here. Probably my doing, testing the flatpak branch is a complicated mess of forced pushes.

Anyway, some polish to the flatpak toolchain and a fix for  #1908. Nothing here should affect anything but the flatpak build besides the #1908 fix.

Closes: #1908