### PR TITLE
Garmin library logging fixes (#1957).

### DIFF
--- a/libs/garmin/CMakeLists.txt
+++ b/libs/garmin/CMakeLists.txt
@@ -34,6 +34,7 @@ set( SRC
     jeeps/gpsrqst.h
     jeeps/gpsserial.h
     jeeps/gpsusbint.h
+    jeeps/gps_wx_logging.h
     jeeps/garminusb.h
     jeeps/gpscom.h
     jeeps/gpsdevice.h
@@ -59,6 +60,7 @@ if (MINGW)
   target_compile_definitions(GARMINHOST PRIVATE "-D_UNICODE")
 endif ()
 
+target_compile_definitions(GARMINHOST PRIVATE "-DUSE_WX_LOGGING")
 set_property(TARGET GARMINHOST PROPERTY COMPILE_FLAGS "${OBJ_VISIBILITY}")
 target_include_directories(GARMINHOST PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/jeeps)
 target_include_directories(GARMINHOST PRIVATE ${wxWidgets_INCLUDE_DIRS})

--- a/libs/garmin/CMakeLists.txt
+++ b/libs/garmin/CMakeLists.txt
@@ -51,7 +51,7 @@ if (WIN32)
   set(SRC ${SRC} jeeps/gpsusbwin.c)
   add_definitions(-D__WIN32__)
 endif ()
-
+set_source_files_properties(${SRC} PROPERTIES LANGUAGE CXX )
 
 add_library(GARMINHOST STATIC ${SRC})
 add_library(ocpn::garminhost ALIAS GARMINHOST)

--- a/libs/garmin/jeeps/garminusb.h
+++ b/libs/garmin/jeeps/garminusb.h
@@ -18,7 +18,12 @@
     Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02111 USA
 
  */
+
+#ifndef _garmingusb_h
+#define _garmingusb_h
+
 #include <stdio.h>
+#include "gpsdevice.h"
 
 /* This structure is a bit funny looking to avoid variable length
  * arrays which aren't present in C89.   This contains the visible
@@ -65,3 +70,5 @@ int gusb_close(gpsdevh *);
 #define GUSB_SESSION_START 5	/* We request units attention */
 #define GUSB_SESSION_ACK   6	/* Unit responds that we have its attention */
 #define GUSB_REQUEST_BULK  2	/* Unit requests we read from bulk pipe */
+
+#endif

--- a/libs/garmin/jeeps/gps_wx_logging.h
+++ b/libs/garmin/jeeps/gps_wx_logging.h
@@ -1,0 +1,72 @@
+/** Remap internal logging functions to wxWidgets logging functions. */
+
+#ifndef wx_log_h_
+#define wx_log_h_
+
+#include <sstream>
+#include <iomanip>
+
+#include <wx/log.h>
+
+void static inline _wxLogError(const char* fmt...) {
+    va_list ap;
+    va_start(ap, fmt);
+    wxVLogError(fmt, ap);
+    va_end(ap);
+}
+
+
+void static inline _wxLogWarning(const char* fmt...) {
+    va_list ap;
+    va_start(ap, fmt);
+    wxVLogWarning(fmt, ap);
+    va_end(ap);
+}
+
+
+void static inline _wxLogMessage(const char* fmt...) {
+    va_list ap;
+    va_start(ap, fmt);
+    wxVLogMessage(fmt, ap);
+    va_end(ap);
+}
+
+
+void static inline _wxLogDebug(const char* fmt...) {
+    va_list ap;
+    va_start(ap, fmt);
+    wxVLogDebug(fmt, ap);
+    va_end(ap);
+}
+
+
+void static do_GPS_Diagnose(int c) {
+    static std::stringstream ss;
+    if (ss.str().length() > 80 || c == 10) {
+        wxLogDebug(ss.str().c_str());
+        ss.clear();
+    }
+    ss << " " << std::setfill('0') << std::setw(2) << c;
+}
+
+
+
+#if defined(__GNUC__) || defined (__clang__)
+
+#define GPS_Error(fmt, ...)     _wxLogError(fmt, ## __VA_ARGS__)
+#define GPS_Warning(fmt, ...)   _wxLogWarning(fmt, ## __VA_ARGS__)
+#define GPS_User(fmt, ...)      _wxLogMessage(fmt, ## __VA_ARGS__)
+#define GPS_Diag(fmt, ...)      _wxLogDebug(fmt, ## __VA_ARGS__)
+
+#else
+
+#define GPS_Error(fmt, ...)     _wxLogError(fmt, __VA_ARGS__)
+#define GPS_Warning(fmt, ...)   _wxLogWarning(fmt, __VA_ARGS__)
+#define GPS_User(fmt, ...)      _wxLogMessage(fmt, __VA_ARGS__)
+#define GPS_Diag(fmt, ...)      _wxLogDebug(fmt, __VA_ARGS__)
+
+#endif   // defined(__GNUC__) || defined (__clang__)
+#define GPS_Diagnose(c)         _do_GPS_Diagnose((int) c);
+
+
+#endif  // wx_log_h_

--- a/libs/garmin/jeeps/gpsapp.c
+++ b/libs/garmin/jeeps/gpsapp.c
@@ -174,7 +174,7 @@ static void   GPS_D501_Send(UC *data, GPS_PAlmanac alm);
 static void   GPS_D550_Send(UC *data, GPS_PAlmanac alm);
 static void   GPS_D551_Send(UC *data, GPS_PAlmanac alm);
 
-void  VerifySerialPortClosed(void);  /*  In gpsserial.c  */
+#include "gpsserial.h"
 
 void VerifyPortClosed()
 {
@@ -7461,7 +7461,7 @@ void GPS_Prepare_Track_For_Device(GPS_PTrack **trk, int32 *n)
 			trkpt->distance_populated = 0;
 			trkpt->heartrate = 0;
 			trkpt->cadence = 0xff;
-			*trk = xrealloc(*trk, (*n+1) * sizeof(GPS_PTrack));
+			*trk = (GPS_STrack**) xrealloc(*trk, (*n+1) * sizeof(GPS_PTrack));
 			memmove(&(*trk)[i+1], &(*trk)[i], (*n-i) * sizeof(GPS_PTrack));
 			(*trk)[i] = trkpt;
 			i++;

--- a/libs/garmin/jeeps/gpsapp.c
+++ b/libs/garmin/jeeps/gpsapp.c
@@ -36,6 +36,10 @@
 #include "garminusb.h"
 #include "gpsusbint.h"
 
+#ifdef USE_WX_LOGGING
+#include "gps_wx_logging.h"
+#endif
+
 #define XMIN(a,b) (a < b? a : b)
 
 static UC Is_Trackpoint_Invalid(GPS_PTrack trk);

--- a/libs/garmin/jeeps/gpsapp.c
+++ b/libs/garmin/jeeps/gpsapp.c
@@ -287,20 +287,22 @@ static int32 GPS_A000(const char *port)
  
         // It seems that sometimes the first byte received after port open is lost...
         //      On error, Flush() and try once more....
-        GPS_Error("GPS_Get_Ack error");
+        GPS_Error("GPS_Get_Ack error: %d", gps_errno);
         
         GPS_Device_Flush(fd);
             
         if(!GPS_Write_Packet(fd,tra))
         {
-            GPS_Error("GPS_Write_Packet error");
+            GPS_Error("GPS_Write_Packet error: %d: %s",
+                       gps_errno, GetDeviceLastError());
             err = -55;
             goto carry_out;
         }
         
         if(!GPS_Get_Ack(fd, &tra, &rec))
         {
-            GPS_Error("GPS_Get_Ack error");
+            GPS_Error("GPS_Get_Ack error %d: %s",
+                      gps_errno, GetDeviceLastError());
             err = -56;
             goto carry_out;
         }            

--- a/libs/garmin/jeeps/gpscom.c
+++ b/libs/garmin/jeeps/gpscom.c
@@ -28,6 +28,10 @@
 #include <stdio.h>
 #include <float.h>
 
+#ifdef USE_WX_LOGGING
+#include "gps_wx_logging.h"
+#endif
+
 
 /* @func GPS_Command_Off ***********************************************
 **

--- a/libs/garmin/jeeps/gpsdatum.h
+++ b/libs/garmin/jeeps/gpsdatum.h
@@ -31,11 +31,13 @@ extern "C"
 #ifndef gpsdatum_h
 #define gpsdatum_h
 
+#include <stddef.h>
+
 
 
 typedef struct GPS_SEllipse
 {
-    char   *name;
+    const char* name;
     double a;
     double invf;
 } GPS_OEllipse, *GPS_PEllipse;
@@ -76,7 +78,7 @@ GPS_OEllipse GPS_Ellipse[]=
 
 typedef struct GPS_SDatum
 {
-    char   *name;
+    const char* name;
     int    ellipse;
     double dx;
     double dy;
@@ -217,7 +219,7 @@ GPS_ODatum GPS_Datum[]=
 
 typedef struct GPS_SDatum_Alias
 {
-    char *alias;
+    const char* alias;
     const int datum;
 } GPS_ODatum_Alias, *GPS_PDatum_Alias;
 
@@ -258,7 +260,7 @@ GPS_ODatum_Alias GPS_DatumAlias[] =
 
 
 /* UK Ordnance Survey Nation Grid Map Codes */
-static char *UKNG[]=
+const static char *UKNG[]=
 {
     "SV","SW","SX","SY","SZ","TV","TW","SQ","SR","SS","ST","SU","TQ","TR",
     "SL","SM","SN","SO","SP","TL","TM","SF","SG","SH","SJ","SK","TF","TG",

--- a/libs/garmin/jeeps/gpsmath.c
+++ b/libs/garmin/jeeps/gpsmath.c
@@ -2547,7 +2547,7 @@ int32 GPS_Lookup_Datum_Index(const char *n)
 	return -1;
 }
 
-char *
+const char *
 GPS_Math_Get_Datum_Name(const int datum_index)
 {
 	return GPS_Datum[datum_index].name;

--- a/libs/garmin/jeeps/gpsmath.h
+++ b/libs/garmin/jeeps/gpsmath.h
@@ -164,7 +164,7 @@ void GPS_Math_UTM_EN_to_LatLon(int ReferenceEllipsoid,
 			       const double lambda0, const double E0, const double N0);
 
 int32 GPS_Lookup_Datum_Index(const char *n);
-char *GPS_Math_Get_Datum_Name(const int datum_index);
+const char *GPS_Math_Get_Datum_Name(const int datum_index);
 
 #endif
 

--- a/libs/garmin/jeeps/gpsprot.c
+++ b/libs/garmin/jeeps/gpsprot.c
@@ -25,6 +25,10 @@
 #include "garmin_gps.h"
 #include <stdio.h>
 
+#ifdef USE_WX_LOGGING
+#include "gps_wx_logging.h"
+#endif
+
 #define GPS_TAGUNK  20
 
 /* Storage for any unknown tags */

--- a/libs/garmin/jeeps/gpsread.c
+++ b/libs/garmin/jeeps/gpsread.c
@@ -109,8 +109,8 @@ int32 GPS_Serial_Packet_Read(gpsdevh *fd, GPS_PPacket *packet)
 	    {
 		if(u != DLE)
 		{
-//		    (void) fprintf(stderr,"GPS_Packet_Read: No DLE.  Data received, but probably not a garmin packet.\n");
-//		    (void) fflush(stderr);
+		    GPS_Error(
+		        "GPS_Packet_Read: No DLE.  Data received, but probably not a garmin packet.\n");
 		    return 0;
 		}
                 ++len;

--- a/libs/garmin/jeeps/gpsread.c
+++ b/libs/garmin/jeeps/gpsread.c
@@ -33,6 +33,9 @@
 #include <windows.h>
 #endif
 
+#ifdef USE_WX_LOGGING
+#include "gps_wx_logging.h"
+#endif
 
 /* @func GPS_Time_Now ***********************************************
 **

--- a/libs/garmin/jeeps/gpsread.c
+++ b/libs/garmin/jeeps/gpsread.c
@@ -212,12 +212,13 @@ int32 GPS_Serial_Packet_Read(gpsdevh *fd, GPS_PPacket *packet)
 
 int32 GPS_Serial_Get_Ack(gpsdevh *fd, GPS_PPacket *tra, GPS_PPacket *rec)
 {
-    if(!GPS_Serial_Packet_Read(fd, rec))
+    if(!GPS_Serial_Packet_Read(fd, rec)) {
+        gps_errno = INPUT_ERROR;
 	return 0;
-
+    }
     if(LINK_ID[0].Pid_Ack_Byte != (*rec)->type)
     {
-          gps_errno = FRAMING_ERROR;
+          gps_errno = PROTOCOL_ERROR;
 /* rjl	return 0; */
     }
 

--- a/libs/garmin/jeeps/gpsrqst.c
+++ b/libs/garmin/jeeps/gpsrqst.c
@@ -24,6 +24,9 @@
 ********************************************************************/
 #include "garmin_gps.h"
 
+#ifdef USE_WX_LOGGING
+#include "gps_wx_logging.h"
+#endif
 
 static int32 GPS_A600_Rqst(gpsdevh *fd, time_t Time);
 static int32 GPS_A700_Rqst(gpsdevh *fd, double lat, double lon);

--- a/libs/garmin/jeeps/gpssend.c
+++ b/libs/garmin/jeeps/gpssend.c
@@ -29,6 +29,9 @@
 #include <errno.h>
 #include <ctype.h>
 
+#ifdef USE_WX_LOGGING
+#include "gps_wx_logging.h"
+#endif
 
 /* @funcstatic Build_Serial_Packet *************************************
 **

--- a/libs/garmin/jeeps/gpssend.h
+++ b/libs/garmin/jeeps/gpssend.h
@@ -31,9 +31,9 @@ extern "C"
 #define gpssend_h
 
 
+#define GPS_ARB_LEN 1024
 #include "garmin_gps.h"
 
-#define GPS_ARB_LEN 1024
 
 int32  GPS_Serial_Write_Packet(gpsdevh *fd, GPS_PPacket packet);
 int32  GPS_Serial_Send_Ack(gpsdevh *fd, GPS_PPacket *tra, GPS_PPacket *rec);

--- a/libs/garmin/jeeps/gpsserial.c
+++ b/libs/garmin/jeeps/gpsserial.c
@@ -36,6 +36,7 @@
 extern char last_error[];
 extern const int LAST_ERROR_SIZE;
 
+
 #if 0
 #define GARMULATOR 1
 char *rxdata[] = {
@@ -355,12 +356,10 @@ int32 GPS_Serial_Open(gpsdevh *dh, const char *port)
  */
 void GPS_Serial_Error(const char *mb, ...)
 {
-      va_list argp;
-      va_start(argp, mb);
-
-      sprintf(last_error, mb, argp);
-
-      va_end(argp);
+      va_list ap;
+      va_start(ap, mb);
+      vsnprintf(last_error, LAST_ERROR_SIZE, mb, ap);
+      va_end(ap);
 
 //      GPS_Error(mb);
 /*dsr

--- a/libs/garmin/jeeps/gpsserial.c
+++ b/libs/garmin/jeeps/gpsserial.c
@@ -33,6 +33,10 @@
 #include <stdio.h>
 #include <time.h>
 
+#ifdef USE_WX_LOGGING
+#include "gps_wx_logging.h"
+#endif
+
 extern char last_error[];
 
 

--- a/libs/garmin/jeeps/gpsserial.c
+++ b/libs/garmin/jeeps/gpsserial.c
@@ -34,7 +34,6 @@
 #include <time.h>
 
 extern char last_error[];
-extern const int LAST_ERROR_SIZE;
 
 
 #if 0
@@ -130,7 +129,7 @@ int32 GPS_Serial_On(const char *port, gpsdevh **dh)
 #endif
 
 	const char *xname = fix_win_serial_name(port);
-	win_serial_data *wsd = xcalloc(sizeof (win_serial_data), 1);
+	win_serial_data *wsd = (win_serial_data*) xcalloc(sizeof (win_serial_data), 1);
 	*dh = (gpsdevh*) wsd;
       g_gps_devh = (gpsdevh*) wsd;        // save a global copy
 
@@ -557,7 +556,7 @@ int32 GPS_Serial_Wait(gpsdevh *dh)
 
 int32 GPS_Serial_On(const char *port, gpsdevh **dh)
 {
-    posix_serial_data *psd = xcalloc(sizeof (posix_serial_data), 1);
+    posix_serial_data *psd = (posix_serial_data*) xcalloc(sizeof (posix_serial_data), 1);
     *dh = (gpsdevh*) psd;
     g_gps_devh = (gpsdevh*) psd;        // save a global copy
 

--- a/libs/garmin/jeeps/gpsserial.c
+++ b/libs/garmin/jeeps/gpsserial.c
@@ -318,7 +318,8 @@ int32 GPS_Serial_Open(gpsdevh *dh, const char *port)
      */
     if((psd->fd = open(port, O_RDWR))==-1)
     {
-	GPS_Serial_Error("XSERIAL: Cannot open serial port '%s'", port);
+	GPS_Serial_Error("XSERIAL: Cannot open serial port '%s': %s",
+                         port, strerror(errno));
 	gps_errno = SERIAL_ERROR;
 	return 0;
     }
@@ -326,7 +327,7 @@ int32 GPS_Serial_Open(gpsdevh *dh, const char *port)
     if(tcgetattr(psd->fd,&psd->gps_ttysave)==-1)
     {
 	gps_errno = HARDWARE_ERROR;
-	GPS_Serial_Error("SERIAL: tcgetattr error");
+	GPS_Serial_Error("SERIAL: tcgetattr error: %s", strerror(errno));
 	return 0;
     }
     tty = psd->gps_ttysave;
@@ -344,7 +345,7 @@ int32 GPS_Serial_Open(gpsdevh *dh, const char *port)
 
     if(tcsetattr(psd->fd,TCSANOW|TCSAFLUSH,&tty)==-1)
     {
-	GPS_Serial_Error("SERIAL: tcsetattr error");
+	GPS_Serial_Error("SERIAL: tcsetattr error: %s", strerror(errno));
 	return 0;
     }
 

--- a/libs/garmin/jeeps/gpsserial.h
+++ b/libs/garmin/jeeps/gpsserial.h
@@ -53,7 +53,7 @@ int32  GPS_Serial_Write_Packet(gpsdevh *fd, GPS_PPacket packet);
 int32  GPS_Serial_Send_Ack(gpsdevh *fd, GPS_PPacket *tra, GPS_PPacket *rec);
 void   GPS_Serial_Error(const char *hdr, ...);
 
-void VerifySerialPortClosed(void);
+void VerifySerialPortClosed();
 int Garmin_Serial_GPS_PVT_On( const char *port_name );
 int Garmin_Serial_GPS_PVT_Off( const char *port_name );
 int GPS_Serial_Command_Pvt_Get(GPS_PPvt_Data *pvt );

--- a/libs/garmin/jeeps/gpsusbcommon.c
+++ b/libs/garmin/jeeps/gpsusbcommon.c
@@ -211,7 +211,7 @@ gusb_list_units()
 void
 gusb_id_unit(struct garmin_unit_info *gu)
 {
-	static const char  oid[12] =
+	static const unsigned char  oid[12] =
 		{20, 0, 0, 0, 0xfe, 0, 0, 0, 0, 0, 0, 0};
 	garmin_usb_packet iresp;
 	int i;

--- a/libs/garmin/jeeps/gpsusbcommon.h
+++ b/libs/garmin/jeeps/gpsusbcommon.h
@@ -23,6 +23,12 @@
  * The 'low level ops' are registered by the OS layer (win32, libusb, etc.)
  * to provide gruntwork features for the common USB layer.
  */
+
+#ifndef gpsusb_common_h
+#define gpsusb_common_h
+
+#include "garminusb.h"
+
 typedef int (*gusb_llop_get)(garmin_usb_packet *ibuf, size_t sz);
 typedef int (*gusb_llop_send)(const garmin_usb_packet *opkt, size_t sz);
 typedef int (*gusb_llop_close) (gpsdevh *dh);
@@ -43,3 +49,4 @@ void gusb_list_units(void);
 /* Provided by the OS layers */
 // int gusb_init(const char *portname, gpsdev **dh);
 
+#endif

--- a/libs/garmin/jeeps/gpsusbint.h
+++ b/libs/garmin/jeeps/gpsusbint.h
@@ -21,6 +21,8 @@
 
  */
 
+#include "gpsdevice.h"
+
 int32 GPS_Packet_Read_usb(gpsdevh *fd, GPS_PPacket *packet, int eatbulk);
 void  GPS_Make_Packet_usb(GPS_PPacket *packet, UC type, UC *data, int16 n);
 int32 GPS_Write_Packet_usb(gpsdevh *fd, GPS_PPacket packet);

--- a/libs/garmin/jeeps/gpsusbread.c
+++ b/libs/garmin/jeeps/gpsusbread.c
@@ -23,6 +23,11 @@
 #include "garminusb.h"
 #include "gpsusbint.h"
 
+#ifdef USE_WX_LOGGING
+#include "gps_wx_logging.h"
+#endif
+
+
 /*
  * Return values are:
  * Negative on error.

--- a/libs/garmin/jeeps/gpsusbwin.c
+++ b/libs/garmin/jeeps/gpsusbwin.c
@@ -53,7 +53,7 @@ typedef struct {
         int booger;
 } winusb_unit_data;
 
-static HANDLE *usb_handle = INVALID_HANDLE_VALUE;
+static HANDLE usb_handle = INVALID_HANDLE_VALUE;
 static int usb_tx_packet_size ;
 //dsr static const gdx_info *gdx;
 
@@ -133,7 +133,7 @@ static gusb_llops_t win_llops = {
 };
 
 static
-HANDLE * garmin_usb_start(HDEVINFO* hdevinfo, SP_DEVICE_INTERFACE_DATA *infodata)
+HANDLE garmin_usb_start(HDEVINFO* hdevinfo, SP_DEVICE_INTERFACE_DATA *infodata)
 {
 	DWORD size;
 	PSP_INTERFACE_DEVICE_DETAIL_DATA pdd = NULL;
@@ -142,7 +142,7 @@ HANDLE * garmin_usb_start(HDEVINFO* hdevinfo, SP_DEVICE_INTERFACE_DATA *infodata
 	SetupDiGetDeviceInterfaceDetail(hdevinfo, infodata, 
 			NULL, 0, &size, NULL);
 
-	pdd = malloc(size);
+	pdd = (PSP_INTERFACE_DEVICE_DETAIL_DATA) malloc(size);
 	pdd->cbSize = sizeof(SP_INTERFACE_DEVICE_DETAIL_DATA);
 
 	devinfo.cbSize = sizeof(SP_DEVINFO_DATA);
@@ -190,7 +190,7 @@ static char ** get_garmin_mountpoints(void)
 #define BUFSIZE 512
   char szTemp[MAX_PATH];
   char *p = szTemp;
-  char **dlist = malloc(sizeof(*dlist));
+  char **dlist = (char**) malloc(sizeof(*dlist));
 
   int i = 0;
   dlist[0] = NULL;
@@ -223,7 +223,7 @@ gusb_init(const char *pname, gpsdevh **dh)
 	HDEVINFO hdevinfo;
 	SP_DEVICE_INTERFACE_DATA devinterface;
 
-	winusb_unit_data *wud = xcalloc(sizeof (winusb_unit_data), 1);
+	winusb_unit_data *wud = (winusb_unit_data*) xcalloc(sizeof (winusb_unit_data), 1);
 	*dh = (gpsdevh*) wud;
 
 	gusb_register_ll(&win_llops);
@@ -265,7 +265,7 @@ gusb_init(const char *pname, gpsdevh **dh)
 			return 0;
 		}
 		/* We've matched.  Now start the specific unit. */
-		garmin_usb_start(hdevinfo, &devinterface);
+		garmin_usb_start(&hdevinfo, &devinterface);
 		return 1;
 	}
 
@@ -287,7 +287,7 @@ gusb_init(const char *pname, gpsdevh **dh)
 			}	
 		}
 		/* We've matched.  Now start the specific unit. */
-		garmin_usb_start(hdevinfo, &devinterface);
+		garmin_usb_start(&hdevinfo, &devinterface);
 		gusb_close(NULL);
 	}
 	gusb_list_units();

--- a/libs/garmin/jeeps/gpsusbwin.c
+++ b/libs/garmin/jeeps/gpsusbwin.c
@@ -33,6 +33,10 @@
 #include "gpsusbcommon.h"
 //#include "../garmin_device_xml.h"
 
+#ifdef USE_WX_LOGGING
+#include "gps_wx_logging.h"
+#endif
+
 /* Constants from Garmin doc. */
 
 // {2C9C45C2-8E7D-4C08-A12D-816BBAE722C0} 

--- a/libs/garmin/jeeps/gpsutil.c
+++ b/libs/garmin/jeeps/gpsutil.c
@@ -35,8 +35,7 @@ int32 gps_user    = 0;
 int32 gps_show_bytes = 0;
 int32 gps_errno = 0;
 
-const int LAST_ERROR_SIZE = 256;
-char last_error[256];
+char last_error[LAST_ERROR_SIZE];
 
 
 char * GetDeviceLastError(void)
@@ -466,7 +465,7 @@ int32 GPS_Util_Block(int32 fd, int32 state)
 ** @@
 ****************************************************************************/
 
-void GPS_Warning(char *s)
+void GPS_Warning(const char *s)
 {
     if(!gps_warning)
 	return;
@@ -489,7 +488,7 @@ void GPS_Warning(char *s)
 ** @@
 ****************************************************************************/
 
-void GPS_Fatal(char *s)
+void GPS_Fatal(const char *s)
 {
 
     fprintf(stderr,"[FATAL] %s\n",s);
@@ -509,7 +508,7 @@ void GPS_Fatal(char *s)
 ** @@
 ****************************************************************************/
 
-void GPS_Error(char *fmt, ...)
+void GPS_Error(const char *fmt, ...)
 {
     va_list ap;
     if(!gps_error)

--- a/libs/garmin/jeeps/gpsutil.c
+++ b/libs/garmin/jeeps/gpsutil.c
@@ -511,20 +511,12 @@ void GPS_Fatal(char *s)
 
 void GPS_Error(char *fmt, ...)
 {
-    va_list argp;
-    va_start(argp, fmt);
-
+    va_list ap;
     if(!gps_error)
 	return;
-
-
-    fprintf(stderr, "[ERROR] ");
-    vfprintf(stderr, fmt, argp);
-    fprintf(stderr, "\n");
-
-    sprintf(last_error, fmt, argp);
-
-    va_end(argp);
+    va_start(ap, fmt);
+    vsnprintf(last_error, LAST_ERROR_SIZE, fmt, ap);
+    va_end(ap);
     return;
 }
 

--- a/libs/garmin/jeeps/gpsutil.h
+++ b/libs/garmin/jeeps/gpsutil.h
@@ -32,6 +32,8 @@ extern "C"
 
 #include "garmin_gps.h"
 
+#define LAST_ERROR_SIZE 256
+
 int32  GPS_Util_Little(void);
 
 US     GPS_Util_Get_Short(const UC *s);
@@ -47,8 +49,8 @@ int32  GPS_Util_Block(int32 fd, int32 state);
 void   GPS_Util_Put_Uint(UC *s, const uint32 v);
 uint32 GPS_Util_Get_Uint(const UC *s);
 
-void   GPS_Warning(char *s);
-void   GPS_Error(char *fmt, ...);
+void   GPS_Warning(const char *s);
+void   GPS_Error(const char *fmt, ...);
 void   GPS_Serial_Error(const char *hdr, ...);
 void   GPS_Fatal(char *s);
 void   GPS_Enable_Error(void);

--- a/src/garmin_wrapper.cpp
+++ b/src/garmin_wrapper.cpp
@@ -280,6 +280,7 @@ int Garmin_GPS_SendRoute( const wxString &port_name, Route *pr, wxGauge *pProgre
       if((gps_rte_hdr_type == pD200) || (gps_rte_hdr_type == pD201))
       {
       //    Retrieve <ALL> routes from the device
+            GPS_Diag("Garmin: trying to get free route number");
             GPS_PWay *pprouteway;
             int32 npacks = GPS_A200_Get(port_name.mb_str(), &pprouteway);
             if(npacks < 0)
@@ -320,6 +321,7 @@ int Garmin_GPS_SendRoute( const wxString &port_name, Route *pr, wxGauge *pProgre
                         break;
                   }
             }
+            GPS_Diag("Using route number: %d", route_number);
 
             //  Ask the user if it is all right to overwrite
             if(!bfound_empty)

--- a/src/garmin_wrapper.cpp
+++ b/src/garmin_wrapper.cpp
@@ -50,16 +50,10 @@ wxString GetLastGarminError(void)
 int Garmin_GPS_Init( const wxString &port_name)
 {
       int ret;
-#ifdef GPS_DEBUG0
-//      if (getenv("OPENCPN_GPS_ERROR") != NULL)
-	GPS_Enable_Error();
-//      if (getenv("OPENCPN_GPS_WARNING") != NULL)
-	GPS_Enable_Warning();
-//      if (getenv("OPENCPN_GPS_USER") != NULL)
-	GPS_Enable_User();
-//      if (getenv("OPENCPN_GPS_DIAGNOSE") != NULL)
-	GPS_Enable_Diagnose();
-#endif
+      GPS_Enable_Error();
+      GPS_Enable_Warning();
+      GPS_Enable_User();
+      GPS_Enable_Diagnose();
       char m[1];
       m[0] = '\0';
 


### PR DESCRIPTION
Various updates to the garmin library to enhance the logging. In short:
  - Enhance error messages, in particular include messages from underlying layers.
  - Use the c++ compiler instead of plain C, requirement to....
  - ...remap the GPS_ XXX logging calls to the regular wxWidgets logging framework.
  - Fix some potentially very dangerous handling of va_list and friends.

For now, please handle this PR as an aid in handling #1495 

Please note that to enable full logging opencpn needs to be started with `--loglevel debug`