### PR TITLE
AIS target track, Check MMSI-PROP TRACKTYPE at AIS Detection and Opti…

### DIFF
--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -1219,6 +1219,14 @@ AIS_Error AIS_Decoder::Decode(const wxString &str) {
         // Check to see if this target has been flagged as a "follower"
         if (props->m_bFollower) follower_mmsi = mmsi;
 
+        // Check if this target has a dedicated tracktype
+        if (TRACKTYPE_NEVER == props->TrackType) {
+          pTargetData->b_show_track = false;
+        }
+        else if (TRACKTYPE_ALWAYS == props->TrackType) {
+          pTargetData->b_show_track = true;
+        }
+
         // Check to see if this MMSI has been configured to be ignored
         // completely...
         if (props->m_bignore) return AIS_NoError;

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -8743,7 +8743,25 @@ void options::OnApplyClick(wxCommandEvent& event) {
   if (g_pAIS) {
     for (const auto& it : g_pAIS->GetTargetList()) {
       AIS_Target_Data* pAISTarget = it.second;
-      if (NULL != pAISTarget) pAISTarget->b_show_track = g_bAISShowTracks;
+      if (NULL != pAISTarget) {
+        pAISTarget->b_show_track = g_bAISShowTracks;
+        // Check for exceptions in MMSI properties
+        for (unsigned int i = 0; i < g_MMSI_Props_Array.GetCount(); i++) {
+          if (pAISTarget->MMSI == g_MMSI_Props_Array[i]->MMSI) {
+            MMSIProperties *props = g_MMSI_Props_Array[i];
+            if (TRACKTYPE_NEVER == props->TrackType) {
+              pAISTarget->b_show_track = false;
+              break;
+            }
+            else if (TRACKTYPE_ALWAYS == props->TrackType) {
+              pAISTarget->b_show_track = true;
+              break;
+            }
+            else
+              break;
+          }
+        }
+      }
     }
   }
 


### PR DESCRIPTION
…ons->AIS show/hide tracks.

Compare the MMSI  properties "Always" discussion [here](https://www.cruisersforum.com/forums/f134/opencpn-5-2-0-issue-with-tracked-vessels-mmsi-properties-238176.html#post3618530)
This PR aims to solve the Always or Never property.

The persistent track part is not that clear. I think we need to discuss in a future issue.