### PR TITLE
flatpak: Flathub fixes.

### DIFF
--- a/data/opencpn.appdata.xml.in
+++ b/data/opencpn.appdata.xml.in
@@ -47,4 +47,5 @@
   </screenshots>
   <url type="homepage">https://opencpn.org/</url>
   <update_contact>https://opencpn.org/flyspray/</update_contact>
+  <content_rating type="oars-1.0" />
 </component>

--- a/data/opencpn.appdata.xml.in
+++ b/data/opencpn.appdata.xml.in
@@ -42,7 +42,7 @@
   <screenshots>
     <screenshot type="default">
       <caption>Main window</caption>
-      <image>https://en.wikipedia.org/wiki/OpenCPN#/media/File:OCPN_5_0.jpg</image>
+      <image>http://download.opencpn.org/screenshots/82434783-624dea00-9a61-11ea-847b-347d91b8f0fd.png</image>
     </screenshot>
   </screenshots>
   <url type="homepage">https://opencpn.org/</url>


### PR DESCRIPTION
Two patches for the appdata metainfo from the upcoming flathub package at https://github.com/flathub/flathub/pull/1533. 

Only affects the software stores in Debian (Linux in general) and flatpak.