### PR TITLE
DB: GNSS status; Show the first (12) group only

### DIFF
--- a/plugins/dashboard_pi/src/gps.cpp
+++ b/plugins/dashboard_pi/src/gps.cpp
@@ -70,6 +70,7 @@ DashboardInstrument_GPS::DashboardInstrument_GPS(wxWindow* parent,
   b_shift = false;
   s_gTalker = wxEmptyString;
   m_iMaster = 1;  // Start with the GPS system
+  m_MaxSatCount = 0;
 }
 
 wxSize DashboardInstrument_GPS::GetSize(int orient, wxSize hint) {
@@ -117,6 +118,7 @@ void DashboardInstrument_GPS::SetSatInfo(int cnt, int seq, wxString talk,
         if (lastUpdate.GetSeconds() < 6) {
           m_iMaster = i;
           b_shift = false;
+          m_MaxSatCount = 0;
           break;
         }
         if (i == 5 && !secondturn) {
@@ -128,26 +130,45 @@ void DashboardInstrument_GPS::SetSatInfo(int cnt, int seq, wxString talk,
     if (talkerID == _T("GP")) {
       m_Gtime[1] = now;
       if (m_iMaster != 1) return;
+      // If two groups of messages in this sequence 
+      // show only the first one with most(12) satellites
+      if (m_MaxSatCount > m_SatCount) return;
+      else m_MaxSatCount = m_SatCount;
       s_gTalker = wxString::Format(_T("GPS\n%d"), m_SatCount);
     } else if (talkerID == _T("GL")) {
       m_Gtime[2] = now;
       if (m_iMaster != 2) return;
+      // See "GP" above
+      if (m_MaxSatCount > m_SatCount) return;
+      else m_MaxSatCount = m_SatCount;
       s_gTalker = wxString::Format(_T("GLONASS\n%d"), m_SatCount);
     } else if (talkerID == _T("GA")) {
       m_Gtime[3] = now;
       if (m_iMaster != 3) return;
+      // See "GP" above
+      if (m_MaxSatCount > m_SatCount) return;
+      else m_MaxSatCount = m_SatCount;
       s_gTalker = wxString::Format(_T("Galileo\n%d"), m_SatCount);
     } else if (talkerID == _T("GB")) {  // BeiDou  BDS
       m_Gtime[4] = now;
       if (m_iMaster != 4) return;
+      // See "GP" above
+      if (m_MaxSatCount > m_SatCount) return;
+      else m_MaxSatCount = m_SatCount;
       s_gTalker = wxString::Format(_T("BeiDou\n%d"), m_SatCount);
     } else if (talkerID == _T("GI")) {
       m_Gtime[5] = now;
       if (m_iMaster != 5) return;
+      // See "GP" above
+      if (m_MaxSatCount > m_SatCount) return;
+      else m_MaxSatCount = m_SatCount;
       s_gTalker = wxString::Format(_T("NavIC\n%d"), m_SatCount);
     } else if (talkerID == _T("GQ")) {
       m_Gtime[0] = now;
       if (m_iMaster != 0) return;
+      // See "GP" above
+      if (m_MaxSatCount > m_SatCount) return;
+      else m_MaxSatCount = m_SatCount;
       s_gTalker = wxString::Format(_T("QZSS\n%d"), m_SatCount);
     }
     else {

--- a/plugins/dashboard_pi/src/gps.h
+++ b/plugins/dashboard_pi/src/gps.h
@@ -61,6 +61,7 @@ protected:
 #define GNSS_SYSTEM 6
   int m_cx, m_cy, m_radius, m_refDim, m_scaleDelta, m_scaleBase;
   int m_SatCount;
+  int m_MaxSatCount;
   wxString talkerID;
   SAT_INFO m_SatInfo[12];
   bool b_shift;


### PR DESCRIPTION
Our Dashboard instrument GNSS Status views 12 satellites only and is of course a compromise.
When the receiver reports more than 12 satellites it uses two groups of GSV messages. The first group with up to 12 and the other with the rest. The second group is though "overwriting" the first group and what we see are the "worse" only. 
This PR is sorting the second group out. (We have to priority :)) 
Compare these GSV sequences:
```
$GPGSV,3,1,11,02,07,130,20,06,21,090,24,12,75,223,30,17,21,042,27,1*6E<0x0D><0x0A>
$GPGSV,3,2,11,19,37,056,27,22,21,317,23,24,56,151,24,25,33,248,34,1*60<0x0D><0x0A>
$GPGSV,3,3,11,32,34,300,39,03,02,018,,10,00,000,,1*52<0x0D><0x0A>
$GPGSV,2,1,06,03,02,018,,06,21,090,,10,00,000,,24,56,151,,8*6D<0x0D><0x0A>
$GPGSV,2,2,06,25,33,248,,32,34,300,,8*67<0x0D><0x0A>
```
After that (GPS) sequence next system is reported.

`$GBGSV,4,1,15,37,11,281,25,34,45,112,28,32,19,261,28,25,61,118,25,1*78<0x0D><0x0A>`
.....
