### PR TITLE
Handle some gcc 12 warnings

### DIFF
--- a/src/Downloader.cpp
+++ b/src/Downloader.cpp
@@ -98,7 +98,7 @@ bool Downloader::download(std::string& path) {
 
 long Downloader::get_filesize() {
   CURL* curl;
-  char curl_errbuf[CURL_ERROR_SIZE];
+  char curl_errbuf[CURL_ERROR_SIZE] = {0};
   double filesize = 0.0;
 
   curl = curl_easy_init();

--- a/src/plugin_blacklist.cpp
+++ b/src/plugin_blacklist.cpp
@@ -230,6 +230,9 @@ public:
     return m_blocks[filename].status != plug_status::unloadable;
   }
 
+// gcc 12 bogus regex warning
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
   std::string get_message(plug_status status, const plug_data& data) {
     if (status == plug_status::unloadable) {
       std::string msg(_("Plugin library %s can not be loaded"));
@@ -247,6 +250,7 @@ public:
     else
       return format_message(found->second.message, data);
   }
+#pragma GCC diagnostic pop
 };
 
 

--- a/src/ser_ports.cpp
+++ b/src/ser_ports.cpp
@@ -148,7 +148,12 @@ static std::string device_path(const char* dev) {
     return std::string("/dev") + path.substr(path.rfind('/'));
 }
 
+
 static int isTTYreal(const char* dev) {
+
+// gcc 12 bogus regex warning
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
 
   // Drop non-readable devices
   std::string path = device_path(dev);
@@ -186,6 +191,8 @@ static int isTTYreal(const char* dev) {
   }
   close(fd);
   return ok ? 1 : 0;
+
+#pragma GCC diagnostic pop
 }
 
 #else
@@ -289,6 +296,10 @@ static std::string get_device_info(struct udev_device* ud) {
   return info;
 }
 
+// gcc bogus regex warning
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 /** Return list of device links pointing to dev. */
 static std::vector<struct device_data> get_links(struct udev_device* dev,
                                                  const std::regex& exclude) {
@@ -332,6 +343,7 @@ static std::vector<struct device_data> enumerate_udev_ports(struct udev* udev) {
   return items;
 }
 
+#pragma GCC diagnostic pop
 static wxArrayString* EnumerateUdevSerialPorts(void) {
   struct udev* udev = udev_new();
   auto dev_items = enumerate_udev_ports(udev);


### PR DESCRIPTION
gcc 12 comes with some new warnings, generating tons of text. Mute those about regex,  they are deemed bogus. Fix an initialized variable.