### PR TITLE
listener_gps_watchdog.Listen: Simplify

### DIFF
--- a/src/ocpn_frame.cpp
+++ b/src/ocpn_frame.cpp
@@ -5406,7 +5406,7 @@ void MyFrame::InitAppMsgBusListener() {
 
   //  GPS Watchdog expiry status
   AppMsg msg_watchdog(AppMsg::Type::GPSWatchdog);
-  listener_gps_watchdog.Listen(msg_watchdog.key(), this, EVT_GPS_WATCHDOG);
+  listener_gps_watchdog.Listen(msg_watchdog, this, EVT_GPS_WATCHDOG);
 
   Bind(EVT_GPS_WATCHDOG, [&](ObservedEvt ev) {
     auto ptr = ev.GetSharedPtr();


### PR DESCRIPTION
AppMsg is a KeyProvider, so there is no need to explicit specify the key. Since this step is error-prone, it is better avoided.