### PR TITLE
Checksum support for downloaded tarballs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -947,6 +947,7 @@ set(
   include/ocpn_utils.h
   include/options.h
   include/piano.h
+  include/plugin_cache.h
   include/PluginHandler.h
   include/pluginmanager.h
   include/PluginPaths.h
@@ -1080,6 +1081,7 @@ set(
   src/pluginmanager.cpp
   src/PluginPaths.cpp
   src/PositionParser.cpp
+  src/plugin_cache.cpp
   src/printtable.cpp
   src/pugixml.cpp
   src/Quilt.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1208,6 +1208,9 @@ find_package(Gettext REQUIRED)
 add_subdirectory(libs/ssl_sha1)
 target_link_libraries(${PACKAGE_NAME} PRIVATE ssl::sha1)
 
+add_subdirectory(libs/picosha2)
+target_link_libraries(${PACKAGE_NAME} PRIVATE pico_sha2)
+
 #
 # Linux: set up GTK
 #

--- a/include/catalog_parser.h
+++ b/include/catalog_parser.h
@@ -62,6 +62,7 @@ struct PluginMetadata {
     std::string target_arch;
     std::string info_url;
     std::string meta_url;
+    std::string checksum;
 
     bool openSource;
 

--- a/include/download_mgr.h
+++ b/include/download_mgr.h
@@ -56,7 +56,7 @@ class GuiDownloader: public Downloader
 
     public:
         GuiDownloader(wxWindow* parent, PluginMetadata plugin);
-        std::string run(wxWindow* parent);
+        std::string run(wxWindow* parent, bool remove_current);
         void on_chunk(const char* buff, unsigned bytes) override;
         void showErrorDialog(const char* msg);
 };

--- a/include/download_mgr.h
+++ b/include/download_mgr.h
@@ -59,8 +59,6 @@ class GuiDownloader: public Downloader
         std::string run(wxWindow* parent);
         void on_chunk(const char* buff, unsigned bytes) override;
         void showErrorDialog(const char* msg);
-        std::string CheckCache();
-
 };
 
 

--- a/include/plugin_cache.h
+++ b/include/plugin_cache.h
@@ -1,0 +1,56 @@
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ *
+ ***************************************************************************
+ *   Copyright (C) 2019 Alec Leamas                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+*/
+
+
+#ifndef PLUGIN_CACHE_H__
+#define PLUGIN_CACHE_H__
+
+#include <string>
+
+namespace ocpn {
+
+std::string get_basename(const char* path);
+
+/** Store metadata in metadata cache, return success/fail. */
+bool store_metadata(const char* path);
+
+/**
+ * Get metadata path for a given name defaulting to ocpn-plugins.xml)
+ * @return Path to cached metadata or "" if not found
+ */
+std::string lookup_metadata(const char* name= 0);
+
+/** Store a tarball in tarball cache, return success/fail. */
+bool store_tarball(const char* path, const char* basename);
+
+/**
+ * Get path to tarball in cache for given filename
+ * @return Path to cached metadata or "" if not found
+ */
+std::string lookup_tarball(const char* basename);
+
+}  // namespace
+#endif
+
+

--- a/libs/picosha2/CMakeLists.txt
+++ b/libs/picosha2/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.1.0)
+
+if (TARGET ocpn::pico_sha2)
+    return ()
+endif ()
+
+add_library(pico_sha2 INTERFACE)
+target_include_directories(pico_sha2 INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})

--- a/libs/picosha2/LICENSE
+++ b/libs/picosha2/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 okdshin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/libs/picosha2/README.md
+++ b/libs/picosha2/README.md
@@ -1,0 +1,138 @@
+# PicoSHA2 - a C++ SHA256 hash generator
+
+Copyright &copy; 2017 okdshin
+
+## Introduction
+
+PicoSHA2 is a tiny SHA256 hash generator for C++ with following properties:
+
+- header-file only
+- no external dependencies (only uses standard C++ libraries)
+- STL-friendly
+- licensed under MIT License
+
+## Generating SHA256 hash and hash hex string
+
+```c++
+// any STL sequantial container (vector, list, dequeue...)
+std::string src_str = "The quick brown fox jumps over the lazy dog";
+
+std::vector<unsigned char> hash(picosha2::k_digest_size);
+picosha2::hash256(src_str.begin(), src_str.end(), hash.begin(), hash.end());
+
+std::string hex_str = picosha2::bytes_to_hex_string(hash.begin(), hash.end());
+```
+
+## Generating SHA256 hash and hash hex string from byte stream
+
+```c++
+picosha2::hash256_one_by_one hasher;
+...
+hasher.process(block.begin(), block.end());
+...
+hasher.finish();
+
+std::vector<unsigned char> hash(picosha2::k_digest_size);
+hasher.get_hash_bytes(hash.begin(), hash.end());
+
+std::string hex_str = picosha2::get_hash_hex_string(hasher);
+```
+
+The file `example/interactive_hasher.cpp` has more detailed information.
+
+## Generating SHA256 hash from a binary file
+
+```c++
+std::ifstream f("file.txt", std::ios::binary);
+std::vector<unsigned char> s(picosha2::k_digest_size);
+picosha2::hash256(f, s.begin(), s.end());
+```
+
+This `hash256` may use less memory than reading whole of the file.
+
+## Generating SHA256 hash hex string from std::string
+
+```c++
+std::string src_str = "The quick brown fox jumps over the lazy dog";
+std::string hash_hex_str;
+picosha2::hash256_hex_string(src_str, hash_hex_str);
+std::cout << hash_hex_str << std::endl;
+//this output is "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"
+```
+
+```c++
+std::string src_str = "The quick brown fox jumps over the lazy dog";
+std::string hash_hex_str = picosha2::hash256_hex_string(src_str);
+std::cout << hash_hex_str << std::endl;
+//this output is "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"
+```
+
+```c++
+std::string src_str = "The quick brown fox jumps over the lazy dog.";//add '.'
+std::string hash_hex_str = picosha2::hash256_hex_string(src_str.begin(), src_str.end());
+std::cout << hash_hex_str << std::endl;
+//this output is "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c"
+```
+
+## Generating SHA256 hash hex string from byte sequence
+
+```c++
+std::vector<unsigned char> src_vect(...);
+std::string hash_hex_str;
+picosha2::hash256_hex_string(src_vect, hash_hex_str);
+```
+
+```c++
+std::vector<unsigned char> src_vect(...);
+std::string hash_hex_str = picosha2::hash256_hex_string(src_vect);
+```
+
+```c++
+unsigned char src_c_array[picosha2::k_digest_size] = {...};
+std::string hash_hex_str;
+picosha2::hash256_hex_string(src_c_array, src_c_array+picosha2::k_digest_size, hash_hex_str);
+```
+
+```c++
+unsigned char src_c_array[picosha2::k_digest_size] = {...};
+std::string hash_hex_str = picosha2::hash256_hex_string(src_c_array, src_c_array+picosha2::k_digest_size);
+```
+
+
+## Generating SHA256 hash byte sequence from STL sequential container
+
+```c++
+//any STL sequantial container (vector, list, dequeue...)
+std::string src_str = "The quick brown fox jumps over the lazy dog";
+
+//any STL sequantial containers (vector, list, dequeue...)
+std::vector<unsigned char> hash(picosha2::k_digest_size);
+
+// in: container, out: container
+picosha2::hash256(src_str, hash);
+```
+
+```c++
+//any STL sequantial container (vector, list, dequeue...)
+std::string src_str = "The quick brown fox jumps over the lazy dog";
+
+//any STL sequantial containers (vector, list, dequeue...)
+std::vector<unsigned char> hash(picosha2::k_digest_size);
+
+// in: iterator pair, out: contaner
+picosha2::hash256(src_str.begin(), src_str.end(), hash);
+```
+
+```c++
+std::string src_str = "The quick brown fox jumps over the lazy dog";
+unsigned char hash_byte_c_array[picosha2::k_digest_size];
+// in: container, out: iterator(pointer) pair
+picosha2::hash256(src_str, hash_byte_c_array, hash_byte_c_array+picosha2::k_digest_size);
+```
+
+```c++
+std::string src_str = "The quick brown fox jumps over the lazy dog";
+std::vector<unsigned char> hash(picosha2::k_digest_size);
+// in: iterator pair, out: iterator pair
+picosha2::hash256(src_str.begin(), src_str.end(), hash.begin(), hash.end());
+```

--- a/libs/picosha2/example/hasher.cpp
+++ b/libs/picosha2/example/hasher.cpp
@@ -1,0 +1,22 @@
+#include <iostream>
+#include "../picosha2.h"
+
+void CalcAndOutput(const std::string& src){
+	std::cout << "src : \"" << src << "\"\n";
+	std::cout << "hash: " << picosha2::hash256_hex_string(src) << "\n" << std::endl;
+}
+
+int main(int argc, char* argv[])
+{
+	if(argc == 1){
+		CalcAndOutput("");
+	}
+	else{
+		for(int i = 1; i < argc; ++i){
+			CalcAndOutput(argv[i]);
+		}
+	}
+
+    return 0;
+}
+

--- a/libs/picosha2/example/interactive_hasher.cpp
+++ b/libs/picosha2/example/interactive_hasher.cpp
@@ -1,0 +1,26 @@
+#include <iostream>
+#include "../picosha2.h"
+
+int main(int argc, char* argv[])
+{
+	std::cout << "Input freely. To get hash, input \"hash!\". " << std::endl;
+	picosha2::hash256_one_by_one hasher;
+	while(true){
+		hasher.init(); //reset hasher state
+		while(true){
+			std::string line;
+			std::getline(std::cin, line);
+			if(line == "hash!"){
+				break;
+			}
+			hasher.process(line.begin(), line.end());
+		}
+		hasher.finish();
+		std::string hex_str;
+		picosha2::get_hash_hex_string(hasher, hex_str);
+		std::cout << hex_str << std::endl;
+	}
+
+    return 0;
+}
+

--- a/libs/picosha2/picosha2.h
+++ b/libs/picosha2/picosha2.h
@@ -1,0 +1,377 @@
+/*
+The MIT License (MIT)
+
+Copyright (C) 2017 okdshin
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+#ifndef PICOSHA2_H
+#define PICOSHA2_H
+// picosha2:20140213
+
+#ifndef PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR
+#define PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR \
+    1048576  //=1024*1024: default is 1MB memory
+#endif
+
+#include <algorithm>
+#include <cassert>
+#include <iterator>
+#include <sstream>
+#include <vector>
+#include <fstream>
+namespace picosha2 {
+typedef unsigned long word_t;
+typedef unsigned char byte_t;
+
+static const size_t k_digest_size = 32;
+
+namespace detail {
+inline byte_t mask_8bit(byte_t x) { return x & 0xff; }
+
+inline word_t mask_32bit(word_t x) { return x & 0xffffffff; }
+
+const word_t add_constant[64] = {
+    0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1,
+    0x923f82a4, 0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3,
+    0x72be5d74, 0x80deb1fe, 0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786,
+    0x0fc19dc6, 0x240ca1cc, 0x2de92c6f, 0x4a7484aa, 0x5cb0a9dc, 0x76f988da,
+    0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7, 0xc6e00bf3, 0xd5a79147,
+    0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc, 0x53380d13,
+    0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+    0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070,
+    0x19a4c116, 0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a,
+    0x5b9cca4f, 0x682e6ff3, 0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208,
+    0x90befffa, 0xa4506ceb, 0xbef9a3f7, 0xc67178f2};
+
+const word_t initial_message_digest[8] = {0x6a09e667, 0xbb67ae85, 0x3c6ef372,
+                                          0xa54ff53a, 0x510e527f, 0x9b05688c,
+                                          0x1f83d9ab, 0x5be0cd19};
+
+inline word_t ch(word_t x, word_t y, word_t z) { return (x & y) ^ ((~x) & z); }
+
+inline word_t maj(word_t x, word_t y, word_t z) {
+    return (x & y) ^ (x & z) ^ (y & z);
+}
+
+inline word_t rotr(word_t x, std::size_t n) {
+    assert(n < 32);
+    return mask_32bit((x >> n) | (x << (32 - n)));
+}
+
+inline word_t bsig0(word_t x) { return rotr(x, 2) ^ rotr(x, 13) ^ rotr(x, 22); }
+
+inline word_t bsig1(word_t x) { return rotr(x, 6) ^ rotr(x, 11) ^ rotr(x, 25); }
+
+inline word_t shr(word_t x, std::size_t n) {
+    assert(n < 32);
+    return x >> n;
+}
+
+inline word_t ssig0(word_t x) { return rotr(x, 7) ^ rotr(x, 18) ^ shr(x, 3); }
+
+inline word_t ssig1(word_t x) { return rotr(x, 17) ^ rotr(x, 19) ^ shr(x, 10); }
+
+template <typename RaIter1, typename RaIter2>
+void hash256_block(RaIter1 message_digest, RaIter2 first, RaIter2 last) {
+    assert(first + 64 == last);
+    static_cast<void>(last);  // for avoiding unused-variable warning
+    word_t w[64];
+    std::fill(w, w + 64, 0);
+    for (std::size_t i = 0; i < 16; ++i) {
+        w[i] = (static_cast<word_t>(mask_8bit(*(first + i * 4))) << 24) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 1))) << 16) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 2))) << 8) |
+               (static_cast<word_t>(mask_8bit(*(first + i * 4 + 3))));
+    }
+    for (std::size_t i = 16; i < 64; ++i) {
+        w[i] = mask_32bit(ssig1(w[i - 2]) + w[i - 7] + ssig0(w[i - 15]) +
+                          w[i - 16]);
+    }
+
+    word_t a = *message_digest;
+    word_t b = *(message_digest + 1);
+    word_t c = *(message_digest + 2);
+    word_t d = *(message_digest + 3);
+    word_t e = *(message_digest + 4);
+    word_t f = *(message_digest + 5);
+    word_t g = *(message_digest + 6);
+    word_t h = *(message_digest + 7);
+
+    for (std::size_t i = 0; i < 64; ++i) {
+        word_t temp1 = h + bsig1(e) + ch(e, f, g) + add_constant[i] + w[i];
+        word_t temp2 = bsig0(a) + maj(a, b, c);
+        h = g;
+        g = f;
+        f = e;
+        e = mask_32bit(d + temp1);
+        d = c;
+        c = b;
+        b = a;
+        a = mask_32bit(temp1 + temp2);
+    }
+    *message_digest += a;
+    *(message_digest + 1) += b;
+    *(message_digest + 2) += c;
+    *(message_digest + 3) += d;
+    *(message_digest + 4) += e;
+    *(message_digest + 5) += f;
+    *(message_digest + 6) += g;
+    *(message_digest + 7) += h;
+    for (std::size_t i = 0; i < 8; ++i) {
+        *(message_digest + i) = mask_32bit(*(message_digest + i));
+    }
+}
+
+}  // namespace detail
+
+template <typename InIter>
+void output_hex(InIter first, InIter last, std::ostream& os) {
+    os.setf(std::ios::hex, std::ios::basefield);
+    while (first != last) {
+        os.width(2);
+        os.fill('0');
+        os << static_cast<unsigned int>(*first);
+        ++first;
+    }
+    os.setf(std::ios::dec, std::ios::basefield);
+}
+
+template <typename InIter>
+void bytes_to_hex_string(InIter first, InIter last, std::string& hex_str) {
+    std::ostringstream oss;
+    output_hex(first, last, oss);
+    hex_str.assign(oss.str());
+}
+
+template <typename InContainer>
+void bytes_to_hex_string(const InContainer& bytes, std::string& hex_str) {
+    bytes_to_hex_string(bytes.begin(), bytes.end(), hex_str);
+}
+
+template <typename InIter>
+std::string bytes_to_hex_string(InIter first, InIter last) {
+    std::string hex_str;
+    bytes_to_hex_string(first, last, hex_str);
+    return hex_str;
+}
+
+template <typename InContainer>
+std::string bytes_to_hex_string(const InContainer& bytes) {
+    std::string hex_str;
+    bytes_to_hex_string(bytes, hex_str);
+    return hex_str;
+}
+
+class hash256_one_by_one {
+   public:
+    hash256_one_by_one() { init(); }
+
+    void init() {
+        buffer_.clear();
+        std::fill(data_length_digits_, data_length_digits_ + 4, 0);
+        std::copy(detail::initial_message_digest,
+                  detail::initial_message_digest + 8, h_);
+    }
+
+    template <typename RaIter>
+    void process(RaIter first, RaIter last) {
+        add_to_data_length(static_cast<word_t>(std::distance(first, last)));
+        std::copy(first, last, std::back_inserter(buffer_));
+        std::size_t i = 0;
+        for (; i + 64 <= buffer_.size(); i += 64) {
+            detail::hash256_block(h_, buffer_.begin() + i,
+                                  buffer_.begin() + i + 64);
+        }
+        buffer_.erase(buffer_.begin(), buffer_.begin() + i);
+    }
+
+    void finish() {
+        byte_t temp[64];
+        std::fill(temp, temp + 64, 0);
+        std::size_t remains = buffer_.size();
+        std::copy(buffer_.begin(), buffer_.end(), temp);
+        temp[remains] = 0x80;
+
+        if (remains > 55) {
+            std::fill(temp + remains + 1, temp + 64, 0);
+            detail::hash256_block(h_, temp, temp + 64);
+            std::fill(temp, temp + 64 - 4, 0);
+        } else {
+            std::fill(temp + remains + 1, temp + 64 - 4, 0);
+        }
+
+        write_data_bit_length(&(temp[56]));
+        detail::hash256_block(h_, temp, temp + 64);
+    }
+
+    template <typename OutIter>
+    void get_hash_bytes(OutIter first, OutIter last) const {
+        for (const word_t* iter = h_; iter != h_ + 8; ++iter) {
+            for (std::size_t i = 0; i < 4 && first != last; ++i) {
+                *(first++) = detail::mask_8bit(
+                    static_cast<byte_t>((*iter >> (24 - 8 * i))));
+            }
+        }
+    }
+
+   private:
+    void add_to_data_length(word_t n) {
+        word_t carry = 0;
+        data_length_digits_[0] += n;
+        for (std::size_t i = 0; i < 4; ++i) {
+            data_length_digits_[i] += carry;
+            if (data_length_digits_[i] >= 65536u) {
+                carry = data_length_digits_[i] >> 16;
+                data_length_digits_[i] &= 65535u;
+            } else {
+                break;
+            }
+        }
+    }
+    void write_data_bit_length(byte_t* begin) {
+        word_t data_bit_length_digits[4];
+        std::copy(data_length_digits_, data_length_digits_ + 4,
+                  data_bit_length_digits);
+
+        // convert byte length to bit length (multiply 8 or shift 3 times left)
+        word_t carry = 0;
+        for (std::size_t i = 0; i < 4; ++i) {
+            word_t before_val = data_bit_length_digits[i];
+            data_bit_length_digits[i] <<= 3;
+            data_bit_length_digits[i] |= carry;
+            data_bit_length_digits[i] &= 65535u;
+            carry = (before_val >> (16 - 3)) & 65535u;
+        }
+
+        // write data_bit_length
+        for (int i = 3; i >= 0; --i) {
+            (*begin++) = static_cast<byte_t>(data_bit_length_digits[i] >> 8);
+            (*begin++) = static_cast<byte_t>(data_bit_length_digits[i]);
+        }
+    }
+    std::vector<byte_t> buffer_;
+    word_t data_length_digits_[4];  // as 64bit integer (16bit x 4 integer)
+    word_t h_[8];
+};
+
+inline void get_hash_hex_string(const hash256_one_by_one& hasher,
+                                std::string& hex_str) {
+    byte_t hash[k_digest_size];
+    hasher.get_hash_bytes(hash, hash + k_digest_size);
+    return bytes_to_hex_string(hash, hash + k_digest_size, hex_str);
+}
+
+inline std::string get_hash_hex_string(const hash256_one_by_one& hasher) {
+    std::string hex_str;
+    get_hash_hex_string(hasher, hex_str);
+    return hex_str;
+}
+
+namespace impl {
+template <typename RaIter, typename OutIter>
+void hash256_impl(RaIter first, RaIter last, OutIter first2, OutIter last2, int,
+                  std::random_access_iterator_tag) {
+    hash256_one_by_one hasher;
+    // hasher.init();
+    hasher.process(first, last);
+    hasher.finish();
+    hasher.get_hash_bytes(first2, last2);
+}
+
+template <typename InputIter, typename OutIter>
+void hash256_impl(InputIter first, InputIter last, OutIter first2,
+                  OutIter last2, int buffer_size, std::input_iterator_tag) {
+    std::vector<byte_t> buffer(buffer_size);
+    hash256_one_by_one hasher;
+    // hasher.init();
+    while (first != last) {
+        int size = buffer_size;
+        for (int i = 0; i != buffer_size; ++i, ++first) {
+            if (first == last) {
+                size = i;
+                break;
+            }
+            buffer[i] = *first;
+        }
+        hasher.process(buffer.begin(), buffer.begin() + size);
+    }
+    hasher.finish();
+    hasher.get_hash_bytes(first2, last2);
+}
+}
+
+template <typename InIter, typename OutIter>
+void hash256(InIter first, InIter last, OutIter first2, OutIter last2,
+             int buffer_size = PICOSHA2_BUFFER_SIZE_FOR_INPUT_ITERATOR) {
+    picosha2::impl::hash256_impl(
+        first, last, first2, last2, buffer_size,
+        typename std::iterator_traits<InIter>::iterator_category());
+}
+
+template <typename InIter, typename OutContainer>
+void hash256(InIter first, InIter last, OutContainer& dst) {
+    hash256(first, last, dst.begin(), dst.end());
+}
+
+template <typename InContainer, typename OutIter>
+void hash256(const InContainer& src, OutIter first, OutIter last) {
+    hash256(src.begin(), src.end(), first, last);
+}
+
+template <typename InContainer, typename OutContainer>
+void hash256(const InContainer& src, OutContainer& dst) {
+    hash256(src.begin(), src.end(), dst.begin(), dst.end());
+}
+
+template <typename InIter>
+void hash256_hex_string(InIter first, InIter last, std::string& hex_str) {
+    byte_t hashed[k_digest_size];
+    hash256(first, last, hashed, hashed + k_digest_size);
+    std::ostringstream oss;
+    output_hex(hashed, hashed + k_digest_size, oss);
+    hex_str.assign(oss.str());
+}
+
+template <typename InIter>
+std::string hash256_hex_string(InIter first, InIter last) {
+    std::string hex_str;
+    hash256_hex_string(first, last, hex_str);
+    return hex_str;
+}
+
+inline void hash256_hex_string(const std::string& src, std::string& hex_str) {
+    hash256_hex_string(src.begin(), src.end(), hex_str);
+}
+
+template <typename InContainer>
+void hash256_hex_string(const InContainer& src, std::string& hex_str) {
+    hash256_hex_string(src.begin(), src.end(), hex_str);
+}
+
+template <typename InContainer>
+std::string hash256_hex_string(const InContainer& src) {
+    return hash256_hex_string(src.begin(), src.end());
+}
+template<typename OutIter>void hash256(std::ifstream& f, OutIter first, OutIter last){
+    hash256(std::istreambuf_iterator<char>(f), std::istreambuf_iterator<char>(), first,last);
+
+}
+}// namespace picosha2
+#endif  // PICOSHA2_H

--- a/libs/picosha2/test/test.cpp
+++ b/libs/picosha2/test/test.cpp
@@ -1,0 +1,255 @@
+#include "../picosha2.h"
+#include <iostream>
+#include <list>
+#include <fstream>
+
+#define PICOSHA2_CHECK_EQUAL(a, b){\
+    if(a == b){\
+        std::cout << "\033[32m" << __FUNCTION__ << "(LINE:" << __LINE__ << ") is succeeded." << "\033[39m" << std::endl;\
+    }\
+    else{\
+        std::cout << "\033[31m" << __FUNCTION__ << "(LINE:" << __LINE__ << ") is failed.\n\t" << #a << " != " << #b \
+        << "\033[39m" << std::endl;\
+    }\
+}
+#define PICOSHA2_CHECK_EQUAL_BYTES(a, b){\
+    if(is_same_bytes(a, b)){\
+        std::cout << "\033[32m" << __FUNCTION__ << "(LINE:" << __LINE__ << ") is succeeded." << "\033[39m" << std::endl;\
+    }\
+    else{\
+        std::cout << "\033[31m" << __FUNCTION__ << "(LINE:" << __LINE__ << ") is failed.\n\t" << #a << " != " << #b \
+        << "\033[39m" << std::endl;\
+    }\
+}
+
+template<typename InIter1, typename InIter2>
+bool is_same_bytes(InIter1 first1, InIter1 last1, InIter2 first2, InIter2 last2){
+    if(std::distance(first1, last1) != std::distance(first2, last2)){
+        return false;
+    }
+    return std::search(first1, last1, first2, last2) != last1;
+}
+
+template<typename InContainer1, typename InContainer2>
+bool is_same_bytes(const InContainer1& bytes1, const InContainer2& bytes2){
+    return is_same_bytes(bytes1.begin(), bytes1.end(), bytes2.begin(), bytes2.end());
+}
+
+template<typename OutIter>
+void input_hex(std::istream& is, OutIter first, OutIter last){
+    char c;
+    std::vector<char> buffer;
+    while(first != last){
+        if(buffer.size() == 2){
+            *(first++) = (buffer.front()*16+buffer.back());
+            buffer.clear();
+        }
+        is >> c;
+        if('0' <= c && c <= '9'){
+            buffer.push_back(c-'0');
+        }else
+        if('a' <= c && c <= 'f'){
+            buffer.push_back(c-'a'+10); 
+        }
+    }
+}
+
+template<typename OutIter>
+void hex_string_to_bytes(const std::string& hex_str, OutIter first, OutIter last){
+    assert(hex_str.length() >= 2*std::distance(first, last));
+    std::istringstream iss(hex_str);
+    input_hex(iss, first, last);
+}
+
+template<typename OutContainer>
+void hex_string_to_bytes(const std::string& hex_str, OutContainer& bytes){
+    hex_string_to_bytes(hex_str, bytes.begin(), bytes.end());
+}
+
+typedef std::pair<std::string, std::string> mess_and_hash;
+const size_t sample_size = 10;
+const std::pair<std::string, std::string> sample_message_list[sample_size] = {
+    mess_and_hash("", 
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"),
+    mess_and_hash("The quick brown fox jumps over the lazy dog",
+            "d7a8fbb307d7809469ca9abcb0082e4f8d5651e46d3cdb762d02d0bf37c9e592"),
+    mess_and_hash("The quick brown fox jumps over the lazy dog.",
+            "ef537f25c895bfa782526529a9b63d97aa631564d5d789c2b765448c8635fb6c"),
+    mess_and_hash("For this sample, this 63-byte string will be used as input data",
+            "f08a78cbbaee082b052ae0708f32fa1e50c5c421aa772ba5dbb406a2ea6be342"),
+    mess_and_hash("abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq",
+            "248d6a61d20638b8e5c026930c3e6039a33ce45964ff2167f6ecedd419db06c1"),
+    mess_and_hash("This is exactly 64 bytes long, not counting the terminating byte",
+            "ab64eff7e88e2e46165e29f2bce41826bd4c7b3552f6b382a9e7d3af47c245f8"),
+    mess_and_hash("This is exactly 64 bytes long, not counting the terminati",
+            "46db250ef6d667908de17333c25343778f495d7a8010b9cfa2af97940772e8cd"),
+    mess_and_hash("This is exactly 64 bytes long, not counting the terminatin",
+            "af38fc14dbbbcc6cd4c9cc73988e1b08373b4e6b04ba61b41f999731185b51af"),
+    mess_and_hash("This is exactly 64 bytes long, not counting the terminating",
+            "f778b361f650cdd9981ca13adb77f26b8419a407b3938fc54b14e9971045fa9d"),
+    mess_and_hash("This is exactly 64 bytes long, not counting the terminating b",
+            "9aa72d139c7d7e5a35ea525e2ba6704163555ba647927765a61ccbf12ec60479")
+};
+
+void test(){
+    for(std::size_t i = 0; i < sample_size; ++i){
+        std::string src_str = sample_message_list[i].first;
+        std::cout << "src_str: " << src_str  << " size: " << src_str.length() << std::endl;
+        std::string ans_hex_str = sample_message_list[i].second;
+        std::vector<unsigned char> ans(picosha2::k_digest_size);
+        hex_string_to_bytes(ans_hex_str, ans);
+        {
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_str.begin(), src_str.end(), hash.begin(), hash.end());
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_str, hash);
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_str.begin(), src_str.end(), hash);
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            unsigned char hash_c_array[picosha2::k_digest_size];
+            picosha2::hash256(src_str.begin(), src_str.end(), hash_c_array, hash_c_array+picosha2::k_digest_size);
+            std::vector<unsigned char> hash(hash_c_array, hash_c_array+picosha2::k_digest_size);
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::list<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_str.begin(), src_str.end(), hash.begin(), hash.end());
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::list<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_str, hash);
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::string hash_hex_str;
+            picosha2::hash256_hex_string(src_str.begin(), src_str.end(), hash_hex_str);
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        {
+            std::string hash_hex_str;
+            picosha2::hash256_hex_string(src_str, hash_hex_str);
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        {
+            std::string hash_hex_str = 
+                picosha2::hash256_hex_string(src_str.begin(), src_str.end());
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        {
+            std::string hash_hex_str = picosha2::hash256_hex_string(src_str);
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        
+        std::vector<unsigned char> src_vect(src_str.begin(), src_str.end());
+        {
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_vect.begin(), src_vect.end(), hash.begin(), hash.end());
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_vect, hash);
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::list<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_vect.begin(), src_vect.end(), hash.begin(), hash.end());
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::list<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_vect.data(), src_vect.data()+src_vect.size(), 
+                    hash.begin(), hash.end());
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::list<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src_vect, hash);
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+        {
+            std::string hash_hex_str;
+            picosha2::hash256_hex_string(src_vect.begin(), src_vect.end(), hash_hex_str);
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        {
+            std::string hash_hex_str;
+            picosha2::hash256_hex_string(src_vect, hash_hex_str);
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        {
+            std::string hash_hex_str = 
+                picosha2::hash256_hex_string(src_vect.begin(), src_vect.end());
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        {
+            std::string hash_hex_str = picosha2::hash256_hex_string(src_vect);
+            PICOSHA2_CHECK_EQUAL(ans_hex_str, hash_hex_str);
+        }
+        {
+            std::list<char> src(src_str.begin(), src_str.end());
+            std::vector<unsigned char> hash(picosha2::k_digest_size);
+            picosha2::hash256(src.begin(), src.end(), hash.begin(), hash.end());
+            PICOSHA2_CHECK_EQUAL_BYTES(ans, hash);
+        }
+    }
+    {
+        picosha2::hash256_one_by_one hasher;
+        std::ifstream ifs("test.cpp");
+        std::string file_str((std::istreambuf_iterator<char>(ifs)), 
+                std::istreambuf_iterator<char>());
+        std::size_t i = 0;
+        std::size_t block_size = file_str.length()/10;
+        for(i = 0; i+block_size <= file_str.length(); i+=block_size){
+            hasher.process(file_str.begin()+i, file_str.begin()+i+block_size);
+        }
+        hasher.process(file_str.begin()+i, file_str.end());
+        hasher.finish();
+        std::string one_by_one_hex_string;
+        get_hash_hex_string(hasher, one_by_one_hex_string);
+
+        std::string hex_string;
+        picosha2::hash256_hex_string(file_str.begin(), file_str.end(), hex_string);
+        PICOSHA2_CHECK_EQUAL(one_by_one_hex_string, hex_string);
+
+    }
+    {
+        std::string one_by_one_hex_string; {
+            picosha2::hash256_one_by_one hasher;
+            std::ifstream ifs("test.cpp");
+            std::string file_str((std::istreambuf_iterator<char>(ifs)), 
+                    std::istreambuf_iterator<char>());
+            std::size_t i = 0;
+            std::size_t block_size = file_str.length()/10;
+            for(i = 0; i+block_size <= file_str.length(); i+=block_size){
+                hasher.process(file_str.begin()+i, file_str.begin()+i+block_size);
+            }
+            hasher.process(file_str.begin()+i, file_str.end());
+            hasher.finish();
+            get_hash_hex_string(hasher, one_by_one_hex_string);
+        }
+
+        std::ifstream ifs("test.cpp");
+        auto first = std::istreambuf_iterator<char>(ifs);
+        auto last = std::istreambuf_iterator<char>();
+        auto hex_string = picosha2::hash256_hex_string(first, last);
+        PICOSHA2_CHECK_EQUAL(one_by_one_hex_string, hex_string);
+    }
+}
+
+int main(int argc, char* argv[])
+{
+    test();
+
+    return 0;
+}
+

--- a/src/catalog_parser.cpp
+++ b/src/catalog_parser.cpp
@@ -110,6 +110,8 @@ bool ParseCatalog(const std::string xml, catalog_ctx* ctx)
                     plugin->target_version = ocpn::trim(plugin_element.first_child().value());
                 } else if (strcmp(plugin_element.name(), "target-arch") == 0) {
                     plugin->target_arch = ocpn::trim(plugin_element.first_child().value());
+                } else if (strcmp(plugin_element.name(), "tarball-checksum") == 0) {
+                    plugin->checksum = ocpn::trim(plugin_element.first_child().value());
                 } else if (strcmp(plugin_element.name(), "open-source") == 0) {
                     plugin->openSource = ocpn::trim(plugin_element.first_child().value()) == "yes";
                 }
@@ -127,6 +129,6 @@ bool ParseCatalog(const std::string xml, catalog_ctx* ctx)
         }
     }
 
- 
+
     return true;
 }

--- a/src/download_mgr.cpp
+++ b/src/download_mgr.cpp
@@ -78,6 +78,11 @@ static bool checksum_ok(const std::string& path,
         wxLogDebug("No metadata checksum, aborting check,");
         return true;
     }
+    const size_t pos = metadata.checksum.find(':');
+    std::string checksum(metadata.checksum);
+    if (pos == std::string::npos) {
+        checksum = std::string("sha256:") + checksum;
+    }
     std::ifstream f(path, std::ios::binary);
     picosha2::hash256_one_by_one hasher;
     while (!f.eof()) {
@@ -87,17 +92,17 @@ static bool checksum_ok(const std::string& path,
         hasher.process(block.begin(), block.end());
     }
     hasher.finish();
-    std::string tarball_hash;
-    picosha2::get_hash_hex_string(hasher, tarball_hash);
+    std::string tarball_hash =
+        std::string("sha256:") + picosha2::get_hash_hex_string(hasher);
 
-    if (tarball_hash == metadata.checksum) {
+    if (tarball_hash == checksum) {
         wxLogDebug("Checksum ok: %s", tarball_hash.c_str());
         return true;
     }
     wxLogMessage("Checksum fail on %s, tarball: %s, metadata: %s",
                  metadata.name.c_str(),
                  tarball_hash.c_str(),
-                 metadata.checksum.c_str());
+                 checksum.c_str());
     return false;
 }
 

--- a/src/download_mgr.cpp
+++ b/src/download_mgr.cpp
@@ -244,7 +244,9 @@ class InstallButton: public wxPanel
         }
 
         void OnClick(wxCommandEvent& event) {
-            if (m_remove) {
+            auto path =
+                ocpn::lookup_tarball(m_metadata.tarball_url.c_str());
+            if (m_remove && path != "") {
                 wxLogMessage("Uninstalling %s", m_metadata.name.c_str());
                 PluginHandler::getInstance()->uninstall(m_metadata.name);
             }
@@ -255,7 +257,7 @@ class InstallButton: public wxPanel
             
             if(!cacheResult){
                 auto downloader = new GuiDownloader(this, m_metadata);
-                downloader->run(this);
+                downloader->run(this, m_remove);
                 auto pic = PlugInByName(m_metadata.name,
                                         g_pi_manager->GetPlugInArray());
                 if (!pic) {
@@ -559,7 +561,7 @@ GuiDownloader::GuiDownloader(wxWindow* parent, PluginMetadata plugin)
             { }
 
         
-std::string GuiDownloader::run(wxWindow* parent)
+std::string GuiDownloader::run(wxWindow* parent, bool remove_current)
 {
             bool ok;
             bool downloaded = false;
@@ -603,6 +605,10 @@ std::string GuiDownloader::run(wxWindow* parent)
             }
 
             auto pluginHandler = PluginHandler::getInstance();
+            if (remove_current) {
+                 wxLogMessage("Uninstalling %s", m_plugin.name.c_str());
+                 pluginHandler->uninstall(m_plugin.name);
+            }
             ok = pluginHandler->installPlugin(m_plugin, path);
             if (!ok) {
                 showErrorDialog("Installation error");

--- a/src/plugin_cache.cpp
+++ b/src/plugin_cache.cpp
@@ -1,0 +1,135 @@
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ *
+ ***************************************************************************
+ *   Copyright (C) 2019 Alec Leamas                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+*/
+
+#include <fstream>
+#include <wx/filename.h>
+#include <wx/filefn.h>
+
+#include "plugin_cache.h"
+#include "ocpn_utils.h"
+#include "OCPNPlatform.h"
+
+#ifdef __OCPN__ANDROID__
+#include "androidUTIL.h"
+#endif
+
+extern OCPNPlatform*  g_Platform;
+
+
+static std::string cache_path()
+{
+    wxFileName path;
+    path.AssignDir(g_Platform->GetPrivateDataDir());
+    path.AppendDir("plugins");
+    path.AppendDir("cache");
+    return path.GetFullPath().ToStdString();
+}
+
+
+
+static std::string tarball_path(const char* basename, bool create = false)
+{
+    wxFileName dirs(cache_path());
+    dirs.AppendDir("tarballs");
+    if (create) {
+        dirs.Mkdir(wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+    }
+    wxFileName path(dirs.GetFullPath(), wxString(basename));
+    return path.GetFullPath().ToStdString();
+}
+
+
+static bool copy_file(const char* src_path, const char* dest_path)
+{
+#ifdef __OCPN__ANDROID__
+    return AndroidSecureCopyFile(src_path, dest_path);
+#else
+    return wxCopyFile(src_path, dest_path);
+#endif
+}
+
+
+namespace ocpn {
+
+
+std::string get_basename(const char* path)
+{
+    wxString sep(wxFileName::GetPathSeparator());
+    auto parts = ocpn::split(path, sep.ToStdString());
+    return parts[parts.size() - 1];
+}
+
+
+static std::string metadata_path(const char* basename, bool create = false)
+{
+    wxFileName dirs(cache_path());
+    dirs.AppendDir("metadata");
+    if (create) {
+        dirs.Mkdir(wxS_DIR_DEFAULT, wxPATH_MKDIR_FULL);
+    }
+    wxFileName path(dirs.GetFullPath(), wxString(basename));
+    return path.GetFullPath().ToStdString();
+}
+
+
+bool store_metadata(const char* path)
+{
+    auto name = get_basename(path);
+    std::string dest = metadata_path(name.c_str(), true);
+    bool ok = ::copy_file(path, dest.c_str());
+    wxLogDebug("Storing metadata %s at %s: %s",
+               path, dest.c_str(), ok ? "ok" : "fail");
+    return ok;
+}
+
+
+std::string lookup_metadata(const char* name)
+{
+    if (name == 0) {
+        name = "ocpn-plugins.xml";
+    }
+    auto path = metadata_path(name);
+    return ocpn::exists(path) ? path : "";
+}
+
+
+bool store_tarball(const char* path, const char* basename)
+{
+    std::string dest = tarball_path(basename, true);
+    bool ok = ::copy_file(path, dest.c_str());
+    wxLogDebug("Storing tarball %s at %s: %s",
+               path, dest.c_str(), ok ? "ok" : "fail");
+    return ok;
+}
+
+
+std::string lookup_tarball(const char* uri)
+{
+    std::string basename = get_basename(uri);
+    std::string path = tarball_path(basename.c_str());
+    return ocpn::exists(path) ? path : "";
+}
+
+
+}  // namespace

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -91,6 +91,7 @@ typedef __LA_INT64_T la_int64_t;      //  "older" libarchive versions support
 #include "SoundFactory.h"
 #include "dychart.h"
 #include "PluginHandler.h"
+#include "plugin_cache.h"
 #include "pluginmanager.h"
 #include "navutil.h"
 #include "ais.h"
@@ -469,28 +470,16 @@ static void run_update_dialog(PluginListPanel* parent,
 
         //  On successful installation, copy the temp tarball to the local cache
         if(bOK){
-            wxLogMessage("Installation of %s successful",  update.name.c_str());
-            
+            wxLogMessage("Installation of %s successful", update.name.c_str());
             wxURI uri( wxString(update.tarball_url.c_str()));
             wxFileName fn(uri.GetPath());
-            wxString tarballFile = fn.GetFullName();
-            wxString cacheDir = g_Platform->GetPrivateDataDir() + _T("/") + _T("plugins");
-            wxString sep = _T("/");
-            if( !wxDirExists(cacheDir) )
-                wxMkdir( cacheDir);
-            cacheDir += sep + wxString(_T("cache"));
-            if( !wxDirExists(cacheDir) )
-                wxMkdir( cacheDir);
-            cacheDir += sep + wxString(_T("tarballs"));
-            if( !wxDirExists(cacheDir) )
-                wxMkdir( cacheDir);
-    
-            wxString destination = cacheDir + _T("/") + tarballFile;
-            wxLogMessage(" Trying to copy %s ",  tempTarballPath.c_str());
-            
-            if(wxFileExists(wxString( tempTarballPath.c_str()))){
-                wxLogMessage("Copying %s to local cache",  tarballFile.c_str());
-                wxCopyFile( wxString( tempTarballPath.c_str()), destination);
+            std::string basename = fn.GetFullName().ToStdString();
+
+            if (ocpn::store_tarball(tempTarballPath.c_str(),
+                                       basename.c_str()))
+            {
+                wxLogDebug("Copied %s to local cache at %s",
+                           tempTarballPath.c_str(), basename);
                 remove(tempTarballPath.c_str());
             }
         }
@@ -5304,29 +5293,13 @@ void CatalogMgrPanel::OnUpdateButton( wxCommandEvent &event)
     
     // If this is the "master" catalog, also copy to plugin cache
     if (catalog == "master") {
-        wxString metaCache = g_Platform->GetPrivateDataDir() + wxFileName::GetPathSeparator() + _T("plugins");
-        if(!wxDirExists( metaCache ))
-            wxMkdir( metaCache );
-        metaCache += wxFileName::GetPathSeparator();
-        metaCache += _T("cache");
-        if(!wxDirExists( metaCache ))
-            wxMkdir( metaCache );
-        metaCache += wxFileName::GetPathSeparator();
-        metaCache += _T("metadata");
-        if(!wxDirExists( metaCache ))
-            wxMkdir( metaCache );
-            
-#ifdef __OCPN__ANDROID__
-        if(!AndroidSecureCopyFile (wxString(filePath.c_str()), metaCache + wxFileName::GetPathSeparator() + _T("ocpn-plugins.xml"))){
-            OCPNMessageBox(this, _("Unable to copy catalog file to cache"), _("OpenCPN Catalog update"), wxICON_ERROR);
+       if (!ocpn::store_metadata(filePath.c_str())) {
+            OCPNMessageBox(this,
+                           _("Unable to copy catalog file to cache"),
+                           _("OpenCPN Catalog update"),
+                           wxICON_ERROR);
             return;
         }
-#else
-        if(!wxCopyFile (wxString(filePath.c_str()), metaCache + wxFileName::GetPathSeparator() + _T("ocpn-plugins.xml"))){
-            OCPNMessageBox(this, _("Unable to copy catalog file to cache"), _("OpenCPN Catalog update"), wxICON_ERROR);
-            return;
-        }
-#endif
     }       
 
     // Record in the config file the name of the catalog downloaded
@@ -5661,30 +5634,17 @@ void CatalogMgrPanel::OnTarballButton( wxCommandEvent &event)
         newCatalog.save_file( catalogName.mb_str(), "  ");
        
         // Copy the metadata to the tarball cache
-        wxString sep = wxFileName::GetPathSeparator();
-        wxString cacheDir = g_Platform->GetPrivateDataDir() + sep + _T("plugins");
-        if( !wxDirExists(cacheDir) )
-            wxMkdir( cacheDir);
-        cacheDir += sep + wxString(_T("cache"));
-        if( !wxDirExists(cacheDir) )
-            wxMkdir( cacheDir);
-        cacheDir += sep + wxString(_T("tarballs"));
-        if( !wxDirExists(cacheDir) )
-             wxMkdir( cacheDir);
-        
+         
         wxFileName fn(tarballPath);
-        wxString destination = cacheDir + sep + fn.GetFullName();
-        if(wxFileExists(wxString( tarballPath.c_str()))){
-            wxLogMessage("Copying %s to local cache",  tarballPath.ToStdString().c_str());
-#ifdef __OCPN__ANDROID__            
-            AndroidSecureCopyFile (tarballPath, destination);
-#else                
-            wxCopyFile( tarballPath, destination);
-#endif            
+        if (ocpn::store_tarball(tarballPath.ToStdString().c_str(),
+                                   fn.GetFullName().ToStdString().c_str())) 
+        {
+            wxLogMessage("Copied %s to local cache",
+                          tarballPath.ToStdString().c_str());
         }
-
-        // Ready to load an process the merged catalog...
         
+        // Ready to load and process the merged catalog...
+
         // Reset the PluginHandler catalog file source.
         // This will cause the Handler to find, load, and parse the just-merged catalog
         // as copied to g_Platform->GetPrivateDataDir()...


### PR DESCRIPTION
Add  sha2 hash support for downloaded  plugin tarballs, the main opencpn side.

Having working hash checks implies changes both in the plugins and in opencpn. This PR is the opencpn side. It basically adds parsing of the specified but yet not used `<tarball-checksum> `xml element in the metadata and compares this with the hash computed on the actual, downloaded data. A new, header-only library is added to compute the sha2 hash.

While on it, the plugin cache is refactored into a separate object, cleaning up some complicated, duplicated code. 

Testing: attaching  ocpn-plugins.xml with checksums added, The logbook plugin has artificial checksum errors on all platforms. 

Also attaching a test  script which is able to add checksums to an existing ocpn-plugins.xml. It's still 
a bit rough, but works well-enough for testing. Invoke using something like `ocpn-fix-checksums ocpn-plugins.xml cache`   It scans the xml file for tarball-url, downloads those, computes the hashes and updates the xml file.

In the end, checksum support needs to be implemented in the plugins. An example is available at https://github.com/leamas/shipdriver_pi/commits/cs. It's based on  a simple python tool which computes the hash.


ocpn-plugins.xmli with hashes: [ocpn-plugins.xml.gz](https://github.com/OpenCPN/OpenCPN/files/5237592/ocpn-plugins.xml.gz)

update checksums test script: [ocpn-fix-checksums.gz](https://github.com/OpenCPN/OpenCPN/files/5237603/ocpn-fix-checksums.gz)


Closes: #2041

