### PR TITLE
wxGesture: removed handling of 'pan' events

### DIFF
--- a/include/chcanv.h
+++ b/include/chcanv.h
@@ -154,7 +154,6 @@ public:
   void OnSetFocus(wxFocusEvent &WXUNUSED(event));
 #ifdef HAVE_WX_GESTURE_EVENTS
   void OnZoom(wxZoomGestureEvent& event);
-  void OnPan(wxPanGestureEvent& event);
   void OnLongPress(wxLongPressEvent& event);
   void OnPressAndTap(wxPressAndTapEvent& event);
 

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -873,15 +873,12 @@ ChartCanvas::ChartCanvas(wxFrame *frame, int canvasIndex)
   SetMinSize(wxSize(200, 200));
 
 #ifdef HAVE_WX_GESTURE_EVENTS
-  //#ifndef ocpnUSE_GL
-
-  if (!EnableTouchEvents(wxTOUCH_ZOOM_GESTURE | wxTOUCH_PAN_GESTURES |
+  if (!EnableTouchEvents(wxTOUCH_ZOOM_GESTURE | 
                          wxTOUCH_PRESS_GESTURES)) {
     wxLogError("Failed to enable touch events");
   }
 
   Bind(wxEVT_GESTURE_ZOOM, &ChartCanvas::OnZoom, this);
-  Bind(wxEVT_GESTURE_PAN, &ChartCanvas::OnPan, this);
 
   Bind(wxEVT_LONG_PRESS, &ChartCanvas::OnLongPress, this);
   Bind(wxEVT_PRESS_AND_TAP, &ChartCanvas::OnPressAndTap, this);
@@ -894,7 +891,6 @@ ChartCanvas::ChartCanvas(wxFrame *frame, int canvasIndex)
 
   Bind(wxEVT_MOUSEWHEEL, &ChartCanvas::OnWheel, this);
   Bind(wxEVT_MOTION, &ChartCanvas::OnMotion, this);
-//#endif
 #endif
 }
 
@@ -1141,11 +1137,6 @@ void ChartCanvas::OnMotion(wxMouseEvent &event) {
      status that we trust */
   event.m_leftDown = m_leftdown;
   MouseEvent(event);
-}
-
-void ChartCanvas::OnPan(wxPanGestureEvent &event) {
-  wxPoint delta = event.GetDelta();
-  PanCanvas(-delta.x, -delta.y);
 }
 
 void ChartCanvas::OnZoom(wxZoomGestureEvent &event) {

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -657,13 +657,12 @@ void glChartCanvas::Init() {
 
 //  Gesture support for platforms other than Android
 #ifdef HAVE_WX_GESTURE_EVENTS
-  if (!EnableTouchEvents(wxTOUCH_ZOOM_GESTURE | wxTOUCH_PAN_GESTURES |
+  if (!EnableTouchEvents(wxTOUCH_ZOOM_GESTURE |
                          wxTOUCH_PRESS_GESTURES)) {
     wxLogError("Failed to enable touch events");
   }
 
   Bind(wxEVT_GESTURE_ZOOM, &ChartCanvas::OnZoom, m_pParentCanvas);
-  Bind(wxEVT_GESTURE_PAN, &ChartCanvas::OnPan, m_pParentCanvas);
 
   Bind(wxEVT_LONG_PRESS, &ChartCanvas::OnLongPress, m_pParentCanvas);
   Bind(wxEVT_PRESS_AND_TAP, &ChartCanvas::OnPressAndTap, m_pParentCanvas);


### PR DESCRIPTION
Pan events come additionnally to the MouseMove
events, that already perform the scrolling.
So when using them, the map slides twice as fast,
as bad side effect.
Moreover, pan events are stuck to 'X only' or
'Y only' moves, leading to bad user experience
when browsing the map.

This fix removes the handling of pan events

Signed-off-by: Thierry Bultel <tbultel@free.fr>