### PR TITLE
Use shared data dir for plugin data

### DIFF
--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -1587,8 +1587,9 @@ static  wxString GetLinuxDataPath()
 
 wxString OCPNPlatform::GetPluginDataPath()
 {
+    const wxString sep = wxFileName::GetPathSeparator();
+
     if(g_bportable){
-        wxString sep = wxFileName::GetPathSeparator();
         wxString ret = GetPrivateDataDir() + sep + _T("plugins");
         return ret;
     }
@@ -1613,13 +1614,13 @@ wxString OCPNPlatform::GetPluginDataPath()
             "~/Library/Application Support/OpenCPN/Contents/SharedSupport/plugins";
     }
     m_pluginDataPath = ExpandPaths(dirs, this);
-    if (m_pluginDataPath != "") {
-        m_pluginDataPath += ";";
+
+    auto const sharedDataDir = GetSharedDataDir();
+    if (!sharedDataDir.IsEmpty ())
+    {
+        m_pluginDataPath += ";" + sharedDataDir + sep + "plugins";
     }
-    m_pluginDataPath += GetPluginDir();
-    if (m_pluginDataPath.EndsWith(wxFileName::GetPathSeparator())) {
-	m_pluginDataPath.RemoveLast();
-    }
+
     wxLogMessage("Using plugin data path: %s",
                  m_pluginDataPath.mb_str().data());
     return m_pluginDataPath;


### PR DESCRIPTION
I have installed OpenCPN from source to have a go at developing a new plugin. I use an install prefix to try to keep my development machine clean. When I try to load data for my plugin it searches the "normal" locations eg. `/home/<user>/.local/share/opencpn/plugins/` (I'm on ubuntu) but the final path that references the install prefixed location gives the path to the plugin lib directory eg. `<install prefix>/lib/opencpn`, not the plugin data directory eg. `<install prefix>/share/opencpn/plugins`.

This is obviously a breaking change if anything was relying on getting the lib directory this way but it seems like this isn't the intention of `GetPluginDataPath ()`?

This is my first time looking at OpenCPN internals (been a user for several years!) please be gentle :smiley: 