### PR TITLE
Datetime from gps rpi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -86,7 +86,7 @@ addons:
   coverity_scan:
     project:
       name: OpenCPN/OpenCPN
-    notification_email: pavel@kalian.cz
+    notification_email: spam.plusminus@gmail.com
     build_command_prepend: mkdir -p build; cd build; cmake ..; make clean
     build_command: make
     branch_pattern: coverity_scan

--- a/include/chart1.h
+++ b/include/chart1.h
@@ -509,6 +509,7 @@ class MyFrame: public wxFrame
     wxMenuBar           *m_pMenuBar;
     int                 nBlinkerTick;
     bool                m_bTimeIsSet;
+    bool                m_bDateIsSet;
 
     wxTimer             InitTimer;
     int                 m_iInitCount;

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -9476,9 +9476,9 @@ void MyFrame::PostProcessNMEA( bool pos_valid, bool cog_sog_valid, const wxStrin
                 a = gRmcDate.Mid( 4, 2 );
                 if( a.ToLong( &b ) ) Fix_Time.SetYear(b+2000);//TODO fix this before the year 2100
                 wxString msg;
-                wxString CommandStr("sudo /bin/date  --utc --set=\"");
+                wxString CommandStr("sudo /bin/date --utc --set=\"");
                 CommandStr.Append( Fix_Time.Format("%D %T\"") );
-                msg.Printf(_T("Linux command is: %s"), CommandStr );
+                msg.Printf(_T("Set Date/Time, Linux command is: %s"), CommandStr );
                 wxLogMessage(msg);
                 wxExecute(CommandStr, wxEXEC_ASYNC);     
 #endif // !__WXMSW__


### PR DESCRIPTION
There is an option (hidden) for setting the system time from GPS already available in O. However to prevent loading bullshit times from some devices it has a build in limit of 2 hours difference between system hardware clock and GPS time.
This makes it not useable for systems without system hardware clock (eg Raspberry), where this function is most needed. 
This patch adds a check for an hw clock onboard, and if not forget about the 2 hours limit.
It is linux only, but afaik all small non clock boards are running linux.