### PR TITLE
Adjust also SK-GGA-GSV prioritization to OCPN after SK's last updates

### DIFF
--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -9201,11 +9201,11 @@ void MyFrame::OnEvtOCPN_NMEA( OCPN_DataStreamEvent & event )
                 break;
 
             case GSV:
-                if (g_priSats >= 2) {
+                if (g_priSats >= 4) {
                     if (m_NMEA0183.Gsv.MessageNumber == 1) {
                         // Some GNSS print SatsInView in message #1 only
                         setSatelitesInView (m_NMEA0183.Gsv.SatsInView);
-                        g_priSats = 2;
+                        g_priSats = 4;
                     }
                 }
                 break;


### PR DESCRIPTION
The last part of this after SignalK updates. Next SK release will also include NMEA0183 GGA more reliable. This PR adjust also O's prioritization between "satellites in use" and "satellites in view".
Again; the reason for this is the new GNSS receivers message xxGSV and "Satellites in view" for each satellite system in a sequence that can make the GNSS status icon to flicker. Therefore it's better to favor "Satellites in use" from GGA when available. 
"Satellites in use" (for the fix calculation) reports the counts of the "best" satellites from all available system used for the fix calculation  