### PR TITLE
ci: Fix mingw build (#1982)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,13 +49,13 @@ matrix:
     compiler: clang
     script:
     - "./ci/generic-build-macos.sh"
-#  - if: branch IN (master, plugins, plugins-build)
-#    env:
-#    - OCPN_TARGET=mingw
-#    services:
-#    - docker
-#    script:
-#    - "./ci/travis-build-mingw.sh"
+  - if: branch IN (master, plugins, plugins-build)
+    env:
+    - OCPN_TARGET=mingw
+    services:
+    - docker
+    script:
+    - "./ci/travis-build-mingw.sh"
   - if: branch = flatpak
     env:
     - OCPN_TARGET=flatpak

--- a/ci/travis-build-mingw.sh
+++ b/ci/travis-build-mingw.sh
@@ -21,7 +21,7 @@ sudo docker pull fedora:31;
 docker run --privileged -d -ti -e "container=docker"  \
     -v /sys/fs/cgroup:/sys/fs/cgroup \
     -v $(pwd):/opencpn-ci:rw \
-    fedora:31   /lib/systemd/systemd
+    fedora:31   /bin/bash
 DOCKER_CONTAINER_ID=$(docker ps | grep fedora | awk '{print $1}')
 docker logs $DOCKER_CONTAINER_ID
 docker exec -ti $DOCKER_CONTAINER_ID /bin/bash -xec \


### PR DESCRIPTION
Simple fix to handle the missing /sbin/init in the fedora 31 docker
image.

Closes: #1982