### PR TITLE
SignalK Don't parse a null position lat/lon

### DIFF
--- a/src/SignalKEventHandler.cpp
+++ b/src/SignalKEventHandler.cpp
@@ -150,8 +150,8 @@ void SignalKEventHandler::updateItem(wxJSONValue &item, wxString &sfixtime) cons
 }
 
 void SignalKEventHandler::updateNavigationPosition(wxJSONValue &value, const wxString &sfixtime) const {
-    if(value.HasMember("latitude")
-       && value.HasMember("longitude")) {
+    if ((value.HasMember("latitude" && value["latitude"].IsDouble()))
+        && (value.HasMember("longitude") && value["longitude"].IsDouble())) {
         //wxLogMessage(_T(" ***** Position Update"));
         m_frame->setPosition(value["latitude"].AsDouble(),
                              value["longitude"].AsDouble());


### PR DESCRIPTION
A possible solution to this CF post: https://www.cruisersforum.com/forums/f134/bug-opencpn-sees-a-fix-while-gps-data-are-not-consistent-240313.html#post3243707
