### PR TITLE
ObservedVar: Handle windows going out of scope.

### DIFF
--- a/include/config_var.h
+++ b/include/config_var.h
@@ -41,6 +41,9 @@ public:
   /** Notify all listeners about variable change. */
   const void notify();
 
+  /** Remove window from list of listeners, return true if listener exists */
+  bool unlisten(wxWindow* listener);
+
 private:
   SingletonVar* const singleton;
 };

--- a/src/config_var.cpp
+++ b/src/config_var.cpp
@@ -36,6 +36,13 @@ void ObservedVar::listen(wxWindow* listener, wxEventType ev_type) {
   singleton->listeners[listener] = ev_type;
 }
 
+bool ObservedVar::unlisten(wxWindow* listener) {
+  auto& listeners = singleton->listeners;
+  if (listeners.find(listener) == listeners.end()) return false;
+  listeners.erase(listener);
+  return true;
+}
+
 const void ObservedVar::notify() {
   auto& listeners = singleton->listeners;
   for (auto l = listeners.begin(); l != listeners.end(); l++) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1644,6 +1644,15 @@ options::options(MyFrame* parent, wxWindowID id, const wxString& caption,
     Fit();
 
   Center();
+
+  wxDEFINE_EVENT(EVT_COMPAT_OS_CHANGE, wxCommandEvent);
+  ocpn::GlobalVar<wxString> compat_os(&g_compatOS);
+  compat_os.listen(this, EVT_COMPAT_OS_CHANGE);
+  Bind(EVT_COMPAT_OS_CHANGE, [&](wxCommandEvent&) {
+    g_pi_manager->LoadAllPlugIns(false);
+    auto plugins = g_pi_manager->GetPlugInArray();
+    m_pPlugInCtrl->ReloadPluginPanels(plugins);
+  });
 }
 
 options::~options(void) {
@@ -9978,15 +9987,7 @@ void options::DoOnPageChange(size_t page) {
 
       ::wxEndBusyCursor();
 
-      wxDEFINE_EVENT(EVT_COMPAT_OS_CHANGE, wxCommandEvent);
-      ocpn::GlobalVar<wxString> compat_os(&g_compatOS);
-      compat_os.listen(this, EVT_COMPAT_OS_CHANGE);
-      Bind(EVT_COMPAT_OS_CHANGE, [&](wxCommandEvent&) {
-        g_pi_manager->LoadAllPlugIns(false);
-        auto plugins = g_pi_manager->GetPlugInArray();
-        m_pPlugInCtrl->ReloadPluginPanels(plugins);
-      });
-    }
+   }
 
     k_plugins = TOOLBAR_CHANGED;
   }

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -1647,6 +1647,8 @@ options::options(MyFrame* parent, wxWindowID id, const wxString& caption,
 }
 
 options::~options(void) {
+  ocpn::GlobalVar<wxString> compat_os(&g_compatOS);
+  compat_os.unlisten(this);
   wxNotebook* nb =
       dynamic_cast<wxNotebook*>(m_pListbook->GetPage(m_pageCharts));
   if (nb)

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -5065,6 +5065,8 @@ CatalogMgrPanel::CatalogMgrPanel(wxWindow *parent)
 }
 
 CatalogMgrPanel::~CatalogMgrPanel() {
+  ocpn::GlobalVar<wxString> catalog(&g_catalog_channel);
+  catalog.unlisten(this);
   m_updateButton->Unbind(wxEVT_COMMAND_BUTTON_CLICKED,
                          &CatalogMgrPanel::OnUpdateButton, this);
   if (m_tarballButton)


### PR DESCRIPTION
This is an attempt to fix #2605. 

Note:
  - I cannot reproduce the bug described in #2605 and thus cannot really test this.
  - The fix is somewhat dirty and will not scale well.

A better approach might be some kind of listener instance which removes itself from the ObservedVar when destroyed. However, this is substantially more  code so this might be better explored in the 5.8.0 cycle. This patch is aimed for 5.6.2, trying to keep it minimal.