### PR TITLE
PluginHandler: Update debian -> ubuntu compat table.

### DIFF
--- a/src/plugin_handler.cpp
+++ b/src/plugin_handler.cpp
@@ -193,35 +193,6 @@ public:
     return plugin.major_version() == m_major_version;
   }
 
-  // clang-format off
-  // Test if plugin abi is a Ubuntu version compatible with hosts's
-  // Debian version. To be removed, see  #2512.
-  bool is_ubuntu_plugin_compatible(const Plugin& plugin) const {
-    static const std::vector<std::string> debian_versions = {
-        // clang-format: off
-        // Assuming Debian 10 users sticks to gtk2:
-        "10;ubuntu-x86_64;18.04",
-        "11;ubuntu-gtk3-x86_64;20.04",
-        "11;ubuntu-x86_64-wx32;22.04",
-        "12;ubuntu-x86_64;23.04",
-        "12;ubuntu-x86_64;23.10",
-        "12;ubuntu-x86_64;24.04",
-        "sid;ubuntu-x86_64;24.04"
-    };   // clang-format: on
-    if (ocpn::startswith(m_abi, "debian-x86_64")) {
-      wxLogDebug("Checking for ubuntu plugin on a debian-x86_64 host");
-      const std::string host_version =
-          m_major_version + ";" + plugin.abi() + ";" + plugin.abi_version();
-      for (auto& v : debian_versions) {
-        if (host_version == v) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-  // clang-format on
-
   // Test if plugin abi is a Debian version compatible with host's Ubuntu
   // abi version on a x86_64 platform.
   bool is_debian_plugin_compatible(const Plugin& plugin) const {
@@ -349,9 +320,6 @@ bool PluginHandler::isCompatible(const PluginMetadata& metadata, const char* os,
   if (host.abi() == plugin.abi() && host.is_version_compatible(plugin)) {
     rv = true;
     wxLogDebug("Found matching abi version %s", plugin.abi_version());
-  } else if (host.is_ubuntu_plugin_compatible(plugin)) {
-    rv = true;
-    wxLogDebug("Found Ubuntu version matching Debian host");
   } else if (host.is_debian_plugin_compatible(plugin)) {
     rv = true;
     wxLogDebug("Found Debian version matching Ubuntu host");

--- a/src/plugin_handler.cpp
+++ b/src/plugin_handler.cpp
@@ -198,13 +198,16 @@ public:
   // Debian version. To be removed, see  #2512.
   bool is_ubuntu_plugin_compatible(const Plugin& plugin) const {
     static const std::vector<std::string> debian_versions = {
+        // clang-format: off
         // Assuming Debian 10 users sticks to gtk2:
         "10;ubuntu-x86_64;18.04",
         "11;ubuntu-gtk3-x86_64;20.04",
-        "11;ubuntu-x86_64;22.04",
+        "11;ubuntu-x86_64-wx32;22.04",
+        "12;ubuntu-x86_64;23.04",
+        "12;ubuntu-x86_64;23.10",
         "12;ubuntu-x86_64;24.04",
         "sid;ubuntu-x86_64;24.04"
-    };
+    };   // clang-format: on
     if (ocpn::startswith(m_abi, "debian-x86_64")) {
       wxLogDebug("Checking for ubuntu plugin on a debian-x86_64 host");
       const std::string host_version =
@@ -224,9 +227,16 @@ public:
   bool is_debian_plugin_compatible(const Plugin& plugin) const {
     if (!ocpn::startswith(m_abi, "ubuntu")) return false;
     static const std::vector<std::string> compat_versions = {
+        // clang-format: off
         // Assuming Debian 10 users sticks to gtk2:
-        "10;ubuntu-x86_64;18.04", "11;ubuntu-gtk3-x86_64;20.04",
-        "11;ubuntu-x86_64;22.04", "sid;ubuntu-gtk3-x86_64;20.04"};
+        "10;ubuntu-x86_64;18.04",
+        "11;ubuntu-gtk3-x86_64;20.04",
+        "11;ubuntu-x86_64-wx32;22.04",
+        "12;ubuntu-x86_64;23.04",
+        "12;ubuntu-x86_64;23.10",
+        "12;ubuntu-x86_64;24.04",
+        "sid;ubuntu-x86_64;24.04"
+    };    // clang-format: on
     if (ocpn::startswith(plugin.abi(), "debian-x86_64")) {
       wxLogDebug("Checking for debian plugin on a ubuntu-x86_64 host");
       const std::string compat_version =

--- a/src/plugin_handler.cpp
+++ b/src/plugin_handler.cpp
@@ -199,15 +199,13 @@ public:
     if (!ocpn::startswith(m_abi, "ubuntu")) return false;
     static const std::vector<std::string> compat_versions = {
         // clang-format: off
-        // Assuming Debian 10 users sticks to gtk2:
-        "10;ubuntu-x86_64;18.04",
         "11;ubuntu-gtk3-x86_64;20.04",
         "11;ubuntu-x86_64-wx32;22.04",
         "12;ubuntu-x86_64;23.04",
         "12;ubuntu-x86_64;23.10",
         "12;ubuntu-x86_64;24.04",
         "sid;ubuntu-x86_64;24.04"
-    };    // clang-format: on
+    };  // clang-format: on
     if (ocpn::startswith(plugin.abi(), "debian-x86_64")) {
       wxLogDebug("Checking for debian plugin on a ubuntu-x86_64 host");
       const std::string compat_version =

--- a/src/plugin_handler.cpp
+++ b/src/plugin_handler.cpp
@@ -250,23 +250,6 @@ public:
     return false;
   }
 
-  // Plugin and host abi differs. Check if plugin is compatible anyway
-  // by comparing the plugin abi with the list of abis similar to the
-  // host abi. Typically a host on a Ubuntu derivative which might be
-  // compatible with a plugin built for the derivative's Ubuntu base.
-  bool is_similar_plugin_compatible(const Plugin& plugin) const {
-    OCPN_OSDetail* os_detail = g_BasePlatform->GetOSDetail();
-    for (auto& name_like : os_detail->osd_names_like) {
-      const std::string osd_abi = name_like + "-" + os_detail->osd_arch;
-      if (osd_abi == plugin.abi()) {
-        if (is_version_compatible(plugin)) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
   // Check the plugin for host run-time ID match.
   // This test is necessary for cross-built hosts.
   // For example, Ubuntu PPA builds for armhf define PKG_TARGET as ubuntu-armhf
@@ -366,9 +349,6 @@ bool PluginHandler::isCompatible(const PluginMetadata& metadata, const char* os,
   if (host.abi() == plugin.abi() && host.is_version_compatible(plugin)) {
     rv = true;
     wxLogDebug("Found matching abi version %s", plugin.abi_version());
-  } else if (host.is_similar_plugin_compatible(plugin)) {
-    rv = true;
-    wxLogDebug("Found similar abi");
   } else if (host.is_ubuntu_plugin_compatible(plugin)) {
     rv = true;
     wxLogDebug("Found Ubuntu version matching Debian host");

--- a/src/plugin_handler.cpp
+++ b/src/plugin_handler.cpp
@@ -221,27 +221,6 @@ public:
     return false;
   }
 
-  // Check the plugin for host run-time ID match.
-  // This test is necessary for cross-built hosts.
-  // For example, Ubuntu PPA builds for armhf define PKG_TARGET as ubuntu-armhf
-  // But run-time reports as raspbian on "Raspberry Pi OS".
-  bool is_plugin_compatible_runtime(const Plugin& plugin) const {
-    OCPN_OSDetail* os_detail = g_BasePlatform->GetOSDetail();
-    const std::string host_osd_abi =
-        os_detail->osd_ID + "-" + os_detail->osd_arch;
-    wxLogDebug("Checking for compatible run-time, host_osd_abi: %s : %s",
-               host_osd_abi, os_detail->osd_version);
-    wxLogDebug("   plugin_abi + version: %s %s", plugin.abi(),
-               plugin.major_version());
-    if (host_osd_abi == plugin.abi()) {
-      wxLogDebug("   plugin_version: %s", major_version());
-      if (os_detail->osd_version == plugin.major_version()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
   const std::string& abi() const { return m_abi; }
 
   const std::string& abi_version() const { return m_abi_version; }
@@ -324,13 +303,6 @@ bool PluginHandler::isCompatible(const PluginMetadata& metadata, const char* os,
     rv = true;
     wxLogDebug("Found Debian version matching Ubuntu host");
   }
-#ifdef ocpnARM
-  // TODO  This conditional may not be needed.  Test on O57+
-  else if (host.is_plugin_compatible_runtime(plugin)) {
-    rv = true;
-    wxLogDebug("Found host OCPN_OSDetail run-time match");
-  }
-#endif
   DEBUG_LOG << "Plugin compatibility check Final: "
             << (rv ? "ACCEPTED: " : "REJECTED: ") << metadata.name;
   return rv;


### PR DESCRIPTION
Rebased and rewritten

This needs a careful review. 

The assumption is that we will use wx32 ABI subtypes as defined in https://github.com/OpenCPN/plugins/pull/747 on Debian 11/Ubuntu 22.04 where we will have both wx32 used by the PPA version and wx30 used by the official. All other versions is using either wx30 or wx32.

This is also modified to accept the  23.04 and 23.10 interim releases opening a path for users of the official package to use wx32 plugins from April 2023.

Here is also the final clean-up of the #2502 roadmap.  After this, hosts on Debian derivatives like Ubuntu, Mint, etc  only accepts Debian plugins besides plugins built for the host platform. This is sensitive, but is should IMHO preferably be done before the alpha so we can handle issues. All done in separate commits which can be reverted if need be.