### PR TITLE
Flatpak: build: Update bundled zlib version 1.2.12 -> 1.2.13

### DIFF
--- a/flatpak/org.opencpn.OpenCPN.yaml
+++ b/flatpak/org.opencpn.OpenCPN.yaml
@@ -83,8 +83,8 @@ modules:
     - name:  zlib
       sources:
           - type: archive
-            url: http://zlib.net/zlib-1.2.12.tar.gz
-            sha256: 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
+            url: http://zlib.net/zlib-1.2.13.tar.gz
+            sha256: b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
 
     - name: opencpn
       buildsystem: cmake


### PR DESCRIPTION
The zlib version referenced in the Flatpak manifest 1.2.12 is not longer available, breaking the Flatpakl build. Update to 1.2.13.