### PR TITLE
Split a route by right-click on a route point or a leg

### DIFF
--- a/include/canvasMenu.h
+++ b/include/canvasMenu.h
@@ -105,6 +105,9 @@ public:
       Route             *m_pSelectedRoute;
       Track             *m_pSelectedTrack;
       RoutePoint        *m_pFoundRoutePoint;
+	  Route				*m_pHead;			//for split function
+	  Route				*m_pTail;
+	  int				m_SelectedIdx;
       int               m_FoundAIS_MMSI;
       void *            m_pIDXCandidate;
       

--- a/src/Route.cpp
+++ b/src/Route.cpp
@@ -116,7 +116,7 @@ void Route::CloneRoute( Route *psourceroute, int start_nPoint, int end_nPoint, c
             RoutePoint *psourcepoint = psourceroute->GetPoint( i );
             RoutePoint *ptargetpoint = new RoutePoint( psourcepoint->m_lat, psourcepoint->m_lon,
                     psourcepoint->GetIconName(), psourcepoint->GetName(), wxEmptyString, false );
-
+			ptargetpoint->m_bShowName = psourcepoint->m_bShowName; //do not change new wpt's name visibility
             AddPoint( ptargetpoint, false );
         }
     }


### PR DESCRIPTION
The right-click context menu has a new option : Split ....
As an example let's start with a route namex with the points A;B;C;D
If we right-click on the point B, then select "split at waypoint"
the route  becomes:
first route namex-A  with A;B and  second route namex_B with B;C;D
this is exactly what does the split function in the route properties dialog
If we right-click on the leg B to C, then select "split around leg"
the route becomes:
first route namex_A with A;B and the second route namex_B with C;D
in this case the leg clicked B to C has disapeared