### PR TITLE
Don't allow "Insert/Happen (part of) this route ..." to ovoid mistake or confusing situation

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -7635,7 +7635,13 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                                            Undo_HasParent, NULL);
 
               tail = g_pRouteMan->FindVisibleRouteContainingWaypoint(pMousePoint);
-              if (tail) {
+			  bool procede = false;
+			  if (tail) {
+				  procede = true;
+				  if (pMousePoint == tail->GetLastPoint()) procede = false;
+				  if (m_routeState > 1 && m_pMouseRoute && tail == m_pMouseRoute) procede = false;
+			  }
+			  if (procede) {
                 int dlg_return;
                 m_FinishRouteOnKillFocus = false;
                 if (m_routeState == 1) {  // first point in new route, preceeding route to be added?  Not touch case
@@ -8158,7 +8164,13 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
               undo->BeforeUndoableAction(Undo_AppendWaypoint, pMousePoint,
                                          Undo_HasParent, NULL);
             tail = g_pRouteMan->FindVisibleRouteContainingWaypoint(pMousePoint);
-            if (tail) {
+			bool procede = false;
+			if (tail) {
+				procede = true;
+				if (pMousePoint == tail->GetLastPoint()) procede = false;
+				if (m_routeState > 1 && m_pMouseRoute && tail == m_pMouseRoute) procede = false;
+			}
+			if (procede) {
               int dlg_return;
               m_FinishRouteOnKillFocus = false;
               if (m_routeState == 1) {  // first point in new route, preceeding route to be added?  Not touch case


### PR DESCRIPTION
The new function allowing to insert or happen a route (or part of) in the new route being created works well. But there is two situations where it can create mistake or at least confusion.
1)when the user create a point  and try to use a nearby point already belonging the new route .Answering Yes to the question "Insert or happen (part of ) this route ... " means inserting  the new route into the new route...
1)when the user create a point  and try to use a nearby point which is the last point of another route. In this case, there is nothing to insert/happen. Answering yes or no is the same but it could be confusing
This patch eliminate this two situations