### PR TITLE
PM_Import_dialog Change init dir to Documents

### DIFF
--- a/include/pluginmanager.h
+++ b/include/pluginmanager.h
@@ -461,6 +461,7 @@ class CatalogMgrPanel: public wxPanel
     protected:
         wxString GetCatalogText(bool);
         void SetUpdateButtonLabel();
+        wxString GetImportInitDir();
 
         wxButton *m_updateButton, *m_advancedButton, *m_tarballButton;
         wxButton* m_adv_button;

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -5457,9 +5457,12 @@ void CatalogMgrPanel::OnTarballButton( wxCommandEvent &event)
 {
     // Present a file selector dialog to get the file name..
     wxString tarballPath;
-   int response = g_Platform->DoFileSelectorDialog( this, &tarballPath, _( "Select tarball file" ),
-                                                      g_Platform->GetPrivateDataDir(), wxEmptyString, wxT ( "tar files (*.tar.gz)|*.tar.gz|All Files (*.*)|*.*" ));
- 
+    int response = g_Platform->DoFileSelectorDialog( this, &tarballPath,
+                                                   _( "Select tarball file" ),
+                                                   GetImportInitDir(),
+                                                   wxEmptyString,
+                                                   wxT ( "tar files (*.tar.gz)|*.tar.gz|All Files (*.*)|*.*" ));
+      
     if( response == wxID_OK )
     {
         // Traverse the tarball to find the required "metadata.xml file
@@ -5672,8 +5675,15 @@ void CatalogMgrPanel::OnTarballButton( wxCommandEvent &event)
         if(m_PluginListPanel)
             m_PluginListPanel->ReloadPluginPanels(g_pi_manager->GetPlugInArray());
 
-        
-        
+        // Record the path to the last import file for next time
+        wxFileName f = tarballPath;
+        wxString used_path = f.GetPath(wxPATH_GET_VOLUME | wxPATH_NO_SEPARATOR);
+        if (used_path != wxEmptyString) {
+            pConfig->SetPath(_T("/PlugIns/"));
+            pConfig->Write("LatestImportDir", used_path);
+            pConfig->Flush();
+        }
+
         // Success!
         wxString msg = _("Plugin imported successfully");
         msg += _T("\n");
@@ -5718,8 +5728,19 @@ void CatalogMgrPanel::SetUpdateButtonLabel()
     m_updateButton->SetLabel(label);
     Layout();
 }
-    
 
+wxString CatalogMgrPanel::GetImportInitDir()
+{
+    // Check the config file for the last Import path.
+    pConfig->SetPath( _T("/PlugIns/") );
+    wxString lastImportDir;
+    lastImportDir = pConfig->Read(_T("LatestImportDir"),
+                    g_Platform->GetWritableDocumentsDir());
+    if ( wxDirExists(lastImportDir) ) {
+        return lastImportDir;
+    }
+    return ( g_Platform->GetWritableDocumentsDir() );
+}
 
 BEGIN_EVENT_TABLE( PluginListPanel, wxScrolledWindow )
 //EVT_BUTTON( ID_CMD_BUTTON_PERFORM_ACTION, PluginListPanel::OnPluginPanelAction )


### PR DESCRIPTION
Pluginmanager Import function now has "GetPrivateDataDir" as the initial directory. It's unlikely a user will save an imported file to a often hidden location. 
Change the default to users "Documents".
Also create a function to save the last used directory for next time import. (If found! Could be a USB stick)
