### PR TITLE
Flatpak: Install appstream metadata as appdata.xml instead of metainfo.xml (#2069)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2232,7 +2232,7 @@ if (NOT APPLE)
     install(
       FILES ${CMAKE_BINARY_DIR}/opencpn.appdata.xml
       DESTINATION ${PREFIX_DATA}/metainfo
-      RENAME opencpn.metainfo.xml
+      RENAME opencpn.appdata.xml
     )
     install(FILES opencpn.1 DESTINATION ${PREFIX_DATA}/man/man1)
   endif (UNIX)

--- a/ci/generic-build-flatpak.sh
+++ b/ci/generic-build-flatpak.sh
@@ -75,4 +75,4 @@ flatpak update --appstream opencpn
 flatpak remote-ls opencpn
 
 # Validate the appstream data:
-appstreamcli validate app/files/share/appdata/org.opencpn.OpenCPN.appdata.xml
+appstreamcli validate app/files/share/metainfo/opencpn.appdata.xml


### PR DESCRIPTION
Use the appdata name instead, using the metainfo name was premature.

This should satisfy both the needs for flatpak (fully qualified name on org.opencpn.OpenCPN) as well as Debian (desktop and appdata should files should have the same basename).

Closes: #2069