### PR TITLE
Decommission a wxList in favor of a std::list.

### DIFF
--- a/include/cm93.h
+++ b/include/cm93.h
@@ -452,7 +452,7 @@ public:
 
   void UpdateLUPs(s57chart *pOwner);
   void ForceEdgePriorityEvaluate(void);
-  ListOfS57Obj *GetAssociatedObjects(S57Obj *obj);
+  std::list<S57Obj*> *GetAssociatedObjects(S57Obj *obj);
   cm93chart *GetCurrentSingleScaleChart() { return m_pcm93chart_current; }
 
   void SetSpecialOutlineCellIndex(int cell_index, int object_id, int subcell) {

--- a/include/s57chart.h
+++ b/include/s57chart.h
@@ -105,9 +105,6 @@ class ChartPlugInWrapper;
 // Declare the Array of S57Obj
 WX_DECLARE_OBJARRAY(S57Obj, ArrayOfS57Obj);
 
-// And also a list
-WX_DECLARE_LIST(S57Obj, ListOfS57Obj);
-
 WX_DECLARE_LIST(ObjRazRules, ListOfObjRazRules);
 
 //----------------------------------------------------------------------------
@@ -199,7 +196,7 @@ public:
   //    DEPCNT VALDCO array access
   bool GetNearestSafeContour(double safe_cnt, double &next_safe_cnt);
 
-  virtual ListOfS57Obj *GetAssociatedObjects(S57Obj *obj);
+  virtual std::list<S57Obj*> *GetAssociatedObjects(S57Obj *obj);
 
   virtual VE_Hash &Get_ve_hash(void) { return m_ve_hash; }
   virtual VC_Hash &Get_vc_hash(void) { return m_vc_hash; }
@@ -333,7 +330,7 @@ private:
                                        ChartPlugInWrapper *target_plugin_chart,
                                        s57chart *Chs57,
                                        ListOfObjRazRules *rule_list,
-                                       ListOfPI_S57Obj *pi_rule_list,
+                                       std::list<S57Obj*> *pi_rule_list,
                                        std::vector<s57Sector_t> &sectorlegs);
 
   // Private Data

--- a/src/cm93.cpp
+++ b/src/cm93.cpp
@@ -6024,7 +6024,7 @@ void cm93compchart::UpdateLUPs(s57chart *pOwner) {
   }
 }
 
-ListOfS57Obj *cm93compchart::GetAssociatedObjects(S57Obj *obj) {
+std::list<S57Obj*> *cm93compchart::GetAssociatedObjects(S57Obj *obj) {
   if (m_pcm93chart_current)
     return m_pcm93chart_current->GetAssociatedObjects(obj);
   else

--- a/src/s52cnsy.cpp
+++ b/src/s52cnsy.cpp
@@ -545,7 +545,7 @@ static wxString *_UDWHAZ03(S57Obj *obj, double depth_value,
 
     // get area DEPARE & DRGARE that intersect this point/line/area
 
-    ListOfS57Obj *pobj_list = NULL;
+    std::list<S57Obj*> *pobj_list = NULL;
 
     if (obj->m_chart_context->chart)
       pobj_list = obj->m_chart_context->chart->GetAssociatedObjects(obj);
@@ -556,9 +556,7 @@ static wxString *_UDWHAZ03(S57Obj *obj, double depth_value,
     }
 
     if (pobj_list) {
-      wxListOfS57ObjNode *node = pobj_list->GetFirst();
-      while (node) {
-        S57Obj *ptest_obj = node->GetData();
+      for (S57Obj* ptest_obj: *pobj_list) {
         if (GEO_LINE == ptest_obj->Primitive_type) {
           double drval2 = 0.0;
           GetDoubleAttr(ptest_obj, "DRVAL2", drval2);
@@ -584,7 +582,6 @@ static wxString *_UDWHAZ03(S57Obj *obj, double depth_value,
             break;
           }
         }
-        node = node->GetNext();
       }
 
       delete pobj_list;

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -132,7 +132,6 @@ static jmp_buf env_ogrf;  // the context saved by setjmp();
 WX_DEFINE_OBJARRAY(ArrayOfS57Obj);
 
 #include <wx/listimpl.cpp>
-WX_DEFINE_LIST(ListOfS57Obj);  // Implement a list of S57 Objects
 WX_DEFINE_LIST(ListOfPI_S57Obj); 
 
 WX_DEFINE_LIST(ListOfObjRazRules);  // Implement a list ofObjRazRules
@@ -3364,12 +3363,11 @@ bool s57chart::GetNearestSafeContour(double safe_cnt, double &next_safe_cnt) {
  --------------------------------------------------------------------------
  */
 
-ListOfS57Obj *s57chart::GetAssociatedObjects(S57Obj *obj) {
+std::list<S57Obj*> *s57chart::GetAssociatedObjects(S57Obj *obj) {
   int disPrioIdx;
   bool gotit;
 
-  ListOfS57Obj *pobj_list = new ListOfS57Obj;
-  pobj_list->Clear();
+  std::list<S57Obj*> *pobj_list = new std::list<S57Obj*>();
 
   double lat, lon;
   fromSM((obj->x * obj->x_rate) + obj->x_origin,
@@ -3394,7 +3392,7 @@ ListOfS57Obj *s57chart::GetAssociatedObjects(S57Obj *obj) {
         if (top->obj->bIsAssociable) {
           if (top->obj->BBObj.Contains(lat, lon)) {
             if (IsPointInObjArea(lat, lon, 0.0, top->obj)) {
-              pobj_list->Append(top->obj);
+              pobj_list->push_back(top->obj);
               gotit = true;
               break;
             }
@@ -3411,7 +3409,7 @@ ListOfS57Obj *s57chart::GetAssociatedObjects(S57Obj *obj) {
           if (top->obj->bIsAssociable) {
             if (top->obj->BBObj.Contains(lat, lon)) {
               if (IsPointInObjArea(lat, lon, 0.0, top->obj)) {
-                pobj_list->Append(top->obj);
+                pobj_list->push_back(top->obj);
                 break;
               }
             }


### PR DESCRIPTION
wxList is a std::list underneath nowadays, and we're not doing
anything wx-specific that would necessitate a wxList.