### PR TITLE
Fix undefined-behavior sanitizer build.

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -996,7 +996,6 @@ class DECL_EXP PI_S57Obj {
 public:
   //  Public Methods
   PI_S57Obj();
-  ~PI_S57Obj();
 
 public:
   // Instance Data

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -133,6 +133,7 @@ WX_DEFINE_OBJARRAY(ArrayOfS57Obj);
 
 #include <wx/listimpl.cpp>
 WX_DEFINE_LIST(ListOfS57Obj);  // Implement a list of S57 Objects
+WX_DEFINE_LIST(ListOfPI_S57Obj); 
 
 WX_DEFINE_LIST(ListOfObjRazRules);  // Implement a list ofObjRazRules
 


### PR DESCRIPTION
ListOfPI_S57Obj was never actually defined, nor was the destructor
for PI_S57Obj. This manifested in build errors related to typeinfo
when linking with undefined-behavior sanitizer enabled.