### PR TITLE
Add AIS Class B High speed craft symbol

### DIFF
--- a/src/ais.cpp
+++ b/src/ais.cpp
@@ -1621,8 +1621,9 @@ static void AISDrawTarget(AIS_Target_Data *td, ocpnDC &dc, ViewPort &vp,
     int navstatus = td->NavStatus;
 
     // HSC usually have correct ShipType but navstatus == 0...
+    // Class B can have (HSC)ShipType but never navstatus.
     if (((td->ShipType >= 40) && (td->ShipType < 50)) &&
-        navstatus == UNDERWAY_USING_ENGINE)
+        (navstatus == UNDERWAY_USING_ENGINE || td->Class == AIS_CLASS_B ))
       navstatus = HSC;
 
     if (targetscale > 90) {


### PR DESCRIPTION
With the "new" AIS Class B transponders it's more common Ship Type "High speed craft" are used. This commit aims to apply to that by using the HSC icon also for such a ship.

![bild](https://user-images.githubusercontent.com/7202854/177049758-8ae4604c-38fb-4db4-87c6-453e6273cdc3.png)
