### PR TITLE
Make s57chart::CompareLights obey sorting rules.

### DIFF
--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -5335,7 +5335,7 @@ wxString s57chart::GetAttributeValueAsString( S57attVal *pAttrVal, wxString Attr
 bool s57chart::CompareLights( const S57Light* l1, const S57Light* l2 )
 {
     int positionDiff = l1->position.Cmp( l2->position );
-    if( positionDiff != 0 ) return true;
+    if( positionDiff < 0 ) return true;
 
 
     int attrIndex1 = l1->attributeNames.Index( _T("SECTR1") );


### PR DESCRIPTION
Found a bug that could interfere with proper sorting of light coordinates.

There may be more going on here still but for now this patch kills a fatal exception in DEBUG mode.  The sort function expects the comparison function to return true if (left < right) but this function was returning true if the coordinates were !=.  That could cause the sort function to misbehave.