### PR TITLE
Observable: Multiple bug fixes

### DIFF
--- a/include/observable.h
+++ b/include/observable.h
@@ -66,8 +66,11 @@ public:
   /** Notify all listeners about variable change. */
   virtual const void notify();
 
-  /** Remove window from list of listeners, return true if listener exists */
-  bool unlisten(wxEvtHandler* listener);
+  /**
+   * Remove window listening to ev from list of listeners.
+   * @return true if such a listener existed, else false.
+   */
+  bool unlisten(wxEvtHandler* listener, wxEventType ev);
 
   /** The key used to create and clone. */
   const std::string key;
@@ -130,7 +133,7 @@ private:
     if (key != "") {
       assert(listener);
       ObservedVar var(key);
-      var.unlisten(listener);
+      var.unlisten(listener, ev_type);
     }
   }
 

--- a/src/catalog_handler.cpp
+++ b/src/catalog_handler.cpp
@@ -36,6 +36,7 @@
 #include "catalog_handler.h"
 #include "catalog_parser.h"
 #include "Downloader.h"
+#include "observable.h"
 #include "ocpn_utils.h"
 #include "BasePlatform.h"
 #include "PluginHandler.h"

--- a/src/observable.cpp
+++ b/src/observable.cpp
@@ -65,20 +65,20 @@ using ev_pair = std::pair<wxEvtHandler*, wxEventType>;
 
 void ObservedVar::listen(wxEvtHandler* listener, wxEventType ev_type) {
   const auto& listeners = singleton->listeners;
-  auto found = std::find_if(listeners.begin(), listeners.end(),
-          [listener](const ev_pair p) { return p.first == listener; });
+  ev_pair keys(listener, ev_type);
+  auto found = std::find(listeners.begin(), listeners.end(), keys);
   if (found != listeners.end()) {
-    wxLogWarning("Duplicate event listener %s (ignored)", ptr_key(listener));
+      wxLogWarning("Duplicate listener, key: %s, listener: %s, ev_type: %d",
+                   key, ptr_key(listener), ev_type);
   }
-  else {
-    singleton->listeners.push_back(ev_pair(listener, ev_type));
-  }
+  singleton->listeners.push_back(ev_pair(listener, ev_type));
 }
 
-bool ObservedVar::unlisten(wxEvtHandler* listener) {
+bool ObservedVar::unlisten(wxEvtHandler* listener, wxEventType ev_type) {
   auto& listeners = singleton->listeners;
-  auto found = std::find_if(listeners.begin(), listeners.end(),
-          [listener](const ev_pair p) { return p.first == listener; });
+
+  ev_pair keys(listener, ev_type);
+  auto found = std::find(listeners.begin(), listeners.end(), keys);
   if (found == listeners.end()) return false;
   listeners.erase(found);
   return true;

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -5006,9 +5006,6 @@ CatalogMgrPanel::CatalogMgrPanel(wxWindow *parent)
                              2 * GetCharWidth());
     m_tarballButton->Bind(wxEVT_COMMAND_BUTTON_CLICKED,
                           &CatalogMgrPanel::OnTarballButton, this);
-
-    GlobalVar<wxString> catalog(&g_catalog_channel);
-    wxDEFINE_EVENT(EVT_CATALOG_CHANGE, wxCommandEvent);
   }
 
 #endif


### PR DESCRIPTION
Fix numerous bugs revealed after looking into errors reported in #2607 post-merge. Kudos to @Hakansv !

From main commit:

    observable: Fix non-symmetric listen-unlisten definition (#2607)
    
    The bug mentioned in #2607 discussion is really about at least
    three things:
    
    - Using unlisten(wxEvtHandler) will close all listeners for given
      window. This of course wrong, listen() is declared as
      listen(wxEvtHandler, wxEvtType) and so should also unlisten()
      be declared and work.
    - Although multiple listening entries is suspicious they can not
      not be removed, it causes problems when listeners goes out of
      scope and removes the only entry left.
    - Some otherwise ignored left-over for some copy-paste contains a
      wxDEFINE_EVENT call which potentially confuses the event types
      used.
    
    Closes after-merge discussion in #2607.

