### PR TITLE
Fix a few warnings reported by clang.

### DIFF
--- a/include/glChartCanvas.h
+++ b/include/glChartCanvas.h
@@ -94,7 +94,7 @@ class ChartCanvas;
 #define GESTURE_FINISH_TIMER 78336
 #define TEX_FADE_TIMER 78337
 
-typedef class {
+class OCPN_GLCaps {
 public:
   wxString Renderer;
   GLenum TextureRectangleFormat;
@@ -124,7 +124,7 @@ public:
   PFNGLCOMPRESSEDTEXIMAGE2DPROC m_glCompressedTexImage2D;
   PFNGLGETCOMPRESSEDTEXIMAGEPROC m_glGetCompressedTexImage;
 
-} OCPN_GLCaps;
+};
 
 void GetglEntryPoints(OCPN_GLCaps *pcaps);
 GLboolean QueryExtension(const char *extName);

--- a/include/plugin_blacklist.h
+++ b/include/plugin_blacklist.h
@@ -67,6 +67,7 @@ typedef struct plug_data {
  */
 class AbstractBlacklist {
 public:
+  virtual ~AbstractBlacklist() = default;
 
   /** Return status for given official plugin name and version. */
   virtual plug_status get_status(const std::string& name,
@@ -86,7 +87,6 @@ public:
 
   /** Return plugin-specific message, possibly "". */
   virtual std::string get_message(plug_status sts, const plug_data& data) = 0;
-
 };
 
 std::unique_ptr<AbstractBlacklist> blacklist_factory();

--- a/src/plugin_blacklist.cpp
+++ b/src/plugin_blacklist.cpp
@@ -195,6 +195,7 @@ private:
   }
 
 public:
+
   virtual plug_data get_library_data(const std::string library_file) {
     std::string filename(normalize_lib(library_file));
     auto found = find_block(filename);


### PR DESCRIPTION
C-style types aren't supposed to have public/private declarations.
Virtual base classes need to have virtual destructors to avoid
undefined behavior where delet is called.