### PR TITLE
libs/wxsvg: Claim leamas's copyright, renormalize

### DIFF
--- a/libs/wxsvg/CMakeLists.txt
+++ b/libs/wxsvg/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Copyright (c) 2019 Alec Leamas
+# License: wxWidgets license
+
 cmake_minimum_required(VERSION 3.1)
 
 if (TARGET ocpn::wxsvg)


### PR DESCRIPTION
The two files NSIS.template.in.in  and plugins/chartdldr_pi/src/icons.bat does not match the declared properties in .gitattributes. Use _git add --renomalize_ to create a sane tree which can be used to make PRs from

libs/wxsvg/CMakeLists.txt is written by me as visible in the git log. Claim the copyright to keep the overall wxsvg library legal status ok.