### PR TITLE
Fix an address sanitizer error.

### DIFF
--- a/src/tcmgr.cpp
+++ b/src/tcmgr.cpp
@@ -7345,8 +7345,9 @@ NV_U_INT32 bit_unpack(NV_U_BYTE buffer[], NV_U_INT32 start,
 
     /*  For the last byte we mask out anything after the end bit and    */
     /*  then shift to the right (8 - end_bit) bits.                     */
-
-    value += (NV_U_INT32)(buffer[start_byte] & mask[end_bit]) >> (8 - end_bit);
+    if (mask[end_bit]) {
+      value += (NV_U_INT32)(buffer[start_byte] & mask[end_bit]) >> (8 - end_bit);
+    }
   }
 
   return (value);


### PR DESCRIPTION
When the last bit to be unpacked happened to fall right on a byte
boundary, we could end up reading an extra byte and then masking
its value away. While normally fine, if that extra byte happened
to be off the end of the input buffer, this extra byte read would
read off the end of the array, potentially causing a segfault and
definitely causing an address sanitizer error.