### PR TITLE
GNSS Add extra sat-system BeiDou TalkerID. Print only two digits PRN

### DIFF
--- a/plugins/dashboard_pi/src/gps.cpp
+++ b/plugins/dashboard_pi/src/gps.cpp
@@ -149,7 +149,7 @@ void DashboardInstrument_GPS::SetSatInfo(int cnt, int seq, wxString talk,
       if (m_MaxSatCount > m_SatCount) return;
       else m_MaxSatCount = m_SatCount;
       s_gTalker = wxString::Format(_T("Galileo\n%d"), m_SatCount);
-    } else if (talkerID == _T("GB")) {  // BeiDou  BDS
+    } else if (talkerID == _T("GB") || talkerID == _T("BD")) {  // BeiDou  BDS
       m_Gtime[4] = now;
       if (m_iMaster != 4) return;
       // See "GP" above
@@ -298,9 +298,12 @@ void DashboardInstrument_GPS::DrawBackground(wxGCDC* dc) {
   int pitch = m_refDim;
   int offset = m_refDim * 12 / 100;
   for (int idx = 0; idx < 12; idx++) {
-    if (m_SatInfo[idx].SatNumber)
-      tdc.DrawText(wxString::Format(_T("%02d"), m_SatInfo[idx].SatNumber),
-                   idx * pitch + offset, 0);
+    if (m_SatInfo[idx].SatNumber) {
+      wxString satno = wxString::Format(_T("%02d"), m_SatInfo[idx].SatNumber);
+      //Avoid three digit sat-number here. Especially for BeiDou(GB/BD)
+      satno = satno.Right(2);
+      tdc.DrawText(satno, idx * pitch + offset, 0);
+    }
     else
       tdc.DrawText(" -", idx * pitch + offset, 0);
   }


### PR DESCRIPTION
Some AIS transceivers are using TalkerID "BD" instead of "GB" for satellite system BeiDou. Even though  it's not described in the NMEA standard I've seen it seems to be a common rule.
This PR add "BD" as a condition to identify the BeiDou system.

Also are some transceivers using a three digit designation for satellite ID, PRN,  especially for the BeiDou system. One mentioned rule is to subtract 100 to get a "normal" PRN number but there are other rules use by single transceivers. I've seen e.g.: "234". To get the PRN number to fit in our GNSS status instrument bottom list this PR use the last two digits instead.  (For 234 use 34)