### PR TITLE
ci: macos: Re-order dmg and pkg builds.

### DIFF
--- a/ci/generic-build-macos.sh
+++ b/ci/generic-build-macos.sh
@@ -59,10 +59,7 @@ make install # Dunno why the second is needed but it is, otherwise
              # plugin data is not included in the bundle
 
 make create-pkg
-
-#make create-dmg
-
-#test -z  "$BUILD_PKG" || make create-pkg
+make create-dmg
 
 # Install the stuff needed by upload.
 pip3 install -q cloudsmith-cli


### PR DESCRIPTION
It looks like _create-dmg_ has side effects and needs to run at the very end of build script.