### PR TITLE
macos: Drop bogus .svgo file (#2006).

### DIFF
--- a/buildosx/OpenCPN.pkgproj.in
+++ b/buildosx/OpenCPN.pkgproj.in
@@ -30722,22 +30722,6 @@
 																			<key>GID</key>
 																			<integer>0</integer>
 																			<key>PATH</key>
-																			<string>/private/tmp/opencpn/bin/OpenCPN.app/Contents/SharedSupport/uidata/traditional/settings.svgo</string>
-																			<key>PATH_TYPE</key>
-																			<integer>0</integer>
-																			<key>PERMISSIONS</key>
-																			<integer>493</integer>
-																			<key>TYPE</key>
-																			<integer>3</integer>
-																			<key>UID</key>
-																			<integer>0</integer>
-																		</dict>
-																		<dict>
-																			<key>CHILDREN</key>
-																			<array/>
-																			<key>GID</key>
-																			<integer>0</integer>
-																			<key>PATH</key>
 																			<string>/private/tmp/opencpn/bin/OpenCPN.app/Contents/SharedSupport/uidata/traditional/settings_disabled.svg</string>
 																			<key>PATH_TYPE</key>
 																			<integer>0</integer>


### PR DESCRIPTION
Not just remove the file, also drop it from buildosx/OpenCPN.pkgproj.in.

Closes: #2006 
Successful build: https://travis-ci.com/github/leamas/OpenCPN/jobs/365332988