### PR TITLE
cmake/FindLibudev.cmake: Bugfix (#2290)

### DIFF
--- a/cmake/FindLibudev.cmake
+++ b/cmake/FindLibudev.cmake
@@ -36,7 +36,7 @@ find_path(UDEV_INCLUDE_DIR
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(
-  Libudev DEFAULT_MSG UDEV_LIBRARY UDEV_INCLUDE_DIR
+  UDEV DEFAULT_MSG UDEV_LIBRARY UDEV_INCLUDE_DIR
 )
 
 if(UDEV_FOUND)


### PR DESCRIPTION
Fix bad package name to find_package_handle_standard_args().

Closes: #2290