### PR TITLE
PluginHandler: isCompatible(): Fix Debian sid compatibility (#2033).

### DIFF
--- a/src/PluginHandler.cpp
+++ b/src/PluginHandler.cpp
@@ -278,7 +278,7 @@ bool PluginHandler::isCompatible(const PluginMetadata& metadata,
                 if( (plugin_os == std::string("ubuntu-x86_64")) && (plugin_os_version == std::string("16.04")) )
                     rv = true;
             }
-            else if(target_vers == std::string("11") ){        // Sid
+            else if (target_vers == "11"  || target_vers == "sid"){        // Sid
                 if( (plugin_os == std::string("ubuntu-gtk3-x86_64")) && (plugin_os_version == std::string("20.04")) )
                     rv = true;
             }


### PR DESCRIPTION
It turns out that before sid is branched, the version identifier is
"sid" rather than "11". Without patch sid loads gtk2 plugins ->
undefined behaviour (icons disappear, cannot leave the options
menu).

Fix is applied in downstream Debian package.

This will eventually break after bullseye is branched. However, it will
not happen overnight and bullseye (11) will be ok.

See: #2033