### PR TITLE
No rename waypoints on insert

### DIFF
--- a/include/routemanagerdialog.h
+++ b/include/routemanagerdialog.h
@@ -96,6 +96,7 @@ private:
   void OnRteActivateClick(wxCommandEvent &event);
   void OnRteReverseClick(wxCommandEvent &event);
   void OnRteExportClick(wxCommandEvent &event);
+  void OnRteRenameClick(wxCommandEvent &event);
   void OnRteToggleVisibility(wxMouseEvent &event);
   void OnRteBtnLeftDown(
       wxMouseEvent &event);  // record control key state for some action buttons
@@ -174,6 +175,7 @@ private:
   wxButton *btnRteReverse;
   wxButton *btnRteDelete;
   wxButton *btnRteExport;
+  wxButton *btnRteRename;
   wxButton *btnRteSendToGPS;
   wxButton *btnRteDeleteAll;
   wxButton *btnTrkNew;

--- a/include/routemanagerdialog.h
+++ b/include/routemanagerdialog.h
@@ -96,7 +96,7 @@ private:
   void OnRteActivateClick(wxCommandEvent &event);
   void OnRteReverseClick(wxCommandEvent &event);
   void OnRteExportClick(wxCommandEvent &event);
-  void OnRteRenameClick(wxCommandEvent &event);
+  void OnRteResequenceClick(wxCommandEvent &event);
   void OnRteToggleVisibility(wxMouseEvent &event);
   void OnRteBtnLeftDown(
       wxMouseEvent &event);  // record control key state for some action buttons
@@ -175,7 +175,7 @@ private:
   wxButton *btnRteReverse;
   wxButton *btnRteDelete;
   wxButton *btnRteExport;
-  wxButton *btnRteRename;
+  wxButton *btnRteResequence;
   wxButton *btnRteSendToGPS;
   wxButton *btnRteDeleteAll;
   wxButton *btnTrkNew;

--- a/src/canvasMenu.cpp
+++ b/src/canvasMenu.cpp
@@ -1489,14 +1489,6 @@ void CanvasMenuHandler::PopupMenuHandler(wxCommandEvent &event) {
     case ID_RT_MENU_INSERT: {
       if (m_pSelectedRoute->m_bIsInLayer) break;
       bool rename = false;
-      int ask_return = OCPNMessageBox(
-          parent,
-          _("Waypoints can be renamed to include the new one, the names will "
-            "be '001', '002' etc.") +
-              _T("\n\n") + _("Do you want to rename the waypoints?"),
-          _("Rename Waypoints?"), wxYES_NO | wxCANCEL);
-      if (ask_return == wxID_YES) rename = true;
-
       m_pSelectedRoute->InsertPointAfter(m_pFoundRoutePoint, zlat, zlon,
                                          rename);
 

--- a/src/routemanagerdialog.cpp
+++ b/src/routemanagerdialog.cpp
@@ -470,11 +470,11 @@ void RouteManagerDialog::Create() {
       wxEVT_COMMAND_BUTTON_CLICKED,
       wxCommandEventHandler(RouteManagerDialog::OnRteExportClick), NULL, this);
 
-  btnRteRename = new wxButton(winr, -1, _("&Rename waypoints"));
-  bsRouteButtonsInner->Add(btnRteRename, 0, wxALL | wxEXPAND, DIALOG_MARGIN);
-  btnRteRename->Connect(
+  btnRteResequence = new wxButton(winr, -1, _("&Resequence Waypoints"));
+  bsRouteButtonsInner->Add(btnRteResequence, 0, wxALL | wxEXPAND, DIALOG_MARGIN);
+  btnRteResequence->Connect(
 	  wxEVT_COMMAND_BUTTON_CLICKED,
-	  wxCommandEventHandler(RouteManagerDialog::OnRteRenameClick), NULL, this);
+	  wxCommandEventHandler(RouteManagerDialog::OnRteResequenceClick), NULL, this);
 
   btnRteSendToGPS = new wxButton(winr, -1, _("&Send to GPS"));
   bsRouteButtonsInner->Add(btnRteSendToGPS, 0, wxALL | wxEXPAND, DIALOG_MARGIN);
@@ -984,7 +984,7 @@ RouteManagerDialog::~RouteManagerDialog() {
   delete m_pLayListCtrl;
 
   delete btnRteDelete;
-  delete btnRteRename;
+  delete btnRteResequence;
   delete btnRteExport;
   delete btnRteZoomto;
   delete btnRteProperties;
@@ -1247,7 +1247,7 @@ void RouteManagerDialog::UpdateRteButtons() {
   btnRteProperties->Enable(enable1);
   btnRteReverse->Enable(enable1);
   btnRteExport->Enable(enablemultiple);
-  btnRteRename->Enable(enable1);
+  btnRteResequence->Enable(enable1);
   btnRteSendToGPS->Enable(enable1);
   btnRteDeleteAll->Enable(m_pRouteListCtrl->GetItemCount() > 0);
 
@@ -1491,7 +1491,7 @@ void RouteManagerDialog::OnRteExportClick(wxCommandEvent &event) {
   ExportGPXRoutes(this, &list, suggested_name);
 }
 
-void RouteManagerDialog::OnRteRenameClick(wxCommandEvent &event) {
+void RouteManagerDialog::OnRteResequenceClick(wxCommandEvent &event) {
 	long item = -1;
 	item = m_pRouteListCtrl->GetNextItem(item, wxLIST_NEXT_ALL,
 		wxLIST_STATE_SELECTED);

--- a/src/routemanagerdialog.cpp
+++ b/src/routemanagerdialog.cpp
@@ -470,6 +470,12 @@ void RouteManagerDialog::Create() {
       wxEVT_COMMAND_BUTTON_CLICKED,
       wxCommandEventHandler(RouteManagerDialog::OnRteExportClick), NULL, this);
 
+  btnRteRename = new wxButton(winr, -1, _("&Rename waypoints"));
+  bsRouteButtonsInner->Add(btnRteRename, 0, wxALL | wxEXPAND, DIALOG_MARGIN);
+  btnRteRename->Connect(
+	  wxEVT_COMMAND_BUTTON_CLICKED,
+	  wxCommandEventHandler(RouteManagerDialog::OnRteRenameClick), NULL, this);
+
   btnRteSendToGPS = new wxButton(winr, -1, _("&Send to GPS"));
   bsRouteButtonsInner->Add(btnRteSendToGPS, 0, wxALL | wxEXPAND, DIALOG_MARGIN);
   btnRteSendToGPS->Connect(
@@ -978,6 +984,7 @@ RouteManagerDialog::~RouteManagerDialog() {
   delete m_pLayListCtrl;
 
   delete btnRteDelete;
+  delete btnRteRename;
   delete btnRteExport;
   delete btnRteZoomto;
   delete btnRteProperties;
@@ -1240,6 +1247,7 @@ void RouteManagerDialog::UpdateRteButtons() {
   btnRteProperties->Enable(enable1);
   btnRteReverse->Enable(enable1);
   btnRteExport->Enable(enablemultiple);
+  btnRteRename->Enable(enable1);
   btnRteSendToGPS->Enable(enable1);
   btnRteDeleteAll->Enable(m_pRouteListCtrl->GetItemCount() > 0);
 
@@ -1481,6 +1489,19 @@ void RouteManagerDialog::OnRteExportClick(wxCommandEvent &event) {
   }
 
   ExportGPXRoutes(this, &list, suggested_name);
+}
+
+void RouteManagerDialog::OnRteRenameClick(wxCommandEvent &event) {
+	long item = -1;
+	item = m_pRouteListCtrl->GetNextItem(item, wxLIST_NEXT_ALL,
+		wxLIST_STATE_SELECTED);
+	if (item == -1) return;
+
+	Route *route = (Route *)m_pRouteListCtrl->GetItemData(item);
+
+	if (!route) return;
+	if (route->m_bIsInLayer) return;
+	route->RenameRoutePoints();
 }
 
 void RouteManagerDialog::OnRteActivateClick(wxCommandEvent &event) {


### PR DESCRIPTION
Looking at https://www.cruisersforum.com/forums/f134/new-insert-waypoint-feature-260769.html there is a complaint about the question on renaming the waypoints when inserting a waypoint in an existing route. This new feature indeed gets irritating when inserting many waypoints. I would think it is better to take the question on renaming out at this point.
But as there could be a need to rename (with numbers in sequence), an additional button for renaming in the Route & Mark Manager could be useful (alternatively one could reverse a route twice).
In this PR I removed the renaming question from the insert and added a button for renaming in the Route & Mark Manager.