### PR TITLE
Draw heading line without WMM PI, if userset variation is available

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -9319,7 +9319,10 @@ void MyFrame::PostProcessNMEA( bool pos_valid, bool cog_sog_valid, const wxStrin
     //    but only if NMEA HDT sentence is not being received
 
     if( !g_bHDT_Rx ) {
-        if( !std::isnan(gVar) && !std::isnan(gHdm)) {
+        if( !std::isnan(gHdm)) {
+            //Set gVar if needed from manual entry. gVar will be overwritten if 
+            // WMM plugin is available
+            if( std::isnan(gVar) && (g_UserVar != 0.0) ) gVar = g_UserVar; 
             gHdt = gHdm + gVar;
             if (gHdt < 0)
                 gHdt += 360.0;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -7675,8 +7675,10 @@ void options::OnApplyClick(wxCommandEvent& event) {
   g_bShowMag = pCBMagShow->GetValue();
   
   b_haveWMM = g_pi_manager && g_pi_manager->IsPlugInAvailable(_T("WMM"));
-  if(!b_haveWMM  && !b_oldhaveWMM)
+  if(!b_haveWMM  && !b_oldhaveWMM){
     pMagVar->GetValue().ToDouble(&g_UserVar);
+    gVar = g_UserVar;
+  }
 
   m_pText_OSCOG_Predictor->GetValue().ToDouble(&g_ownship_predictor_minutes);
   m_pText_OSHDT_Predictor->GetValue().ToDouble(&g_ownship_HDTpredictor_miles);


### PR DESCRIPTION
If you have a compass connected (nmea $xxHDG) but no WMM plugin running the heading is not used for a heading line and rotating own ship icon. Seems logical as you want a true heading on the chart.
However it is still not drawn if there is a manual setting available for the variation.
This commit will allow to use the user setting, at least if it is not 0.0 (the 'factory' setting). 0.001 will do.