### PR TITLE
Work around glewInit problem on Wayland

### DIFF
--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -1069,9 +1069,9 @@ void glChartCanvas::SetupOpenGL() {
 #ifndef __OCPN__ANDROID__
 #ifndef __WXOSX__
   GLenum err = glewInit();
-  if (GLEW_OK != err)
+  if (GLEW_OK != err && GLEW_ERROR_NO_GLX_DISPLAY != err)
   {
-    printf("GLEW init failed: %s!n", glewGetErrorString(err));
+    printf("GLEW init failed: %s\n", glewGetErrorString(err));
     exit(1);
   }
   else

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -1069,7 +1069,11 @@ void glChartCanvas::SetupOpenGL() {
 #ifndef __OCPN__ANDROID__
 #ifndef __WXOSX__
   GLenum err = glewInit();
+#ifdef GLEW_ERROR_NO_GLX_DISPLAY
   if (GLEW_OK != err && GLEW_ERROR_NO_GLX_DISPLAY != err)
+#else
+  if (GLEW_OK != err)
+#endif
   {
     printf("GLEW init failed: %s\n", glewGetErrorString(err));
     exit(1);


### PR DESCRIPTION
Makes OpenCPN start on modern distros with Wayland (Fedora 37 in my case)
More details on the problem in https://github.com/nigels-com/glew/issues/172