### PR TITLE
Print to AIS target name cache only if the MSSI numberis is valid

### DIFF
--- a/src/AIS_Decoder.cpp
+++ b/src/AIS_Decoder.cpp
@@ -1440,7 +1440,10 @@ AIS_Error AIS_Decoder::Decode(const wxString &str) {
     //  If the message was decoded correctly
     //  Update the AIS Target information
     if (bdecode_result) {
-      AISshipNameCache(pTargetData, AISTargetNamesC, AISTargetNamesNC, mmsi);
+      // Print to name cache only if not mmsi = 0
+      if (mmsi) {
+        AISshipNameCache(pTargetData, AISTargetNamesC, AISTargetNamesNC, mmsi);
+      }
       AISTargetList[pTargetData->MMSI] =
           pTargetData;  // update the hash table entry
 


### PR DESCRIPTION
AIS targets can show up using a null or 000000000 MMSI number. The reason for this "misuse" can be discussed but it's there. When one or two targets use a null MMSI number our AIS target name cache list is "screwed up" leading to unexpected behavior.
This PR omits a null MMSI to be added to the target name list.

