### PR TITLE
ci: Flatpak: Resurrect caching (#2475)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,10 +59,10 @@ jobs:
        - run: ci/docker-auth.sh
        - restore_cache:
            keys:
-              - fp-cache-v1-{{checksum "flatpak/org.opencpn.OpenCPN.yaml"}}
+              - fp-cache-v2-{{checksum "flatpak/org.opencpn.OpenCPN.yaml"}}
        - run: ci/circleci-build-flatpak.sh
        - save_cache:
-           key: fp-cache-v1-{{checksum "flatpak/org.opencpn.OpenCPN.yaml"}}
+           key: fp-cache-v2-{{checksum "flatpak/org.opencpn.OpenCPN.yaml"}}
            paths:
              - build/.flatpak-builder/cache
              - build/.flatpak-builder/ccache

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -59,7 +59,10 @@ fi
 # The build heavy lifting
 test -d ../build || mkdir ../build
 cd ../build
-make -f ../flatpak/Makefile build
+flatpak-builder --repo=repo --force-clean --default-branch=devel \
+    --state-dir=../cache  --delete-build-dirs \
+    app ../flatpak/org.opencpn.OpenCPN.yaml
+flatpak install -y --user --reinstall repo org.opencpn.OpenCPN
 flatpak list
 
 # Decrypt and unpack gpg keys, sign and install into website/


### PR DESCRIPTION
Cache the builds to avoid re-building wxWidgets et. al. each time. Still a slow build due to the two slow uploads to RPi-3 boxes, but shaves off some 10-15 minutes build time.

EDIT: there is more work to be done to make this faster, but we should IMHO first merge this.


Closes: #2475