### PR TITLE
Correct inversely positioned To and From info in NMEA0183 RMB messages

### DIFF
--- a/libs/nmea0183/src/rmb.cpp
+++ b/libs/nmea0183/src/rmb.cpp
@@ -132,8 +132,8 @@ bool RMB::Parse( const SENTENCE& sentence )
    IsDataValid = mode_valid ? sentence.Boolean( 1 ) : NFalse;
    CrossTrackError                 = sentence.Double( 2 );
    DirectionToSteer                = sentence.LeftOrRight( 3 );
-   From                            = sentence.Field( 4 );
-   To                              = sentence.Field( 5 );
+   To                              = sentence.Field( 4 );
+   From                            = sentence.Field( 5 );
    DestinationPosition.Parse( 6, 7, 8, 9, sentence );
    RangeToDestinationNauticalMiles = sentence.Double( 10 );
    BearingToDestinationDegreesTrue = sentence.Double( 11 );
@@ -159,8 +159,8 @@ bool RMB::Write( SENTENCE& sentence )
    else
        sentence += _T("R");
 
-   sentence += From;
    sentence += To;
+   sentence += From;
    sentence += DestinationPosition;
    sentence += RangeToDestinationNauticalMiles;
    sentence += BearingToDestinationDegreesTrue;
@@ -181,8 +181,8 @@ const RMB& RMB::operator = ( const RMB& source )
    IsDataValid                     = source.IsDataValid;
    CrossTrackError                 = source.CrossTrackError;
    DirectionToSteer                = source.DirectionToSteer;
-   From                            = source.From;
    To                              = source.To;
+   From                            = source.From;
    DestinationPosition             = source.DestinationPosition;
    RangeToDestinationNauticalMiles = source.RangeToDestinationNauticalMiles;
    BearingToDestinationDegreesTrue = source.BearingToDestinationDegreesTrue;

--- a/plugins/dashboard_pi/src/nmea0183/rmb.cpp
+++ b/plugins/dashboard_pi/src/nmea0183/rmb.cpp
@@ -118,8 +118,8 @@ bool RMB::Parse( const SENTENCE& sentence )
    IsDataValid                     = sentence.Boolean( 1 );
    CrossTrackError                 = sentence.Double( 2 );
    DirectionToSteer                = sentence.LeftOrRight( 3 );
-   From                            = sentence.Field( 4 );
-   To                              = sentence.Field( 5 );
+   To                              = sentence.Field( 4 );
+   From                            = sentence.Field( 5 );   
    DestinationPosition.Parse( 6, 7, 8, 9, sentence );
    RangeToDestinationNauticalMiles = sentence.Double( 10 );
    BearingToDestinationDegreesTrue = sentence.Double( 11 );
@@ -145,8 +145,8 @@ bool RMB::Write( SENTENCE& sentence )
    else
        sentence += _T("R");
 
-   sentence += From;
    sentence += To;
+   sentence += From;
    sentence += DestinationPosition;
    sentence += RangeToDestinationNauticalMiles;
    sentence += BearingToDestinationDegreesTrue;
@@ -166,8 +166,8 @@ const RMB& RMB::operator = ( const RMB& source )
    IsDataValid                     = source.IsDataValid;
    CrossTrackError                 = source.CrossTrackError;
    DirectionToSteer                = source.DirectionToSteer;
-   From                            = source.From;
    To                              = source.To;
+   From                            = source.From;
    DestinationPosition             = source.DestinationPosition;
    RangeToDestinationNauticalMiles = source.RangeToDestinationNauticalMiles;
    BearingToDestinationDegreesTrue = source.BearingToDestinationDegreesTrue;


### PR DESCRIPTION
This patch may fix:  [FS#2723 - NMEA RMB wrong waypoint IDs](https://opencpn.org/flyspray/index.php?do=details&task_id=2723)
The RMB fields 4) and 5) are switched at several places.

![bild](https://user-images.githubusercontent.com/7202854/101278834-61429700-37be-11eb-9600-d60d8f488451.png)
