### PR TITLE
Connection parameters: unreadable data fix (#2538)

### DIFF
--- a/src/ConnectionParams.cpp
+++ b/src/ConnectionParams.cpp
@@ -40,6 +40,34 @@
 #define wxAtoi(arg) atoi(arg)
 #endif
 
+
+/** A wxStaticText bold label with correct width, see #2538 */
+class ConnBoldLabel: public wxStaticText {
+public:
+  ConnBoldLabel(wxWindow* parent, const wxString& label)
+      : wxStaticText(parent, wxID_ANY, "") {
+    font = parent->GetFont();
+    font.MakeBold();
+    SetFont(font);
+    SetLabel(label);
+    Connect(wxEVT_LEFT_DOWN,
+            wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
+            parent);
+  }
+
+  void SetLabel(const wxString& label) {
+    wxStaticText::SetLabel(label);
+    dc.SetFont(font);
+    auto size = dc.GetTextExtent(label).Scale(1.1, 1.1);
+    SetMinSize(size);
+  }
+
+private:
+  wxScreenDC dc;
+  wxFont font;
+};
+
+
 ConnectionParams::ConnectionParams(const wxString &configStr) {
   m_optionsPanel = NULL;
   Deserialize(configStr);

--- a/src/ConnectionParams.cpp
+++ b/src/ConnectionParams.cpp
@@ -476,7 +476,7 @@ void ConnectionParamsPanel::CreateControls(void) {
         proto = "NMEA 2000";
         break;
       default:
-        proto = "Undefined";
+        proto = _("Undefined");
         break;
     }
 

--- a/src/ConnectionParams.cpp
+++ b/src/ConnectionParams.cpp
@@ -455,74 +455,44 @@ void ConnectionParamsPanel::CreateControls(void) {
                  this);
 
     // line 2
-    t2 = new wxStaticText(this, wxID_ANY, _("Serial"));
-    t2->SetFont(*bFont);
+    t2 = new ConnBoldLabel(this, _("Serial"));
     serialGrid->Add(t2, 0, wxALIGN_CENTER_HORIZONTAL);
-    t2->Connect(wxEVT_LEFT_DOWN,
-                wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
-                this);
 
-    t4 = new wxStaticText(this, wxID_ANY, _T(""));
+    t4 = new ConnBoldLabel(this, "");
     serialGrid->Add(t4, 0, wxALIGN_CENTER_HORIZONTAL);
-    t4->Connect(wxEVT_LEFT_DOWN,
-                wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
-                this);
 
-    t6 = new wxStaticText(this, wxID_ANY, ioDir);
-    t6->SetFont(*bFont);
+    t6 = new ConnBoldLabel(this, ioDir);
     serialGrid->Add(t6, 0, wxALIGN_CENTER_HORIZONTAL);
-    t6->Connect(wxEVT_LEFT_DOWN,
-                wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
-                this);
 
     wxString proto;
     switch (m_pConnectionParams->Protocol) {
       case PROTO_NMEA0183:
-        proto = _T("NMEA 0183");
+        proto = "NMEA 0183";
         break;
       case PROTO_SEATALK:
-        proto = _T("SEATALK");
+        proto = "SEATALK";
         break;
       case PROTO_NMEA2000:
-        proto = _T("NMEA 2000");
+        proto = "NMEA 2000";
         break;
       default:
-        proto = _("Undefined");
+        proto = "Undefined";
         break;
     }
 
-    t12 = new wxStaticText(this, wxID_ANY, proto);
-    t12->SetFont(*bFont);
+    t12 = new ConnBoldLabel(this, proto);
     serialGrid->Add(t12, 0, wxALIGN_CENTER_HORIZONTAL);
-    t12->Connect(wxEVT_LEFT_DOWN,
-                 wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
-                 this);
 
-    wxString serialPort = m_pConnectionParams->Port;
-    t14 = new wxStaticText(this, wxID_ANY, serialPort);
-    t14->SetFont(*bFont);
+    t14 = new ConnBoldLabel(this, m_pConnectionParams->Port);
     serialGrid->Add(t14, 0, wxALIGN_CENTER_HORIZONTAL);
-    t14->Connect(wxEVT_LEFT_DOWN,
-                 wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
-                 this);
 
-    wxString baudRate;
-    baudRate.Printf(_T("%d"), m_pConnectionParams->Baudrate);
-    t16 = new wxStaticText(this, wxID_ANY, baudRate);
-    t16->SetFont(*bFont);
+    auto baudRate = wxString::Format("%d", m_pConnectionParams->Baudrate);
+    t16 = new ConnBoldLabel(this, baudRate);
     serialGrid->Add(t16, 0, wxALIGN_CENTER_HORIZONTAL);
-    t16->Connect(wxEVT_LEFT_DOWN,
-                 wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
-                 this);
 
-    wxString priority;
-    priority.Printf(_T("%d"), m_pConnectionParams->Priority);
-    t18 = new wxStaticText(this, wxID_ANY, priority);
-    t18->SetFont(*bFont);
+    auto priority = wxString::Format("%d", m_pConnectionParams->Priority);
+    t18 = new ConnBoldLabel(this, priority);
     serialGrid->Add(t18, 0, wxALIGN_CENTER_HORIZONTAL);
-    t18->Connect(wxEVT_LEFT_DOWN,
-                 wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
-                 this);
 
     wxStaticLine *line = new wxStaticLine(this, wxID_ANY, wxDefaultPosition,
                                           wxDefaultSize, wxLI_HORIZONTAL);


### PR DESCRIPTION
The culprit is that wxStaticText for some reason does not respect the font when calculating the minimum width, at least on GTK. Issue is present also in recent GTK 3.1.5.

Work around using a new bold label class.

Tested on Windows, Flatpak, Focal, and MacOS.

Closes: #2538