### PR TITLE
Fix wrong desktop filename in appdata (#2503).

### DIFF
--- a/data/opencpn.appdata.xml.in
+++ b/data/opencpn.appdata.xml.in
@@ -10,7 +10,7 @@
   <provides>
     <binary>opencpn</binary>
   </provides>
-  <launchable type="desktop-id">org.opencpn.OpenCPN.desktop</launchable>
+  <launchable type="desktop-id">opencpn.desktop</launchable>
   <description>
     <p>
       A cross-platform ship-borne GUI navigation application made


### PR DESCRIPTION
Warnings from debian checks -- the GUI install is not able  start the program.

EDIT: This fix is applied to downstream Debian packaging.

Closes: #2503