### PR TITLE
Update persistent tracks. Add all mmsi-props for SignalK

### DIFF
--- a/include/AIS_Decoder.h
+++ b/include/AIS_Decoder.h
@@ -113,7 +113,7 @@ private:
   void getAISTarget(long mmsi, AIS_Target_Data *&pTargetData,
                     AIS_Target_Data *&pStaleTarget, bool &bnewtarget,
                     int &last_report_ticks, wxDateTime &now);
-
+  void getMMSIProperties(AIS_Target_Data *&pTargetData);
   void handleUpdate(AIS_Target_Data *pTargetData, bool bnewtarget,
                     wxJSONValue &update);
   void updateItem(AIS_Target_Data *pTargetData, bool bnewtarget,

--- a/include/AIS_Target_Data.h
+++ b/include/AIS_Target_Data.h
@@ -113,7 +113,8 @@ public:
   //                     MMSI Properties
   bool b_NoTrack;
   bool b_OwnShip;
-  bool b_PersistTrack;
+  bool b_PersistTrack; // For AIS target query
+  bool b_mPropPersistTrack; // For mmsi_prop
 
   int m_utc_hour;
   int m_utc_min;

--- a/src/AIS_Target_Data.cpp
+++ b/src/AIS_Target_Data.cpp
@@ -143,6 +143,7 @@ AIS_Target_Data::AIS_Target_Data() {
   b_NoTrack = false;
   b_OwnShip = false;
   b_PersistTrack = false;
+  b_mPropPersistTrack = false;
   b_in_ack_timeout = false;
 
   b_active = false;


### PR DESCRIPTION
Fixed a  bug in persistent track update.
Add aistarget parameter for persistent track controlled by mmsi properties to avoid confusion between that track and the one controlled by AIS Target query.
Add general mmsi properties for AIS targets from a SignalK connection.

Tested on Win and Linux-RPi but not MacOs. 