### PR TITLE
travis: drop cruft causing a bad build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,6 @@ matrix:
     compiler: gcc
     script:
     - "./ci/generic-build-debian.sh"
-  - if: branch IN (master, plugins, plugins-build)
-    env:
   - if: branch = flatpak
     env:
     - OCPN_TARGET=flatpak


### PR DESCRIPTION
There is cruft, probably caused by at rebase, which causes a bogus
travis build to start. Nuke it.