### PR TITLE
ocpn_plugin.h: Mute useless clang warning.

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -455,6 +455,11 @@ public:
  typedef opencpn_plugin* create_t(void*);
  typedef void destroy_t(opencpn_plugin*);
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Woverloaded-virtual"
+#endif
+
  class DECL_EXP opencpn_plugin_16 : public opencpn_plugin
  {
        public:
@@ -492,6 +497,11 @@ class DECL_EXP opencpn_plugin_18 : public opencpn_plugin
             virtual void SetPositionFixEx(PlugIn_Position_Fix_Ex &pfix);
 
 };
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
+
 
 class DECL_EXP opencpn_plugin_19 : public opencpn_plugin_18
 {


### PR DESCRIPTION
Just disable the noisy diagnostics.  This is for old parts of the API, it cannot be changed.

Closes: #2025