### PR TITLE
added vscode configuration file for headers paths

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+    "files.associations": {
+        "condition_variable": "cpp"
+    },
+    
+       "C_Cpp.default.includePath": [
+        ".",
+        "/usr/include", 
+        "include",
+        "/usr/include/wx-3.1",
+        "build/include",
+        "libs/nmea0183/src",
+        "libs/gdal/include",
+        "libs/sound/include",
+        "libs/iso8211/include",
+        "libs/wxcurl/include",
+        "libs/wxJSON/include",
+    ],
+}
+
+


### PR DESCRIPTION
VsCode cannot perform references lookup when
there are unresolved headers paths, leading
to harmfull code browsing.
This patch adds the needed, unconventional
include paths used by OpenCpn.

Signed-off-by: Thierry Bultel <thierry.bultel@iot.bzh>