### PR TITLE
Make frame style match between MUI bar and toolbar.

### DIFF
--- a/src/MUIBar.cpp
+++ b/src/MUIBar.cpp
@@ -553,7 +553,7 @@ MUIBar::MUIBar(ChartCanvas* parent, int orientation, float size_factor,
   // wxWindow::Create(parent, id, pos, size, style, name);
   // long mstyle = wxSIMPLE_BORDER;
   long mstyle = wxNO_BORDER | wxFRAME_NO_TASKBAR | wxFRAME_SHAPED |
-                wxFRAME_FLOAT_ON_PARENT;
+                wxFRAME_FLOAT_ON_PARENT | wxFRAME_TOOL_WINDOW;
 
   m_scaleFactor = size_factor;
   m_cs = (ColorScheme)-1;


### PR DESCRIPTION
This fixes an issue on macOS where the MUI bar would draw on top
of non-OpenCPN windows when OpenCPN is in the background.