### PR TITLE
CMakeLists: Handle FTBFS when OCPN_USE_CURL=OFF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1608,10 +1608,13 @@ target_link_libraries(
     ocpn::tinyxml
 )
 
-IF(NOT QT_ANDROID)
-   target_link_libraries(S57ENC PUBLIC ocpn::wxcurl
-)
-ENDIF(NOT QT_ANDROID)
+if (NOT QT_ANDROID)
+  target_link_libraries(S57ENC PUBLIC ocpn::wxsvg)
+endif ()
+
+if (OCPN_USE_CURL)
+  target_link_libraries(S57ENC PUBLIC ocpn::wxcurl)
+endif ()
 
 add_subdirectory(libs/iso8211)
 target_link_libraries(S57ENC PUBLIC ocpn::iso8211)


### PR DESCRIPTION
Closes: #2698

Originally from #2689, but useful in it's  own right