### PR TITLE
Update org.opencpn.OpenCPN.yaml

### DIFF
--- a/flatpak/org.opencpn.OpenCPN.yaml
+++ b/flatpak/org.opencpn.OpenCPN.yaml
@@ -26,6 +26,7 @@ finish-args:
     - --filesystem=home
     - --share=network
     - --device=all
+    - --allow=canbus
 
 add-extensions:
     org.opencpn.OpenCPN.Plugin:


### PR DESCRIPTION
Add canbus permissions
TwoCan uses the SocketCAN API, which requires access to the canbus.

Otherwise users have to execute an additional command line in order for the TwoCan plugin to work in the flatpak sandbox
flatpak override --user --allow=canbus  org.opencpn.OpenCPN