### PR TITLE
build: Clean up handling of tinyxml (#2786).

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1143,13 +1143,6 @@ IF(QT_ANDROID)
   SET(SRCS ${SRCS} src/shaders.cpp)
 ENDIF(QT_ANDROID)
 
-SET(SRC_TINYXML
-  src/tinyxml.cpp
-  src/tinyxmlerror.cpp
-  src/tinyxmlparser.cpp
-  include/tinyxml.h
-)
-
 set(SRCS ${SRCS} ${MODEL_SRC})
 
 if (APPLE)
@@ -1625,19 +1618,8 @@ target_link_libraries(${PACKAGE_NAME} PRIVATE ocpn::sound)
 add_subdirectory(libs/wxJSON)
 target_link_libraries(${PACKAGE_NAME} PRIVATE ocpn::wxjson)
 
-
-if (TINYXML_FOUND)
-  message(STATUS "Building with system tinyxml")
-  add_library(TINYXML INTERFACE)
-  target_include_directories(TINYXML INTERFACE ${TINYXML_INCLUDE_DIR})
-  target_link_libraries(TINYXML INTERFACE ${TINYXML_LIBRARIES})
-  add_library(ocpn::tinyxml ALIAS TINYXML)
-else (TINYXML_FOUND)
-  add_subdirectory(libs/tinyxml)
-  target_link_libraries(${PACKAGE_NAME} PRIVATE ocpn::tinyxml)
-  message(STATUS "Building with bundled tinyxml")
-endif (TINYXML_FOUND)
-set(TIXML_USE_STL 1) # -> config.h
+add_subdirectory(libs/tinyxml)
+target_link_libraries(${PACKAGE_NAME} PRIVATE ocpn::tinyxml)
 
 message(STATUS "S57 ENC support: enabled")
 set(

--- a/cmake/in-files/config.h.in
+++ b/cmake/in-files/config.h.in
@@ -24,11 +24,6 @@
 #cmakedefine ocpnUSE_GLES
 
 
-#ifndef TIXML_USE_STL
-#cmakedefine TIXML_USE_STL
-#endif
-
-
 #cmakedefine OPENGL_FOUND
 #undef HAVE_UNISTD_H
 #cmakedefine OCPN_USE_UDEV_PORTS

--- a/libs/tinyxml/CMakeLists.txt
+++ b/libs/tinyxml/CMakeLists.txt
@@ -1,17 +1,33 @@
 cmake_minimum_required(VERSION 3.1.0)
 
 if (TARGET ocpn::tinyxml)
-    return ()
+  return ()
 endif ()
 
-set (SRC
-  src/tinyxml.cpp
-  src/tinyxmlerror.cpp
-  src/tinyxmlparser.cpp
-  include/tinyxml.h
-)
-add_library(TINYXML STATIC ${SRC})
-target_compile_definitions(TINYXML PUBLIC -DTIXML_USE_STL)
-set_property(TARGET TINYXML PROPERTY COMPILE_FLAGS "${OBJ_VISIBILITY}")
-target_include_directories(TINYXML PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+if (NOT APPLE)
+  # TinyXML from Homebrew is not good enough for our GpxDocument needs We
+  # should probably replace it with pugixml completely anyway...
+  find_package(TinyXML)
+endif ()
+
+if (TINYXML_FOUND)
+  message(STATUS "Building with system tinyxml")
+  add_library(TINYXML INTERFACE)
+  target_include_directories(TINYXML INTERFACE ${TINYXML_INCLUDE_DIR})
+  target_link_libraries(TINYXML INTERFACE ${TINYXML_LIBRARIES})
+else ()
+  message(STATUS "Building with bundled tinyxml")
+  set (SRC
+    src/tinyxml.cpp
+    src/tinyxmlerror.cpp
+    src/tinyxmlparser.cpp
+    include/tinyxml.h
+  )
+  add_library(TINYXML STATIC ${SRC})
+  target_compile_definitions(TINYXML PUBLIC -DTIXML_USE_STL)
+  if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang|GNU")   # Apple is AppleClang
+    target_compile_options(TINYXML PRIVATE -fvisibility=default -fPIC)
+  endif ()
+  target_include_directories(TINYXML PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include)
+endif ()
 add_library(ocpn::tinyxml ALIAS TINYXML)

--- a/libs/tinyxml/CMakeLists.txt
+++ b/libs/tinyxml/CMakeLists.txt
@@ -4,9 +4,17 @@ if (TARGET ocpn::tinyxml)
   return ()
 endif ()
 
-if (NOT APPLE)
+if (APPLE)
   # TinyXML from Homebrew is not good enough for our GpxDocument needs We
   # should probably replace it with pugixml completely anyway...
+  set(USE_BUNDLED_TINYXML ON)
+elseif (COMMAND use_bundled_lib)
+  use_bundled_lib(USE_BUNDLED_TINYXML tinyxml)
+else ()
+  set (USE_BUNDLED_TINYXML OFF)
+endif ()
+
+if (NOT USE_BUNDLED_TINYXML)
   find_package(TinyXML)
 endif ()
 


### PR DESCRIPTION
Make libs/tinyxml using the system  tinyxml library or the bundled one as appropriate. Obsoletes #2786.