### PR TITLE
Add a changed AIS ship name to the not confirmed list

### DIFF
--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -3183,6 +3183,9 @@ void AISshipNameCache(AIS_Target_Data *pTargetData,
                         if (g_bUseOnlyConfirmedAISName)
                             strncpy(pTargetData->ShipName, (*AISTargetNamesC)[mmsi].mb_str(), (*AISTargetNamesC)[mmsi].Left(20).Length() + 1);
                     }
+                    else { // The C list name is different but no NC entry. Add it.
+                        (*AISTargetNamesNC)[mmsi] = ship_name;
+                    }
                 }
             }
             else { //No confirmed entry available


### PR DESCRIPTION
A suggestion to solve the missing update of a changed AIS ship name.
I've no idea why and when this stopped to work but now there's no update of the non confirmed hash list and thus no update of the confirmed list. So a changed ship name is never updated in the mmsi(to)name-file.
