### PR TITLE
Dialog color fixes

### DIFF
--- a/include/chart1.h
+++ b/include/chart1.h
@@ -58,6 +58,18 @@ wxFont GetOCPNGUIScaledFont( wxString item );
 
 wxArrayString *EnumerateSerialPorts(void);
 wxColour GetGlobalColor(wxString colorName);
+enum DialogColor
+{
+    DLG_BACKGROUND,
+    DLG_SELECTED_BACKGROUND,
+    DLG_UNSELECTED_BACKGROUND,
+    DLG_ACCENT,
+    DLG_SELECTED_ACCENT,
+    DLG_UNSELECTED_ACCENT,
+    DLG_TEXT,
+    DLG_HIGHLIGHT
+};
+wxColour GetDialogColor(DialogColor color);
 
 int GetApplicationMemoryUse(void);
 

--- a/plugins/chartdldr_pi/src/chartdldrgui.cpp
+++ b/plugins/chartdldr_pi/src/chartdldrgui.cpp
@@ -402,6 +402,22 @@ ChartPanel::ChartPanel(wxWindow *parent, wxWindowID id, const wxPoint &pos, cons
     wxString Descriptor = Name + _T("\n    ") + stat + _T("   ") + latest;
     wxColour bColor;
     GetGlobalColor(_T("DILG0"), &bColor);
+    bool bUseSysColors = false;
+#ifdef __WXOSX__
+    if( wxPlatformInfo::Get().CheckOSVersion(10, 14) )
+        bUseSysColors = true;
+#endif
+#ifdef __WXGTK__
+    bUseSysColors= true;
+#endif
+
+    if(bUseSysColors) {
+        wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
+        if(bg.Red() < 128) {
+            bColor = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
+        }
+    }
+
     SetBackgroundColour( bColor );
     
     wxBoxSizer* m_sizer = new wxBoxSizer(wxVERTICAL);

--- a/src/ConnectionParams.cpp
+++ b/src/ConnectionParams.cpp
@@ -368,37 +368,12 @@ void ConnectionParamsPanel::SetSelected( bool selected )
     
     if (selected)
     {
-        GetGlobalColor(_T("UIBCK"), &colour);
-        m_boxColour = colour;
+        m_boxColour = GetDialogColor(DLG_HIGHLIGHT);
     }
     else
     {
-        GetGlobalColor(_T("DILG0"), &colour);
-        m_boxColour = colour;
+        m_boxColour = GetDialogColor(DLG_BACKGROUND);
     }
-
-    
-    bool bUseSysColors = false;
-#ifdef __WXOSX__
-    if( wxPlatformInfo::Get().CheckOSVersion(10, 14) )
-        bUseSysColors = true;
-#endif
-#ifdef __WXGTK__
-    bUseSysColors= true;
-#endif    
-
-    if(bUseSysColors){
-        wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
-        if( bg.Red() < 128 ) {          // is Dark...
-            if(selected) {
-                m_boxColour=wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT/*wxSYS_COLOUR_WINDOW*/);
-            } else {
-                m_boxColour=wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
-            }
-        }
-    }
-
-
 
     wxWindowList kids = GetChildren();
     for( unsigned int i = 0; i < kids.GetCount(); i++ ) {

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -11578,6 +11578,83 @@ OCPNMessageDialog::OCPNMessageDialog( wxWindow *parent,
     Centre( wxBOTH | wxCENTER_FRAME);
 }
 
+wxColour GetDialogColor(DialogColor color)
+{
+    wxColour col = *wxRED;
+    
+    bool bUseSysColors = false;
+    bool bIsDarkMode = false;
+#ifdef __WXOSX__
+    if( wxPlatformInfo::Get().CheckOSVersion(10, 14) )
+        bUseSysColors = true;
+#endif
+#ifdef __WXGTK__
+    bUseSysColors= true;
+#endif
+
+    if(bUseSysColors) {
+        wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
+        if(bg.Red() < 128) {
+            bIsDarkMode = true;
+        }
+            
+    }
+    
+    switch(color) {
+        case DLG_BACKGROUND:
+            if(bUseSysColors && bIsDarkMode) {
+                col = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
+            } else {
+                col = GetGlobalColor("DILG0");
+            }
+            break;
+        case DLG_SELECTED_BACKGROUND:
+            if(bUseSysColors && bIsDarkMode) {
+                col = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+            } else {
+                col = GetGlobalColor("DILG1");
+            }
+            break;
+        case DLG_UNSELECTED_BACKGROUND:
+            if(bUseSysColors && bIsDarkMode) {
+                col = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
+            } else {
+                col = GetGlobalColor("DILG0");
+            }
+            break;
+        case DLG_ACCENT:
+        case DLG_SELECTED_ACCENT:
+            if(bUseSysColors && bIsDarkMode) {
+                col = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+            } else {
+                col = GetGlobalColor("DILG3");
+            }
+            break;
+        case DLG_UNSELECTED_ACCENT:
+            if(bUseSysColors && bIsDarkMode) {
+                col = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+            } else {
+                col = GetGlobalColor("DILG1");
+            }
+            break;
+        case DLG_TEXT:
+            if(bUseSysColors && bIsDarkMode) {
+                col = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT);
+            } else {
+                col = GetGlobalColor("DILG3");
+            }
+            break;
+        case DLG_HIGHLIGHT:
+            if(bUseSysColors && bIsDarkMode) {
+                col = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT);
+            } else {
+                col = GetGlobalColor("UIBCK");
+            }
+            break;
+    }
+    return col;
+}
+
 void OCPNMessageDialog::OnYes(wxCommandEvent& WXUNUSED(event))
 {
     SetReturnCode(wxID_YES);

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -843,17 +843,17 @@ class StatusIconPanel: public wxPanel
                 return;
             }
             
-            wxString color = "DILG0";
             int penWidth = m_penWidthUnselected;
+            wxColour border = GetDialogColor(DLG_UNSELECTED_ACCENT);
             
             if(m_parent->GetSelected()){
-                color = "DILG1";
                 penWidth = m_penWidthSelected;
+                border = GetDialogColor(DLG_SELECTED_ACCENT);
             }
             
-            wxBrush b(GetGlobalColor(color), wxSOLID);
+            wxBrush b(m_parent->GetBackgroundColour(), wxSOLID);
             dc.SetBrush(b);
-            dc.SetPen( wxPen(*wxBLACK, penWidth ));
+            dc.SetPen( wxPen(border, penWidth) );
 
             dc.DrawRoundedRectangle(-20, 5, GetSize().x-5, GetSize().y-10, 5);
             dc.DrawBitmap(m_bitmap, offset, offset*2, true);
@@ -6260,8 +6260,8 @@ void PluginPanel::SetSelected( bool selected )
     
 
     if (selected) {
-        m_status_icon->SetBackgroundColour(GetGlobalColor(_T("DILG1")));
-        SetBackgroundColour(GetGlobalColor(_T("DILG1")));
+        m_status_icon->SetBackgroundColour(GetDialogColor(DLG_SELECTED_BACKGROUND));
+        SetBackgroundColour(GetDialogColor(DLG_SELECTED_BACKGROUND));
         m_pButtons->Show(true);
         bool unInstallPossible = canUninstall(m_pPlugin->m_common_name.ToStdString());
         
@@ -6337,8 +6337,8 @@ void PluginPanel::SetSelected( bool selected )
         Layout();
     }
     else {
-        m_status_icon->SetBackgroundColour(GetGlobalColor(_T("DILG0")));
-        SetBackgroundColour(GetGlobalColor(_T("DILG0")));
+        m_status_icon->SetBackgroundColour(GetDialogColor(DLG_UNSELECTED_BACKGROUND));
+        SetBackgroundColour(GetDialogColor(DLG_UNSELECTED_BACKGROUND));
         //m_pDescription->SetLabel( m_pPlugin->m_short_description );
 #ifndef __WXQT__
         //m_pButtons->Show(false);
@@ -6368,26 +6368,15 @@ void PluginPanel::SetSelected( bool selected )
     
     Layout();
 
-    bool bUseSysColors = false;
-#ifdef __WXOSX__
-    if( wxPlatformInfo::Get().CheckOSVersion(10, 14) )
-        bUseSysColors = true;
-#endif
-#ifdef __WXGTK__
-    bUseSysColors= true;
-#endif    
 
-    if(bUseSysColors){
-        wxColour bg = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
-        if( bg.Red() < 128 ) {          // is Dark...
-            if(selected) {
-                SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
-                m_status_icon->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW));
-            } else {
-                SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE));
-                m_status_icon->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE));
-            }
-        }
+
+
+    if(selected) {
+                SetBackgroundColour(GetDialogColor(DLG_SELECTED_BACKGROUND));
+                m_status_icon->SetBackgroundColour(GetDialogColor(DLG_SELECTED_BACKGROUND));
+    } else {
+                SetBackgroundColour(GetDialogColor(DLG_UNSELECTED_BACKGROUND));
+                m_status_icon->SetBackgroundColour(GetDialogColor(DLG_UNSELECTED_BACKGROUND));
     }
 
     SetEnabled( m_pPlugin->m_bEnabled );
@@ -6411,17 +6400,19 @@ void PluginPanel::OnPaint(wxPaintEvent &event)
 {
     wxPaintDC dc( this );
     
-    wxString color = "DILG0";
-    
     int penWidth = m_penWidthUnselected;
-    if(m_bSelected){
-        color = "DILG1";
+    wxColour color = GetDialogColor(DLG_UNSELECTED_BACKGROUND);
+    wxColour border = GetDialogColor(DLG_UNSELECTED_ACCENT);
+    
+    if(m_bSelected) {
         penWidth = m_penWidthSelected;
+        color = GetDialogColor(DLG_SELECTED_BACKGROUND);
+        border = GetDialogColor(DLG_SELECTED_ACCENT);
     }
-        
-    wxBrush b(GetGlobalColor(color), wxSOLID);
+
+    wxBrush b(color, wxSOLID);
     dc.SetBrush(b);
-    dc.SetPen( wxPen(*wxBLACK, penWidth) );
+    dc.SetPen( wxPen(border, penWidth) );
  
     dc.DrawRoundedRectangle( 5, 5, GetSize().x - 10, GetSize().y - 10, 5);
     //dc.DrawLine( 5, 5, 1000, 5 ); 


### PR DESCRIPTION
Fixes for https://www.cruisersforum.com/forums/f134/invisible-text-in-mac-os-catalina-opencpn-5-2-a-243433.html

The colors for the dialogs are managed centrally through `GetDialogColor`, so we can work on getting rid of all the direct calls to `GetGlobalColor()` and get consistency throughout the whole application.

It also probably is a candidate for plugin API export.