### PR TITLE
Revert "Rename appdata.xml to metainfo.xml on linux install." (#1919).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2210,7 +2210,6 @@ if (NOT APPLE)
     install(
       FILES ${CMAKE_BINARY_DIR}/opencpn.appdata.xml
       DESTINATION ${PREFIX_DATA}/metainfo
-      RENAME opencpn.metainfo.xml
     )
     install(FILES opencpn.1 DESTINATION ${PREFIX_DATA}/man/man1)
   endif (UNIX)


### PR DESCRIPTION
This reverts commit e041ba0932c9d157e5f79e1d7b36a40cb1b4d8dd.

Renaming the appdata file to opencpn.metainfo.xml seems to break undocumented (?)
features of flatpak-builder(1), eventually ending up in file not being processed.

EDIT: Closes: #1919.