### PR TITLE
DSC distress update

### DIFF
--- a/buildwin/.directory
+++ b/buildwin/.directory
@@ -1,4 +1,0 @@
-[Dolphin]
-Timestamp=2021,10,5,22,8,18
-Version=4
-ViewMode=1

--- a/buildwin/.directory
+++ b/buildwin/.directory
@@ -1,0 +1,4 @@
+[Dolphin]
+Timestamp=2021,10,5,22,8,18
+Version=4
+ViewMode=1

--- a/include/AIS_Target_Data.h
+++ b/include/AIS_Target_Data.h
@@ -48,6 +48,7 @@ public:
   wxString Get_class_string(bool b_short = false);
   wxString GetFullName(void);
   wxString GetCountryCode(bool b_CntryLongStr);
+  wxString GetNatureofDistress(int dscnature);
   void Toggle_AIS_CPA(void);
   void ToggleShowTrack(void);
   void CloneFrom(AIS_Target_Data* q);
@@ -108,6 +109,8 @@ public:
   bool b_positionOnceValid;
   bool b_nameValid;
   bool b_isFollower;
+  int  m_dscNature;
+  int  m_dscTXmmsi;
 
   //                     MMSI Properties
   bool b_NoTrack;
@@ -147,6 +150,7 @@ public:
                                                 // AIS_TARGETDATA_MAX_CANVAS is
                                                 // the max number of chartcanvas
   wxDateTime dtAlertExpireTime;
+  long dsc_NatureOfDistress;
 };
 
 #endif

--- a/include/AIS_Target_Data.h
+++ b/include/AIS_Target_Data.h
@@ -109,8 +109,9 @@ public:
   bool b_positionOnceValid;
   bool b_nameValid;
   bool b_isFollower;
+  bool b_isDSCtarget; // DSC flag to a possible simultaneous AIS target
   int  m_dscNature;
-  int  m_dscTXmmsi;
+  int  m_dscTXmmsi;   // MMSI for the DSC relay issuer
 
   //                     MMSI Properties
   bool b_NoTrack;

--- a/src/AISTargetAlertDialog.cpp
+++ b/src/AISTargetAlertDialog.cpp
@@ -180,8 +180,8 @@ void AISTargetAlertDialog::CreateControls() {
 
   topSizer->Add(m_pAlertTextCtl, 1, wxALL | wxEXPAND, 5);
 
-  // A horizontal box sizer to contain Ack
-  wxBoxSizer *AckBox = new wxBoxSizer(wxHORIZONTAL);
+  // A flex sizer to contain Ack and more buttons
+  wxFlexGridSizer *AckBox = new wxFlexGridSizer(2);
   topSizer->Add(AckBox, 0, wxALL, 5);
 
   // The Silence button
@@ -190,14 +190,7 @@ void AISTargetAlertDialog::CreateControls() {
                                      wxDefaultPosition, wxDefaultSize, 0);
     AckBox->Add(silence, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
   }
-
-  // The Ack button
-  if (m_back) {
-    wxButton *ack = new wxButton(this, ID_ACKNOWLEDGE, _("&Acknowledge"),
-                                 wxDefaultPosition, wxDefaultSize, 0);
-    AckBox->Add(ack, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
-  }
-
+    
   if (m_bjumpto) {
     wxButton *jumpto = new wxButton(this, ID_JUMPTO, _("&Jump To"),
                                     wxDefaultPosition, wxDefaultSize, 0);
@@ -209,6 +202,19 @@ void AISTargetAlertDialog::CreateControls() {
         new wxButton(this, ID_WPT_CREATE, _("Create Waypoint"),
                      wxDefaultPosition, wxDefaultSize, 0);
     AckBox->Add(createWptBtn, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+  }
+  // The Ack button
+  // Also used to close a DSC Alert
+  wxString acktext = _("&Acknowledge");
+  bool show_ack_button = false;
+  if (m_bjumpto && m_bcreateWP) { //DSC Alert only
+    acktext = _("&Close Alert");
+    show_ack_button = true;
+  }
+  if (m_back || show_ack_button) {
+    wxButton *ack = new wxButton(this, ID_ACKNOWLEDGE, acktext,
+                                 wxDefaultPosition, wxDefaultSize, 0);
+    AckBox->Add(ack, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
   }
 
   UpdateText();
@@ -325,8 +331,12 @@ void AISTargetAlertDialog::OnClose(wxCloseEvent &event) {
         td->m_ack_time = wxDateTime::Now();
         td->b_in_ack_timeout = true;
       }
-      if (td->b_isDSCtarget)
+      if (td->b_isDSCtarget) {
         td->b_isDSCtarget = false;
+        if (td->n_alert_state) {
+          td->n_alert_state = AIS_NO_ALERT;
+        }
+      }
     }
   }
 
@@ -340,9 +350,15 @@ void AISTargetAlertDialog::OnIdAckClick(wxCommandEvent &event) {
     AIS_Target_Data *td =
         m_pdecoder->Get_Target_Data_From_MMSI(Get_Dialog_MMSI());
     if (td) {
-      if (AIS_ALERT_SET == td->n_alert_state) {
+      if (AIS_ALERT_SET == td->n_alert_state ) {
         td->m_ack_time = wxDateTime::Now();
         td->b_in_ack_timeout = true;
+      }
+      if (td->b_isDSCtarget) {
+        td->b_isDSCtarget = false;
+        if (td->n_alert_state) {
+          td->n_alert_state = AIS_NO_ALERT;
+        }              
       }
     }
   }

--- a/src/AISTargetAlertDialog.cpp
+++ b/src/AISTargetAlertDialog.cpp
@@ -325,6 +325,8 @@ void AISTargetAlertDialog::OnClose(wxCloseEvent &event) {
         td->m_ack_time = wxDateTime::Now();
         td->b_in_ack_timeout = true;
       }
+      if (td->b_isDSCtarget)
+        td->b_isDSCtarget = false;
     }
   }
 

--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -1700,7 +1700,7 @@ AIS_Target_Data *AIS_Decoder::ProcessDSx(const wxString &str, bool b_take_dsc) {
     m_ptentative_dsctarget->StaticReportTicks = now.GetTicks();
 
     m_ptentative_dsctarget->MMSI = mmsi;
-    m_ptentative_dsctarget->NavStatus = 0;  // underway
+    m_ptentative_dsctarget->NavStatus = 99; //Undefind. "-" in the AIS target list
     m_ptentative_dsctarget->Lat = dsc_lat;
     m_ptentative_dsctarget->Lon = dsc_lon;
     m_ptentative_dsctarget->b_positionOnceValid = true;

--- a/src/AIS_Target_Data.cpp
+++ b/src/AIS_Target_Data.cpp
@@ -350,7 +350,7 @@ wxString AIS_Target_Data::BuildQueryResult(void) {
          << MMSIstr << _T("</b></td><td>&nbsp;</td><td align=right><b>")
          << ClassStr << rowEnd << _T("</table></td></tr>");
 
-  if ((Class != AIS_SART) && (Class != AIS_DSC))
+  if ((Class != AIS_SART) ) //&& (Class != AIS_DSC))
     html << _T("<tr><td colspan=2><table width=100% border=0 cellpadding=0 ")
             _T("cellspacing=0>")
          << rowStart
@@ -478,7 +478,22 @@ wxString AIS_Target_Data::BuildQueryResult(void) {
     html << rowEnd << _T("<tr><td colspan=2>")
          << _T("<b>") << sizeString << rowEnd;
   }
-
+  else if (Class == AIS_DSC && (ShipType == 12 || ShipType == 16) ) {
+    if (ShipType == 16) {  //Distress relay
+      html << _T("<tr><td colspan=2>") << _T("<b>") << _("Distress relay");
+      if (m_dscTXmmsi > 2000000) {
+        wxString mmsirelay = wxString::Format(_T(" %09d"), abs(m_dscTXmmsi));
+        html << _T(" ") << _("by:") << mmsirelay;
+      }
+      html << _T("<b>") << sizeString << rowEnd;
+    }
+    html << _T("<tr><td colspan=2>") << _("Nature of distress: ")
+         << rowEnd << _T("<tr><td colspan=2>");
+    if (m_dscNature < 13) {
+      html << _T("<tr><td colspan=2>") << _T("<b>") << GetNatureofDistress(m_dscNature)
+           << _T("<b>") << sizeString << rowEnd << _T("<tr><td colspan=2>");
+    }
+  }
   else if ((Class != AIS_BASE) && (Class != AIS_DSC)) {
     html << _T("<tr><td colspan=2>")
          << _T("<b>") << AISTypeStr;
@@ -753,7 +768,7 @@ wxString AIS_Target_Data::GetRolloverString(void) {
       }
 
       if ((Class != AIS_CLASS_B) && (Class != AIS_SART) &&
-          !b_SarAircraftPosnReport) {
+          Class != AIS_DSC && !b_SarAircraftPosnReport) {
         if ((NavStatus <= 15) && (NavStatus >= 0)) {
           result.Append(_T(" ("));
           result.Append(wxGetTranslation(ais_get_status(NavStatus)));
@@ -765,7 +780,10 @@ wxString AIS_Target_Data::GetRolloverString(void) {
           result.Append(_("Active"));
         else if (NavStatus == UNDEFINED)
           result.Append(_("Testing"));
-
+        result.Append(_T(")"));
+      } else if (Class == AIS_DSC) {
+        result.Append(_T(" ("));
+        result.Append(GetNatureofDistress(m_dscNature));
         result.Append(_T(")"));
       }
     }
@@ -888,7 +906,7 @@ wxString AIS_Target_Data::Get_vessel_type_string(bool b_short) {
   else if (Class == AIS_APRS)
     i = 56;
   else if (Class == AIS_DSC)
-    i = (ShipType == 12) ? 54 : 53;  // 12 is distress
+    i = (ShipType == 12 || ShipType == 16) ? 54 : 53;  // 12 & 16 is distress
 
   if (!b_short)
     return ais_get_type(i);
@@ -909,7 +927,7 @@ wxString AIS_Target_Data::Get_class_string(bool b_short) {
     case AIS_GPSG_BUDDY:
       return b_short ? _("Buddy") : _("GPSGate Buddy");
     case AIS_DSC:
-      if (ShipType == 12)
+      if (ShipType == 12 || ( ShipType == 16 && m_dscNature < 13))
         return b_short ? _("DSC") : _("DSC Distress");
       else
         return b_short ? _("DSC") : _("DSC Position Report");
@@ -923,6 +941,20 @@ wxString AIS_Target_Data::Get_class_string(bool b_short) {
     default:
       return b_short ? _("Unk") : _("Unknown");
   }
+}
+
+wxString AIS_Target_Data::GetNatureofDistress(int dscnature) {
+  // Natures of distress from: Rec. ITU-R M.493-10. 
+  wxString dscDistressType[] = { _("Fire, explosion"), _("Floding"),
+                                     _("Collision"), _("Grounding"),
+                 _("Listing, in danger of capsazing"), _("Sinking"),
+               _("Disabled and adrift"), _("Undesignated distress"),
+             _("Abandoning ship"), _("Pirazy/armed robbery attack"),
+                 _("Man overboard"), _T("-"), _("EPIRB emission") };
+  if (dscnature >= 0 && dscnature < 13)
+    return dscDistressType[dscnature];
+  
+  return wxEmptyString;
 }
 
 void AIS_Target_Data::Toggle_AIS_CPA(void) {

--- a/src/AIS_Target_Data.cpp
+++ b/src/AIS_Target_Data.cpp
@@ -105,6 +105,9 @@ AIS_Target_Data::AIS_Target_Data() {
   SyncState = 888;
   SlotTO = 999;
   ShipType = 19;  // "Unknown"
+  b_isDSCtarget = false;
+  m_dscNature = 99;
+  m_dscTXmmsi = 666;
 
   CPA = 100;  // Large values avoid false alarms
   TCPA = 100;
@@ -193,6 +196,9 @@ void AIS_Target_Data::CloneFrom(AIS_Target_Data *q) {
   SyncState = q->SyncState;
   SlotTO = q->SlotTO;
   ShipType = q->ShipType;
+  b_isDSCtarget = q->b_isDSCtarget;
+  m_dscNature = q->m_dscNature;
+  m_dscTXmmsi = q->m_dscTXmmsi;
 
   CPA = q->CPA;
   TCPA = q->TCPA;

--- a/src/ais.cpp
+++ b/src/ais.cpp
@@ -1160,7 +1160,7 @@ static void AISDrawTarget(AIS_Target_Data *td, ocpnDC &dc, ViewPort &vp,
   // and....
   wxColour URED = GetGlobalColor(_T ( "URED" ));
   if (!td->b_nameValid) target_brush = wxBrush(GetGlobalColor(_T ( "CHYLW" )));
-  if ((td->Class == AIS_DSC) && (td->ShipType == 12))  // distress
+  if ((td->Class == AIS_DSC) && ((td->ShipType == 12) || (td->ShipType == 16)) )  // distress(relayed)
     target_brush = wxBrush(URED);
   if (td->b_SarAircraftPosnReport) target_brush = wxBrush(UINFG);
 


### PR DESCRIPTION
This tries to fix  [FS2816](https://opencpn.org/flyspray/index.php?do=details&task_id=2816) 
Two parts

1. A DSC distress received from a VHF radio use the present AIS Alert logic and dialog.
This commit correct shown mmsi from the distress target and also if it's a relayed message the relay station's mmsi is shown. 
Also is the nature of distress shown on the alert and the rollover message if included in the DSC messages. 
A DSC alert is active a long time after the message is received. If the user want to close the alert a "Close alert" button is added to the alert dialog.
See picture 1 and 2.

2. The other part take care of the situation when a VHF-DSC alert is received from a ship also present as a AIS target, i.e. the same mmsi. 
As long the DSC alert is active the alert dialog will combine DSC and AIS info so the ships name is shown if received or present in the AIS hash table. See picture 3.
The DSC target is normally shown as a red square and that one persist until timed out even if the alert is closed. If the same mmsi target also is received as an AIS the ship symbol will though shift to a normal AIS symbol if the DSC alert is closed.


If the code changes are studied for relevance it's appreciated. The solution to override some AIS info by an active DSC distress for the same mmsi may be called a hack?
The code is tested by constructed DSC messages only. Thanks to TwoCan for support with this and good background info.

Thanks
Håkan

![bild](https://user-images.githubusercontent.com/7202854/158079322-ef5527ba-b902-4f04-a405-a87f8588e37a.png)



     