### PR TITLE
Format PR 2425

### DIFF
--- a/src/S57QueryDialog.cpp
+++ b/src/S57QueryDialog.cpp
@@ -246,7 +246,7 @@ void S57QueryDialog::OnHtmlLinkClicked(wxHtmlLinkEvent& event) {
         MessageHardBreakWrapper wrapper(ExtraObjInfoDlg->m_phtml, str,
                                         m_phtml->GetSize().x * 9 / 10);
         contents += wrapper.GetWrapped();
-        contents += _T("<br>");
+        contents += "<br>";
 
         str = txf.GetNextLine();
       } while (!txf.Eof());

--- a/src/S57QueryDialog.cpp
+++ b/src/S57QueryDialog.cpp
@@ -41,33 +41,30 @@ extern bool g_bresponsive;
 extern bool g_btouch;
 
 // Private class implementations
-class MessageHardBreakWrapper : public wxTextWrapper
-    {
-    public:
-        MessageHardBreakWrapper(wxWindow *win, const wxString& text, int widthMax)
-        {
-            m_lineCount = 0;
-            Wrap(win, text, widthMax);
-        }
-        wxString const& GetWrapped() const { return m_wrapped; }
-        int const GetLineCount() const { return m_lineCount; }
-        wxArrayString GetLineArray(){ return m_array; }
+class MessageHardBreakWrapper : public wxTextWrapper {
+public:
+  MessageHardBreakWrapper(wxWindow* win, const wxString& text, int widthMax) {
+    m_lineCount = 0;
+    Wrap(win, text, widthMax);
+  }
+  wxString const& GetWrapped() const { return m_wrapped; }
+  int const GetLineCount() const { return m_lineCount; }
+  wxArrayString GetLineArray() { return m_array; }
 
-    protected:
-        virtual void OnOutputLine(const wxString& line)
-        {
-            m_wrapped += line;
-            m_array.Add(line);
-        }
-        virtual void OnNewLine()
-        {
-            m_wrapped += '\n';
-            m_lineCount++;
-        }
-    private:
-        wxString m_wrapped;
-        int m_lineCount;
-        wxArrayString m_array;
+protected:
+  virtual void OnOutputLine(const wxString& line) {
+    m_wrapped += line;
+    m_array.Add(line);
+  }
+  virtual void OnNewLine() {
+    m_wrapped += '\n';
+    m_lineCount++;
+  }
+
+private:
+  wxString m_wrapped;
+  int m_lineCount;
+  wxArrayString m_array;
 };
 
 IMPLEMENT_CLASS(S57QueryDialog, wxFrame)
@@ -232,25 +229,26 @@ void S57QueryDialog::OnHtmlLinkClicked(wxHtmlLinkEvent& event) {
       GetParent(), wxID_ANY, _("Extra Object Info"),
       wxPoint(GetPosition().x + 20, GetPosition().y + 20),
       wxSize(g_S57_extradialog_sx, g_S57_extradialog_sy));
-  
-  //Check te kind of file, load text files serial and pictures direct
-  wxFileName filen( event.GetLinkInfo().GetHref() );
+
+  // Check te kind of file, load text files serial and pictures direct
+  wxFileName filen(event.GetLinkInfo().GetHref());
   wxString Extensions = wxString("txt,html,rtf");
 
-  if( Extensions.Find( filen.GetExt().Lower() )  == wxNOT_FOUND )
-    ExtraObjInfoDlg->m_phtml->LoadPage(event.GetLinkInfo().GetHref());   
-  else{      
-    wxTextFile txf( filen.GetFullPath() );
-    if(txf.Open()){
+  if (Extensions.Find(filen.GetExt().Lower()) == wxNOT_FOUND)
+    ExtraObjInfoDlg->m_phtml->LoadPage(event.GetLinkInfo().GetHref());
+  else {
+    wxTextFile txf(filen.GetFullPath());
+    if (txf.Open()) {
       wxString contents;
       wxString str;
       str = txf.GetFirstLine();
       do {
-      MessageHardBreakWrapper wrapper(ExtraObjInfoDlg->m_phtml, str, m_phtml->GetSize().x * 9 / 10);
-      contents += wrapper.GetWrapped();
-      contents += _T("<br>");
+        MessageHardBreakWrapper wrapper(ExtraObjInfoDlg->m_phtml, str,
+                                        m_phtml->GetSize().x * 9 / 10);
+        contents += wrapper.GetWrapped();
+        contents += _T("<br>");
 
-      str = txf.GetNextLine();
+        str = txf.GetNextLine();
       } while (!txf.Eof());
 
       ExtraObjInfoDlg->m_phtml->SetPage(contents);


### PR DESCRIPTION
As heading says: keep the consistent clang-format style broken by #2425.  While on it, drop  useless _T() macro in the new parts. 

No manual changes besides the _T() part. Part of a missionary mission...