### PR TITLE
Update linux and flatpak builds to wxWidgets 3.1.5 (#2396)

### DIFF
--- a/ci/control
+++ b/ci/control
@@ -24,6 +24,7 @@ Build-Depends: debhelper (>= 9),
  base-files (>=11) | libwxgtk-webview3.0-dev,
  libwxgtk3.1-gtk3-dev | libwxgtk3.0-gtk3-dev | base-files (<< 10),
  libwxgtk-webview3.1-gtk3-dev | libwxgtk-webview3.0-gtk3-dev | base-files (<< 10),
+ libwxsvg-dev | base-files (<< 11),
  portaudio19-dev
 
 # libwxsvg-dev | base-files (<< 11),

--- a/ci/control
+++ b/ci/control
@@ -21,12 +21,12 @@ Build-Depends: debhelper (>= 9),
  libusb-1.0-0-dev,
  base-files (>=11) | libwxgtk3.0-dev,
  base-files (>=11) | libwxgtk3.0-0v5 | libwxgtk3.0-0,
- libwxgtk3.0-gtk3-dev | base-files (<< 10),
  base-files (>=11) | libwxgtk-webview3.0-dev,
- libwxgtk-webview3.0-gtk3-dev | base-files (<< 10),
- libwxsvg-dev | base-files (<< 11),
+ libwxgtk3.1-gtk3-dev | libwxgtk3.0-gtk3-dev | base-files (<< 10),
+ libwxgtk-webview3.1-gtk3-dev | libwxgtk-webview3.0-gtk3-dev | base-files (<< 10),
  portaudio19-dev
 
+# libwxsvg-dev | base-files (<< 11),
 Standards-Version: 4.3.0
 Homepage: https://opencpn.org
 

--- a/ci/generic-build-debian.sh
+++ b/ci/generic-build-debian.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
 
 #
-# Build the Travis Debian artifacts
+# Build the Debian artifacts
 #
 set -xe
 sudo apt-get -qq update
 sudo apt-get install -q devscripts equivs
+
+if [ "$OCPN_TARGET" = focal-gtk3 ]; then
+    # Build against temporary wxWidgets 3.1 packaging (#2396)
+    sudo apt install -y software-properties-common
+    sudo add-apt-repository -y ppa:leamas-alec/wxwidgets
+    sudo apt-get -qq update
+fi
 
 mk-build-deps ./ci/control --install --root-cmd=sudo --remove
 sudo apt-get --allow-unauthenticated install -f

--- a/debian/control
+++ b/debian/control
@@ -26,12 +26,15 @@ Build-Depends: debhelper (>= 9),
  libusb-1.0-0-dev,
  base-files (>=11) | libwxgtk3.0-dev,
  base-files (>=11) | libwxgtk3.0-0v5 | libwxgtk3.0-0,
- libwxgtk3.0-gtk3-dev | base-files (<< 10),
- libwxsvg-dev | base-files (<< 11),
- libwxgtk-webview3.0-gtk3-dev | base-files (<< 10),
+ libwxgtk3.1-gtk3-dev | libwxgtk3.0-gtk3-dev | base-files (<< 10),
+ libwxgtk-webview3.1-gtk3-dev | libwxgtk-webview3.0-gtk3-dev | base-files (<< 10),
  base-files (>=10) | libwxgtk-webview3.0-dev,
+ libwxsvg-dev | base-files (<< 11),
  portaudio19-dev
+
 #For the ARM build, perhaps add: , libdri2-dev [armhf],libgles1-mesa-dev [armhf]
+#Temporarly removedb-d  until built against 3.1
+
 Standards-Version: 3.9.3
 Homepage: http://www.opencpn.org
 #Vcs-Git: git://git.debian.org/collab-maint/opencpn.git

--- a/flatpak/org.opencpn.OpenCPN.yaml
+++ b/flatpak/org.opencpn.OpenCPN.yaml
@@ -72,6 +72,10 @@ modules:
             path: src/Fix-missing-mouse-events-when-using-gesture-events-i.patch
           - type: patch
             path: src/warn-for-compiler-abi-mismatch.patch
+          - type: patch
+            path: src/0002-Fix-wxGTK-build-after-WXSetInitialFittingClientSize-.patch
+          - type: patch
+            path: src/0003-Make-wxSizer-SetSizeHints-work-again.patch
       config-opts:
           - --with-gtk=3
           - --with-opengl

--- a/flatpak/org.opencpn.OpenCPN.yaml
+++ b/flatpak/org.opencpn.OpenCPN.yaml
@@ -64,16 +64,20 @@ modules:
     - name: wxGTK3
       sources:
           - type: archive
-            url: https://github.com/wxWidgets/wxWidgets/releases/download/v3.0.4/wxWidgets-3.0.4.tar.bz2
-            sha256: 96157f988d261b7368e5340afa1a0cad943768f35929c22841f62c25b17bf7f0
+            url: https://github.com/wxWidgets/wxWidgets/releases/download/v3.1.5/wxWidgets-3.1.5.tar.bz2
+            sha256: d7b3666de33aa5c10ea41bb9405c40326e1aeb74ee725bb88f90f1d50270a224
+          - type: patch
+            path: src/doxyfile-update.patch
+          - type: patch
+            path: src/Fix-missing-mouse-events-when-using-gesture-events-i.patch
+          - type: patch
+            path: src/warn-for-compiler-abi-mismatch.patch
       config-opts:
           - --with-gtk=3
           - --with-opengl
           - --with-sdl
-          - --with-gnomeprint
           - --with-libmspack
           - --enable-intl
-          - --enable-no_deps
           - --disable-rpath
           - --enable-ipv6
       cleanup:

--- a/flatpak/src/0002-Fix-wxGTK-build-after-WXSetInitialFittingClientSize-.patch
+++ b/flatpak/src/0002-Fix-wxGTK-build-after-WXSetInitialFittingClientSize-.patch
@@ -1,0 +1,50 @@
+From 912f4b76ac42a79ff772cc9ea5cf8cb5c3f09960 Mon Sep 17 00:00:00 2001
+From: Vadim Zeitlin <vadim@wxwidgets.org>
+Date: Sat, 24 Jul 2021 19:15:55 +0200
+Subject: [PATCH] Fix wxGTK build after WXSetInitialFittingClientSize() change
+
+This should have been part of 136574b1e0 (Make wxSizer::SetSizeHints()
+work again, 2021-07-24).
+
+See #19170.
+
+Applied-upstream: https://github.com/wxWidgets/wxWidgets/commit/912f4b7
+---
+ include/wx/gtk/toplevel.h | 2 +-
+ src/gtk/toplevel.cpp      | 5 +++--
+ 2 files changed, 4 insertions(+), 3 deletions(-)
+
+diff --git a/include/wx/gtk/toplevel.h b/include/wx/gtk/toplevel.h
+index 88abfd03cf..b057a4a0ce 100644
+--- a/include/wx/gtk/toplevel.h
++++ b/include/wx/gtk/toplevel.h
+@@ -143,7 +143,7 @@ public:
+ 
+     virtual void SetMinSize(const wxSize& minSize) wxOVERRIDE;
+ 
+-    virtual void WXSetInitialFittingClientSize(int flags) wxOVERRIDE;
++    virtual void WXSetInitialFittingClientSize(int flags, wxSizer* sizer = NULL) wxOVERRIDE;
+ 
+ private:
+     // Flags to call WXSetInitialFittingClientSize() with if != 0.
+diff --git a/src/gtk/toplevel.cpp b/src/gtk/toplevel.cpp
+index 6060a7a3ac..6b01391e3e 100644
+--- a/src/gtk/toplevel.cpp
++++ b/src/gtk/toplevel.cpp
+@@ -1567,10 +1567,11 @@ void wxTopLevelWindowGTK::SetMinSize(const wxSize& minSize)
+     m_pendingFittingClientSizeFlags &= ~wxSIZE_SET_MIN;
+ }
+ 
+-void wxTopLevelWindowGTK::WXSetInitialFittingClientSize(int flags)
++void
++wxTopLevelWindowGTK::WXSetInitialFittingClientSize(int flags, wxSizer* sizer)
+ {
+     // In any case, update the size immediately.
+-    wxTopLevelWindowBase::WXSetInitialFittingClientSize(flags);
++    wxTopLevelWindowBase::WXSetInitialFittingClientSize(flags, sizer);
+ 
+     // But if we're not shown yet, the fitting size may be wrong because GTK
+     // style cache hasn't been updated yet and we need to do it again when the
+-- 
+2.33.0
+

--- a/flatpak/src/0003-Make-wxSizer-SetSizeHints-work-again.patch
+++ b/flatpak/src/0003-Make-wxSizer-SetSizeHints-work-again.patch
@@ -1,0 +1,91 @@
+From 136574b1e0ca3a7165d379261952dfb3fb2f5ca6 Mon Sep 17 00:00:00 2001
+From: Vadim Zeitlin <vadim@wxwidgets.org>
+Date: Sat, 24 Jul 2021 16:59:14 +0100
+Subject: [PATCH] Make wxSizer::SetSizeHints() work again
+
+This function was broken when it was called for a window which was not
+the window the sizer was associated with since the recent (pre-3.1.5)
+changes trying to work around the problem with the initial windows size
+when using GTK 3, see 9c0a8be1dc (Merge branch 'gtk-initial-size',
+2021-04-13).
+
+Fix it by passing the sizer to use for calculating the size explicitly
+to WXSetInitialFittingClientSize() when we have it, and only falling
+back on the window's own sizer if we don't.
+
+Closes #19170.
+Applied-upstream: https://github.com/wxWidgets/wxWidgets/commit/136574b1e0ca3a
+---
+ include/wx/window.h   |  6 +++++-
+ src/common/sizer.cpp  |  5 +++--
+ src/common/wincmn.cpp | 12 +++++++++---
+ 3 files changed, 17 insertions(+), 6 deletions(-)
+
+diff --git a/include/wx/window.h b/include/wx/window.h
+index 794d7a0a15..393d71ba49 100644
+--- a/include/wx/window.h
++++ b/include/wx/window.h
+@@ -1571,7 +1571,11 @@ public:
+     // that we really need to use is not known until the window is actually
+     // shown, as is the case for TLWs with recent GTK versions, as it will
+     // update the size again when it does become known, if necessary.
+-    virtual void WXSetInitialFittingClientSize(int flags);
++    //
++    // The optional sizer argument can be passed to use the given sizer for
++    // laying out the window, which is useful if this function is called before
++    // SetSizer(). By default the window sizer is used.
++    virtual void WXSetInitialFittingClientSize(int flags, wxSizer* sizer = NULL);
+ 
+         // get the handle of the window for the underlying window system: this
+         // is only used for wxWin itself or for user code which wants to call
+diff --git a/src/common/sizer.cpp b/src/common/sizer.cpp
+index 755ba7fd3e..3b18ac910f 100644
+--- a/src/common/sizer.cpp
++++ b/src/common/sizer.cpp
+@@ -1079,7 +1079,7 @@ wxSize wxSizer::Fit( wxWindow *window )
+     wxCHECK_MSG( window, wxDefaultSize, "window can't be NULL" );
+ 
+     // set client size
+-    window->WXSetInitialFittingClientSize(wxSIZE_SET_CURRENT);
++    window->WXSetInitialFittingClientSize(wxSIZE_SET_CURRENT, this);
+ 
+     // return entire size
+     return window->GetSize();
+@@ -1119,7 +1119,8 @@ void wxSizer::SetSizeHints( wxWindow *window )
+ {
+     // Preserve the window's max size hints, but set the
+     // lower bound according to the sizer calculations.
+-    window->WXSetInitialFittingClientSize(wxSIZE_SET_CURRENT | wxSIZE_SET_MIN);
++    window->WXSetInitialFittingClientSize(wxSIZE_SET_CURRENT | wxSIZE_SET_MIN,
++                                          this);
+ }
+ 
+ #if WXWIN_COMPATIBILITY_2_8
+diff --git a/src/common/wincmn.cpp b/src/common/wincmn.cpp
+index bb8127670c..a851b371ce 100644
+--- a/src/common/wincmn.cpp
++++ b/src/common/wincmn.cpp
+@@ -999,11 +999,17 @@ wxSize wxWindowBase::WindowToClientSize(const wxSize& size) const
+                   size.y == -1 ? -1 : size.y - diff.y);
+ }
+ 
+-void wxWindowBase::WXSetInitialFittingClientSize(int flags)
++void wxWindowBase::WXSetInitialFittingClientSize(int flags, wxSizer* sizer)
+ {
+-    wxSizer* const sizer = GetSizer();
++    // Use the window sizer by default.
+     if ( !sizer )
+-        return;
++    {
++        sizer = GetSizer();
++
++        // If there is none, we can't compute the fitting size.
++        if ( !sizer )
++            return;
++    }
+ 
+     const wxSize
+         size = sizer->ComputeFittingClientSize(static_cast<wxWindow *>(this));
+-- 
+2.33.0
+

--- a/flatpak/src/Fix-missing-mouse-events-when-using-gesture-events-i.patch
+++ b/flatpak/src/Fix-missing-mouse-events-when-using-gesture-events-i.patch
@@ -1,0 +1,164 @@
+From 746da37c4d569c024c3b92a6b198eaa50b5368fe Mon Sep 17 00:00:00 2001
+From: Thierry Bultel <tbultel@free.fr>
+Date: Mon, 27 Sep 2021 14:00:16 +0200
+Subject: [PATCH] Fix missing mouse events when using gesture events in wxGTK
+
+When touch events were enabled, normal mouse move and click events were
+not generated any longer. Fix this by doing the following two things:
+
+First, emulate the LeftDown, LeftUp, and Motion events, that are no
+longer triggered when using the "touch-event".
+
+In addition, remove GDK_BUTTON1_MASK in the press callback, that is
+never set when using a mouse, but that is set for some reason by GTK
+when using a touchscreen.
+
+See https://github.com/wxWidgets/wxWidgets/pull/2539
+
+Closes #19265.
+
+Signed-off-by: Thierry Bultel <tbultel@free.fr>
+
+Applied-Upstream: https://github.com/wxWidgets/wxWidgets/commit/746da37
+---
+ src/gtk/window.cpp | 94 +++++++++++++++++++++++++++++++++++++++++++++-
+ 1 file changed, 93 insertions(+), 1 deletion(-)
+
+diff --git a/src/gtk/window.cpp b/src/gtk/window.cpp
+index ba59cb5cdd..b9fc42d760 100644
+--- a/src/gtk/window.cpp
++++ b/src/gtk/window.cpp
+@@ -1594,6 +1594,13 @@ gtk_window_button_press_callback( GtkWidget* WXUNUSED_IN_GTK3(widget),
+                                   GdkEventButton *gdk_event,
+                                   wxWindowGTK *win )
+ {
++    /*
++      GTK does not set the button1 mask when the event comes from the left
++      button of a mouse. but for some reason, it sets it when the event comes
++      from a touchscreen, so we simply remove it here for consistency.
++    */
++    gdk_event->state &= ~GDK_BUTTON1_MASK;
++
+     wxPROCESS_EVENT_ONCE(GdkEventButton, gdk_event);
+ 
+     wxCOMMON_CALLBACK_PROLOGUE(gdk_event, win);
+@@ -3371,9 +3378,91 @@ wxEmitPressAndTapEvent(GdkEventTouch* gdk_event, wxWindow* win)
+     win->GTKProcessEvent(event);
+ }
+ 
++namespace
++{
++
++template <typename EventType>
++void
++wxEventMouseFromEventTouch(EventType* event,
++                           const GdkEventTouch* gdk_event_touch)
++{
++    event->window = gdk_event_touch->window;
++    event->send_event = gdk_event_touch->send_event;
++    event->time = gdk_event_touch->time;
++    event->x = gdk_event_touch->x;
++    event->y = gdk_event_touch->y;
++    event->axes = gdk_event_touch->axes;
++    event->state = gdk_event_touch->state;
++    event->device = gdk_event_touch->device;
++    event->x_root = gdk_event_touch->x_root;
++    event->y_root = gdk_event_touch->y_root;
++}
++
++void
++wxEventButtonFromEventTouch(GdkEventButton* gdk_event_button,
++                            const GdkEventTouch* gdk_event_touch)
++{
++    wxEventMouseFromEventTouch(gdk_event_button, gdk_event_touch);
++
++    gdk_event_button->type = GDK_BUTTON_PRESS;
++    gdk_event_button->button = 1; // left button
++}
++
++void
++wxEventMotionFromEventTouch(GdkEventMotion* gdk_event_motion,
++                            const GdkEventTouch* gdk_event_touch)
++{
++    wxEventMouseFromEventTouch(gdk_event_motion, gdk_event_touch);
++
++    gdk_event_motion->type = GDK_MOTION_NOTIFY;
++    gdk_event_motion->is_hint = true;
++}
++
++void
++wxEmulateLeftDownEvent(GtkWidget* widget, GdkEventTouch* gdk_event, wxWindow* win)
++{
++    GdkEventButton gdk_event_button;
++
++    if (!gdk_event->emulating_pointer)
++        return;
++
++    wxEventButtonFromEventTouch(&gdk_event_button, gdk_event);
++    gtk_window_button_press_callback( widget,
++                                      &gdk_event_button,
++                                      win );
++}
++
++void
++wxEmulateLeftUpEvent(GtkWidget* widget,GdkEventTouch* gdk_event, wxWindow* win)
++{
++    GdkEventButton gdk_event_button;
++
++    if (!gdk_event->emulating_pointer)
++        return;
++
++    wxEventButtonFromEventTouch(&gdk_event_button, gdk_event);
++    gtk_window_button_release_callback( widget,
++                                        &gdk_event_button,
++                                        win );
++}
++
++void
++wxEmulateMotionEvent(GtkWidget* widget, GdkEventTouch* gdk_event, wxWindow* win)
++{
++    GdkEventMotion gdk_event_motion;
++
++    if (!gdk_event->emulating_pointer)
++        return;
++
++    wxEventMotionFromEventTouch(&gdk_event_motion, gdk_event);
++    gtk_window_motion_notify_callback(widget, &gdk_event_motion, win);
++}
++
++} // anonymous namespace
++
+ extern "C" {
+ static void
+-touch_callback(GtkWidget* WXUNUSED(widget), GdkEventTouch* gdk_event, wxWindow* win)
++touch_callback(GtkWidget* widget, GdkEventTouch* gdk_event, wxWindow* win)
+ {
+     wxWindowGesturesData* const data = wxWindowGestures::FromObject(win);
+     if ( !data )
+@@ -3382,6 +3471,7 @@ touch_callback(GtkWidget* WXUNUSED(widget), GdkEventTouch* gdk_event, wxWindow*
+     switch ( gdk_event->type )
+     {
+         case GDK_TOUCH_BEGIN:
++            wxEmulateLeftDownEvent(widget, gdk_event, win);
+             data->m_touchCount++;
+ 
+             data->m_allowedGestures &= ~two_finger_tap;
+@@ -3411,6 +3501,7 @@ touch_callback(GtkWidget* WXUNUSED(widget), GdkEventTouch* gdk_event, wxWindow*
+             break;
+ 
+         case GDK_TOUCH_UPDATE:
++            wxEmulateMotionEvent(widget, gdk_event, win);
+             // If press and tap gesture is active and touch corresponding to that gesture is moving
+             if ( (data->m_activeGestures & press_and_tap) && gdk_event->sequence == data->m_touchSequence )
+             {
+@@ -3421,6 +3512,7 @@ touch_callback(GtkWidget* WXUNUSED(widget), GdkEventTouch* gdk_event, wxWindow*
+ 
+         case GDK_TOUCH_END:
+         case GDK_TOUCH_CANCEL:
++            wxEmulateLeftUpEvent(widget, gdk_event, win);
+             data->m_touchCount--;
+ 
+             if ( data->m_touchCount == 1 )
+-- 
+2.31.1
+

--- a/flatpak/src/doxyfile-update.patch
+++ b/flatpak/src/doxyfile-update.patch
@@ -1,0 +1,46 @@
+From: wxWidgets Maintainers <team+wx@tracker.debian.org>
+Date: Mon, 15 Feb 2021 10:41:56 +0100
+Subject: doxyfile-update
+
+Forwarded: not-needed
+
+---
+ docs/doxygen/Doxyfile | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/docs/doxygen/Doxyfile b/docs/doxygen/Doxyfile
+index 47f6c81..4305837 100644
+--- a/docs/doxygen/Doxyfile
++++ b/docs/doxygen/Doxyfile
+@@ -29,7 +29,6 @@ MULTILINE_CPP_IS_BRIEF = NO
+ INHERIT_DOCS           = YES
+ SEPARATE_MEMBER_PAGES  = NO
+ TAB_SIZE               = 4
+-TCL_SUBST              =
+ OPTIMIZE_OUTPUT_FOR_C  = NO
+ OPTIMIZE_OUTPUT_JAVA   = NO
+ OPTIMIZE_FOR_FORTRAN   = NO
+@@ -338,7 +337,6 @@ VERBATIM_HEADERS       = NO # Default: YES
+ #---------------------------------------------------------------------------
+ 
+ ALPHABETICAL_INDEX     = YES
+-COLS_IN_ALPHA_INDEX    = 5
+ IGNORE_PREFIX          = wx
+ 
+ 
+@@ -539,7 +537,6 @@ GENERATE_TAGFILE       = $(GENERATE_TAGFILE)
+ ALLEXTERNALS           = NO
+ EXTERNAL_GROUPS        = YES
+ EXTERNAL_PAGES         = YES
+-PERL_PATH              = /usr/bin/perl
+ 
+ 
+ #---------------------------------------------------------------------------
+@@ -547,7 +544,6 @@ PERL_PATH              = /usr/bin/perl
+ #---------------------------------------------------------------------------
+ 
+ CLASS_DIAGRAMS         = YES
+-MSCGEN_PATH            =
+ DIA_PATH               =
+ HIDE_UNDOC_RELATIONS   = YES
+ HAVE_DOT               = YES # Default: NO

--- a/flatpak/src/warn-for-compiler-abi-mismatch.patch
+++ b/flatpak/src/warn-for-compiler-abi-mismatch.patch
@@ -1,0 +1,38 @@
+Description: Suppress error about mismatching C++ ABI version
+ In practice, the differences between recent ABI versions don't seem to be
+ incompatible since they apparently only affect obscure corner cases.  So
+ suppress this error so we don't have to rebuild the entire wx world in one
+ go.
+Author: Olly Betts <olly@survex.com>
+Forwarded: not-needed
+Last-Update: 2017-07-26
+
+--- a/src/common/appbase.cpp
++++ b/src/common/appbase.cpp
+@@ -766,6 +766,26 @@
+         msg.Printf(wxT("Mismatch between the program and library build versions detected.\nThe library used %s,\nand %s used %s."),
+                    lib.c_str(), progName.c_str(), prog.c_str());
+ 
++	int l_off = lib.Find("compiler with C++ ABI ");
++	int p_off = prog.Find("compiler with C++ ABI ");
++	if (l_off != wxNOT_FOUND && p_off != wxNOT_FOUND) {
++	    int space;
++	    space = lib.find(',', l_off + 22);
++	    lib.erase(l_off, space - l_off);
++	    space = prog.find(',', p_off + 22);
++	    prog.erase(p_off, space - p_off);
++	    if (lib == prog) {
++		// The only difference is the ABI version, which apparently only
++		// affect obscure cases.  We used to warn here, so at least
++		// there was an indication of what's up if there is a problem
++		// due to ABI incompatibilities, but wxLogWarning() can result
++		// in a pop up dialog with some applications, which is just too
++		// intrusive, so just quietly ignore instead.
++		//wxLogWarning(msg.c_str());
++		return false;
++	    }
++	}
++
+         wxLogFatalError(msg.c_str());
+ 
+         // normally wxLogFatalError doesn't return

--- a/src/ser_ports.cpp
+++ b/src/ser_ports.cpp
@@ -527,12 +527,14 @@ static wxArrayString* EnumerateWindowsSerialPorts(void) {
 
 
 #if defined(OCPN_USE_SYSFS_PORTS) && defined(HAVE_SYSFS_PORTS)
+#pragma message("Using SYSFS port enumeration")
 
 wxArrayString* EnumerateSerialPorts(void) {
   return EnumerateSysfsSerialPorts();
 }
 
 #elif defined(OCPN_USE_UDEV_PORTS) && defined(HAVE_LIBUDEV)
+#pragma message("Using UDEV port enumeration")
 
 wxArrayString* EnumerateSerialPorts(void) { return EnumerateUdevSerialPorts(); }
 
@@ -566,6 +568,7 @@ wxArrayString* EnumerateSerialPorts(void) {
 }
 
 #elif defined(OCPN_USE_NEWSERIAL)
+#pragma message("Using NEWSERIAL port enumeration")
 
 wxArrayString* EnumerateSerialPorts(void) {
   wxArrayString* preturn = new wxArrayString;


### PR DESCRIPTION
As discussed in #2396. Update focal and flatpak builds to use wxWidgets 3.1.5 instead of the released 3.0 packages which are available in Debian.
 
I suggest that we keep the discussion about merging this  or not in #2396 where we have some context.

For flatpak, this is just about updating the bundled sources to 3.1.5, adding the patches from wxWidget's upstream we have in the Ubuntu package.

For Ubuntu, the CI build scripts are updated.  PR uses wXWidgets packages built in my [PPA](https://launchpad.net/~leamas-alec/+archive/ubuntu/wxwidgets). This could easily be switched to some other PPA if that is deemed better for maintenance reasons. The packages includes a few (currently three) patches imported from wxWidgets master branch.

Only Focal is affected by the changes here. It is certainly possible to do this also for bionic, it's just work I havn't done. I will not do this for Xenial.

Havn't really looked into how this affects upcoming PPA builds. However, I don't see any major problems, it should basically be about declaring the wxWidgets PPA as a dependency of the PPA where OpenCPN is built.