### PR TITLE
Compare against the correct enum values.

### DIFF
--- a/plugins/grib_pi/src/pi_ocpndc.cpp
+++ b/plugins/grib_pi/src/pi_ocpndc.cpp
@@ -274,22 +274,22 @@ void pi_ocpnDC::SetGLStipple() const {
 
 #ifndef USE_ANDROID_GLES2
   switch (m_pen.GetStyle()) {
-    case wxDOT: {
+    case wxPENSTYLE_DOT: {
       glLineStipple(1, 0x3333);
       glEnable(GL_LINE_STIPPLE);
       break;
     }
-    case wxLONG_DASH: {
+    case wxPENSTYLE_LONG_DASH: {
       glLineStipple(1, 0xFFF8);
       glEnable(GL_LINE_STIPPLE);
       break;
     }
-    case wxSHORT_DASH: {
+    case wxPENSTYLE_SHORT_DASH: {
       glLineStipple(1, 0x3F3F);
       glEnable(GL_LINE_STIPPLE);
       break;
     }
-    case wxDOT_DASH: {
+    case wxPENSTYLE_DOT_DASH: {
       glLineStipple(1, 0x8FF1);
       glEnable(GL_LINE_STIPPLE);
       break;

--- a/plugins/wmm_pi/src/pi_ocpndc.cpp
+++ b/plugins/wmm_pi/src/pi_ocpndc.cpp
@@ -267,22 +267,22 @@ void pi_ocpnDC::SetGLStipple() const {
 
 #ifndef USE_ANDROID_GLES2
   switch (m_pen.GetStyle()) {
-    case wxDOT: {
+    case wxPENSTYLE_DOT: {
       glLineStipple(1, 0x3333);
       glEnable(GL_LINE_STIPPLE);
       break;
     }
-    case wxLONG_DASH: {
+    case wxPENSTYLE_LONG_DASH: {
       glLineStipple(1, 0xFFF8);
       glEnable(GL_LINE_STIPPLE);
       break;
     }
-    case wxSHORT_DASH: {
+    case wxPENSTYLE_SHORT_DASH: {
       glLineStipple(1, 0x3F3F);
       glEnable(GL_LINE_STIPPLE);
       break;
     }
-    case wxDOT_DASH: {
+    case wxPENSTYLE_DOT_DASH: {
       glLineStipple(1, 0x8FF1);
       glEnable(GL_LINE_STIPPLE);
       break;

--- a/src/Track.cpp
+++ b/src/Track.cpp
@@ -702,22 +702,22 @@ void Track::Draw(ChartCanvas *cc, ocpnDC &dc, ViewPort &VP, const LLBBox &box) {
     glEnable(GL_BLEND);
 
     switch (style) {
-    case wxDOT: {
+    case wxPENSTYLE_DOT: {
       glLineStipple(1, 0x3333);
       glEnable(GL_LINE_STIPPLE);
       break;
     }
-    case wxLONG_DASH: {
+    case wxPENSTYLE_LONG_DASH: {
       glLineStipple(1, 0xFFF8);
       glEnable(GL_LINE_STIPPLE);
       break;
     }
-    case wxSHORT_DASH: {
+    case wxPENSTYLE_SHORT_DASH: {
       glLineStipple(1, 0x3F3F);
       glEnable(GL_LINE_STIPPLE);
       break;
     }
-    case wxDOT_DASH: {
+    case wxPENSTYLE_DOT_DASH: {
       glLineStipple(1, 0x8FF1);
       glEnable(GL_LINE_STIPPLE);
       break;

--- a/src/ocpndc.cpp
+++ b/src/ocpndc.cpp
@@ -246,22 +246,22 @@ void ocpnDC::SetGLStipple() const {
 
 #ifndef USE_ANDROID_GLES2
   switch (m_pen.GetStyle()) {
-    case wxDOT: {
+    case wxPENSTYLE_DOT: {
       glLineStipple(1, 0x3333);
       glEnable(GL_LINE_STIPPLE);
       break;
     }
-    case wxLONG_DASH: {
+    case wxPENSTYLE_LONG_DASH: {
       glLineStipple(1, 0xFFF8);
       glEnable(GL_LINE_STIPPLE);
       break;
     }
-    case wxSHORT_DASH: {
+    case wxPENSTYLE_SHORT_DASH: {
       glLineStipple(1, 0x3F3F);
       glEnable(GL_LINE_STIPPLE);
       break;
     }
-    case wxDOT_DASH: {
+    case wxPENSTYLE_DOT_DASH: {
       glLineStipple(1, 0x8FF1);
       glEnable(GL_LINE_STIPPLE);
       break;


### PR DESCRIPTION
This happened to work before because the underlying wx enums
happened to be compatible, but we should really be using the
correct wxPenStyle enums.