### PR TITLE
flatpak: Add portaudio sound (#1995)

### DIFF
--- a/flatpak/org.opencpn.OpenCPN.yaml
+++ b/flatpak/org.opencpn.OpenCPN.yaml
@@ -43,7 +43,13 @@ modules:
             sha256: 1f7ad0d379a722fcbd303aa5650c6d7d5544fde83196b42a73d1193568a4df12
       config-opts:
           - --disable-static
-
+    - name: portaudio
+      sources:
+          - type: archive
+            url: http://www.portaudio.com/archives/pa_stable_v190600_20161030.tgz
+            sha256: f5a21d7dcd6ee84397446fa1fa1a0675bb2e8a4a6dceb4305a8404698d8d1513
+      config-opts:
+          - --disable-static
     - name: wxGTK3
       sources:
           - type: archive


### PR DESCRIPTION
Add portaudio to the flatpak dependencies which enables the portaudio
sound backend when configuring.

Closes: #1995