### PR TITLE
appdata: Fix broken screenshot link (#2179)

### DIFF
--- a/data/opencpn.appdata.xml.in
+++ b/data/opencpn.appdata.xml.in
@@ -42,7 +42,7 @@
   <screenshots>
     <screenshot type="default">
       <caption>Main window</caption>
-      <image>http://download.opencpn.org/screenshots/82434783-624dea00-9a61-11ea-847b-347d91b8f0fd.png</image>
+      <image>https://download.opencpn.org/s/ZNRdz7K8XXdTxnR/download</image>
     </screenshot>
   </screenshots>
   <url type="homepage">https://opencpn.org/</url>


### PR DESCRIPTION
Fix broken link after update on opencpn.org. While on it, scale
image to recommended size and remove windows decorations.

Closes: #2179