### PR TITLE
GNSS status. SK adaptation and bug fix.

### DIFF
--- a/plugins/dashboard_pi/src/dashboard_pi.h
+++ b/plugins/dashboard_pi/src/dashboard_pi.h
@@ -198,7 +198,7 @@ private:
 
   void ParseSignalK(wxString &msg);
   void handleSKUpdate(wxJSONValue &update);
-  void updateSKItem(wxJSONValue &item, wxString &sfixtime);
+  void updateSKItem(wxJSONValue &item, wxString &talker, wxString &sfixtime);
   wxString m_self;
 
   wxFileConfig *m_pconfig;

--- a/plugins/dashboard_pi/src/gps.cpp
+++ b/plugins/dashboard_pi/src/gps.cpp
@@ -93,15 +93,9 @@ void DashboardInstrument_GPS::SetSatInfo(int cnt, int seq, wxString talk,
   talkerID = talk;
 
   /* Some GNSS receivers may emit more than (3*4)=12 sats info.
-     There can be up to 9 sequences in one group so we divide
-     them in subgroups of 3 to be able to show all
-     with our limited space.*/
-  if (seq < 1) return;
-  if (seq > 3) {
-    if (seq < 7) seq -= 3;
-    else if (seq < 10) seq -= 6;
-    else return; // not to standard but u never know
-  }
+     We read the three first only since our graphic is
+     is not adapted for more than 12 satellites*/
+  if (seq < 1 || seq > 3) return;
 
   if (talkerID != wxEmptyString) {
     /* Switch view between the six GNSS system

--- a/plugins/dashboard_pi/src/nmea0183/gsv.cpp
+++ b/plugins/dashboard_pi/src/nmea0183/gsv.cpp
@@ -126,20 +126,14 @@ Where:
     NumberOfMessages = sentence.Integer( 1 );
     MessageNumber = sentence.Integer( 2 );
     SatsInView = sentence.Integer( 3 );
-    bool valid_SNR = false;
-    for (int idx = 0; idx < satInfoCnt; idx++)
-    {
-        SatInfo[idx].SatNumber = sentence.Integer( idx * 4 + 4 );
-        SatInfo[idx].ElevationDegrees = sentence.Integer( idx * 4 + 5 );
-        SatInfo[idx].AzimuthDegreesTrue = sentence.Integer( idx * 4 + 6 );
-        SatInfo[idx].SignalToNoiseRatio = sentence.Integer( idx * 4 + 7 );
-        if (!valid_SNR) {
-          if (SatInfo[idx].SignalToNoiseRatio > 0) valid_SNR = true;
-        }
+
+    for (int idx = 0; idx < satInfoCnt; idx++) {
+      SatInfo[idx].SatNumber = sentence.Integer(idx * 4 + 4);
+      SatInfo[idx].ElevationDegrees = sentence.Integer(idx * 4 + 5);
+      SatInfo[idx].AzimuthDegreesTrue = sentence.Integer(idx * 4 + 6);
+      SatInfo[idx].SignalToNoiseRatio = sentence.Integer(idx * 4 + 7);
     }
-    // Don't PreParse GSV messages with only zero or NULL SNR.
-    if ( valid_SNR ) return(TRUE); 
-    else return(FALSE);
+    return( TRUE );
 }
 
 bool GSV::Write( SENTENCE& sentence )


### PR DESCRIPTION
Abstract:

- The GNSS satellites in view received from Signal K, SK, previously didn't contained info about NMEA0183 Talker ID. Talker ID for sentence GSV is rare since it contains navigation info instead of only "type of talker". In this case origin satellite system like GPS and Galileo. The "Talker" is now available also from SK (NMEA0183) and the code is updated to handle that.
 
- What's not yet tested is GNSS info parsed from N2k PGN's via CanBus to a SK path. So far due to lack of real test data. We've to trust the SK specification will be valid also here. Let's hope for future test participating and possible correction. I've though seen some N2k->NMEA0183 converters not meeting the NMEA standard and thus we also receive limited info.
 
- During the SK talker update a bug in the Dashboard message priority logic was detected and here corrected.
 
- In present code are "bad" satellite data having low "Signal to Noise Ratio" (SNR) sorted out from the satellite status view. That made the view not understandable and misleading. The text instrument could info about for example eight satellites in view but only four was graphically shown since the rest was sorted out. Now all eight are listed in the graph even if they lack SNR. The info for the user would be more clear.
 
- This PR have parts in common with another [PR: Fix Dashboard ](https://github.com/OpenCPN/OpenCPN/pull/2565) but that one lack bug fixes and has error.

