### PR TITLE
Fix build without OpenGL

### DIFF
--- a/src/cm93.cpp
+++ b/src/cm93.cpp
@@ -5696,7 +5696,9 @@ bool cm93compchart::RenderNextSmallerCellOutlines(ocpnDC &dc, ViewPort &vp,
   if (m_cmscale >= 7) return false;
 
   wxColour col;
-  //#ifdef ocpnUSE_GL
+  #ifdef ocpnUSE_GL
+  return false;
+  #else
   ViewPort nvp;
   bool secondpass = false;
   glChartCanvas *glcc = cc->GetglCanvas();
@@ -5848,6 +5850,8 @@ bool cm93compchart::RenderNextSmallerCellOutlines(ocpnDC &dc, ViewPort &vp,
   }
 #endif
   return true;
+  
+  #endif //ocpnUSE_GL
 }
 
 bool cm93compchart::RenderCellOutlinesOnDC(ocpnDC &dc, ViewPort &vp,

--- a/src/s52plib.cpp
+++ b/src/s52plib.cpp
@@ -102,7 +102,7 @@ typedef struct {
   wxFont *key;
 } TexFontCache;
 
-#define TXF_CACHE 8
+#define CACHE 8
 static TexFontCache s_txf[TXF_CACHE];
 #endif
 
@@ -1315,8 +1315,6 @@ void s52plib::FlushSymbolCaches(void) {
     glDeleteLists(list, 1);
   }
   m_CARC_DL_hashmap.clear();
-#endif
-#endif
 
   // Flush all texFonts
   TexFont *f_cache = 0;
@@ -1328,6 +1326,9 @@ void s52plib::FlushSymbolCaches(void) {
       s_txf[i].key = 0;
     }
   }
+  
+#endif
+#endif
 }
 
 void s52plib::DestroyPattRules(RuleHash *rh) { DestroyRules(rh); }


### PR DESCRIPTION
Not sure why line 5702 was commented out.

But it breaks the build without Open GL ( `OCPN_USE_GL=OFF`). Not sure my solution is the best but it fixes the issue.