### PR TITLE
Move hex degree sign out of Format strings

### DIFF
--- a/plugins/grib_pi/src/CursorData.cpp
+++ b/plugins/grib_pi/src/CursorData.cpp
@@ -396,7 +396,7 @@ void CursorData::UpdateTrackingControls(void) {
                 wxString::Format(_T("%2d bf"), (int)round(vk))));
     }
 
-    m_tcWindDirection->SetValue(wxString::Format(_T("%03d\u00B0"), (int)(ang)));
+    m_tcWindDirection->SetValue(wxString::Format(_T("%03d%c"), (int)(ang), 0x00B0));
   } else {
     m_tcWindSpeed->SetValue(_("N/A"));
     m_tcWindSpeedBf->SetValue(_("N/A"));
@@ -477,7 +477,7 @@ void CursorData::UpdateTrackingControls(void) {
         m_cursor_lon, m_cursor_lat, true, true);
     if (direction != GRIB_NOTDEF)
       m_tcWaveDirection->SetValue(
-          wxString::Format(_T("%03d\u00B0"), (int)direction));
+          wxString::Format(_T("%03d%c"), (int)direction, 0x00B0));
     else
       m_tcWaveDirection->SetValue(_("N/A"));
   }
@@ -502,7 +502,7 @@ void CursorData::UpdateTrackingControls(void) {
         vkn));
 
     m_tcCurrentDirection->SetValue(
-        wxString::Format(_T("%03d\u00B0"), (int)(ang)));
+        wxString::Format(_T("%03d%c"), (int)(ang), 0x00B0));
   } else {
     m_tcCurrentVelocity->SetValue(_("N/A"));
     m_tcCurrentDirection->SetValue(_("N/A"));

--- a/plugins/grib_pi/src/CustomGrid.cpp
+++ b/plugins/grib_pi/src/CustomGrid.cpp
@@ -389,7 +389,7 @@ void CustomRenderer::Draw(wxGrid& grid, wxGridCellAttr& attr, wxDC& dc,
   dc.DrawRectangle(rect);
   if (m_IsDigit || m_dDir == GRIB_NOTDEF) {  // digital format
     wxString text(wxEmptyString);
-    if (m_dDir != GRIB_NOTDEF) text.Printf(_T("%03d\u00B0"), (int)m_dDir);
+    if (m_dDir != GRIB_NOTDEF) text.Printf(_T("%03d%c"), (int)m_dDir, 0x00B0);
     dc.DrawLabel(text, rect,
                  wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL);
   } else {  // graphical format

--- a/plugins/wmm_pi/src/wmm_pi.cpp
+++ b/plugins/wmm_pi/src/wmm_pi.cpp
@@ -512,10 +512,10 @@ void wmm_pi::SetCursorLatLon(double lat, double lon) {
   m_pWmmDialog->m_tcZ->SetValue(
       wxString::Format(_T("%-9.1lf nT"), GeoMagneticElements.Z));
   m_pWmmDialog->m_tcD->SetValue(
-      wxString::Format(_T("%-5.1lf\u00B0 (%s)"), GeoMagneticElements.Decl,
+      wxString::Format(_T("%-5.1lf%c (%s)"), GeoMagneticElements.Decl, 0x00B0,
                        AngleToText(GeoMagneticElements.Decl).c_str()));
   m_pWmmDialog->m_tcI->SetValue(
-      wxString::Format(_T("%-5.1lf\u00B0"), GeoMagneticElements.Incl));
+      wxString::Format(_T("%-5.1lf%c"), GeoMagneticElements.Incl, 0x00B0));
 
   m_cursorVariation = GeoMagneticElements;
   SendCursorVariation();
@@ -653,10 +653,10 @@ void wmm_pi::SetPositionFix(PlugIn_Position_Fix &pfix) {
   m_pWmmDialog->m_tbZ->SetValue(
       wxString::Format(_T("%-9.1lf nT"), GeoMagneticElements.Z));
   m_pWmmDialog->m_tbD->SetValue(
-      wxString::Format(_T("%-5.1lf\u00B0 (%s)"), GeoMagneticElements.Decl,
+      wxString::Format(_T("%-5.1lf%c (%s)"), GeoMagneticElements.Decl, 0x00B0,
                        AngleToText(GeoMagneticElements.Decl).c_str()));
   m_pWmmDialog->m_tbI->SetValue(
-      wxString::Format(_T("%-5.1lf\u00B0"), GeoMagneticElements.Incl));
+      wxString::Format(_T("%-5.1lf%c"), GeoMagneticElements.Incl, 0x00B0));
 }
 
 // Demo implementation of response mechanism
@@ -781,9 +781,9 @@ wxString wmm_pi::AngleToText(double angle) {
   int deg = (int)fabs(angle);
   int min = (fabs(angle) - deg) * 60;
   if (angle < 0)
-    return wxString::Format(_T("%u\u00B0%u' W"), deg, min);
+    return wxString::Format(_T("%u%c%u' W"), deg, 0x00B0, min);
   else
-    return wxString::Format(_T("%u\u00B0%u' E"), deg, min);
+    return wxString::Format(_T("%u%c%u' E"), deg, 0x00B0, min);
 }
 
 bool wmm_pi::LoadConfig(void) {

--- a/src/AIS_Target_Data.cpp
+++ b/src/AIS_Target_Data.cpp
@@ -618,8 +618,8 @@ wxString AIS_Target_Data::BuildQueryResult(void) {
       (fabs(Lat) < 85.)) {
     wxString magString, trueString;
     if (g_bShowMag)
-      magString << wxString::Format(wxString("%03d\u00B0(M)"),
-                                    (int)gFrame->GetMag(Brg));
+      magString << wxString::Format(wxString("%03d%c(M)"),
+                                    (int)gFrame->GetMag(Brg), 0x00B0);
     if (g_bShowTrue)
       trueString << wxString::Format( wxString("%03d%c "), (int)Brg, 0x00B0 );
 

--- a/src/TCWin.cpp
+++ b/src/TCWin.cpp
@@ -992,7 +992,7 @@ void TCWin::OnTCWinPopupTimerEvent(wxTimerEvent &event) {
 
     // set current direction
     if (CURRENT_PLOT == m_plot_type) {
-      s.Printf("%3.0f\u00B0", d);
+      s.Printf("%3.0f%c", d, 0x00B0);
       p.Append(_T("\n"));
       p.Append(s);
     }

--- a/src/TrackPropDlg.cpp
+++ b/src/TrackPropDlg.cpp
@@ -1838,7 +1838,7 @@ wxString OCPNTrackListCtrl::OnGetItemText(long item, long column) const {
     case 2:
       DistanceBearingMercator(this_point->m_lat, this_point->m_lon, slat, slon,
                               &gt_brg, &gt_leg_dist);
-      ret.Printf("%03.0f \u00B0T", gt_brg);
+      ret.Printf("%03.0f %cT", gt_brg, 0x00B0);
       break;
 
     case 3:

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -9101,13 +9101,13 @@ void MyFrame::PostProcessNMEA(bool pos_valid, bool cog_sog_valid,
 
       wxString cogs;
       if (std::isnan(gCog))
-        cogs.Printf("COG ---\u00B0");
+        cogs.Printf("COG ---%c"), 0x00B0;
       else {
         if (g_bShowTrue)
-          cogs << wxString::Format(wxString("COG %03d\u00B0  "), (int)gCog);
+          cogs << wxString::Format(wxString("COG %03d%c  "), (int)gCog, 0x00B0);
         if (g_bShowMag)
-          cogs << wxString::Format(wxString("COG %03d\u00B0(M)  "),
-                                   (int)gFrame->GetMag(gCog));
+          cogs << wxString::Format(wxString("COG %03d%c(M)  "),
+                                   (int)gFrame->GetMag(gCog), 0x00B0);
       }
 
       sogcog.Append(cogs);

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -4128,9 +4128,9 @@ void ChartCanvas::SetCursorStatus(double cursor_lat, double cursor_lon) {
   wxString s;
   DistanceBearingMercator(cursor_lat, cursor_lon, gLat, gLon, &brg, &dist);
   if (g_bShowMag)
-    s.Printf("%03d\u00B0(M)  ", (int)gFrame->GetMag(brg));
+    s.Printf("%03d%c(M)  ", (int)gFrame->GetMag(brg), 0x00B0);
   else
-    s.Printf("%03d\u00B0  ", (int)brg);
+    s.Printf("%03d%c  ", (int)brg, 0x00B0);
 
   s << FormatDistanceAdaptive(dist);
 

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -4490,21 +4490,21 @@ wxString toSDMM(int NEflag, double a, bool hi_precision) {
       if (!NEflag || NEflag < 1 || NEflag > 2)  // Does it EVER happen?
       {
         if (hi_precision)
-          s.Printf(_T ( "%d\u00B0 %02ld.%04ld'" ), d, m / 10000, m % 10000);
+          s.Printf(_T ( "%d%c %02ld.%04ld'" ), d, 0x00B0, m / 10000, m % 10000);
         else
-          s.Printf(_T ( "%d\u00B0 %02ld.%01ld'" ), d, m / 10, m % 10);
+          s.Printf(_T ( "%d%c %02ld.%01ld'" ), d, 0x00B0, m / 10, m % 10);
       } else {
         if (hi_precision)
           if (NEflag == 1)
-            s.Printf(_T ( "%02d\u00B0 %02ld.%04ld' %c" ), d, m / 10000,
+            s.Printf(_T ( "%02d%c %02ld.%04ld' %c" ), d, 0x00B0, m / 10000,
                      (m % 10000), c);
           else
-            s.Printf(_T ( "%03d\u00B0 %02ld.%04ld' %c" ), d, m / 10000,
+            s.Printf(_T ( "%03d%c %02ld.%04ld' %c" ), d, 0x00B0, m / 10000,
                      (m % 10000), c);
         else if (NEflag == 1)
-          s.Printf(_T ( "%02d\u00B0 %02ld.%01ld' %c" ), d, m / 10, (m % 10), c);
+          s.Printf(_T ( "%02d%c %02ld.%01ld' %c" ), d, 0x00B0, m / 10, (m % 10), c);
         else
-          s.Printf(_T ( "%03d\u00B0 %02ld.%01ld' %c" ), d, m / 10, (m % 10), c);
+          s.Printf(_T ( "%03d%c %02ld.%01ld' %c" ), d, 0x00B0, m / 10, (m % 10), c);
       }
       break;
     case 1:
@@ -4525,23 +4525,23 @@ wxString toSDMM(int NEflag, double a, bool hi_precision) {
       if (!NEflag || NEflag < 1 || NEflag > 2)  // Does it EVER happen?
       {
         if (hi_precision)
-          s.Printf(_T ( "%d\u00B0 %ld'%ld.%ld\"" ), d, m, sec / 1000,
+          s.Printf(_T ( "%d%c %ld'%ld.%ld\"" ), d, 0x00B0, m, sec / 1000,
                    sec % 1000);
         else
-          s.Printf(_T ( "%d\u00B0 %ld'%ld.%ld\"" ), d, m, sec / 10, sec % 10);
+          s.Printf(_T ( "%d%c %ld'%ld.%ld\"" ), d, 0x00B0, m, sec / 10, sec % 10);
       } else {
         if (hi_precision)
           if (NEflag == 1)
-            s.Printf(_T ( "%02d\u00B0 %02ld' %02ld.%03ld\" %c" ), d, m,
+            s.Printf(_T ( "%02d%c %02ld' %02ld.%03ld\" %c" ), d, 0x00B0, m,
                      sec / 1000, sec % 1000, c);
           else
-            s.Printf(_T ( "%03d\u00B0 %02ld' %02ld.%03ld\" %c" ), d, m,
+            s.Printf(_T ( "%03d%c %02ld' %02ld.%03ld\" %c" ), d, 0x00B0, m,
                      sec / 1000, sec % 1000, c);
         else if (NEflag == 1)
-          s.Printf(_T ( "%02d\u00B0 %02ld' %02ld.%ld\" %c" ), d, m, sec / 10,
+          s.Printf(_T ( "%02d%c %02ld' %02ld.%ld\" %c" ), d, 0x00B0, m, sec / 10,
                    sec % 10, c);
         else
-          s.Printf(_T ( "%03d\u00B0 %02ld' %02ld.%ld\" %c" ), d, m, sec / 10,
+          s.Printf(_T ( "%03d%c %02ld' %02ld.%ld\" %c" ), d, 0x00B0, m, sec / 10,
                    sec % 10, c);
       }
       break;
@@ -4640,12 +4640,12 @@ double fromDMM(wxString sdms) {
 wxString formatAngle(double angle) {
   wxString out;
   if (g_bShowMag && g_bShowTrue) {
-    out.Printf(wxT("%03.0f \u00B0T (%.0f \u00B0M)"), angle,
-               gFrame->GetMag(angle));
+    out.Printf(wxT("%03.0f %cT (%.0f %cM)"), angle, 0x00B0,
+               gFrame->GetMag(angle), 0x00B0);
   } else if (g_bShowTrue) {
-    out.Printf(wxT("%03.0f \u00B0T"), angle);
+    out.Printf(wxT("%03.0f %cT"), angle, 0x00B0);
   } else {
-    out.Printf(wxT("%03.0f \u00B0M"), gFrame->GetMag(angle));
+    out.Printf(wxT("%03.0f %cM"), gFrame->GetMag(angle), 0x00B0);
   }
   return out;
 }


### PR DESCRIPTION
Most "\u00B0" moved outside Format-strings. My (Buster/Bullseye)-GCC and wx3.0 wasn't happy with the "\u.." format. 