### PR TITLE
Enable popup upon long press event

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -870,7 +870,8 @@ else( wxWidgets_VERSION_STRING)
     set(wxWidgets_VERSION_STRING "3.0")
 endif( wxWidgets_VERSION_STRING)
 
-if ( wxWidgets_VERSION_STRING VERSION_GREATER "3.1.0")
+# Enable zoom gesture
+if ( wxWidgets_VERSION_STRING VERSION_GREATER_EQUAL "3.1.1")
     add_definitions("-DHAVE_WX_GESTURE_EVENTS")
 endif()
 

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -875,10 +875,11 @@ ChartCanvas::ChartCanvas(wxFrame *frame, int canvasIndex)
   SetMinSize(wxSize(200, 200));
 
 #ifdef HAVE_WX_GESTURE_EVENTS
-//#ifndef ocpnUSE_GL
+  //#ifndef ocpnUSE_GL
 
-  if ( !EnableTouchEvents( wxTOUCH_ZOOM_GESTURE | wxTOUCH_PAN_GESTURES | wxTOUCH_PRESS_GESTURES )){
-      wxLogError("Failed to enable touch events");
+  if (!EnableTouchEvents(wxTOUCH_ZOOM_GESTURE | wxTOUCH_PAN_GESTURES |
+                         wxTOUCH_PRESS_GESTURES)) {
+    wxLogError("Failed to enable touch events");
   }
 
   Bind(wxEVT_GESTURE_ZOOM, &ChartCanvas::OnZoom, this);
@@ -897,7 +898,6 @@ ChartCanvas::ChartCanvas(wxFrame *frame, int canvasIndex)
   Bind(wxEVT_MOTION, &ChartCanvas::OnMotion, this);
 //#endif
 #endif
-
 }
 
 ChartCanvas::~ChartCanvas() {
@@ -1090,40 +1090,34 @@ void ChartCanvas::OnRouteFinishTimerEvent(wxTimerEvent &event) {
 }
 
 #ifdef HAVE_WX_GESTURE_EVENTS
-void ChartCanvas::OnLongPress(wxLongPressEvent& event) {
-
+void ChartCanvas::OnLongPress(wxLongPressEvent &event) {
   /* we defer the popup menu call upon the leftup event
   else the menu disappears immediately,
-  (see http://wxwidgets.10942.n7.nabble.com/Popupmenu-disappears-immediately-if-called-from-QueueEvent-td92572.html)
+  (see
+  http://wxwidgets.10942.n7.nabble.com/Popupmenu-disappears-immediately-if-called-from-QueueEvent-td92572.html)
   */
   m_popupWanted = true;
-
 }
 
-void ChartCanvas::OnPressAndTap(wxPressAndTapEvent& event) {
+void ChartCanvas::OnPressAndTap(wxPressAndTapEvent &event) {
   // not implemented yet
 }
 
-void ChartCanvas::OnRightUp(wxMouseEvent& event) {
-  MouseEvent(event);
-}
+void ChartCanvas::OnRightUp(wxMouseEvent &event) { MouseEvent(event); }
 
-void ChartCanvas::OnRightDown(wxMouseEvent& event) {
-  MouseEvent(event);
-}
+void ChartCanvas::OnRightDown(wxMouseEvent &event) { MouseEvent(event); }
 
-void ChartCanvas::OnLeftUp(wxMouseEvent& event) {
-
+void ChartCanvas::OnLeftUp(wxMouseEvent &event) {
   wxPoint pos = event.GetPosition();
 
   m_leftdown = false;
 
   if (!m_popupWanted) {
-      wxMouseEvent ev(wxEVT_LEFT_UP);
-      ev.m_x = pos.x;
-      ev.m_y = pos.y;
-      MouseEvent(ev);
-      return;
+    wxMouseEvent ev(wxEVT_LEFT_UP);
+    ev.m_x = pos.x;
+    ev.m_y = pos.y;
+    MouseEvent(ev);
+    return;
   }
 
   m_popupWanted = false;
@@ -1135,65 +1129,55 @@ void ChartCanvas::OnLeftUp(wxMouseEvent& event) {
   MouseEvent(ev);
 }
 
-void ChartCanvas::OnLeftDown(wxMouseEvent& event) {
-
+void ChartCanvas::OnLeftDown(wxMouseEvent &event) {
   m_leftdown = true;
 
   wxPoint pos = event.GetPosition();
   MouseEvent(event);
-
 }
 
-void ChartCanvas::OnMotion(wxMouseEvent& event) {
-    /* This is a workaround, to the fact that on touchscreen, OnMotion comes with dragging,
-       upon simple click, and without the OnLeftDown event before
-       Thus, this consists in skiping it, and setting the leftdown bit according to a status
-       that we trust */
+void ChartCanvas::OnMotion(wxMouseEvent &event) {
+  /* This is a workaround, to the fact that on touchscreen, OnMotion comes with
+     dragging, upon simple click, and without the OnLeftDown event before Thus,
+     this consists in skiping it, and setting the leftdown bit according to a
+     status that we trust */
   event.m_leftDown = m_leftdown;
   MouseEvent(event);
 }
 
-void ChartCanvas::OnPan(wxPanGestureEvent& event) {
-
+void ChartCanvas::OnPan(wxPanGestureEvent &event) {
   wxPoint delta = event.GetDelta();
   PanCanvas(-delta.x, -delta.y);
 }
 
-void ChartCanvas::OnZoom(wxZoomGestureEvent& event)
-{
-
+void ChartCanvas::OnZoom(wxZoomGestureEvent &event) {
   /* there are spurious end zoom events upon right-click */
-  if (event.IsGestureEnd())
-    return;
+  if (event.IsGestureEnd()) return;
 
   double factor = event.GetZoomFactor();
 
   if (event.IsGestureStart() || m_oldVPSScale < 0) {
-      m_oldVPSScale = GetVPScale();
+    m_oldVPSScale = GetVPScale();
   }
 
   double current_vps = GetVPScale();
-  double wanted_factor = m_oldVPSScale/current_vps*factor;
+  double wanted_factor = m_oldVPSScale / current_vps * factor;
 
-  ZoomCanvas( wanted_factor, true, false );
+  ZoomCanvas(wanted_factor, true, false);
 
   //  Allow combined zoom/pan operation
-  if(event.IsGestureStart()){
+  if (event.IsGestureStart()) {
     m_zoomStartPoint = event.GetPosition();
-  }
-  else{
+  } else {
     wxPoint delta = event.GetPosition() - m_zoomStartPoint;
     PanCanvas(-delta.x, -delta.y);
     m_zoomStartPoint = event.GetPosition();
   }
-
 }
 
-void ChartCanvas::OnWheel(wxMouseEvent& event) {
-  MouseEvent(event);
-}
+void ChartCanvas::OnWheel(wxMouseEvent &event) { MouseEvent(event); }
 
-void ChartCanvas::OnDoubleLeftClick(wxMouseEvent& event) {
+void ChartCanvas::OnDoubleLeftClick(wxMouseEvent &event) {
   DoRotateCanvas(0.0);
 }
 #endif /* HAVE_WX_GESTURE_EVENTS */
@@ -8340,7 +8324,6 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
               pSelect->AddSelectablePoint(
                   dragHandlePoint.m_y, dragHandlePoint.m_x,
                   m_pRoutePointEditTarget, SELTYPE_DRAGHANDLE);
-
             }
           } else {  // Deselect everything
             if (m_lastRoutePointEditTarget) {

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -877,7 +877,7 @@ ChartCanvas::ChartCanvas(wxFrame *frame, int canvasIndex)
 #ifdef HAVE_WX_GESTURE_EVENTS
 //#ifndef ocpnUSE_GL
 
-  if ( !EnableTouchEvents( wxTOUCH_ZOOM_GESTURE | wxTOUCH_PAN_GESTURES )){
+  if ( !EnableTouchEvents( wxTOUCH_ZOOM_GESTURE | wxTOUCH_PAN_GESTURES | wxTOUCH_PRESS_GESTURES )){
       wxLogError("Failed to enable touch events");
   }
 
@@ -1161,6 +1161,11 @@ void ChartCanvas::OnPan(wxPanGestureEvent& event) {
 
 void ChartCanvas::OnZoom(wxZoomGestureEvent& event)
 {
+
+  /* there are spurious end zoom events upon right-click */
+  if (event.IsGestureEnd())
+    return;
+
   double factor = event.GetZoomFactor();
 
   if (event.IsGestureStart() || m_oldVPSScale < 0) {

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -39,7 +39,7 @@
 #if defined(__UNIX__) && \
     !defined(__WXOSX__)  // high resolution stopwatch for profiling
 class OCPNStopWatch {
-public:
+ public:
   OCPNStopWatch() { Reset(); }
   void Reset() { clock_gettime(CLOCK_REALTIME, &tp); }
 
@@ -50,7 +50,7 @@ public:
            (tp_end.tv_nsec - tp.tv_nsec) / 1.e6;
   }
 
-private:
+ private:
   timespec tp;
 };
 #endif
@@ -98,7 +98,7 @@ private:
 #define GL_ETC1_RGB8_OES 0x8D64
 #endif
 
-#include "cm93.h"      // for chart outline draw
+#include "cm93.h"  // for chart outline draw
 #include "s57chart.h"  // for ArrayOfS57Obj
 #include "s52plib.h"
 
@@ -115,7 +115,7 @@ extern "C" void glOrthof(float left, float right, float bottom, float top,
 
 #endif
 
-#include "cm93.h"      // for chart outline draw
+#include "cm93.h"  // for chart outline draw
 #include "s57chart.h"  // for ArrayOfS57Obj
 #include "s52plib.h"
 
@@ -239,7 +239,7 @@ extern float g_ChartScaleFactorExp;
 extern MyFrame *gFrame;
 
 //#if defined(__MSVC__) && !defined(ocpnUSE_GLES) /* this compiler doesn't
-//support vla */ const #endif extern int g_mipmap_max_level;
+// support vla */ const #endif extern int g_mipmap_max_level;
 int panx, pany;
 
 bool glChartCanvas::s_b_useScissorTest;
@@ -552,11 +552,11 @@ int attribs[] = {WX_GL_RGBA, WX_GL_DOUBLEBUFFER, WX_GL_DEPTH_SIZE,
                  16,         WX_GL_STENCIL_SIZE, 8,
                  0};
 BEGIN_EVENT_TABLE(glChartCanvas, wxGLCanvas)
-EVT_PAINT(glChartCanvas::OnPaint) EVT_ACTIVATE(glChartCanvas::OnActivate)
-    EVT_SIZE(glChartCanvas::OnSize) EVT_MOUSE_EVENTS(glChartCanvas::MouseEvent)
-        END_EVENT_TABLE()
+EVT_PAINT(glChartCanvas::OnPaint)
+EVT_ACTIVATE(glChartCanvas::OnActivate) EVT_SIZE(glChartCanvas::OnSize)
+    EVT_MOUSE_EVENTS(glChartCanvas::MouseEvent) END_EVENT_TABLE()
 
-            glChartCanvas::glChartCanvas(wxWindow *parent, wxGLCanvas *share)
+        glChartCanvas::glChartCanvas(wxWindow *parent, wxGLCanvas *share)
     : wxGLCanvas(parent, wxID_ANY, attribs, wxDefaultPosition, wxSize(256, 256),
                  wxFULL_REPAINT_ON_RESIZE | wxBG_STYLE_CUSTOM, _T(""))
 
@@ -621,13 +621,13 @@ void glChartCanvas::Init() {
       NULL, this);
 
   Connect(GESTURE_EVENT_TIMER, wxEVT_TIMER,
-          (wxObjectEventFunction)(wxEventFunction)&glChartCanvas::
-              onGestureTimerEvent,
+          (wxObjectEventFunction)(
+              wxEventFunction)&glChartCanvas::onGestureTimerEvent,
           NULL, this);
 
   Connect(GESTURE_FINISH_TIMER, wxEVT_TIMER,
-          (wxObjectEventFunction)(wxEventFunction)&glChartCanvas::
-              onGestureFinishTimerEvent,
+          (wxObjectEventFunction)(
+              wxEventFunction)&glChartCanvas::onGestureFinishTimerEvent,
           NULL, this);
 
   Connect(
@@ -653,8 +653,9 @@ void glChartCanvas::Init() {
 
 //  Gesture support for platforms other than Android
 #ifdef HAVE_WX_GESTURE_EVENTS
-  if ( !EnableTouchEvents( wxTOUCH_ZOOM_GESTURE | wxTOUCH_PAN_GESTURES | wxTOUCH_PRESS_GESTURES )){
-      wxLogError("Failed to enable touch events");
+  if (!EnableTouchEvents(wxTOUCH_ZOOM_GESTURE | wxTOUCH_PAN_GESTURES |
+                         wxTOUCH_PRESS_GESTURES)) {
+    wxLogError("Failed to enable touch events");
   }
 
   Bind(wxEVT_GESTURE_ZOOM, &ChartCanvas::OnZoom, m_pParentCanvas);
@@ -1615,7 +1616,7 @@ void glChartCanvas::SetupCompression() {
     }
   }
 
-#ifdef ocpnUSE_GLES            /* gles doesn't have GetTexLevelParameter */
+#ifdef ocpnUSE_GLES /* gles doesn't have GetTexLevelParameter */
   g_tile_size = 512 * 512 / 2; /* 4bpp */
 #else
   /* determine compressed size of a level 0 single tile */
@@ -4329,7 +4330,7 @@ void glChartCanvas::Render() {
   // to accelerate drawing this frame (if overlapping)
   if (m_b_BuiltFBO && !m_bfogit && !scale_it && !bpost_hilite
       //&& VPoint.tilt == 0 // disabling fbo in tilt mode gives better quality
-      //but slower
+      // but slower
   ) {
     //  Is this viewpoint the same as the previously painted one?
     bool b_newview = true;

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -653,7 +653,7 @@ void glChartCanvas::Init() {
 
 //  Gesture support for platforms other than Android
 #ifdef HAVE_WX_GESTURE_EVENTS
-  if ( !EnableTouchEvents( wxTOUCH_ZOOM_GESTURE | wxTOUCH_PAN_GESTURES )){
+  if ( !EnableTouchEvents( wxTOUCH_ZOOM_GESTURE | wxTOUCH_PAN_GESTURES | wxTOUCH_PRESS_GESTURES )){
       wxLogError("Failed to enable touch events");
   }
 


### PR DESCRIPTION
This makes the popup come with long press,
which is usefull when using a touchscreen
without an additionnal mouse.

Tested on a Lenovo T480 with touchscreen lcd.

Signed-off-by: Thierry Bultel <tbultel@free.fr>