### PR TITLE
Add "object query" to show additional files for rastercharts and mbtiles

### DIFF
--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -5726,36 +5726,6 @@ wxString s57chart::CreateObjDescriptions(ListOfObjRazRules *rule_list) {
     }
   }  // Object for loop
 
-  // Add the additional info files
-  wxArrayString files;
-  file.Assign(GetFullPath());
-  wxString AddFiles = wxString::Format(
-      _T("<hr noshade><br><b>Additional info files attached to: </b> <font ")
-      _T("size=-2>%s</font><br><table border=0 cellspacing=0 cellpadding=3>"),
-      file.GetFullName());
-  file.Normalize();
-  file.Assign(file.GetPath(), wxT(""));
-  wxDir::GetAllFiles(file.GetFullPath(), &files, wxT("*.TXT"), wxDIR_FILES);
-  wxDir::GetAllFiles(file.GetFullPath(), &files, wxT("*.txt"), wxDIR_FILES);
-  if (files.Count() > 0) {
-    for (size_t i = 0; i < files.Count(); i++) {
-      file.Assign(files.Item(i));
-      AddFiles << wxString::Format(
-          _T("<tr><td valign=top><font size=-2><a ")
-          _T("href=\"%s\">%s</a></font></")
-          _T("td><td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp</td>"),
-          file.GetFullPath(), file.GetFullName());
-      if (files.Count() > ++i) {
-        file.Assign(files.Item(i));
-        AddFiles << wxString::Format(
-            _T("<td valign=top><font size=-2><a ")
-            _T("href=\"%s\">%s</a></font></td>"),
-            file.GetFullPath(), file.GetFullName());
-      }
-    }
-    ret_val << AddFiles << _T("</table>");
-  }
-
   if (!lights.empty()) {
     assert(curLight != nullptr);
 


### PR DESCRIPTION
The Objectwuery for vector charts is well known and also use to show additional information files. However for raster charts and mbtiles this doesn't work. There are no objects offcourse but sometimes there are additional info files.
This commit wil show those additional infofiles if available. If not, then nothing will happen. If only one file is attached it will be opened right away. 
If charts are shown using a plugin then the plugin is responsible for the objectquery info.
Commit has been tested on linux using ENC, KAP CM93 , mbTiles and O-chart_plugin
An example with a mbtiles chart using public available radar scan information for the netherland
![Screenshot_20210917_155130](https://user-images.githubusercontent.com/2668258/133794173-f6a754ed-f004-4577-9e92-29bae269ea8d.png)
s
