### PR TITLE
Take out a doubled definition of the serial Datastream variable: dstr

### DIFF
--- a/src/multiplexer.cpp
+++ b/src/multiplexer.cpp
@@ -1190,8 +1190,8 @@ int Multiplexer::SendWaypointToGPS(RoutePoint *prp, const wxString &com_name,
         baud = _T("4800");
       }
 
-      DataStream *dstr = makeSerialDataStream(this, SERIAL, com_name, baud,
-                                              DS_TYPE_INPUT_OUTPUT, 0, false);
+      dstr = makeSerialDataStream(this, SERIAL, com_name, baud,
+                                  DS_TYPE_INPUT_OUTPUT, 0, false);
       btempStream = true;
 
 #ifdef __OCPN__ANDROID__


### PR DESCRIPTION
Fixes #2705
Please check if the solution can be this simple!? 
It works on Win10 for "General" wpl output. (See shot)
Furuno output is still working.
Garmin is "working" but not finalized due to "Time out..." in the log since no Garmin is connected so probably also OK. (Let's hope for testers)

![bild](https://user-images.githubusercontent.com/7202854/170877543-41e46242-a108-4529-9fe7-2d37d3795303.png)

