### PR TITLE
Add additional source to chart downloader

### DIFF
--- a/plugins/chartdldr_pi/data/chart_sources.xml
+++ b/plugins/chartdldr_pi/data/chart_sources.xml
@@ -1029,5 +1029,16 @@
         </catalog>
       </catalogs>
     </section>
+    <section>
+      <name>Layers (import as layer after download)</name>
+      <catalogs>
+        <catalog>
+          <name>Netherlands and surroundings waypoint layers</name>
+          <type>GPX</type>
+          <location>https://raw.githubusercontent.com/marcelrv/OpenCPN-Waypoints/main/chartcatalog/NL-waypoints.xml</location>
+          <dir>{USERDATA}/layers/NL-Waypoints</dir>
+        </catalog>
+      </catalogs>
+    </section>
   </sections>
 </ChartCatalog>


### PR DESCRIPTION
Adds a chartcatalog containing several Dutch waypoint gpx files from https://github.com/marcelrv/OpenCPN-Waypoints to ease loading files to openhab