### PR TITLE
Update opencpn_fr_FR.po

### DIFF
--- a/po/opencpn_fr_FR.po
+++ b/po/opencpn_fr_FR.po
@@ -4532,7 +4532,7 @@ msgstr "0.05"
 
 #: src/MarkInfo.cpp:636 src/navutil.cpp:4239
 msgid "NMi"
-msgstr "Nds"
+msgstr "M"
 
 #: src/MarkInfo.cpp:636 src/navutil.cpp:4245
 msgid "km"


### PR DESCRIPTION
Translation of Nautical Mile (symbol NM) in French should be Mille Marin or Mille Nautique (symbol M).