### PR TITLE
Removed unused/deprecated function MapBbox()

### DIFF
--- a/include/bbox.h
+++ b/include/bbox.h
@@ -49,7 +49,6 @@ public:
   void Reset();
 
   void Translate(wxPoint2DDouble&);
-  void MapBbox(const wxTransformMatrix& matrix);
 
   double GetWidth() const { return m_maxx - m_minx; };
   double GetHeight() const { return m_maxy - m_miny; };

--- a/include/bbox.h
+++ b/include/bbox.h
@@ -6,7 +6,6 @@
 #include "wx/wx.h"
 #endif
 
-#include "wx/matrix.h"
 #include "wx/geometry.h"
 
 enum OVERLAP { _IN, _ON, _OUT };

--- a/src/bbox.cpp
+++ b/src/bbox.cpp
@@ -266,39 +266,6 @@ wxBoundingBox& wxBoundingBox::operator=(const wxBoundingBox& other) {
   return *this;
 }
 
-void wxBoundingBox::MapBbox(const wxTransformMatrix& matrix) {
-  assert(m_validbbox == TRUE);
-
-  double x1, y1, x2, y2, x3, y3, x4, y4;
-
-  matrix.TransformPoint(m_minx, m_miny, x1, y1);
-  matrix.TransformPoint(m_minx, m_maxy, x2, y2);
-  matrix.TransformPoint(m_maxx, m_maxy, x3, y3);
-  matrix.TransformPoint(m_maxx, m_miny, x4, y4);
-
-  double xmin = wxMin(x1, x2);
-  xmin = wxMin(xmin, x3);
-  xmin = wxMin(xmin, x4);
-
-  double xmax = wxMax(x1, x2);
-  xmax = wxMax(xmax, x3);
-  xmax = wxMax(xmax, x4);
-
-  double ymin = wxMin(y1, y2);
-  ymin = wxMin(ymin, y3);
-  ymin = wxMin(ymin, y4);
-
-  double ymax = wxMax(y1, y2);
-  ymax = wxMax(ymax, y3);
-  ymax = wxMax(ymax, y4);
-
-  // Use these min and max values to set the new boundingbox
-  m_minx = xmin;
-  m_miny = ymin;
-  m_maxx = xmax;
-  m_maxy = ymax;
-}
-
 //----------------------------------------------------------------
 //    LLBBox Implementation
 //----------------------------------------------------------------


### PR DESCRIPTION
wxWidgets has deprecated wxTransformMatrix object used by now deprecated MapBbox() function.  So just remove MapBbox() altogether to avoid future confusion and compiler errors.