### PR TITLE
Changed termination of SignalKDataStream on websocket:

### DIFF
--- a/src/SignalKDataStream.cpp
+++ b/src/SignalKDataStream.cpp
@@ -578,23 +578,20 @@ void *WebSocketThread::Entry()
     while (true) {
         if(TestDestroy()){
             //printf("receiving delete\n");
-            break;
+	    ws->close();
         }
         
+        if(ws->getReadyState() == WebSocket::CLOSED){
+	    //printf("closed\n");
+	    break;
+	}
+    	ws->poll(10);
         if(ws->getReadyState() == WebSocket::OPEN){
-            ws->poll(10);
-            if(ws->getReadyState() == WebSocket::CLOSED){
-                //printf("closed\n");
-                break;
-            }
             ws->dispatch(HandleMessage);
         }
-        else
-            wxThread::Sleep(1);
     }
     
-    //printf("ws close\n");
-    ws->close();
+    //printf("ws delete\n");
     delete ws; 
 
     m_parentStream->SetThreadRunning(false);


### PR DESCRIPTION
easywsclient doesn't directly close socket-fd on calling close() which leads to lingering
sockets if deleting the object without going through poll() to wait for the ready-state CLOSED.
---
Details:

Noticed on my idle signalk-server that the websocket connection count was constantly growing.
sockstat / lsof showed dozens of connections coming from opencpn. OpenCPN runs into a timeout
when it gets no data from SigK, closes the socket and reopens a new connection.
Unfortunately easywsclient seems to be broken. It doesn't close the socket upon destruction
of the instance. One needs to go through WebSocket::close() and then poll() and wait until the
readystate changes to CLOSED before deleting the instance.

Changed WebSocketThread::Entry accordingly.

