### PR TITLE
GNSS. Prefer the number of satellites in use from ..GGA instead of ..GSV

### DIFF
--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -876,7 +876,7 @@ void dashboard_pi::SetNMEASentence( wxString &sentence )
                     if (m_NMEA0183.Gsv.MessageNumber == 1) {
                         //Some GNSS print SatsInView in message #1 only
                         mSatsInView = m_NMEA0183.Gsv.SatsInView;
-                        SendSentenceToAllInstruments (OCPN_DBP_STC_SAT, 
+                        SendSentenceToAllInstruments (OCPN_DBP_STC_SAT,
                                       m_NMEA0183.Gsv.SatsInView, _T (""));
                     }
                     SendSatInfoToAllInstruments (mSatsInView, 

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -1754,7 +1754,7 @@ void dashboard_pi::updateSKItem(wxJSONValue &item, wxString &sfixtime) {
             SendSentenceToAllInstruments(OCPN_DBP_STC_RSA, m_rudangle, _T("\u00B0"));
             mRSA_Watchdog = gps_watchdog_timeout_ticks;
         }
-        else if (update_path == _T("navigation.satellitesInView")) { //GNSS satellites
+        else if (update_path == _T("navigation.gnss.satellitesInView")) { //GNSS satellites
             if (mPriSatUsed >= 2) {
                 if (value.HasMember ("count") && value["count"].IsInt ()) {
                     double m_SK_SatsInView = (value["count"].AsInt ());

--- a/plugins/dashboard_pi/src/dashboard_pi.h
+++ b/plugins/dashboard_pi/src/dashboard_pi.h
@@ -194,6 +194,7 @@ private:
       short                mPriPosition, mPriCOGSOG, mPriHeadingM, mPriHeadingT; 
       short                mPriVar, mPriDateTime, mPriAWA, mPriTWA, mPriDepth;
       short                mPriSTW, mPriWTP, mPriATMP, mPriWDN, mPriSatStatus;
+      //Prio: Pos from O, SK gnss.satellites, GGA sats in use, SK gnss satellitesinView, GSV sats in view
       short                mPriSatUsed;
       double               mVar;
       // FFU

--- a/plugins/dashboard_pi/src/dashboard_pi.h
+++ b/plugins/dashboard_pi/src/dashboard_pi.h
@@ -193,17 +193,19 @@ private:
       NMEA0183             m_NMEA0183;                 // Used to parse NMEA Sentences
       short                mPriPosition, mPriCOGSOG, mPriHeadingM, mPriHeadingT; 
       short                mPriVar, mPriDateTime, mPriAWA, mPriTWA, mPriDepth;
-      short                mPriSTW, mPriWTP, mPriATMP, mPriWDN, mPriSats;
+      short                mPriSTW, mPriWTP, mPriATMP, mPriWDN, mPriSatStatus;
+      short                mPriSatUsed;
       double               mVar;
       // FFU
-      double               mSatsInView;
+      int                  mSatsInView;
       double               mHdm;
       wxDateTime           mUTCDateTime;
       int                  m_config_version;
       wxString             m_VDO_accumulator;
       int                  mHDx_Watchdog;
       int                  mHDT_Watchdog;
-      int                  mGPS_Watchdog;
+      int                  mSatsUsed_Wdog;
+      int                  mSatStatus_Wdog;
       int                  mVar_Watchdog;
       int                  mMWVA_Watchdog;
       int                  mMWVT_Watchdog;

--- a/src/SignalKEventHandler.cpp
+++ b/src/SignalKEventHandler.cpp
@@ -123,7 +123,7 @@ void SignalKEventHandler::updateItem(wxJSONValue &item, wxString &sfixtime) cons
             updateNavigationCourseOverGround(value, sfixtime);
         } else if(update_path == _T("navigation.courseOverGroundMagnetic"))
         {  // Ignore magnetic COG as OpenCPN don't handle yet.
-        } else if(update_path == _T("navigation.satellitesInView"))
+        } else if(update_path == _T("navigation.gnss.satellitesInView"))
         {
             updateGnssSatellites(value, sfixtime);
         } else if(update_path == _T("navigation.headingTrue"))


### PR DESCRIPTION
Now while using modern GNSS receivers when several GNSS system are available the use of NMEA sentences GSV has changed in its structure. There can be about twelve GSV message every second all including counts of satellites seen for each GNSS system. So numbers of satellites in view can alter between 1 to 14 or so.  
The GGA sentence though is used to indicate satellites in use for the fix calculation. The talker is then GN, GNGGA, indicating several GNSS system are used for the fix. 

Since both OCPN core and Dashboard now use both GGA and GSV simultaneously to catch satellites used for the upper right "GPS  bar" and the instrument "GPS in view" the result is a frequent "jumping".

This patch includes:
- Added a prioritizing so if GGA is present we prefer that before GSV for "satellites in use" 
- Changed the Dashboard instrument label  from "GNSS in view" to "GNSS in use" since that's what GGA reports. 
