### PR TITLE
Flatpak: broken build fixes, build distribution enhancements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
      environment:
        - OCPN_TARGET:  flatpak
      steps:
-       - run: cd ~; git clone https://github.com/OpenCPN/OpenCPN.git
+       - run: cd ~; git clone "$CIRCLE_REPOSITORY_URL" -b "$CIRCLE_BRANCH"
        - run: ci/docker-auth.sh
        - restore_cache:
            keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,8 @@ jobs:
      environment:
        - OCPN_TARGET:  flatpak
      steps:
-       - run: ci/docker-auth.sh
        - run: cd ~; git clone https://github.com/OpenCPN/OpenCPN.git
+       - run: ci/docker-auth.sh
        - restore_cache:
            keys:
               - fp-cache-v1-{{checksum "flatpak/org.opencpn.OpenCPN.yaml"}}

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -64,9 +64,19 @@ ccdecrypt --envvar FLATPAK_KEY id_opencpn.tar.cpt
 tar -xf id_opencpn.tar
 chmod 600 .ssh/id_opencpn
 
+# Old, published channel
 rsync -a --info=stats --delete-after \
     --rsh="ssh -o 'StrictHostKeyChecking no' -i .ssh/id_opencpn" \
     website/ opencpn@mumin.crabdance.com:/var/www/ocpn-flatpak/website
+
+# Seed the two masters in the opencpn cloud with new build
+rsync -a  --info=stats --rsh="ssh" website/ \
+    --delete-after \
+    rsync@mumin.crabdance.com:/home/rsync/flatpak/website
+rsync -a  --info=stats --rsh="ssh -p 2222" website/ \
+    --delete-after \
+    rsync@gafsan.crabdance.com:/home/rsync/flatpak/website
+
 rm -f .ssh/id_opencpn*
 
 # Restore the patched file so the caching works.

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -58,7 +58,7 @@ flatpak remote-add  \
 flatpak update --appstream local
 flatpak remote-ls local
 
-# Deploy website/ to deployment server.
+# Deploy website/ to deployment servers.
 cp ../ci/id_opencpn.tar.cpt .
 ccdecrypt --envvar FLATPAK_KEY id_opencpn.tar.cpt
 tar -xf id_opencpn.tar
@@ -70,12 +70,12 @@ rsync -a --info=stats --delete-after \
     website/ opencpn@mumin.crabdance.com:/var/www/ocpn-flatpak/website
 
 # Seed the two masters in the opencpn cloud with new build
-rsync -a  --info=stats --rsh="ssh" website/ \
-    --delete-after \
-    rsync@mumin.crabdance.com:/home/rsync/flatpak/website
-rsync -a  --info=stats --rsh="ssh -p 2222" website/ \
-    --delete-after \
-    rsync@gafsan.crabdance.com:/home/rsync/flatpak/website
+rsync -a --info=stats --delete-after \
+    --rsh="ssh -o 'StrictHostKeyChecking no' -i .ssh/id_opencpn" \
+    website/ rsync@mumin.crabdance.com:/home/rsync/flatpak/website
+rsync -a --info=stats --delete-after \
+    --rsh="ssh -p 2222 -o 'StrictHostKeyChecking no' -i .ssh/id_opencpn" \
+    website/ rsync@gafsan.crabdance.com:/home/rsync/flatpak/website
 
 rm -f .ssh/id_opencpn*
 
@@ -83,7 +83,7 @@ rm -f .ssh/id_opencpn*
 git checkout ../flatpak/org.opencpn.OpenCPN.yaml
 
 # Debug: show version in remote repo.
-flatpak remote-add --user opencpn $PWD/website/opencpn.flatpakrepo
+flatpak remote-add --user --no-gpg-verify opencpn $PWD/website/repo
 flatpak update --appstream opencpn
 flatpak remote-ls opencpn
 

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -13,7 +13,15 @@ fi
 
 set -xe
 
-test -d /opencpn-ci && cd /opencpn-ci || :
+# The flatpak manifest is setup to build the master branch. If we are
+# on another branch, make it match the manifest. However, unless 
+# FP_BUILD_ORIGINAL_BRANCH is set, this is not used anyway since the
+# default master branch from main github repo is used then.
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" != "master" ]; then
+    git branch -m $current_branch master
+fi
 
 wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
     | sudo apt-key add -
@@ -33,12 +41,17 @@ flatpak --user remote-add --if-not-exists \
 flatpak --user install -y org.freedesktop.Platform//18.08
 flatpak --user install -y org.freedesktop.Sdk//18.08
 
-# Patch to use official master branch from github and build + build number.
 cd flatpak
-sed -i -e '/url:/s|\.\.|https://github.com/OpenCPN/OpenCPN.git|' \
-    -e "/BUILD_NUMBER/s/0/$BUILD_NUMBER/" \
-    org.opencpn.OpenCPN.yaml
+# By default, script packages master branch from main github repo, as a
+# proper packagoing branch should do. Setting FP_BUILD_ORIGINAL_BRANCH
+# makes it build same branch as the script instead, for testing.
+if [ -z "$FP_BUILD_ORIGINAL_BRANCH" ]; then
+    sed -i -e '/url:/s|\.\.|https://github.com/OpenCPN/OpenCPN.git|' \
+        -e "/BUILD_NUMBER/s/0/$BUILD_NUMBER/" \
+        org.opencpn.OpenCPN.yaml
+fi
 
+# The build heavy lifting
 test -d ../build || mkdir ../build
 cd ../build
 make -f ../flatpak/Makefile build
@@ -70,14 +83,16 @@ rsync -a --info=stats --delete-after \
     website/ opencpn@mumin.crabdance.com:/var/www/ocpn-flatpak/website
 
 # Seed the two masters in the opencpn cloud with new build
-rsync -a --info=stats --delete-after \
-    --rsh="ssh -o 'StrictHostKeyChecking no' -i .ssh/id_opencpn" \
-    website/ rsync@mumin.crabdance.com:/home/rsync/flatpak/website
-rsync -a --info=stats --delete-after \
-    --rsh="ssh -p 2222 -o 'StrictHostKeyChecking no' -i .ssh/id_opencpn" \
-    website/ rsync@gafsan.crabdance.com:/home/rsync/flatpak/website
-
-rm -f .ssh/id_opencpn*
+if [ -n "$OCPN_CLOUD_TEST" ]; then
+    rsync -a --info=stats --delete-after \
+        --rsh="ssh -o 'StrictHostKeyChecking no' -i .ssh/id_opencpn" \
+        website/ rsync@mumin.crabdance.com:/home/rsync/flatpak/website
+    rsync -a --info=stats --delete-after \
+        --rsh="ssh -p 2222 -o 'StrictHostKeyChecking no' -i .ssh/id_opencpn" \
+        website/ rsync@gafsan.crabdance.com:/home/rsync/flatpak/website
+    
+    rm -f .ssh/id_opencpn*
+fi
 
 # Restore the patched file so the caching works.
 git checkout ../flatpak/org.opencpn.OpenCPN.yaml

--- a/flatpak/Makefile
+++ b/flatpak/Makefile
@@ -27,6 +27,7 @@ install: .phony
 	rm -rf $(DESTDIR); mkdir $(DESTDIR)
 	cp ../flatpak/repo/*flat* ../flatpak/repo/index.html $(DESTDIR)
 	cp -ar repo $(DESTDIR)
+	rm -f $(DESTDIR)/repo/.lock
 
 sign:   .phony
 	@test -d $(GPG_HOMEDIR) || { \

--- a/flatpak/Makefile
+++ b/flatpak/Makefile
@@ -60,4 +60,12 @@ publish:
 	    --delete-after \
 	    $(RSYNC_HOST):/var/www/ocpn-flatpak/website
 
+cloud-publish:
+	rsync -a  --info=stats --rsh="ssh" website/ \
+	    --delete-after \
+	    rsync@mumin.crabdance.com:/home/rsync/flatpak/website
+	rsync -a  --info=stats --rsh="ssh -p 2222" website/ \
+	    --delete-after \
+	    rsync@gafsan.crabdance.com:/home/rsync/flatpak/website
+
 .phony:

--- a/flatpak/Makefile
+++ b/flatpak/Makefile
@@ -6,7 +6,6 @@
 #   cd build; make -f ../flatpak/Makefile ...
 #
 
-BRANCH          ?= master
 GPG_KEY         ?= leamas@opencpn.org
 DESTDIR         ?= website
 GPG_HOMEDIR     ?= $(shell readlink -fn gpg)
@@ -18,6 +17,7 @@ all: build sign
 
 build:
 	flatpak-builder --repo=$(CURDIR)/repo --force-clean \
+	    --default-branch=devel \
 	    app ../flatpak/org.opencpn.OpenCPN.yaml
 	-flatpak uninstall --user -y org.opencpn.OpenCPN.Locale
 	flatpak install -y --user --reinstall \


### PR DESCRIPTION
Fix the broken flatpak build reported in #2132. penCPN/plugins/issues/295. This was about multiple errors.

Change the nightly builds so they are installed in the new *devel* branch making it possile to install flatpak nigtly builds in parallel with official builds from flathub.

Here is also several patches which only are in effect when doing test builds. By default, the flatpak packaging builds from the sources at the github master branch. This is correct, a packaging branch like flatpak should package the master branch. However, when testing the packaging there is a need to build from the same sources as the flatpak branch. This is now possible using special environment variables.

In particular, the  "ocpn cloud" test support is conditionalized on the environment and is not used in regular builds.

No changes to core opencpn, this is just about the ci setup.

Closes: #2132
Closes: #2141