### PR TITLE
Mouse zoom sensitivity (#2557)

### DIFF
--- a/include/navutil.h
+++ b/include/navutil.h
@@ -59,7 +59,7 @@ enum { SPEED_KTS = 0, SPEED_MPH, SPEED_KMH, SPEED_MS };
 
 enum { TEMPERATURE_C = 0, TEMPERATURE_F = 1, TEMPERATURE_K = 2 };
 
-double mouseZoom2config(int slider_pos);
+
 extern bool LogMessageOnce(const wxString &msg);
 extern double toUsrDistance(double nm_distance, int unit = -1);
 extern double fromUsrDistance(double usr_distance, int unit = -1);
@@ -140,6 +140,22 @@ bool ExportGPXTracks(wxWindow *parent, TrackList *pRoutes,
                      const wxString suggestedName = _T("tracks"));
 bool ExportGPXWaypoints(wxWindow *parent, RoutePointList *pRoutePoints,
                         const wxString suggestedName = _T("waypoints"));
+
+
+class MouseZoom {
+public:
+
+  /** Convert a slider scale 1-100 value to configuration value 1.02..3.0. */
+  static double ui_to_config(int slider_pos) {
+    return (2.0/100) * static_cast<double>(slider_pos) + 1.02;
+  }
+
+  /** Convert configuration 1.02..3.0 value to slider scale 1..100. */
+  static int config_to_ui(double value) {
+    return std::round((100.0 * (static_cast<double>(value) - 1.02)) / 2.0);
+  }
+};
+
 
 //----------------------------------------------------------------------------
 //    Config

--- a/include/navutil.h
+++ b/include/navutil.h
@@ -59,6 +59,7 @@ enum { SPEED_KTS = 0, SPEED_MPH, SPEED_KMH, SPEED_MS };
 
 enum { TEMPERATURE_C = 0, TEMPERATURE_F = 1, TEMPERATURE_K = 2 };
 
+double mouseZoom2config(int slider_pos);
 extern bool LogMessageOnce(const wxString &msg);
 extern double toUsrDistance(double nm_distance, int unit = -1);
 extern double fromUsrDistance(double usr_distance, int unit = -1);

--- a/include/options.h
+++ b/include/options.h
@@ -436,6 +436,7 @@ public:
   wxChoice *m_pShipIconType, *m_pcTCDatasets;
   wxSlider *m_pSlider_Zoom, *m_pSlider_GUI_Factor, *m_pSlider_Chart_Factor,
       *m_pSlider_Ship_Factor, *m_pSlider_Text_Factor;
+  wxSlider *m_pMouse_Zoom_Slider;
   wxSlider *m_pSlider_Zoom_Vector;
   wxSlider *m_pSlider_CM93_Zoom;
   // LIVE ETA OPTION

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -124,6 +124,7 @@
 
 extern float g_ChartScaleFactorExp;
 extern float g_ShipScaleFactorExp;
+extern double g_mouse_zoom_sensitivity;
 
 #include <vector>
 //#include <wx-3.0/wx/aui/auibar.h>
@@ -9154,7 +9155,7 @@ bool ChartCanvas::MouseEventProcessCanvas(wxMouseEvent &event) {
     int mouse_wheel_oneshot = abs(wheel_dir) * 4;  // msec
     wheel_dir = wheel_dir > 0 ? 1 : -1;            // normalize
 
-    double factor = 1.2;
+    double factor = g_mouse_zoom_sensitivity;
     if (wheel_dir < 0) factor = 1 / factor;
 
     if (g_bsmoothpanzoom) {

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -9154,7 +9154,7 @@ bool ChartCanvas::MouseEventProcessCanvas(wxMouseEvent &event) {
     int mouse_wheel_oneshot = abs(wheel_dir) * 4;  // msec
     wheel_dir = wheel_dir > 0 ? 1 : -1;            // normalize
 
-    double factor = 2.0;
+    double factor = 1.2;
     if (wheel_dir < 0) factor = 1 / factor;
 
     if (g_bsmoothpanzoom) {

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -468,6 +468,7 @@ wxString g_catalog_custom_url;
 wxString g_catalog_channel;
 
 int g_trackFilterMax;
+double g_mouse_zoom_sensitivity;
 
 #ifdef ocpnUSE_GL
 extern ocpnGLOptions g_GLOptions;
@@ -624,6 +625,7 @@ int MyConfig::LoadMyConfig() {
   g_benableAISNameCache = true;
   g_n_arrival_circle_radius = 0.05;
   g_plus_minus_zoom_factor = 2.0;
+  g_mouse_zoom_sensitivity = 1.5;
 
   g_AISShowTracks_Mins = 20;
   g_AISShowTracks_Limit = 300.0;
@@ -945,6 +947,7 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   Read(_T ( "ZoomDetailFactor" ), &g_chart_zoom_modifier);
   Read(_T ( "ZoomDetailFactorVector" ), &g_chart_zoom_modifier_vector);
   Read(_T ( "PlusMinusZoomFactor" ), &g_plus_minus_zoom_factor, 2.0);
+  Read(_T ( "MouseZoomSensitivity" ), &g_mouse_zoom_sensitivity, 1.5);
 
   Read(_T ( "CM93DetailFactor" ), &g_cm93_zoom_factor);
 
@@ -2349,6 +2352,7 @@ void MyConfig::UpdateSettings() {
   Write(_T ( "OverzoomVectorScale" ), g_oz_vector_scale);
   Write(_T ( "OverzoomEmphasisBase" ), g_overzoom_emphasis_base);
   Write(_T ( "PlusMinusZoomFactor" ), g_plus_minus_zoom_factor);
+  Write(_T ( "MouseZoomSensitivity" ), g_mouse_zoom_sensitivity);
   Write(_T ( "ShowMUIZoomButtons" ), g_bShowMuiZoomButtons);
 
 #ifdef ocpnUSE_GL

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -469,6 +469,7 @@ wxString g_catalog_channel;
 
 int g_trackFilterMax;
 double g_mouse_zoom_sensitivity;
+int g_mouse_zoom_sensitivity_ui;
 
 #ifdef ocpnUSE_GL
 extern ocpnGLOptions g_GLOptions;
@@ -499,6 +500,18 @@ void appendOSDirSlash(wxString *pString);
 //-----------------------------------------------------------------------------
 //          MyConfig Implementation
 //-----------------------------------------------------------------------------
+//
+
+
+/** Convert a slider scale 1-100 value to configuration value 1.0..3.0. */
+double mouseZoom2config(int slider_pos) {
+  return (2.0/100) * static_cast<double>(slider_pos) + 1.05;
+}
+
+/** Convert configuration 1.05..3.0 value to slider scale 1..100. */
+static int mouseZoom2slider(double value) {
+  return std::round((100.0 * (static_cast<double>(value) - 1.05)) / 2.0);
+}
 
 MyConfig::MyConfig(const wxString &LocalFileName)
     : wxFileConfig(_T (""), _T (""), LocalFileName, _T (""),
@@ -947,8 +960,8 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   Read(_T ( "ZoomDetailFactor" ), &g_chart_zoom_modifier);
   Read(_T ( "ZoomDetailFactorVector" ), &g_chart_zoom_modifier_vector);
   Read(_T ( "PlusMinusZoomFactor" ), &g_plus_minus_zoom_factor, 2.0);
-  Read(_T ( "MouseZoomSensitivity" ), &g_mouse_zoom_sensitivity, 1.5);
-
+  Read("MouseZoomSensitivity", &g_mouse_zoom_sensitivity, 1.3);
+  g_mouse_zoom_sensitivity_ui = mouseZoom2slider(g_mouse_zoom_sensitivity);
   Read(_T ( "CM93DetailFactor" ), &g_cm93_zoom_factor);
 
   Read(_T ( "CM93DetailZoomPosX" ), &g_detailslider_dialog_x);
@@ -2352,7 +2365,7 @@ void MyConfig::UpdateSettings() {
   Write(_T ( "OverzoomVectorScale" ), g_oz_vector_scale);
   Write(_T ( "OverzoomEmphasisBase" ), g_overzoom_emphasis_base);
   Write(_T ( "PlusMinusZoomFactor" ), g_plus_minus_zoom_factor);
-  Write(_T ( "MouseZoomSensitivity" ), g_mouse_zoom_sensitivity);
+  Write("MouseZoomSensitivity", mouseZoom2config(g_mouse_zoom_sensitivity_ui));
   Write(_T ( "ShowMUIZoomButtons" ), g_bShowMuiZoomButtons);
 
 #ifdef ocpnUSE_GL

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -502,17 +502,6 @@ void appendOSDirSlash(wxString *pString);
 //-----------------------------------------------------------------------------
 //
 
-
-/** Convert a slider scale 1-100 value to configuration value 1.0..3.0. */
-double mouseZoom2config(int slider_pos) {
-  return (2.0/100) * static_cast<double>(slider_pos) + 1.05;
-}
-
-/** Convert configuration 1.05..3.0 value to slider scale 1..100. */
-static int mouseZoom2slider(double value) {
-  return std::round((100.0 * (static_cast<double>(value) - 1.05)) / 2.0);
-}
-
 MyConfig::MyConfig(const wxString &LocalFileName)
     : wxFileConfig(_T (""), _T (""), LocalFileName, _T (""),
                    wxCONFIG_USE_LOCAL_FILE) {
@@ -961,7 +950,8 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   Read(_T ( "ZoomDetailFactorVector" ), &g_chart_zoom_modifier_vector);
   Read(_T ( "PlusMinusZoomFactor" ), &g_plus_minus_zoom_factor, 2.0);
   Read("MouseZoomSensitivity", &g_mouse_zoom_sensitivity, 1.3);
-  g_mouse_zoom_sensitivity_ui = mouseZoom2slider(g_mouse_zoom_sensitivity);
+  g_mouse_zoom_sensitivity_ui =
+      MouseZoom::config_to_ui(g_mouse_zoom_sensitivity);
   Read(_T ( "CM93DetailFactor" ), &g_cm93_zoom_factor);
 
   Read(_T ( "CM93DetailZoomPosX" ), &g_detailslider_dialog_x);
@@ -2365,7 +2355,8 @@ void MyConfig::UpdateSettings() {
   Write(_T ( "OverzoomVectorScale" ), g_oz_vector_scale);
   Write(_T ( "OverzoomEmphasisBase" ), g_overzoom_emphasis_base);
   Write(_T ( "PlusMinusZoomFactor" ), g_plus_minus_zoom_factor);
-  Write("MouseZoomSensitivity", mouseZoom2config(g_mouse_zoom_sensitivity_ui));
+  Write("MouseZoomSensitivity",
+        MouseZoom::ui_to_config(g_mouse_zoom_sensitivity_ui));
   Write(_T ( "ShowMUIZoomButtons" ), g_bShowMuiZoomButtons);
 
 #ifdef ocpnUSE_GL

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -289,6 +289,8 @@ extern wxString g_compatOS;
 extern wxLocale* plocale_def_lang;
 #endif
 
+extern double g_mouse_zoom_sensitivity;
+
 extern OcpnSound* g_anchorwatch_sound;
 extern wxString g_anchorwatch_sound_file;
 extern wxString g_DSC_sound_file;
@@ -6967,6 +6969,20 @@ void options::CreatePanel_UI(size_t parent, int border_size,
 #ifdef __OCPN__ANDROID__
   m_pSlider_Text_Factor->GetHandle()->setStyleSheet(getQtStyleSheet());
 #endif
+  m_pMouse_Zoom_Slider =
+      new wxSlider(itemPanelFont, wxID_ANY, 13, 11, 30, wxDefaultPosition,
+                   m_sliderSize, SLIDER_STYLE);
+  m_pSlider_Text_Factor->Hide();
+  sliderSizer->Add(
+      new wxStaticText(itemPanelFont, wxID_ANY, "Mouse zoom sensitivity"),
+      inputFlags);
+  sliderSizer->Add(m_pMouse_Zoom_Slider, 0, wxALL, border_size);
+  m_pMouse_Zoom_Slider->Show();
+
+#ifdef __OCPN__ANDROID__
+  m_pMouse_Zoom_Slider->GetHandle()->setStyleSheet(getQtStyleSheet());
+#endif
+
 
   miscOptions->Add(sliderSizer, 0, wxEXPAND, 5);
   miscOptions->AddSpacer(20);
@@ -7735,6 +7751,7 @@ void options::SetInitialSettings(void) {
   m_pSlider_Chart_Factor->SetValue(g_ChartScaleFactor);
   m_pSlider_Ship_Factor->SetValue(g_ShipScaleFactor);
   m_pSlider_Text_Factor->SetValue(g_ENCSoundingScaleFactor);
+  m_pMouse_Zoom_Slider->SetValue(g_mouse_zoom_sensitivity * 10.0);
   wxString screenmm;
 
   if (!g_config_display_size_manual) {
@@ -8883,6 +8900,7 @@ void options::OnApplyClick(wxCommandEvent& event) {
   g_ShipScaleFactor = m_pSlider_Ship_Factor->GetValue();
   g_ShipScaleFactorExp = g_Platform->getChartScaleFactorExp(g_ShipScaleFactor);
   g_ENCSoundingScaleFactor = m_pSlider_Text_Factor->GetValue();
+  g_mouse_zoom_sensitivity = m_pMouse_Zoom_Slider->GetValue()/10.0;
 
   //  Only reload the icons if user has actually visted the UI page
   // if(m_bVisitLang)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -8911,7 +8911,8 @@ void options::OnApplyClick(wxCommandEvent& event) {
   g_ShipScaleFactorExp = g_Platform->getChartScaleFactorExp(g_ShipScaleFactor);
   g_ENCSoundingScaleFactor = m_pSlider_Text_Factor->GetValue();
   g_mouse_zoom_sensitivity_ui = m_pMouse_Zoom_Slider->GetValue();
-  g_mouse_zoom_sensitivity = mouseZoom2config(g_mouse_zoom_sensitivity_ui);
+  g_mouse_zoom_sensitivity =
+    MouseZoom::ui_to_config(g_mouse_zoom_sensitivity_ui);
 
 
 

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -290,6 +290,7 @@ extern wxLocale* plocale_def_lang;
 #endif
 
 extern double g_mouse_zoom_sensitivity;
+extern int g_mouse_zoom_sensitivity_ui;
 
 extern OcpnSound* g_anchorwatch_sound;
 extern wxString g_anchorwatch_sound_file;
@@ -5746,6 +5747,8 @@ void options::CreatePanel_Display(size_t parent, int border_size,
   }
 }
 
+
+
 void options::CreatePanel_Units(size_t parent, int border_size,
                                 int group_item_spacing) {
   wxScrolledWindow* panelUnits = AddPage(parent, _("Units"));
@@ -6676,6 +6679,20 @@ void options::CreatePanel_AIS(size_t parent, int border_size,
   panelAIS->Layout();
 }
 
+class MouseZoomSlider : public wxSlider {
+    public:
+        MouseZoomSlider(wxWindow* parent, wxSize size) :
+            wxSlider(parent, wxID_ANY, 10, 1, 100, wxDefaultPosition,
+                     size, SLIDER_STYLE)
+        {
+            Show();
+#ifdef __OCPN__ANDROID__
+            GetHandle()->setStyleSheet(getQtStyleSheet());
+#endif
+        }
+};
+
+
 void options::CreatePanel_UI(size_t parent, int border_size,
                              int group_item_spacing) {
   wxScrolledWindow* itemPanelFont = AddPage(parent, _("General Options"));
@@ -6969,20 +6986,12 @@ void options::CreatePanel_UI(size_t parent, int border_size,
 #ifdef __OCPN__ANDROID__
   m_pSlider_Text_Factor->GetHandle()->setStyleSheet(getQtStyleSheet());
 #endif
-  m_pMouse_Zoom_Slider =
-      new wxSlider(itemPanelFont, wxID_ANY, 13, 11, 30, wxDefaultPosition,
-                   m_sliderSize, SLIDER_STYLE);
-  m_pSlider_Text_Factor->Hide();
+
   sliderSizer->Add(
       new wxStaticText(itemPanelFont, wxID_ANY, "Mouse zoom sensitivity"),
       inputFlags);
+  m_pMouse_Zoom_Slider = new MouseZoomSlider(itemPanelFont, m_sliderSize);
   sliderSizer->Add(m_pMouse_Zoom_Slider, 0, wxALL, border_size);
-  m_pMouse_Zoom_Slider->Show();
-
-#ifdef __OCPN__ANDROID__
-  m_pMouse_Zoom_Slider->GetHandle()->setStyleSheet(getQtStyleSheet());
-#endif
-
 
   miscOptions->Add(sliderSizer, 0, wxEXPAND, 5);
   miscOptions->AddSpacer(20);
@@ -7751,7 +7760,7 @@ void options::SetInitialSettings(void) {
   m_pSlider_Chart_Factor->SetValue(g_ChartScaleFactor);
   m_pSlider_Ship_Factor->SetValue(g_ShipScaleFactor);
   m_pSlider_Text_Factor->SetValue(g_ENCSoundingScaleFactor);
-  m_pMouse_Zoom_Slider->SetValue(g_mouse_zoom_sensitivity * 10.0);
+  m_pMouse_Zoom_Slider->SetValue(g_mouse_zoom_sensitivity_ui);
   wxString screenmm;
 
   if (!g_config_display_size_manual) {
@@ -8900,7 +8909,10 @@ void options::OnApplyClick(wxCommandEvent& event) {
   g_ShipScaleFactor = m_pSlider_Ship_Factor->GetValue();
   g_ShipScaleFactorExp = g_Platform->getChartScaleFactorExp(g_ShipScaleFactor);
   g_ENCSoundingScaleFactor = m_pSlider_Text_Factor->GetValue();
-  g_mouse_zoom_sensitivity = m_pMouse_Zoom_Slider->GetValue()/10.0;
+  g_mouse_zoom_sensitivity_ui = m_pMouse_Zoom_Slider->GetValue();
+  g_mouse_zoom_sensitivity = mouseZoom2config(g_mouse_zoom_sensitivity_ui);
+
+
 
   //  Only reload the icons if user has actually visted the UI page
   // if(m_bVisitLang)

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -6987,9 +6987,10 @@ void options::CreatePanel_UI(size_t parent, int border_size,
   m_pSlider_Text_Factor->GetHandle()->setStyleSheet(getQtStyleSheet());
 #endif
 
-  sliderSizer->Add(
-      new wxStaticText(itemPanelFont, wxID_ANY, "Mouse zoom sensitivity"),
-      inputFlags);
+  sliderSizer->Add(new wxStaticText(itemPanelFont,
+                                    wxID_ANY,
+                                    "Mouse wheel zoom sensitivity"),
+                   inputFlags);
   m_pMouse_Zoom_Slider = new MouseZoomSlider(itemPanelFont, m_sliderSize);
   sliderSizer->Add(m_pMouse_Zoom_Slider, 0, wxALL, border_size);
 


### PR DESCRIPTION
Add a new UI setting which handles how "fast" the zoom is when using the mouse. Avoids problems described in #2557 for those who finds the setting.

Sreenshot with new setting:
![zoom](https://user-images.githubusercontent.com/405541/154267948-d505c0cb-2998-4b5f-bb21-2fab152e104d.png)
