### PR TITLE
chartdldr_pi: Don't paint list of charts until fully populated

### DIFF
--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -1560,12 +1560,11 @@ void ChartDldrPanelImpl::AddSource( wxCommandEvent& event )
     ChartDldrGuiAddSourceDlg *dialog = new ChartDldrGuiAddSourceDlg(this);
     dialog->SetBasePath(pPlugIn->GetBaseChartDir());
     
-#ifdef __OCPN__ANDROID__    
-    wxSize sz = GetParent()->GetSize();          // This is the panel true size
+//#ifdef __OCPN__ANDROID__    
+    wxSize sz = GetParent()->GetGrandParent()->GetSize();          // This is the options panel true size
     dialog->SetSize(sz.GetWidth(), sz.GetHeight());
-    dialog->CenterOnScreen();
-    //Hide();                     // This cleans up the screen a bit, avoiding confusion...
-#endif    
+    dialog->Center();
+//#endif    
 
     dialog->ShowWindowModalThenDo([this,dialog](int retcode){
         if ( retcode == wxID_OK ) {

--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -48,6 +48,7 @@
 #include <wx/wfstream.h>
 #include <memory>
 #include <wx/regex.h>
+#include <wx/wupdlock.h>
 #ifdef DLDR_USE_LIBARCHIVE
   #include <archive.h>
   #include <archive_entry.h>
@@ -748,7 +749,7 @@ void ChartDldrPanelImpl::FillFromFile( wxString url, wxString dir, bool selnew, 
         m_panelArray.Clear();
         
         m_scrollWinChartList->ClearBackground();
-        
+        wxWindowUpdateLocker noUpdates(m_scrollWinChartList);
         for( size_t i = 0; i < pPlugIn->m_pChartCatalog->charts.Count(); i++ )
         {
             wxString status;

--- a/plugins/chartdldr_pi/src/chartdldr_pi.h
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.h
@@ -229,10 +229,8 @@ protected:
     bool            isChartChecked( int i );
     void            CheckAllCharts( bool value );
     void            InvertCheckAllCharts( );
-#ifdef NEW_LIST
     void            CheckNewCharts( bool value );
     void            CheckUpdatedCharts(bool value);
-#endif	/* NEW_LIST */
 
 public:
     //ChartDldrPanelImpl() { m_bconnected = false; DownloadIsCancel = false; }


### PR DESCRIPTION
Speed up populating long list of charts by freezing the window until it is fully populated.