### PR TITLE
Ci flatpak tls 2419

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
    build-flatpak:
      working_directory: ~/OpenCPN
      machine:
-         image: ubuntu-1604:201903-01
+       image: ubuntu-2004:202101-01
      environment:
        - OCPN_TARGET:  flatpak
      steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,6 +91,7 @@ workflows:
             branches:
               only:
                 - flatpak
+                - master
       - build-macos:
           filters:
             branches:

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -31,6 +31,9 @@ sudo apt-key adv \
 sudo add-apt-repository -y ppa:alexlarsson/flatpak
 sudo apt update -y
 
+# Avoid using outdated TLS certificates, see #2419.
+sudo apt install --reinstall  ca-certificates
+
 # Install required packages
 sudo apt install -q -y appstream flatpak flatpak-builder git ccrypt make rsync gnupg2
 


### PR DESCRIPTION
Update the TLS certificates before use to avoid errors described in #2419.

Incorporate the flatpak build in the ones done when updating master so errors gets noticed also here.


Closes: #2419