### PR TITLE
MacOS: use new ABI specification darwin-wx31

### DIFF
--- a/cmake/TargetSetup.cmake
+++ b/cmake/TargetSetup.cmake
@@ -32,7 +32,7 @@ elseif (MSVC)
         set(PKG_TARGET_VERSION 10)
     endif ()
 elseif (APPLE)
-    set(PKG_TARGET "darwin")
+    set(PKG_TARGET "darwin-wx31")
     execute_process(COMMAND "sw_vers" "-productVersion"
                     OUTPUT_VARIABLE PKG_TARGET_VERSION)
 elseif (UNIX)

--- a/include/OCPNPlatform.h
+++ b/include/OCPNPlatform.h
@@ -60,10 +60,6 @@ public:
   std::vector<std::string> osd_names_like;
   std::string osd_arch;
   std::string osd_ID;
-  std::string osd_build_name;
-  std::string osd_build_version;
-  std::string osd_build_arch;
-  std::string osd_build_gtk;
 };
 
 //--------------------------------------------------------------------------

--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -355,10 +355,6 @@ bool OCPNPlatform::DetectOSDetail(OCPN_OSDetail *detail) {
   // We take some defaults from build-time definitions
   detail->osd_name = std::string(PKG_TARGET);
   detail->osd_version = std::string(PKG_TARGET_VERSION);
-  detail->osd_build_name = std::string(PKG_TARGET);
-  detail->osd_build_version = std::string(PKG_TARGET_VERSION);
-  detail->osd_build_arch = std::string(PKG_TARGET_ARCH);
-  detail->osd_build_gtk = std::string(PKG_BUILD_GTK);
 
   // Now parse by basic platform
 #ifdef __linux__

--- a/src/PluginHandler.cpp
+++ b/src/PluginHandler.cpp
@@ -289,7 +289,9 @@ bool PluginHandler::isCompatible(const PluginMetadata& metadata, const char* os,
   Host host(compatOS);
   Plugin plugin(metadata);
 
-  if (plugin.abi() == "msvc" || plugin.abi() == "darwin" ||
+  if (plugin.abi() == "msvc" ||
+      plugin.abi() == "darwin" ||
+      plugin.abi() == "darwin-wx31" ||
       plugin.abi() == "android-armeabi-v7a" ||
       plugin.abi() == "android-arm64-v8a") {
     bool ok = plugin.abi() == host.abi();


### PR DESCRIPTION
The 5.6.0 MacOS  will use wxWidgets 3.1.5.   This requires a new ABI spec, so that old clients does not try to load the wx 3.1.5 plugins and the othwer way around.

See: https://github.com/OpenCPN/plugins/pull/452