### PR TITLE
Add RUDDER to XDR in dashboard_pi

### DIFF
--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -1381,16 +1381,7 @@ void dashboard_pi::SetNMEASentence( wxString &sentence )
                         }
                         // XDR Rudder Angle
                         else if (m_NMEA0183.Xdr.TransducerInfo[i].TransducerName == _T("RUDDER")) {
-                            if (m_NMEA0183.Xdr.TransducerInfo[i].MeasurementData > 0) {
-                                xdrunit = _T("\u00B0 (\u003E") + _("Stbd)");
-                            }
-                            else if (m_NMEA0183.Xdr.TransducerInfo[i].MeasurementData < 0) {
-                                xdrunit = _T("\u00B0 (\u003C") + _("Port)");
-                            }
-                            else {
-                                xdrunit = _T("\u00B0");
-                            }
-                            SendSentenceToAllInstruments(OCPN_DBP_STC_RSA,xdrdata,xdrunit);
+                            SendSentenceToAllInstruments(OCPN_DBP_STC_RSA,xdrdata,_T("\u00B0"));
                             mRSA_Watchdog = gps_watchdog_timeout_ticks;
                         }
                     }

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -1379,8 +1379,22 @@ void dashboard_pi::SetNMEASentence( wxString &sentence )
                             SendSentenceToAllInstruments(OCPN_DBP_STC_HEEL, xdrdata, xdrunit);
                             mHEEL_Watchdog = gps_watchdog_timeout_ticks;
                         }
+                        // XDR Rudder Angle
+                        else if (m_NMEA0183.Xdr.TransducerInfo[i].TransducerName == _T("RUDDER")) {
+                            if (m_NMEA0183.Xdr.TransducerInfo[i].MeasurementData > 0) {
+                                xdrunit = _T("\u00B0 (\u003E") + _("Stbd)");
+                            }
+                            else if (m_NMEA0183.Xdr.TransducerInfo[i].MeasurementData < 0) {
+                                xdrunit = _T("\u00B0 (\u003C") + _("Port)");
+                            }
+                            else {
+                                xdrunit = _T("\u00B0");
+                            }
+                            SendSentenceToAllInstruments(OCPN_DBP_STC_RSA,xdrdata,xdrunit);
+                            mRSA_Watchdog = gps_watchdog_timeout_ticks;
+                        }
                     }
-		     //Nasa style water temp
+                    //Nasa style water temp
                     if (m_NMEA0183.Xdr.TransducerInfo[i].TransducerName == _T("ENV_WATER_T")){
                         if (mPriWTP >= 2) {
                             mPriWTP = 2;

--- a/plugins/dashboard_pi/src/rudder_angle.cpp
+++ b/plugins/dashboard_pi/src/rudder_angle.cpp
@@ -122,10 +122,10 @@ void DashboardInstrument_RudderAngle::DrawFrame(wxGCDC* dc)
 void DashboardInstrument_RudderAngle::DrawBackground(wxGCDC* dc)
 {
       wxCoord x = m_cx - (m_radius * 0.3);
-      wxCoord y = m_cy - (m_radius * 0.5);
+      wxCoord y = m_cy - (m_radius*1.1);
       wxColour cl;
       GetGlobalColor(_T("DASH1"), &cl);
       dc->SetBrush( cl );
-      dc->DrawEllipticArc(x, y, m_radius * 0.6, m_radius * 1.4, 0, 180);
+      dc->DrawEllipticArc(x, y, m_radius * 0.6, m_radius * 1.4, 0, -180);
 }
 


### PR DESCRIPTION
RUDDER is a valid angular transducer type for the XDR sentence (tested with B&G Zeus3).
Text display in dashboard includes sign of angle unfortunately (due to structure of dashboard_pi), but I followed the example of the other angular instrument displays and included the '> Stbd' and '< Port' unit.
I'll probably do a PR later to remove the sign from the angle display.