### PR TITLE
BasePlatform: Add missing ocpn_plugin.h header

### DIFF
--- a/src/BasePlatform.cpp
+++ b/src/BasePlatform.cpp
@@ -58,6 +58,7 @@
 #include "BasePlatform.h"
 #include "logger.h"
 #include "ocpn_utils.h"
+#include "ocpn_plugin.h"
 
 #ifdef __ANDROID__
 #include <QDebug>


### PR DESCRIPTION
Without ocpn_plugin.h it still compiles and links seemingly without
errors on VS 2017, but with strange runtime errors on windows when loading
plugins probably caused by missing linker interface info available in
ocpn_plugin.h.

Referencing a method not defined in a header is an error on all platforms, but 
seemingly works everywhere besides windows.

The VS linker is a major trouble being unaware of polymorphism and with overall 
odd behaviour :( However, this fix is sound on all platforms.

Closes discussions in #2731