### PR TITLE
Solution to #FS2648 

### DIFF
--- a/include/routeman.h
+++ b/include/routeman.h
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *
  * Project:  OpenCPN
  * Purpose:  Route Manager
@@ -180,6 +180,7 @@ public:
       wxString CreateGUID(RoutePoint *pRP);
       RoutePoint *GetNearbyWaypoint(double lat, double lon, double radius_meters);
       RoutePoint *GetOtherNearbyWaypoint(double lat, double lon, double radius_meters, const wxString &guid);
+      bool IsReallyVisible(RoutePoint* pWP );
       void SetColorScheme(ColorScheme cs);
       bool SharedWptsExist();
       void DeleteAllWaypoints(bool b_delete_used);

--- a/src/MarkInfo.cpp
+++ b/src/MarkInfo.cpp
@@ -1,4 +1,4 @@
-/**************************************************************************
+﻿/**************************************************************************
 *
 * Project:  OpenCPN
 * Purpose:  MarkProperties Support
@@ -1663,6 +1663,10 @@ bool MarkInfoDlg::SaveChanges()
         if( m_pRoutePoint->m_bIsInRoute ) {
             bool b_name_is_numeric = true;
             for( unsigned int i = 0; i < m_pRoutePoint->GetName().Len(); i++ ) {
+                if( i < 2 && wxChar( 'N' ) == m_pRoutePoint->GetName()[0]
+                          && wxChar( 'M' ) == m_pRoutePoint->GetName()[1]
+                          && m_pRoutePoint->GetName().Len() > 2 )
+                    continue;
                 if( wxChar( '0' ) > m_pRoutePoint->GetName()[i] ) b_name_is_numeric = false;
                 if( wxChar( '9' ) < m_pRoutePoint->GetName()[i] ) b_name_is_numeric = false;
             }

--- a/src/canvasMenu.cpp
+++ b/src/canvasMenu.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *
  * Project:  OpenCPN
  * Purpose:  CanvasMenuHandler
@@ -1376,11 +1376,16 @@ void CanvasMenuHandler::PopupMenuHandler( wxCommandEvent& event )
 
         break;
 
-    case ID_RT_MENU_INSERT:
+    case ID_RT_MENU_INSERT: {
 
         if( m_pSelectedRoute->m_bIsInLayer ) break;
+        bool rename = false;
+        int ask_return = OCPNMessageBox( parent, _("Waypoints can be renamed to include the new one, the names will be '001', '002' etc.")
+                               + _T("\n\n") + _("Do you want to rename the waypoints?"),
+                               _("Rename Waypoints?"), wxYES_NO | wxCANCEL );
+        if( ask_return == wxID_YES ) rename = true;
 
-        m_pSelectedRoute->InsertPointAfter( m_pFoundRoutePoint, zlat, zlon );
+        m_pSelectedRoute->InsertPointAfter( m_pFoundRoutePoint, zlat, zlon, rename );
 
         pSelect->DeleteAllSelectableRoutePoints( m_pSelectedRoute );
         pSelect->DeleteAllSelectableRouteSegments( m_pSelectedRoute );
@@ -1406,6 +1411,7 @@ void CanvasMenuHandler::PopupMenuHandler( wxCommandEvent& event )
         }
 
         break;
+    }
 
     case ID_RT_MENU_APPEND:
 

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *
  * Project:  OpenCPN
  * Purpose:  Chart Canvas
@@ -8442,12 +8442,76 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
             
             if( m_bRouteEditing/* && !b_startedit_route*/) {            // End of RoutePoint drag
             if( m_pRoutePointEditTarget ) {
-                pSelect->UpdateSelectableRouteSegments( m_pRoutePointEditTarget );
+                //Check to see if there is a nearby point which may replace the dragged one
+                RoutePoint *pMousePoint = NULL;
+                if( m_bRoutePoinDragging && !m_pRoutePointEditTarget->m_bIsActive )
+                {
+                    double nearby_radius_meters = g_Platform->GetSelectRadiusPix() / m_true_scale_ppm;
+                    RoutePoint *pNearbyPoint = pWayPointMan->GetOtherNearbyWaypoint( m_pRoutePointEditTarget->m_lat, m_pRoutePointEditTarget->m_lon,
+                                                                                           nearby_radius_meters, m_pRoutePointEditTarget->m_GUID);
+                    if( pNearbyPoint && !pNearbyPoint->m_bIsInLayer && pWayPointMan->IsReallyVisible(pNearbyPoint) )
+                    {
+                        bool duplicate = false; //ensure we won't create duplicate point in routes
+                        if( m_pEditRouteArray && !pNearbyPoint->m_bIsolatedMark ){
+                            for( unsigned int ir = 0; ir < m_pEditRouteArray->GetCount(); ir++ ) {
+                                Route *pr = (Route *) m_pEditRouteArray->Item( ir );
+                                if( pr && pr->pRoutePointList ) {
+                                    if( pr->pRoutePointList->IndexOf(pNearbyPoint) != wxNOT_FOUND ){
+                                        duplicate = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        if( !duplicate ) {
+                            int dlg_return;
+                        #ifndef __WXOSX__
+                            dlg_return = OCPNMessageBox( this, _("Replace this WayPoint by the nearby one?"),
+                                       _("OpenCPN RoutePoint change"),
+                                       (long) wxYES_NO | wxCANCEL | wxYES_DEFAULT );
+                            if( dlg_return == wxID_YES ) {
+                                /*double confirmation if the dragged point has been manually created
+                                 * which can be important and could be deleted unintentionally*/
+                                if( m_pRoutePointEditTarget->m_bKeepXRoute ){
+                                  //  dlg_return = wxID_NO;
+                                    dlg_return = OCPNMessageBox( this, _("Do you really want to delete and replace this WayPoint")
+                                                + _T("\n") + _("which has been created manually?"),
+                                                ("OpenCPN RoutePoint warning"),
+                                                (long) wxYES_NO | wxCANCEL | wxYES_DEFAULT );
+                                }
+                            }
+                            if( dlg_return == wxID_YES ) {
+                                pMousePoint = pNearbyPoint;
+                                if( pMousePoint->m_bIsolatedMark ) {
+                                    pMousePoint->m_bKeepXRoute = true;
+                                }
+                                pMousePoint->m_bIsolatedMark = false;       // definitely no longer isolated
+                                pMousePoint->m_bIsInRoute = true;
+                            }
+                        #endif
+                        }
+                    }
+                }
+                if( !pMousePoint )
+                    pSelect->UpdateSelectableRouteSegments( m_pRoutePointEditTarget );
                 
                 if( m_pEditRouteArray ) {
                     for( unsigned int ir = 0; ir < m_pEditRouteArray->GetCount(); ir++ ) {
                         Route *pr = (Route *) m_pEditRouteArray->Item( ir );
                         if( g_pRouteMan->IsRouteValid(pr) ) {
+                            if( pMousePoint ) { //remove the dragged point and insert the nearby
+                                int nRP = pr->pRoutePointList->IndexOf( m_pRoutePointEditTarget );
+
+                                pSelect->DeleteAllSelectableRoutePoints( pr );
+                                pSelect->DeleteAllSelectableRouteSegments( pr );
+
+                                pr->pRoutePointList->Insert( nRP, pMousePoint );
+                                pr->pRoutePointList->DeleteObject( m_pRoutePointEditTarget );
+
+                                pSelect->AddAllSelectableRouteSegments( pr );
+                                pSelect->AddAllSelectableRoutePoints( pr );
+
+                            }
                             pr->FinalizeForRendering();
                             pr->UpdateSegmentDistances();
                             if( m_bRoutePoinDragging ) pConfig->UpdateRoute( pr );
@@ -8473,6 +8537,19 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
                         }
                     }
                 }
+                if( pMousePoint ) {  //clear all about the dragged point
+                    pConfig->DeleteWayPoint( m_pRoutePointEditTarget );
+                    pWayPointMan->RemoveRoutePoint( m_pRoutePointEditTarget );
+                    //Hide mark properties dialog if open on the replaced point
+                    if( ( NULL != g_pMarkInfoDialog ) && ( g_pMarkInfoDialog->IsShown() ) )
+                        if( m_pRoutePointEditTarget == g_pMarkInfoDialog->GetRoutePoint() ) g_pMarkInfoDialog->Hide();
+
+                    delete m_pRoutePointEditTarget;
+                    m_lastRoutePointEditTarget = NULL;
+                    m_pRoutePointEditTarget = NULL;
+                    undo->AfterUndoableAction( pMousePoint );
+                    undo->InvalidateUndo();
+                }
                 
             }
             }
@@ -8497,13 +8574,77 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
         else{                   // !g_btouch
         if( m_bRouteEditing ) {            // End of RoutePoint drag
             if( m_pRoutePointEditTarget ) {
-                pSelect->UpdateSelectableRouteSegments( m_pRoutePointEditTarget );
                 m_pRoutePointEditTarget->m_bBlink = false;
-                
+                //Check to see if there is a nearby point which may replace the dragged one
+                RoutePoint *pMousePoint = NULL;
+                if( m_bRoutePoinDragging && !m_pRoutePointEditTarget->m_bIsActive )
+                {
+                    double nearby_radius_meters = g_Platform->GetSelectRadiusPix() / m_true_scale_ppm;
+                    RoutePoint *pNearbyPoint = pWayPointMan->GetOtherNearbyWaypoint( m_pRoutePointEditTarget->m_lat, m_pRoutePointEditTarget->m_lon,
+                                                                            nearby_radius_meters, m_pRoutePointEditTarget->m_GUID);
+                    if( pNearbyPoint && !pNearbyPoint->m_bIsInLayer && pWayPointMan->IsReallyVisible(pNearbyPoint) )
+                    {
+                        bool duplicate = false; //don't create duplicate point in routes
+                        if( m_pEditRouteArray && !pNearbyPoint->m_bIsolatedMark ){
+                            for( unsigned int ir = 0; ir < m_pEditRouteArray->GetCount(); ir++ ) {
+                                Route *pr = (Route *) m_pEditRouteArray->Item( ir );
+                                if( pr && pr->pRoutePointList ) {
+                                    if( pr->pRoutePointList->IndexOf(pNearbyPoint) != wxNOT_FOUND ){
+                                        duplicate = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        if( !duplicate ) {
+                            int dlg_return;
+                        #ifndef __WXOSX__
+                            dlg_return = OCPNMessageBox( this, _("Replace this WayPoint by the nearby one?"),
+                                       _("OpenCPN RoutePoint change"),
+                                            (long) wxYES_NO | wxCANCEL | wxYES_DEFAULT );
+                            if( dlg_return == wxID_YES ) {
+                                /*double confirmation if the dragged point has been manually created
+                                * which can be important and could be deleted unintentionally*/
+                                if( m_pRoutePointEditTarget->m_bKeepXRoute ){
+                                    dlg_return = wxID_NO;
+                                    dlg_return = OCPNMessageBox( this, _("Do you really want to delete and replace this WayPoint")
+                                                + _T("\n") + _("which has been created manually?"),
+                                                ("OpenCPN RoutePoint warning"),
+                                                (long) wxYES_NO | wxCANCEL | wxYES_DEFAULT );
+                                }
+                            }
+                            if( dlg_return == wxID_YES ) {
+                                pMousePoint = pNearbyPoint;
+                                if( pMousePoint->m_bIsolatedMark ) {
+                                    pMousePoint->m_bKeepXRoute = true;
+                                }
+                                pMousePoint->m_bIsolatedMark = false;       // definitely no longer isolated
+                                pMousePoint->m_bIsInRoute = true;
+                            }
+                       #endif
+                        }
+                    }
+                }
+                if( !pMousePoint )
+                    pSelect->UpdateSelectableRouteSegments( m_pRoutePointEditTarget );
+
                 if( m_pEditRouteArray ) {
                     for( unsigned int ir = 0; ir < m_pEditRouteArray->GetCount(); ir++ ) {
                         Route *pr = (Route *) m_pEditRouteArray->Item( ir );
                         if( g_pRouteMan->IsRouteValid(pr) ) {
+                            if( pMousePoint ) {  //replace dragged point by nearby one
+                                int nRP = pr->pRoutePointList->IndexOf( m_pRoutePointEditTarget );
+
+                                pSelect->DeleteAllSelectableRoutePoints( pr );
+                                pSelect->DeleteAllSelectableRouteSegments( pr );
+
+                                pr->pRoutePointList->Insert( nRP, pMousePoint );
+                                pr->pRoutePointList->DeleteObject( m_pRoutePointEditTarget );
+
+                                pSelect->AddAllSelectableRouteSegments( pr );
+                                pSelect->AddAllSelectableRoutePoints( pr );
+
+                            }
                             pr->FinalizeForRendering();
                             pr->UpdateSegmentDistances();
                             pr->m_bIsBeingEdited = false;
@@ -8515,7 +8656,7 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
                     }
                     Refresh( false );
                 }
-                
+
                 //    Update the RouteProperties Dialog, if currently shown
                 if( pRoutePropDialog && pRoutePropDialog->IsShown() ) {
                     if( m_pEditRouteArray ) {
@@ -8529,19 +8670,33 @@ bool ChartCanvas::MouseEventProcessObjects( wxMouseEvent& event )
                         }
                     }
                 }
-                
-                m_pRoutePointEditTarget->m_bPtIsSelected = false;
-                m_pRoutePointEditTarget->m_bRPIsBeingEdited = false;
-                
+
+                if( pMousePoint ) {
+                    pConfig->DeleteWayPoint( m_pRoutePointEditTarget );
+                    pWayPointMan->RemoveRoutePoint( m_pRoutePointEditTarget );
+                    //Hide mark properties dialog if open on the replaced point
+                    if( ( NULL != g_pMarkInfoDialog ) && ( g_pMarkInfoDialog->IsShown() ) )
+                        if( m_pRoutePointEditTarget == g_pMarkInfoDialog->GetRoutePoint() ) g_pMarkInfoDialog->Hide();
+
+                    delete m_pRoutePointEditTarget;
+                    m_lastRoutePointEditTarget = NULL;
+                    undo->AfterUndoableAction( pMousePoint );
+                    undo->InvalidateUndo();
+                } else {
+                    m_pRoutePointEditTarget->m_bPtIsSelected = false;
+                    m_pRoutePointEditTarget->m_bRPIsBeingEdited = false;
+
+                    undo->AfterUndoableAction( m_pRoutePointEditTarget );
+                }
+
                 delete m_pEditRouteArray;
                 m_pEditRouteArray = NULL;
-                undo->AfterUndoableAction( m_pRoutePointEditTarget );
             }
             
             InvalidateGL();
             m_bRouteEditing = false;
             m_pRoutePointEditTarget = NULL;
-            
+
             if( m_toolBar && !m_toolBar->IsToolbarShown())
                 SurfaceToolbar();
             ret = true;

--- a/src/routeman.cpp
+++ b/src/routeman.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *
  * Project:  OpenCPN
  * Purpose:  Route Manager
@@ -2223,6 +2223,29 @@ RoutePoint *WayPointman::GetOtherNearbyWaypoint( double lat, double lon, double 
     }
     return NULL;
 
+}
+
+bool WayPointman::IsReallyVisible( RoutePoint* pWP )
+{
+    if( pWP->m_bIsolatedMark)
+                return pWP->IsVisible(); // isolated point
+    else {
+        wxRouteListNode *node = pRouteList->GetFirst();
+        while( node ) {
+            Route *proute = node->GetData();
+            if( proute && proute->pRoutePointList ) {
+                if( proute->pRoutePointList->IndexOf(pWP) != wxNOT_FOUND ){
+                    if(proute->IsVisible())
+                        return true;
+                }
+            }
+            node = node->GetNext();
+        }
+    }
+    if( pWP->m_bKeepXRoute ) // is not visible as part of route, but still exists as a waypoint
+        return pWP->IsVisible(); // so treat as isolated point
+
+    return false;
 }
 
 void WayPointman::ClearRoutePointFonts( void )


### PR DESCRIPTION
I propose here another solution to include a Way  Point in an existing route. Instead of creating a new insert functionality,
I propose this patch:
- The insert functionality is not changed
- When a route point is being dragged, and the drag ends near another point, it is proposed to replace it by the nearby one.
          - the nearby one is inserted and the dragged one is deleted
          - Assuming that an originally manually created point could be important, there is a double validation in this case
          to ovoid deleting it unintentionally.
          - Activated points are excluded of this functionality
The code has been tested on Linux Mint - Ubuntu and Windows 10
OSX is excluded . I have neither knowledge nor device for this platform

Added improvement for Insert and Reverse functions
Insert : add the possibility to reorder and rename all way points of the route including the new inserted one.
Reverse : We can choose to renamed all points in the new order. But it don't work for the previously inserted one which are
named "NMxxx". When insertion appends, the "DynamicName" state is set but is lost  as soon as the wpt properties dialog has been open on one, then  it no longer can be renamed automatically.
I propose to correct that.