### PR TITLE
plugins manager: Add OCPN_KEEP_PLUGIN debugging.

### DIFF
--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -505,6 +505,10 @@ static void run_update_dialog(PluginListPanel* parent,
         wxString val;
         for ( wxString str = manifest_file.GetFirstLine(); !manifest_file.Eof() ; str = manifest_file.GetNextLine() ){
             if(str.Contains(pispec)){
+                if (getenv("OCPN_KEEP_PLUGINS")) {
+                    // Undocumented debug hook
+                    continue;
+                }
                 if( !g_pi_manager->CheckPluginCompatibility(str)){
                     wxString msg = _("The plugin is not compatible with this version of OpenCPN, and will be uninstalled.");
                     OCPNMessageBox( NULL, msg, wxString(_("OpenCPN Info")), wxICON_INFORMATION | wxOK, 10 );


### PR DESCRIPTION
Debugging plugin installation problems is hard since the plugin manager rightfully removes all traces of failed installation attempts. Add an undocumented environment variable OCPN_KEEP_PLUGINS which makes opencpn leave the failed plugin installation in place to be examined.