### PR TITLE
Added multitouch zoom and rotation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -870,6 +870,10 @@ else( wxWidgets_VERSION_STRING)
     set(wxWidgets_VERSION_STRING "3.0")
 endif( wxWidgets_VERSION_STRING)
 
+if ( wxWidgets_VERSION_STRING VERSION_GREATER_EQUAL "3.1.1")
+    add_definitions("-DHAVE_WX_GESTURE_EVENTS")
+endif()
+
 message(STATUS "")
 message(STATUS "*** Staging to build ${PACKAGE_NAME}  ***")
 message(STATUS "*** Build type: ${CMAKE_BUILD_TYPE}")

--- a/include/chcanv.h
+++ b/include/chcanv.h
@@ -164,6 +164,25 @@ public:
       void SetCanvasCursor( wxMouseEvent& event );
       void OnKillFocus( wxFocusEvent& WXUNUSED(event) );
       void OnSetFocus( wxFocusEvent& WXUNUSED(event) );
+#ifdef HAVE_WX_GESTURE_EVENTS
+      void OnZoom(wxZoomGestureEvent& event);
+      void OnPan(wxPanGestureEvent& event);
+      void OnRotate(wxRotateGestureEvent& event);
+      void OnTwoFingerTap(wxTwoFingerTapEvent& event);
+      void OnLongPress(wxLongPressEvent& event);
+      void OnPressAndTap(wxPressAndTapEvent& event);
+
+      void OnLeftDown(wxMouseEvent& evt);
+      void OnLeftUp(wxMouseEvent& evt);
+
+      void OnRightUp(wxMouseEvent& event);
+      void OnRightDown(wxMouseEvent& event);
+
+      void OnDoubleLeftClick(wxMouseEvent& event);
+
+      void OnWheel(wxMouseEvent& event);
+      void OnMotion(wxMouseEvent& event);
+#endif /* HAVE_WX_GESTURE_EVENTS */
 
       void PopupMenuHandler(wxCommandEvent& event);
       bool IsPrimaryCanvas(){ return (m_canvasIndex == 0); }
@@ -400,6 +419,13 @@ public:
       int         m_upMode;
       bool        m_bLookAhead;
       double      m_VPRotate;
+
+#ifdef HAVE_WX_GESTURE_EVENTS
+      double      m_oldVPSScale;
+      double      m_oldRotationAngle;
+      bool        m_popupWanted;
+      bool        m_leftdown;
+#endif /* HAVE_WX_GESTURE_EVENTS */
 
       void DrawBlinkObjects( void );
 

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -1170,8 +1170,13 @@ void ChartCanvas::OnLeftUp(wxMouseEvent& event) {
 
     m_leftdown = false;
 
-    if (!m_popupWanted)
+    if (!m_popupWanted) {
+        wxMouseEvent ev(wxEVT_LEFT_UP);
+        ev.m_x = pos.x;
+        ev.m_y = pos.y;
+        MouseEvent(ev);
         return;
+    }
 
     m_popupWanted = false;
 

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -542,7 +542,9 @@ int attribs[] = { WX_GL_RGBA, WX_GL_DOUBLEBUFFER, WX_GL_DEPTH_SIZE, 16, WX_GL_ST
 BEGIN_EVENT_TABLE ( glChartCanvas, wxGLCanvas ) EVT_PAINT ( glChartCanvas::OnPaint )
     EVT_ACTIVATE ( glChartCanvas::OnActivate )
     EVT_SIZE ( glChartCanvas::OnSize )
+#ifndef HAVE_WX_GESTURE_EVENTS
     EVT_MOUSE_EVENTS ( glChartCanvas::MouseEvent )
+#endif /* HAVE_WX_GESTURE_EVENTS */
 END_EVENT_TABLE()
 
 glChartCanvas::glChartCanvas( wxWindow *parent, wxGLCanvas *share ) :
@@ -551,6 +553,31 @@ glChartCanvas::glChartCanvas( wxWindow *parent, wxGLCanvas *share ) :
 
 {
     m_pParentCanvas = dynamic_cast<ChartCanvas *>( parent );
+
+#ifdef HAVE_WX_GESTURE_EVENTS
+    if ( !EnableTouchEvents( wxTOUCH_ALL_GESTURES ))
+    {
+        wxLogError("Failed to enable touch events");
+        // Still bind event handlers just in case they still work?
+    }
+
+    Bind(wxEVT_GESTURE_ZOOM, &ChartCanvas::OnZoom, m_pParentCanvas);
+    Bind(wxEVT_GESTURE_PAN, &ChartCanvas::OnPan, m_pParentCanvas);
+    Bind(wxEVT_GESTURE_ROTATE, &ChartCanvas::OnRotate, m_pParentCanvas);
+    Bind(wxEVT_TWO_FINGER_TAP, &ChartCanvas::OnTwoFingerTap, m_pParentCanvas);
+    Bind(wxEVT_LONG_PRESS, &ChartCanvas::OnLongPress, m_pParentCanvas);
+    Bind(wxEVT_PRESS_AND_TAP, &ChartCanvas::OnPressAndTap, m_pParentCanvas);
+
+    Bind(wxEVT_RIGHT_UP, &ChartCanvas::OnRightUp, m_pParentCanvas);
+    Bind(wxEVT_RIGHT_DOWN, &ChartCanvas::OnRightDown, m_pParentCanvas);
+
+    Bind(wxEVT_LEFT_UP, &ChartCanvas::OnLeftUp, m_pParentCanvas);
+    Bind(wxEVT_LEFT_DOWN, &ChartCanvas::OnLeftDown, m_pParentCanvas);
+
+    Bind(wxEVT_MOUSEWHEEL, &ChartCanvas::OnWheel, m_pParentCanvas);
+    Bind(wxEVT_LEFT_DCLICK, &ChartCanvas::OnDoubleLeftClick, m_pParentCanvas);
+    Bind(wxEVT_MOTION, &ChartCanvas::OnMotion, m_pParentCanvas);
+#endif /* HAVE_WX_GESTURE_EVENTS */
 
     Init();
 }


### PR DESCRIPTION
This adds multitouch zoom and rotation support (with 2 fingers)
This requires a wxWidgets version that has the support
for gestures, that is to say, a version greater than 3.1.1

The pan gesture is not usable (tested with wxWidgets 3.1.5),
there are a lot of missed events. So dragging is done the old way with
the motion events.

Additionnaly to zoom, the left long press makes the context
menu appear, and the doubletap resets the rotation to zero.

Tested on a Lenovo T480 with touchscreen lcd.

Signed-off-by: Thierry Bultel <tbultel@free.fr>