### PR TITLE
DB: Add $xxMDA airtemp as source

### DIFF
--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -1060,12 +1060,22 @@ void dashboard_pi::SetNMEASentence(wxString &sentence) {
          double   m_NMEA0183.Mda.Pressure;
          wxString m_NMEA0183.Mda.UnitOfMeasurement;
          */
-
         if (m_NMEA0183.Mda.Pressure > .8 && m_NMEA0183.Mda.Pressure < 1.1) {
           SendSentenceToAllInstruments(
               OCPN_DBP_STC_MDA, m_NMEA0183.Mda.Pressure * 1000,
               _T("hPa"));  // Convert to hpa befor sending to instruments.
-          mMDA_Watchdog = gps_watchdog_timeout_ticks;
+          mMDA_Watchdog = no_nav_watchdog_timeout_ticks;
+        }
+        if (mPriATMP >= 4) {
+          double airtemp = m_NMEA0183.Mda.AirTemp;
+          if (airtemp < 999.0) {
+            SendSentenceToAllInstruments(
+              OCPN_DBP_STC_ATMP,
+              toUsrTemp_Plugin(airtemp, g_iDashTempUnit),
+              getUsrTempUnit_Plugin(g_iDashTempUnit));
+            mATMP_Watchdog = no_nav_watchdog_timeout_ticks;
+            mPriATMP = 4;
+          }
         }
       }
 

--- a/plugins/dashboard_pi/src/nmea0183/mda.cpp
+++ b/plugins/dashboard_pi/src/nmea0183/mda.cpp
@@ -59,6 +59,7 @@ void MDA::Empty( void )
 
    Pressure = 0.0;
    UnitOfMeasurement.Empty();
+   AirTemp = 999.0;
 }
 
 bool MDA::Parse( const SENTENCE& sentence )
@@ -95,6 +96,7 @@ bool MDA::Parse( const SENTENCE& sentence )
 
 Pressure       = sentence.Double( 3 );
 UnitOfMeasurement = sentence.Field( 4 );
+AirTemp = sentence.Double(5);
 
 if(UnitOfMeasurement==wxT("B"))
 {

--- a/plugins/dashboard_pi/src/nmea0183/mda.hpp
+++ b/plugins/dashboard_pi/src/nmea0183/mda.hpp
@@ -53,7 +53,7 @@ class MDA : public RESPONSE
       ** Data
       */
 
-      double  Pressure;
+      double  Pressure, AirTemp;
       wxString UnitOfMeasurement;
 
       /*


### PR DESCRIPTION
Late change but some users with old instruments complained the air temperature was not shown in Dashboard. 
Added MDA: AirTemp although this is an obsolete sentence. 
Used the watchdog according to non navigational data.