### PR TITLE
CI: Drop trusty builds (#2241)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,19 +14,6 @@ jobs:
        - run: cat /etc/apt/sources.list
        - run: ci/generic-build-debian.sh
        - run: ci/generic-upload.sh
-   build-trusty:
-     docker:
-       - image: circleci/buildpack-deps:trusty-scm
-         auth:
-           username: $DOCKER_USER
-           password: $DOCKER_PW
-     environment:
-       - OCPN_TARGET:  trusty
-     steps:
-       - checkout
-       - run: cat /etc/apt/sources.list
-       - run: ci/generic-build-debian.sh
-       - run: ci/generic-upload.sh
    build-mingw:
      docker:
          - image: fedora:33
@@ -90,11 +77,6 @@ workflows:
   build_all:
     jobs:
       - build-xenial:
-          filters:
-            branches:
-              only:
-                - master
-      - build-trusty:
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,12 +11,6 @@ jobs:
        - OCPN_TARGET:  xenial
      steps:
        - checkout
-       - run: >
-           echo "deb-src http://us.archive.ubuntu.com/ubuntu/ xenial main"
-           | sudo tee -a /etc/apt/sources.list
-       - run: >
-           echo "deb-src http://us.archive.ubuntu.com/ubuntu/ xenial-updates main"
-           | sudo tee -a /etc/apt/sources.list
        - run: cat /etc/apt/sources.list
        - run: ci/generic-build-debian.sh
        - run: ci/generic-upload.sh
@@ -30,12 +24,6 @@ jobs:
        - OCPN_TARGET:  trusty
      steps:
        - checkout
-       - run: >
-           echo "deb-src http://us.archive.ubuntu.com/ubuntu/ trusty main"
-           | sudo tee -a /etc/apt/sources.list
-       - run: >
-           echo "deb-src http://us.archive.ubuntu.com/ubuntu/ trusty-updates main"
-           | sudo tee -a /etc/apt/sources.list
        - run: cat /etc/apt/sources.list
        - run: ci/generic-build-debian.sh
        - run: ci/generic-upload.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,6 @@ matrix:
     - "./ci/generic-build-debian.sh"
   - if: branch IN (master, plugins, plugins-build)
     env:
-    - OCPN_TARGET=trusty
-    dist: trusty
-    compiler: gcc
-    script:
-    - "./ci/generic-build-debian.sh"
-  - if: branch IN (master, plugins, plugins-build)
-    env:
     - OCPN_TARGET=mingw
     services:
     - docker


### PR DESCRIPTION
This PR drops the trusty build from both Travis and CircleCI in separate commits.  If it's still necessary to support trusty, the circleci build which works could be left in place by dropping the last commit. However, for reasons described in #2241 I still suggest that we drop it completely by accepting this complete PR.

Closes: #2241