### PR TITLE
Solution to #FS2558

### DIFF
--- a/include/Route.h
+++ b/include/Route.h
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *
  * Project:  OpenCPN
  *
@@ -106,6 +106,8 @@ public:
       bool ContainsSharedWP();
       void SetSharedWPViz( bool sharedWPVIZ){ m_bsharedWPViz = sharedWPVIZ; }
       bool GetSharedWPViz(){ return m_bsharedWPViz; }
+      void SetOverrideWPNViz( bool OverrideWPNViz){ m_OverrideWPNViz = OverrideWPNViz; }
+      bool GetOverrideWPNViz(){ return m_OverrideWPNViz; }
       
       int SendToGPS(const wxString & com_name, bool bsend_waypoints, wxGauge *pProgress);
 
@@ -157,6 +159,7 @@ private:
       bool        m_bListed;
       double      m_ArrivalRadius;
       bool        m_bsharedWPViz;
+      bool        m_OverrideWPNViz;  //should the way point names be always shown?
 };
 
 WX_DECLARE_LIST(Route, RouteList); // establish class Route as list member

--- a/include/RoutePoint.h
+++ b/include/RoutePoint.h
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *
  * Project:  OpenCPN
  *
@@ -48,7 +48,7 @@ public:
       RoutePoint( RoutePoint* orig );
       RoutePoint();
       virtual ~RoutePoint(void);
-      void Draw(ocpnDC& dc, ChartCanvas *canvas, wxPoint *rpn = NULL, bool boverride_viz = false);
+      void Draw(ocpnDC& dc, ChartCanvas *canvas, wxPoint *rpn = NULL, bool boverride_viz = false, bool bwptVizOverride = false);
       void ReLoadIcon(void);
       
       void SetPosition(double lat, double lon);
@@ -182,7 +182,7 @@ public:
       
 
 #ifdef ocpnUSE_GL
-      void DrawGL( ViewPort &vp, ChartCanvas *canvas, bool use_cached_screen_coords=false, bool bVizOverride=false );
+      void DrawGL( ViewPort &vp, ChartCanvas *canvas, bool use_cached_screen_coords=false, bool bVizOverride=false, bool bwptVizOverride = false );
       unsigned int m_iTextTexture;
       int m_iTextTextureWidth, m_iTextTextureHeight;
 

--- a/src/NavObjectCollection.cpp
+++ b/src/NavObjectCollection.cpp
@@ -1,4 +1,4 @@
-/******************************************************************************
+﻿/******************************************************************************
  *
  * Project:  OpenCPN
  *
@@ -483,8 +483,10 @@ static Route *GPXLoadRoute1( pugi::xml_node &wpt_node, bool b_fullviz,
     wxString DescString;
     bool b_propviz = false;
     bool b_propSWPviz =false;
+    bool b_propWPNviz = false;
     bool b_viz = true;
     bool swpViz = false;
+    bool WPNviz = false;
     Route *pTentRoute = NULL;
     
     wxString Name = wxString::FromUTF8( wpt_node.name() );
@@ -524,6 +526,12 @@ static Route *GPXLoadRoute1( pugi::xml_node &wpt_node, bool b_fullviz,
                                 wxString viz = wxString::FromUTF8(ext_child.first_child().value());
                                 b_propSWPviz = true;
                                 swpViz = ( viz == _T("1") );
+                    }
+                    else
+                    if( ext_name == _T ( "opencpn:WPNviz" ) ) {
+                                wxString viz = wxString::FromUTF8(ext_child.first_child().value());
+                                b_propWPNviz = true;
+                                WPNviz = ( viz == _T("1") );
                     }
                     else
                     if( ext_name == _T ( "opencpn:style" ) ) {
@@ -666,7 +674,10 @@ static Route *GPXLoadRoute1( pugi::xml_node &wpt_node, bool b_fullviz,
         
         if( b_propSWPviz)
             pTentRoute->SetSharedWPViz( swpViz );
- 
+
+        if( b_propWPNviz)
+            pTentRoute->SetOverrideWPNViz(WPNviz);
+
         if( b_layer ){
             pTentRoute->SetVisible( b_layerviz );
             pTentRoute->m_bIsInLayer = true;
@@ -1034,6 +1045,12 @@ static bool GPXCreateRoute( pugi::xml_node node, Route *pRoute )
     if(pRoute->ContainsSharedWP()){
         child = child_ext.append_child("opencpn:sharedWPviz");
         child.append_child(pugi::node_pcdata).set_value(pRoute->GetSharedWPViz() == true ? "1" : "0");
+
+    }
+
+    if(pRoute->GetOverrideWPNViz()){
+        child = child_ext.append_child("opencpn:WPNviz");
+        child.append_child(pugi::node_pcdata).set_value("1");
 
     }
  

--- a/src/Route.cpp
+++ b/src/Route.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *
  * Project:  OpenCPN
  *
@@ -90,6 +90,7 @@ Route::Route()
     m_HyperlinkList = new HyperlinkList;
     
     m_bsharedWPViz = false;
+    m_OverrideWPNViz = false;
 }
 
 Route::~Route()
@@ -186,7 +187,7 @@ RoutePoint *Route::GetPoint( const wxString &guid )
 void Route::DrawPointWhich( ocpnDC& dc, ChartCanvas *canvas, int iPoint, wxPoint *rpn )
 {
     if( iPoint <= GetnPoints() )
-        GetPoint( iPoint )->Draw( dc, canvas, rpn );
+        GetPoint( iPoint )->Draw( dc, canvas, rpn, false, m_OverrideWPNViz );
 }
 
 void Route::DrawSegment( ocpnDC& dc, ChartCanvas *canvas, wxPoint *rp1, wxPoint *rp2, ViewPort &vp, bool bdraw_arrow )
@@ -264,9 +265,9 @@ void Route::Draw( ocpnDC& dc, ChartCanvas *canvas, const LLBBox &box )
 
         RoutePoint *prp2 = node->GetData();
         if ( !m_bVisible && prp2->m_bKeepXRoute )
-            prp2->Draw( dc, canvas, &rpt2, sharedVizOveride );
+            prp2->Draw( dc, canvas, &rpt2, sharedVizOveride, m_OverrideWPNViz );
         else if (m_bVisible)
-            prp2->Draw( dc, canvas, &rpt2 );
+            prp2->Draw( dc, canvas, &rpt2, false, m_OverrideWPNViz );
 
         if ( m_bVisible )
         {
@@ -509,9 +510,9 @@ void Route::DrawGL( ViewPort &vp, ChartCanvas *canvas )
         //  Maybe better to use the mark's drawn box, once it is known.
         if(vp.GetBBox().ContainsMarge(prp->m_lat, prp->m_lon, .5)){
             if ( !m_bVisible && prp->m_bKeepXRoute )
-                prp->DrawGL( vp, canvas, false, bVizOverride );
+                prp->DrawGL( vp, canvas, false, bVizOverride, m_OverrideWPNViz );
             else if (m_bVisible)
-                prp->DrawGL( vp, canvas );
+                prp->DrawGL( vp, canvas, false, false, m_OverrideWPNViz );
         }
     }
     
@@ -1000,7 +1001,7 @@ void Route::CalculateDCRect( wxDC& dc_route, ChartCanvas *canvas, wxRect *prect 
             bool blink_save = prp2->m_bBlink;
             prp2->m_bBlink = false;
             ocpnDC odc_route( dc_route );
-            prp2->Draw( odc_route, canvas, NULL );
+            prp2->Draw( odc_route, canvas, NULL, false, m_OverrideWPNViz );
             prp2->m_bBlink = blink_save;
 
             wxRect r =  prp2->CurrentRect_in_DC ;

--- a/src/RoutePoint.cpp
+++ b/src/RoutePoint.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *
  * Project:  OpenCPN
  *
@@ -538,7 +538,7 @@ bool RoutePoint::IsVisibleSelectable(ChartCanvas *canvas, bool boverrideViz)
     return true;
 }
 
-void RoutePoint::Draw( ocpnDC& dc, ChartCanvas *canvas, wxPoint *rpn, bool boverride_viz )
+void RoutePoint::Draw(ocpnDC& dc, ChartCanvas *canvas, wxPoint *rpn, bool boverride_viz , bool bwptVizOverride)
 {
     wxPoint r;
     wxRect hilitebox;
@@ -591,7 +591,7 @@ void RoutePoint::Draw( ocpnDC& dc, ChartCanvas *canvas, wxPoint *rpn, bool bover
 //    Calculate the mark drawing extents
     wxRect r1( r.x - sx2, r.y - sy2, sx2 * 2, sy2 * 2 );           // the bitmap extents
 
-    if( m_bShowName ) {
+    if( m_bShowName || (bwptVizOverride && !m_bPtIsSelected) ) {
         if( 0 == m_pMarkFont ) {
             m_pMarkFont = FontMgr::Get().GetFont( _( "Marks" ) );
             m_FontColor = FontMgr::Get().GetFontColor( _( "Marks" ) );
@@ -644,7 +644,7 @@ void RoutePoint::Draw( ocpnDC& dc, ChartCanvas *canvas, wxPoint *rpn, bool bover
         dc.CalcBoundingBox( r.x + sx2, r.y + sy2 );
     }
 
-    if( m_bShowName ) {
+    if( m_bShowName || (bwptVizOverride && !m_bPtIsSelected) ) {
         if( m_pMarkFont ) {
             dc.SetFont( *m_pMarkFont );
             dc.SetTextForeground( m_FontColor );
@@ -695,7 +695,7 @@ void RoutePoint::Draw( ocpnDC& dc, ChartCanvas *canvas, wxPoint *rpn, bool bover
 }
 
 #ifdef ocpnUSE_GL
-void RoutePoint::DrawGL( ViewPort &vp, ChartCanvas *canvas, bool use_cached_screen_coords, bool bVizOverride )
+void RoutePoint::DrawGL( ViewPort &vp, ChartCanvas *canvas, bool use_cached_screen_coords, bool bVizOverride, bool bwptVizOverride )
 {
     if ( !IsVisibleSelectable(canvas, bVizOverride) ) return;
     
@@ -758,7 +758,7 @@ void RoutePoint::DrawGL( ViewPort &vp, ChartCanvas *canvas, bool use_cached_scre
     wxRect r1( r.x - sx2, r.y - sy2, sx2 * 2, sy2 * 2 );           // the bitmap extents
 
     wxRect r3 = r1;
-    if( m_bShowName ) {
+    if( m_bShowName || (bwptVizOverride && !m_bPtIsSelected) ) {
         if( !m_pMarkFont ) {
             m_pMarkFont = FontMgr::Get().GetFont( _( "Marks" ) );
             m_FontColor = FontMgr::Get().GetFontColor( _( "Marks" ) );
@@ -890,7 +890,7 @@ void RoutePoint::DrawGL( ViewPort &vp, ChartCanvas *canvas, bool use_cached_scre
         glDisable(GL_TEXTURE_2D);
     }
 
-    if( m_bShowName && m_pMarkFont ) {
+    if( (m_bShowName || (bwptVizOverride && !m_bPtIsSelected)) && m_pMarkFont ) {
         int w = m_NameExtents.x, h = m_NameExtents.y;
         if(!m_iTextTexture && w && h) {
             wxBitmap tbm(w, h); /* render text on dc */

--- a/src/RoutePoint.cpp
+++ b/src/RoutePoint.cpp
@@ -591,7 +591,8 @@ void RoutePoint::Draw(ocpnDC& dc, ChartCanvas *canvas, wxPoint *rpn, bool boverr
 //    Calculate the mark drawing extents
     wxRect r1( r.x - sx2, r.y - sy2, sx2 * 2, sy2 * 2 );           // the bitmap extents
 
-    if( m_bShowName || (bwptVizOverride && !m_bPtIsSelected) ) {
+    bool bwptVizOver = bwptVizOverride && !(m_bPtIsSelected && g_btouch);
+    if( m_bShowName || bwptVizOver ) {
         if( 0 == m_pMarkFont ) {
             m_pMarkFont = FontMgr::Get().GetFont( _( "Marks" ) );
             m_FontColor = FontMgr::Get().GetFontColor( _( "Marks" ) );
@@ -644,7 +645,7 @@ void RoutePoint::Draw(ocpnDC& dc, ChartCanvas *canvas, wxPoint *rpn, bool boverr
         dc.CalcBoundingBox( r.x + sx2, r.y + sy2 );
     }
 
-    if( m_bShowName || (bwptVizOverride && !m_bPtIsSelected) ) {
+    if( m_bShowName || bwptVizOver ) {
         if( m_pMarkFont ) {
             dc.SetFont( *m_pMarkFont );
             dc.SetTextForeground( m_FontColor );
@@ -758,7 +759,8 @@ void RoutePoint::DrawGL( ViewPort &vp, ChartCanvas *canvas, bool use_cached_scre
     wxRect r1( r.x - sx2, r.y - sy2, sx2 * 2, sy2 * 2 );           // the bitmap extents
 
     wxRect r3 = r1;
-    if( m_bShowName || (bwptVizOverride && !m_bPtIsSelected) ) {
+    bool bwptVizOver = bwptVizOverride && !(m_bPtIsSelected && g_btouch);
+    if( m_bShowName || bwptVizOver ) {
         if( !m_pMarkFont ) {
             m_pMarkFont = FontMgr::Get().GetFont( _( "Marks" ) );
             m_FontColor = FontMgr::Get().GetFontColor( _( "Marks" ) );
@@ -890,7 +892,7 @@ void RoutePoint::DrawGL( ViewPort &vp, ChartCanvas *canvas, bool use_cached_scre
         glDisable(GL_TEXTURE_2D);
     }
 
-    if( (m_bShowName || (bwptVizOverride && !m_bPtIsSelected)) && m_pMarkFont ) {
+    if( (m_bShowName || bwptVizOver) && m_pMarkFont ) {
         int w = m_NameExtents.x, h = m_NameExtents.y;
         if(!m_iTextTexture && w && h) {
             wxBitmap tbm(w, h); /* render text on dc */

--- a/src/canvasMenu.cpp
+++ b/src/canvasMenu.cpp
@@ -1,4 +1,4 @@
-/***************************************************************************
+﻿/***************************************************************************
  *
  * Project:  OpenCPN
  * Purpose:  CanvasMenuHandler
@@ -155,6 +155,7 @@ enum
     ID_PASTE_TRACK,
     ID_RT_MENU_DELETE,
     ID_RT_MENU_REVERSE,
+    ID_RT_MENU_CHECK_WPTNVIZ,
     ID_RT_MENU_DELPOINT,
     ID_RT_MENU_ACTPOINT,
     ID_RT_MENU_DEACTPOINT,
@@ -257,7 +258,7 @@ void MenuPrepend1( wxMenu *menu, int id, wxString label)
 
 void MenuAppend1( wxMenu *menu, int id, wxString label)
 {
-    wxMenuItem *item = new wxMenuItem(menu, id, label);
+        wxMenuItem *item = new wxMenuItem(menu, id, label);
 #if defined(__WXMSW__)
    
     wxFont *qFont = GetOCPNScaledFont(_("Menu"));
@@ -640,7 +641,18 @@ if( !g_bBasicMenus && (nChartStack > 1 ) ) {
             MenuAppend1( menuRoute, ID_RT_MENU_COPY, _( "Copy as KML" ) + _T( "..." ) );
             MenuAppend1( menuRoute, ID_RT_MENU_DELETE, _( "Delete" ) + _T( "..." ) );
             MenuAppend1( menuRoute, ID_RT_MENU_REVERSE, _( "Reverse..." ) );
-
+            //Is there at least one wpt name not set visible
+            wxRoutePointListNode *node = m_pSelectedRoute->pRoutePointList->GetFirst();
+            while(node) {
+                RoutePoint *prp = node->GetData();
+                if( prp && !prp->m_bShowName ){
+                    MenuAppend1( menuRoute, ID_RT_MENU_CHECK_WPTNVIZ,
+                                 m_pSelectedRoute->GetOverrideWPNViz()?
+                                _( "Hide Wpt Names" ): _( "Show All Wpt Names" ) );
+                    break;
+                }
+                node = node->GetNext();
+            }
 //#ifndef __OCPN__ANDROID__
             wxString port = parent->FindValidUploadPort();
             parent->m_active_upload_port = port;
@@ -1314,7 +1326,15 @@ void CanvasMenuHandler::PopupMenuHandler( wxCommandEvent& event )
         }
         break;
     }
-
+    case ID_RT_MENU_CHECK_WPTNVIZ: {
+        if( m_pSelectedRoute->GetOverrideWPNViz() )
+            m_pSelectedRoute->SetOverrideWPNViz(false);
+        else
+             m_pSelectedRoute->SetOverrideWPNViz(true);
+        gFrame->InvalidateAllGL();
+        gFrame->RefreshAllCanvas();
+        break;
+    }
     case ID_RT_MENU_DELETE: {
         int dlg_return = wxID_YES;
         if( g_bConfirmObjectDelete ) {


### PR DESCRIPTION
I propose here to add a line in the route menu "Show All Wpt Names"
Selecting this menu will show  all the way point names of the selected route what ever are 
the way points setting. This concerns generally all route points created with the route.
Now clicking again on the same menu which is now "Hide Wpt Names" line will show way point names accordingly to the way points setting, hiding all with "ShowName" parameter not set. 
To avoid a double display of the yellow zone for common way point ( a route with name and possibly another
route without name), the function is deactivated for a selected way point in touch mode