### PR TITLE
Sk gps watchdog

### DIFF
--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -1496,14 +1496,16 @@ void dashboard_pi::updateSKItem(wxJSONValue &item, wxString &sfixtime) {
         wxJSONValue &value = item["value"];
         if(update_path == _T("navigation.position")) {
             if (mPriPosition >= 2) {
-                mPriPosition = 2;
-                double lat = value["latitude"].AsDouble();
-                double lon = value["longitude"].AsDouble();
-                SendSentenceToAllInstruments(OCPN_DBP_STC_LAT, lat, _T("SDMM"));
-                SendSentenceToAllInstruments(OCPN_DBP_STC_LON, lon, _T("SDMM"));
+                if (value["latitude"].IsDouble() && value["longitude"].IsDouble()) {
+                    double lat = value["latitude"].AsDouble();
+                    double lon = value["longitude"].AsDouble();
+                    SendSentenceToAllInstruments(OCPN_DBP_STC_LAT, lat, _T("SDMM"));
+                    SendSentenceToAllInstruments(OCPN_DBP_STC_LON, lon, _T("SDMM"));
+                    mPriPosition = 2;
+                }
             }
         } 
-        else if(update_path == _T("navigation.speedOverGround")){
+        else if(update_path == _T("navigation.speedOverGround") && 2 == mPriPosition){
             double sog_knot = GetJsonDouble(value);
             if (std::isnan(sog_knot)) return;
 
@@ -1511,7 +1513,7 @@ void dashboard_pi::updateSKItem(wxJSONValue &item, wxString &sfixtime) {
                         toUsrSpeed_Plugin( mSOGFilter.filter(sog_knot), 
                         g_iDashSpeedUnit ), getUsrSpeedUnit_Plugin( g_iDashSpeedUnit ) );
         }
-        else if(update_path == _T("navigation.courseOverGroundTrue")){
+        else if(update_path == _T("navigation.courseOverGroundTrue") && 2 == mPriPosition){
             double cog_rad = GetJsonDouble(value);
             if (std::isnan(cog_rad)) return;
 

--- a/src/SignalKEventHandler.cpp
+++ b/src/SignalKEventHandler.cpp
@@ -39,6 +39,7 @@
 
 extern PlugInManager    *g_pi_manager;
 wxString                g_ownshipMMSI_SK;
+extern bool             bGPSValid;
 
 void SignalKEventHandler::OnEvtOCPN_SignalK(OCPN_SignalKEvent &event)
 {
@@ -114,10 +115,10 @@ void SignalKEventHandler::updateItem(wxJSONValue &item, wxString &sfixtime) cons
         wxJSONValue &value = item["value"];
         if(update_path == _T("navigation.position")) {
             updateNavigationPosition(value, sfixtime);
-        } else if(update_path == _T("navigation.speedOverGround"))
+        } else if(update_path == _T("navigation.speedOverGround") && bGPSValid)
         {
             updateNavigationSpeedOverGround(value, sfixtime);
-        } else if(update_path == _T("navigation.courseOverGroundTrue"))
+        } else if(update_path == _T("navigation.courseOverGroundTrue") && bGPSValid)
         {
             updateNavigationCourseOverGround(value, sfixtime);
         } else if(update_path == _T("navigation.courseOverGroundMagnetic"))
@@ -180,7 +181,8 @@ void SignalKEventHandler::updateNavigationCourseOverGround(wxJSONValue &value,
 void SignalKEventHandler::updateGnssSatellites(wxJSONValue &value,
                                                const wxString &sfixtime) const
 {
-    m_frame->setSatelitesInView(value.AsInt());
+    int sats = value.AsInt();
+    if (sats > 0) m_frame->setSatelitesInView(sats);
 }
 
 void SignalKEventHandler::updateHeadingTrue(wxJSONValue &value,

--- a/src/SignalKEventHandler.cpp
+++ b/src/SignalKEventHandler.cpp
@@ -39,7 +39,7 @@
 
 extern PlugInManager    *g_pi_manager;
 wxString                g_ownshipMMSI_SK;
-extern bool             bGPSValid;
+bool             bGPSValid_SK;
 
 void SignalKEventHandler::OnEvtOCPN_SignalK(OCPN_SignalKEvent &event)
 {
@@ -115,10 +115,10 @@ void SignalKEventHandler::updateItem(wxJSONValue &item, wxString &sfixtime) cons
         wxJSONValue &value = item["value"];
         if(update_path == _T("navigation.position")) {
             updateNavigationPosition(value, sfixtime);
-        } else if(update_path == _T("navigation.speedOverGround") && bGPSValid)
+        } else if(update_path == _T("navigation.speedOverGround") && bGPSValid_SK)
         {
             updateNavigationSpeedOverGround(value, sfixtime);
-        } else if(update_path == _T("navigation.courseOverGroundTrue") && bGPSValid)
+        } else if(update_path == _T("navigation.courseOverGroundTrue") && bGPSValid_SK)
         {
             updateNavigationCourseOverGround(value, sfixtime);
         } else if(update_path == _T("navigation.courseOverGroundMagnetic"))
@@ -157,6 +157,10 @@ void SignalKEventHandler::updateNavigationPosition(wxJSONValue &value, const wxS
         m_frame->setPosition(value["latitude"].AsDouble(),
                              value["longitude"].AsDouble());
         m_frame->PostProcessNMEA(true, false, sfixtime);
+        bGPSValid_SK = true;
+    }
+    else {
+        bGPSValid_SK = false;
     }
 }
 
@@ -181,8 +185,7 @@ void SignalKEventHandler::updateNavigationCourseOverGround(wxJSONValue &value,
 void SignalKEventHandler::updateGnssSatellites(wxJSONValue &value,
                                                const wxString &sfixtime) const
 {
-    int sats = value.AsInt();
-    if (sats > 0) m_frame->setSatelitesInView(sats);
+    m_frame->setSatelitesInView(value.AsInt());
 }
 
 void SignalKEventHandler::updateHeadingTrue(wxJSONValue &value,

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -8874,7 +8874,6 @@ void MyFrame::setCourseOverGround(double cog)
     if(!g_own_ship_sog_cog_calc) {
         wxLogDebug(wxString::Format(_T("COG: %f"), cog));
         gCog = cog;
-        gGPS_Watchdog = gps_watchdog_timeout_ticks;
     }
 }
 
@@ -8883,7 +8882,6 @@ void MyFrame::setSpeedOverGround(double sog)
     if(!g_own_ship_sog_cog_calc) {
         wxLogDebug(wxString::Format(_T("SOG: %f"), sog));
         gSog = sog;
-        gGPS_Watchdog = gps_watchdog_timeout_ticks;
     }
 }
 


### PR DESCRIPTION
Correct SignalK GPS Watchdog to also make GPS Icon, COG and SOG not valid.

The GPS Watchdog was kept alive by "0" values for COG and SOG.
Changes:
- Don't use SOG or COG from SK when position is not valid, i.e GPS Watchdog is released. They have a all time value >= 0.
- Don't use a "0" value for number of satellites in view.
- There's no obvious reason for COG or SOG to update the GPS Watchdog.

- Correct Dashboard to not use SK values position NULL and meanwhile neither SOG nor COG.
