### PR TITLE
Flatpak: Check flatpak version >= 1.2.0 (#1934)

### DIFF
--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -18,20 +18,21 @@ Cons:
 
   - Device access requires installing udev rules.
   - One single package without options do drop docs etc.
-  - Plugins need to be patched and packaged to be usable.
 
 
-Usage:
-------
+End-user usage:
+---------------
 
 Users might need to install flatpak, described in https://flatpak.org/setup/.
-Using the provisionary beta-test directory
-
-    $ flatpak remote-add --if-not-exists \
-       flathub https://flathub.org/repo/flathub.flatpakrepo
+Using the provisionary beta-test directory:
 
     $ flatpak install --user \
-       http://opencpn.duckdns.org/opencpn-beta/website/opencpn.flatpakref
+          http://opencpn.duckdns.org/opencpn-beta/opencpn.flatpakref
+
+Using the provisionary nigtly builds:
+
+    $ flatpak install --user \
+          http://opencpn.duckdns.org/opencpn/opencpn.flatpakref
 
 
 In order to fix device permissions, a udev rule needs to be installed. Create
@@ -46,11 +47,33 @@ take effect. Normally, only one of the three lines is required depending
 on the device used - the rest could be dropped.
 
 
+Developer usage
+---------------
+
+The Makefile is capable of building installing the opencpn flatpak
+package locally. The first steps are about installing *flatpak* and
+*flatpak-builder* as described at https://flatpak.org/setup/
+
+Armed with these tools, initialize by installing the runtime and sdk:
+
+    $ sudo flatpak install flathub org.freedesktop.Platform//18.08
+    $ sudo flatpak install flathub org.freedesktop.Sdk//18.08
+
+Review the `org.opencpn.OpenCPN.yaml` manifest file. In the very end
+are the definitions for the opencpn source; the current setup is
+to build the tip of the master branch.  Review and update as
+required. Build and install the opencpn flatpak package:
+
+    $ cd build; make -f ../flatpak/Makefile build
+
 Repo maintenance
 ----------------
 
-The first steps is about installing *flatpak* and *flatpak-builder* as
-described at https://flatpak.org/setup/
+The first steps are to build as described in Developer Usage above.
+
+Then, install the results of the build into the website/ directory:
+
+    $ cd build; make -f ../flatpak/Makefile install
 
 In order to sign the repo a public gpg key should be available. The
 urban wisdom seems to be to use a specific key created for this purpose.
@@ -60,106 +83,11 @@ Create and export one using something like:
     $ gpg2 --homedir=~/opencpn-gpg --quick-gen-key leamas@opencpn.org
     $ gpg2 --homedir=~/opencpn-gpg --export -a leamas@opencpn.org > opencpn.key
 
+Sign contents + summary i. e., the result of the build:
 
-Armed with these tools, initialize by installing the runtime and sdk:
+    $ cd build; GPG_HOMEDIR=~/opencpn-gpg GPG_KEY=leamas@opencpn.org \
+          make -f ../flatpak/Makefile sign
 
-     $ sudo flatpak remote-add --if-not-exists flathub \
-           https://dl.flathub.org/repo/flathub.flatpakrepo
-     $ sudo flatpak install flathub org.freedesktop.Platform//18.08
-     $ sudo flatpak install flathub org.freedesktop.Sdk//18.08
+Given proper permissions, the result can be published using
 
-Review the org.opencpn.OpenCPN.yaml manifest file. In the very end
-are the definitions for the opencpn source; the current setup is
-to build the tip of the plug-mgr branch.  Review and update as
-rquired. Then build the packages in *opencpn/* and *base*
-
-    $ BRANCH=stable make build
-
-Build the repo stable branch and sign contents + summary:
-
-    $ GPG_HOMEDIR=~/opencpn-gpg GPG_KEY=leamas@opencpn.org make sign
-
-Create the website repo directory 
-
-    $ make DESTDIR=~/opencpn-website install
-
-
-Packaging plugins
------------------
-
-The file system used by flatpak apps is not available in a form where
-users could just drop a file. Note that once the plugin installer
-(PR #1457) is merged all these plugin can be used .
-
-The alternative is to package the plugin which normally is
-trivial. An example from the shipdriver plugin, 
-https://github.com/lea~/opencpn-gpgmas/shipdriver\_pi.
-
-The first step is to update the API. Copy the file ocpn\_plugin.h
-from the opencpn package to shipdriver src directory. Then, patch
-the plugin to use *GetPluginDataDir* instead of *GetpSharedDataLocation()*,
-for  the shipdriver this looks like:
-
-    --- a/src/icons.cpp
-    +++ b/src/icons.cpp
-
-         wxFileName fn;
-    -    fn.SetPath(*GetpSharedDataLocation());
-    -    fn.AppendDir(_T("plugins"));
-    -    fn.AppendDir(_T("ShipDriver_pi"));
-    +    fn.SetPath(GetPluginDataDir("ShipDriver_pi"));
-         fn.AppendDir(_T("data"));
-         //* The argument to GetPluginDataDir() is the name of the plugin
-         //  data directory, as used to compute it in the old code.
- 
-The part(s) to patch could usually be found by searching for
-GetpSharedDataLocation(). Not all plugins uses a data location though.
-
-Pick a unique id on the form *org.opencpn.OpenCPN.Plugin.MyPlugin*. Ensure 
-that the plugin builds in a normal context. Create the plugin manifest with 
-the name *org.opencpn.OpenCPN.Plugin.MyPlugin.yaml* like:
-
-    id: org.opencpn.OpenCPN.Plugin.ShipDriver
-    runtime: org.opencpn.OpenCPN
-    runtime-version: stable
-    sdk: org.freedesktop.Sdk//18.08
-    build-extension: true
-    separate-locales: false
-    appstream-compose: false
-    modules: 
-        - name: shipdriver
-          no-autogen: true
-          cmake: true
-          config-opts: 
-              - -DCMAKE_INSTALL_PREFIX:PATH=/app/extensions/ShipDriver
-          sources: 
-              - type: git
-                url: https://github.com/Rasbats/shipdriver_pi.git
-                tag: v0.5
-
-Refer to the flatpak docs how to modify this. Note the *id* and 
-*CMAKE_INSTALL_PREFIX*. The manifest supports all kinds of sources, patches 
-and simple scripting required to build the package.  See
-http://docs.flatpak.org/en/latest/getting-started.html. The crash-course:
-
-See above for how to initialize the build environment. Install 
-*org.opencpn.OpenCPN*. Then, build package in directory *app* using:
-
-    $ flatpak-builder app org.opencpn.OpenCPN.Plugin.PluginName.yaml
-
-Export the built package to a repo directory (here named *repo*) on the stable 
-branch using:
-
-    $ flatpak build-export repo app stable
-
-Add a local remote pointing to the repo dir:
-
-    $ sudo flatpak remote-add my-repo $PWD/repo
-
-List the repo contents:
-
-    $ flatpak remote-ls my-repo
-
-Install and test the plugin:
-
-    $ sudo flatpak install my-repo org.opencpn.OpenCPN.Plugin.MyPLugin
+    $ cd build; make -f ../flatpak/Makefile publish

--- a/flatpak/README.md
+++ b/flatpak/README.md
@@ -50,7 +50,7 @@ on the device used - the rest could be dropped.
 Developer usage
 ---------------
 
-The Makefile is capable of building installing the opencpn flatpak
+The Makefile is capable of building and installing the opencpn flatpak
 package locally. The first steps are about installing *flatpak* and
 *flatpak-builder* as described at https://flatpak.org/setup/
 
@@ -61,10 +61,12 @@ Armed with these tools, initialize by installing the runtime and sdk:
 
 Review the `org.opencpn.OpenCPN.yaml` manifest file. In the very end
 are the definitions for the opencpn source; the current setup is
-to build the tip of the master branch.  Review and update as
-required. Build and install the opencpn flatpak package:
+to build the tip of the master branch. Update as required.
+
+Build and install the opencpn flatpak package:
 
     $ cd build; make -f ../flatpak/Makefile build
+
 
 Repo maintenance
 ----------------
@@ -91,3 +93,6 @@ Sign contents + summary i. e., the result of the build:
 Given proper permissions, the result can be published using
 
     $ cd build; make -f ../flatpak/Makefile publish
+
+There are multiple variables in the Makefile making it possible to tweak 
+this workflow in various ways.

--- a/flatpak/org.opencpn.OpenCPN.yaml
+++ b/flatpak/org.opencpn.OpenCPN.yaml
@@ -59,6 +59,8 @@ modules:
           - --enable-no_deps
           - --disable-rpath
           - --enable-ipv6
+      cleanup:
+          - /include/
 
     - name:  zlib
       sources:

--- a/flatpak/src/0008-flatpak-Add-a-shell-wrapper.patch
+++ b/flatpak/src/0008-flatpak-Add-a-shell-wrapper.patch
@@ -1,25 +1,36 @@
-From 0ef7d9ef5f4ce1d8c03294ea198f54a18f826e63 Mon Sep 17 00:00:00 2001
+From fc232a016a70bb764669ac61f86c297cb03eb1dc Mon Sep 17 00:00:00 2001
 From: Alec Leamas <leamas@nowhere.net>
 Date: Fri, 3 Aug 2018 18:50:08 +0200
 Subject: [PATCH] flatpak: Add a shell wrapper.
 
 ---
- data/opencpn.sh | 6 ++++++
- 1 file changed, 6 insertions(+)
+ data/opencpn.sh | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
  create mode 100644 data/opencpn.sh
 
 diff --git a/data/opencpn.sh b/data/opencpn.sh
 new file mode 100644
-index 00000000..a9bc4ef3
+index 000000000..698d4dd9a
 --- /dev/null
 +++ b/data/opencpn.sh
-@@ -0,0 +1,6 @@
-+#!/bin/sh
+@@ -0,0 +1,17 @@
++#!/bin/bash
++set -o pipefail
 +
 +export XDG_DATA_DIRS=$XDG_DATA_DIRS:/app/extensions/share
 +export OPENCPN_PLUGIN_DIRS=/app/extensions/lib/opencpn:/app/lib/opencpn
 +
++if [ -f /.flatpak-info ]; then
++    fp_vers="$(grep flatpak-version /.flatpak-info | sed -e 's/.*=//')"
++    num_vers="$(echo $fp_vers | tr -d '.')"
++    if (( num_vers < 120 )); then
++        export OPENPN_FATAL_ERROR="Flatpak version $fp_vers is too old."
++    fi
++else
++    export OPENPN_FATAL_ERROR="Flatpak version is too old."
++fi
++
 +exec opencpn $@
 -- 
-2.17.1
+2.24.1
 

--- a/opencpn.1
+++ b/opencpn.1
@@ -88,6 +88,9 @@ Plugin load path, see PLUGIN LOADING
 .B OPENCPN_LOGLEVEL
 Default loglevel if not defined on command line using -l/--loglevel. See
 the --loglevel option for allowed values.
+.TP
+.B OPENCPN_FATAL_ERROR
+If defined, displays the message and exits on startup.
 
 .SH FILES
 .TP

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -1788,6 +1788,10 @@ bool MyApp::OnInit()
     }
 #endif  // __OCPN__ANDROID__
 
+    if (getenv("OPENCPN_FATAL_ERROR") != 0) {
+        wxLogFatalError(getenv("OPENCPN_FATAL_ERROR"));
+    }
+
     // Check if last run failed, set up safe_mode.
     if (!safe_mode::get_mode()) {
         safe_mode::check_last_start();


### PR DESCRIPTION
The main purpose is to check that the installed flatpak version is recent enough to avoid problems described in #1934. The fix is somewhat generic, opening a path for wrappers to trigger an arbitrary fatal error message using an environment variable.

While on it, fix some docs and remove large and useless gtk3 headers from installed package.

The changes on the main opencpn code  (1133692) are minimal and seems IMHO safe.

Closes: #1934.