### PR TITLE
Correct typo in chcanv

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -1945,7 +1945,7 @@ bool ChartCanvas::DoCanvasUpdate( void )
 #ifdef ocpnUSE_GL
     // If a new chart, need to invalidate gl viewport for refresh
     // so the fbo gets flushed
-    if(m_glcc && g_bopengl & bNewChart)
+    if(m_glcc && g_bopengl && bNewChart)
         GetglCanvas()->Invalidate();
 #endif
         


### PR DESCRIPTION
Although I have never seen all three conditions true it would be a typo? (& >> &&)
if(m_glcc && g_bopengl & bNewChart)