### PR TITLE
Add option: Sync AIS and own ship COG predictor time

### DIFF
--- a/include/options.h
+++ b/include/options.h
@@ -316,6 +316,7 @@ public:
   void OnChooseFont(wxCommandEvent &event);
   void OnFontChoice(wxCommandEvent &event);
   void OnCPAWarnClick(wxCommandEvent &event);
+  void OnSyncCogPredClick(wxCommandEvent &event);
   void OnSizeAutoButton(wxCommandEvent &event);
   void OnSizeManualButton(wxCommandEvent &event);
 
@@ -559,7 +560,8 @@ public:
 
   // For the "AIS" page
   wxCheckBox *m_pCheck_CPA_Max, *m_pCheck_CPA_Warn, *m_pCheck_CPA_WarnT;
-  wxCheckBox *m_pCheck_Mark_Lost, *m_pCheck_Remove_Lost, *m_pCheck_Show_COG;
+  wxCheckBox *m_pCheck_Mark_Lost, *m_pCheck_Remove_Lost;
+  wxCheckBox *m_pCheck_Show_COG, *m_pCheck_Sync_OCOG_ACOG;
   wxCheckBox *m_pCheck_Show_Tracks, *m_pCheck_Hide_Moored,
       *m_pCheck_Scale_Priority;
   wxCheckBox *m_pCheck_AlertDialog, *m_pCheck_AlertAudio;

--- a/src/ConfigMgr.cpp
+++ b/src/ConfigMgr.cpp
@@ -161,6 +161,7 @@ extern double g_MarkLost_Mins;
 extern bool g_bRemoveLost;
 extern double g_RemoveLost_Mins;
 extern bool g_bShowCOG;
+extern bool g_bSyncCogPredictors;
 extern double g_ShowCOG_Mins;
 extern bool g_bAISShowTracks;
 extern bool g_bTrackCarryOver;
@@ -1519,6 +1520,7 @@ bool ConfigMgr::CheckTemplate(wxString fileName) {
   CHECK_INT(_T ( "bRemoveLostTargets" ), &g_bRemoveLost);
   CHECK_FLT(_T ( "RemoveLost_Minutes" ), &g_RemoveLost_Mins, 1)
   CHECK_INT(_T ( "bShowCOGArrows" ), &g_bShowCOG);
+  CHECK_INT(_T ( "bSyncCogPredictors" ), &g_bSyncCogPredictors);
   CHECK_FLT(_T ( "CogArrowMinutes" ), &g_ShowCOG_Mins, 1);
   CHECK_INT(_T ( "bShowTargetTracks" ), &g_bAISShowTracks);
   CHECK_FLT(_T ( "TargetTracksMinutes" ), &g_AISShowTracks_Mins, 1)

--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -153,6 +153,7 @@ extern double g_MarkLost_Mins;
 extern bool g_bRemoveLost;
 extern double g_RemoveLost_Mins;
 extern bool g_bShowCOG;
+extern bool g_bSyncCogPredictors;
 extern double g_ShowCOG_Mins;
 extern bool g_bHideMoored;
 extern double g_ShowMoored_Kts;
@@ -1147,6 +1148,7 @@ void OCPNPlatform::SetDefaultOptions(void) {
   g_RemoveLost_Mins = 10;
   g_bShowCOG = true;
   g_ShowCOG_Mins = 6;
+  g_bSyncCogPredictors = false;
   g_bHideMoored = false;
   g_ShowMoored_Kts = 0.2;
   g_bTrackDaily = false;

--- a/src/chart1.cpp
+++ b/src/chart1.cpp
@@ -606,6 +606,7 @@ double g_MarkLost_Mins;
 bool g_bRemoveLost;
 double g_RemoveLost_Mins;
 bool g_bShowCOG;
+bool g_bSyncCogPredictors;
 double g_ShowCOG_Mins;
 bool g_bAISShowTracks;
 double g_AISShowTracks_Mins;

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -193,6 +193,7 @@ extern double g_MarkLost_Mins;
 extern bool g_bRemoveLost;
 extern double g_RemoveLost_Mins;
 extern bool g_bShowCOG;
+extern bool g_bSyncCogPredictors;
 extern double g_ShowCOG_Mins;
 extern bool g_bAISShowTracks;
 extern bool g_bTrackCarryOver;
@@ -1144,6 +1145,8 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   s.ToDouble(&g_RemoveLost_Mins);
 
   Read(_T ( "bShowCOGArrows" ), &g_bShowCOG);
+
+  Read(_T ("bSyncCogPredictors"), &g_bSyncCogPredictors);
 
   Read(_T ( "CogArrowMinutes" ), &s);
   s.ToDouble(&g_ShowCOG_Mins);
@@ -2578,6 +2581,7 @@ void MyConfig::UpdateSettings() {
   Write(_T ( "bRemoveLostTargets" ), g_bRemoveLost);
   Write(_T ( "RemoveLost_Minutes" ), g_RemoveLost_Mins);
   Write(_T ( "bShowCOGArrows" ), g_bShowCOG);
+  Write(_T ( "bSyncCogPredictors" ), g_bSyncCogPredictors);
   Write(_T ( "CogArrowMinutes" ), g_ShowCOG_Mins);
   Write(_T ( "bShowTargetTracks" ), g_bAISShowTracks);
   Write(_T ( "TargetTracksMinutes" ), g_AISShowTracks_Mins);

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -188,6 +188,7 @@ extern bool g_bRemoveLost;
 extern double g_RemoveLost_Mins;
 extern bool g_bShowCOG;
 extern double g_ShowCOG_Mins;
+extern bool g_bSyncCogPredictors;
 extern bool g_bAISShowTracks;
 extern double g_AISShowTracks_Mins;
 extern double g_ShowMoored_Kts;
@@ -6338,6 +6339,16 @@ void options::CreatePanel_AIS(size_t parent, int border_size,
   pDisplayGrid->Add(m_pText_COG_Predictor, 1, wxALL | wxALIGN_RIGHT,
                     group_item_spacing);
 
+  m_pCheck_Sync_OCOG_ACOG = new wxCheckBox(
+    panelAIS, -1, _("Sync AIS arrow length with own ship's COG predictor"));
+  pDisplayGrid->Add(m_pCheck_Sync_OCOG_ACOG, 1, wxALL, group_item_spacing);
+  m_pCheck_Sync_OCOG_ACOG->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
+                             wxCommandEventHandler(options::OnSyncCogPredClick),
+                             NULL, this);
+
+  wxStaticText* pStatic_Dummy4a = new wxStaticText(panelAIS, -1, _T(""));
+  pDisplayGrid->Add(pStatic_Dummy4a, 1, wxALL, group_item_spacing);
+
   m_pCheck_Show_Tracks =
       new wxCheckBox(panelAIS, -1, _("Show target tracks, length (min)"));
   pDisplayGrid->Add(m_pCheck_Show_Tracks, 1, wxALL, group_item_spacing);
@@ -7504,6 +7515,9 @@ void options::SetInitialSettings(void) {
   s.Printf(_T("%4.0f"), g_ShowCOG_Mins);
   m_pText_COG_Predictor->SetValue(s);
 
+  m_pCheck_Sync_OCOG_ACOG->SetValue(g_bSyncCogPredictors);
+  if(g_bSyncCogPredictors) m_pText_COG_Predictor->Disable();
+
   m_pCheck_Show_Tracks->SetValue(g_bAISShowTracks);
 
   s.Printf(_T("%4.0f"), g_AISShowTracks_Mins);
@@ -7879,6 +7893,19 @@ void options::OnCPAWarnClick(wxCommandEvent& event) {
   } else {
     m_pCheck_CPA_WarnT->SetValue(FALSE);
     m_pCheck_CPA_WarnT->Disable();
+  }
+}
+
+void options::OnSyncCogPredClick(wxCommandEvent &event) {
+  if (m_pCheck_Sync_OCOG_ACOG->GetValue()) {
+    m_pText_COG_Predictor->SetValue(m_pText_OSCOG_Predictor->GetValue());
+    m_pText_COG_Predictor->Disable();
+  }
+  else {
+    wxString s;
+    s.Printf(_T("%4.0f"), g_ShowCOG_Mins);
+    m_pText_COG_Predictor->SetValue(s);
+    m_pText_COG_Predictor->Enable();
   }
 }
 
@@ -8677,6 +8704,11 @@ void options::OnApplyClick(wxCommandEvent& event) {
 
   //   Display
   g_bShowCOG = m_pCheck_Show_COG->GetValue();
+  // If synchronized with own ship predictor
+  g_bSyncCogPredictors = m_pCheck_Sync_OCOG_ACOG->GetValue();
+  if (g_bSyncCogPredictors) {
+    m_pText_COG_Predictor->SetValue(m_pText_OSCOG_Predictor->GetValue());
+  }
   m_pText_COG_Predictor->GetValue().ToDouble(&g_ShowCOG_Mins);
 
   g_bAISShowTracks = m_pCheck_Show_Tracks->GetValue();


### PR DESCRIPTION
When this option is selected the AIS predictor time value is updated from own ship's COG predictor time.
The AIS predictor time value text box is deactivated while this option is active.
A similar function is default active on many ECDIS nav program but here it's default off to not surprise a present user. 

![bild](https://user-images.githubusercontent.com/7202854/172781535-45a9672a-dd8a-4fee-9377-19aafec68bc4.png)

