### PR TITLE
DB: GNSS Status instr: Omit GSV messages with all SNR fields empty.

### DIFF
--- a/plugins/dashboard_pi/src/gps.cpp
+++ b/plugins/dashboard_pi/src/gps.cpp
@@ -94,15 +94,17 @@ void DashboardInstrument_GPS::SetSatInfo(int cnt, int seq, wxString talk, SAT_IN
       m_SatCount = cnt;
       talkerID = talk;
 
-      // Some GPS receivers may emit more than 12 sats info
-      if (seq < 1 || seq > 3)
+      /* Some GNSS receivers may emit more than (3*4)=12 sats info.
+         We accept a group of sentences containing up to 5 messages but 
+         will only parse the first four.*/
+      if (seq < 1 || seq > 4)
           return;
 
       if (talkerID != wxEmptyString) {
-          // Switch view between the six GNSS system,
-          // mentioned in NMEA0183, when available.
-          // Show each system for 15 seconds.
-          // Time to shift?
+          /* Switch view between the six GNSS system
+             mentioned in NMEA0183, when available.
+             Show each system for 15 seconds.
+             Time to shift now? */
           wxDateTime now = wxDateTime::Now();
           wxTimeSpan sinceLastShift = now - m_lastShift;
           if (sinceLastShift.GetSeconds() >= 15){

--- a/plugins/dashboard_pi/src/nmea0183/gsv.cpp
+++ b/plugins/dashboard_pi/src/nmea0183/gsv.cpp
@@ -126,16 +126,20 @@ Where:
     NumberOfMessages = sentence.Integer( 1 );
     MessageNumber = sentence.Integer( 2 );
     SatsInView = sentence.Integer( 3 );
-
+    bool valid_SNR = false;
     for (int idx = 0; idx < satInfoCnt; idx++)
     {
-        SatInfo[idx].SatNumber = sentence.Integer( idx*4+4 );
-        SatInfo[idx].ElevationDegrees = sentence.Integer( idx*4+5 );
-        SatInfo[idx].AzimuthDegreesTrue = sentence.Integer( idx*4+6 );
-        SatInfo[idx].SignalToNoiseRatio = sentence.Integer( idx*4+7 );
+        SatInfo[idx].SatNumber = sentence.Integer( idx * 4 + 4 );
+        SatInfo[idx].ElevationDegrees = sentence.Integer( idx * 4 + 5 );
+        SatInfo[idx].AzimuthDegreesTrue = sentence.Integer( idx * 4 + 6 );
+        SatInfo[idx].SignalToNoiseRatio = sentence.Integer( idx * 4 + 7 );
+        if (!valid_SNR) {
+          if (SatInfo[idx].SignalToNoiseRatio > 0) valid_SNR = true;
+        }
     }
-
-    return( TRUE );
+    // Don't PreParse GSV messages with only zero or NULL SNR.
+    if ( valid_SNR ) return(TRUE); 
+    else return(FALSE);
 }
 
 bool GSV::Write( SENTENCE& sentence )


### PR DESCRIPTION
- From different "new" GNSS receivers I've seen GSV sentences without any satellites with a valid Signal to Noise Ratio. These messages are not valuable for our GNSS status instrument but more disturbing. This commit sort them out before being processed by the preparser function.
- Minor text adjustments. 