### PR TITLE
Read SatsInView from GSV message #1 only

### DIFF
--- a/libs/nmea0183/src/gsv.cpp
+++ b/libs/nmea0183/src/gsv.cpp
@@ -55,6 +55,7 @@ GSV::~GSV()
 
 void GSV::Empty( void )
 {
+   MessageNumber = 0;
    SatsInView = 0;
 }
 
@@ -101,7 +102,7 @@ Where:
    ** Ignore the checksum...
    */
 
-
+   MessageNumber = sentence.Integer( 2 );
    SatsInView = sentence.Integer( 3 );
 
    return( TRUE );

--- a/libs/nmea0183/src/gsv.hpp
+++ b/libs/nmea0183/src/gsv.hpp
@@ -53,7 +53,8 @@ class GSV : public RESPONSE
       ** Data
       */
 
-      int   SatsInView;
+      int MessageNumber;
+      int SatsInView;
 
       /*
       ** Methods

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -857,12 +857,14 @@ void dashboard_pi::SetNMEASentence( wxString &sentence )
 
         else if( m_NMEA0183.LastSentenceIDReceived == _T("GSV") ) {
             if( m_NMEA0183.Parse() ) {
-                mSatsInView = m_NMEA0183.Gsv.SatsInView;
                 // m_NMEA0183.Gsv.NumberOfMessages;
-                SendSentenceToAllInstruments( OCPN_DBP_STC_SAT, m_NMEA0183.Gsv.SatsInView, _T("") );
-                SendSatInfoToAllInstruments( m_NMEA0183.Gsv.SatsInView,
-                        m_NMEA0183.Gsv.MessageNumber, m_NMEA0183.Gsv.SatInfo );
-
+                if (m_NMEA0183.Gsv.MessageNumber == 1) { 
+                    //Some GNSS print SatsInView in message #1 only
+                    mSatsInView = m_NMEA0183.Gsv.SatsInView;
+                    SendSentenceToAllInstruments (OCPN_DBP_STC_SAT, m_NMEA0183.Gsv.SatsInView, _T (""));
+                }
+                SendSatInfoToAllInstruments (mSatsInView,       //m_NMEA0183.Gsv.SatsInView,
+                                             m_NMEA0183.Gsv.MessageNumber, m_NMEA0183.Gsv.SatInfo);
                 mGPS_Watchdog = gps_watchdog_timeout_ticks;
             }
         }

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -863,7 +863,7 @@ void dashboard_pi::SetNMEASentence( wxString &sentence )
                     mSatsInView = m_NMEA0183.Gsv.SatsInView;
                     SendSentenceToAllInstruments (OCPN_DBP_STC_SAT, m_NMEA0183.Gsv.SatsInView, _T (""));
                 }
-                SendSatInfoToAllInstruments (mSatsInView,       //m_NMEA0183.Gsv.SatsInView,
+                SendSatInfoToAllInstruments (mSatsInView, 
                                              m_NMEA0183.Gsv.MessageNumber, m_NMEA0183.Gsv.SatInfo);
                 mGPS_Watchdog = gps_watchdog_timeout_ticks;
             }

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -9175,7 +9175,10 @@ void MyFrame::OnEvtOCPN_NMEA( OCPN_DataStreamEvent & event )
                 break;
 
             case GSV:
-                setSatelitesInView(m_NMEA0183.Gsv.SatsInView);
+                if (m_NMEA0183.Gsv.MessageNumber == 1) {
+                    // Some GNSS print SatsInView in message #1 only
+                    setSatelitesInView (m_NMEA0183.Gsv.SatsInView);
+                }
                 break;
 
             case GGA:


### PR DESCRIPTION
Some AirMar instruments do misuse the NMEA0183 GSV message.
The SatsInView info should have been printed in all of 1/2/3 messages in one group. Now they use only message No 1 for that and omit it in message 2 and 3. See message examples below.
The effect of this is the DB instrument Sats in view are fluctuating from 0 to actual value and the O GPS compass staples are also fluctuating.
With this patch we only read the first message of one group. No other harm with that for "normal" GPS. The SatsInView info in message 2(3) is not any new information.

Number of satellites is in field 3.  (here 10)
`12:28:02 $GPGSV,3,1,10,8,13,62,35,13,50,277,39,18,18,324,33,5,53,228,38*48<0x0D><0x0A>
 12:28:02 $GPGSV,,2,,7,43,71,39,30,73,107,38,27,13,26,34,15,14,289,37*7F<0x0D><0x0A>
 12:28:02 $GPGSV,,3,,14,33,150,40,28,26,155,37*44<0x0D><0x0A>

 12:28:04 $GPGSV,3,1,10,8,13,62,35,13,50,277,39,18,18,324,32,5,53,228,38*49<0x0D><0x0A>
 12:28:04 $GPGSV,,2,,7,43,71,38,30,73,107,38,27,13,26,34,15,14,289,37*7E<0x0D><0x0A>
 12:28:04 $GPGSV,,3,,14,33,150,40,28,26,155,36*45<0x0D><0x0A>`