### PR TITLE
Do not try to stop a track that is not running

### DIFF
--- a/src/routeman.cpp
+++ b/src/routeman.cpp
@@ -1060,7 +1060,7 @@ void Routeman::DeleteTrack(Track *pTrack) {
       pTrackPropDialog->Hide();
     }
 
-    if (pTrack == g_pActiveTrack) {
+    if (pTrack == g_pActiveTrack && g_pActiveTrack->IsRunning()) {
       pTrack = m_pparent_app->TrackOff();
     }
     //    Remove the track from associated lists


### PR DESCRIPTION
In a rare corner case, trying to stop the ownship track if it is not running results in infinite recursion.