### PR TITLE
Ci macos 2300

### DIFF
--- a/buildosx/OpenCPN.pkgproj.in
+++ b/buildosx/OpenCPN.pkgproj.in
@@ -193,7 +193,7 @@ ${LIBARCHIVE_COMMENT_END}
                                                                                                                         <key>GID</key>
                                                                                                                         <integer>20</integer>
                                                                                                                         <key>PATH</key>
-                                                                                                                        <string>${CMAKE_INSTALL_PREFIX}/bin/OpenCPN.app/Contents/Frameworks/libzstd.1.4.9.dylib</string>
+                                                                                                                        <string>${CMAKE_INSTALL_PREFIX}/bin/OpenCPN.app/Contents/Frameworks/libzstd.1.5.0.dylib</string>
                                                                                                                         <key>PATH_TYPE</key>
                                                                                                                         <integer>0</integer>
                                                                                                                         <key>PERMISSIONS</key>

--- a/ci/generic-build-macos.sh
+++ b/ci/generic-build-macos.sh
@@ -75,9 +75,11 @@ make install # Dunno why the second is needed but it is, otherwise
 #  Or the second install kills it...
 #  So we do it explicitely.
 rm /tmp/opencpn/bin/OpenCPN.app/Contents/Frameworks/libpixman-1.0.dylib
-cp /usr/local/Cellar/pixman/0.40.0/lib/libpixman-1.0.40.0.dylib /tmp/opencpn/bin/OpenCPN.app/Contents/Frameworks/libpixman-1.0.dylib
+cp /usr/local/Cellar/pixman/0.*.*/lib/libpixman-1.0.*.*.dylib \
+    /tmp/opencpn/bin/OpenCPN.app/Contents/Frameworks/libpixman-1.0.dylib
 # and some dependencies which failed to get softlinks
-cp /usr/local/Cellar/zstd/1.4.9_1/lib/libzstd.1.4.9.dylib /tmp/opencpn/bin/OpenCPN.app/Contents/Frameworks/libzstd.1.dylib
+cp /usr/local/Cellar/zstd/1.[0-9].*/lib/libzstd.1.[0-9].*.dylib \
+    /tmp/opencpn/bin/OpenCPN.app/Contents/Frameworks/libzstd.1.dylib
 
 sudo ls -l /tmp/opencpn/bin/OpenCPN.app/Contents/Frameworks
 

--- a/cmake/FindPANGO.cmake
+++ b/cmake/FindPANGO.cmake
@@ -51,6 +51,7 @@ if(PANGO_LIBRARIES AND NOT PANGO_FOUND)
   target_compile_options(_PANGO INTERFACE "${PANGO_PKG_CFLAGS_OTHER}")
 
   find_path(PANGO_INCLUDE_DIR "pango/pango.h"
+      PATH_SUFFIXES pango-1.0
       HINTS ${PANGO_PKG_INCLUDE_DIRS})
   if(PANGO_INCLUDE_DIR)
     file(STRINGS "${PANGO_INCLUDE_DIR}/pango/pango-features.h"


### PR DESCRIPTION
Fix  a new cmake bug which seems to have surfaced after the 69228f627 fix.

While on it, add an alternative installation path for the pango headers. Hasn't arrived to Debian yet, but will no doubt do later.

Closes: #2300