### PR TITLE
ci: ubuntu: update to build jammy + focal.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 ---
 version: 2
 jobs:
-   build-bionic:
+   build-focal:
      docker:
-       - image: circleci/buildpack-deps:bionic-scm
+       - image: circleci/buildpack-deps:focal-scm
          auth:
            username: $DOCKER_USER
            password: $DOCKER_PW
@@ -14,9 +14,9 @@ jobs:
        - run: cat /etc/apt/sources.list
        - run: ci/generic-build-debian.sh
        - run: ci/generic-upload.sh
-   build-focal:
+   build-jammy:
      docker:
-       - image: circleci/buildpack-deps:focal-scm
+       - image: cimg/base:edge-22.04
          auth:
            username: $DOCKER_USER
            password: $DOCKER_PW
@@ -81,12 +81,12 @@ workflows:
   version: 2
   build_all:
     jobs:
-      - build-bionic:
+      - build-focal:
           filters:
             branches:
               only:
                 - master
-      - build-focal:
+      - build-jammy:
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
            username: $DOCKER_USER
            password: $DOCKER_PW
      environment:
-       - OCPN_TARGET:  bionic
+       - OCPN_TARGET:  focal
      steps:
        - checkout
        - run: cat /etc/apt/sources.list
@@ -21,8 +21,7 @@ jobs:
            username: $DOCKER_USER
            password: $DOCKER_PW
      environment:
-       - OCPN_TARGET:  focal-gtk3
-       - CMAKE_BUILD_PARALLEL_LEVEL: 2
+       - OCPN_TARGET:  jammy
      steps:
        - checkout
        - run: cat /etc/apt/sources.list

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ jobs:
    build-focal:
      docker:
        - image: circleci/buildpack-deps:focal-scm
-         auth:
-           username: $DOCKER_USER
-           password: $DOCKER_PW
      environment:
        - OCPN_TARGET:  focal
      steps:
@@ -17,9 +14,6 @@ jobs:
    build-jammy:
      docker:
        - image: cimg/base:edge-22.04
-         auth:
-           username: $DOCKER_USER
-           password: $DOCKER_PW
      environment:
        - OCPN_TARGET:  jammy
      steps:

--- a/ci/generic-build-debian.sh
+++ b/ci/generic-build-debian.sh
@@ -10,6 +10,11 @@ sudo apt-get install -q devscripts equivs
 mk-build-deps ./ci/control --install --root-cmd=sudo --remove
 sudo apt-get --allow-unauthenticated install -f
 
+if [ "$OCPN_TARGET" = "jammy" ]; then
+  sudo add-apt-repository -y ppa:leamas-alec/wxwidgets
+  sudo apt update
+fi
+
 rm -rf build && mkdir build && cd build
 cmake $WEBVIEW_OPT  $EXTRA_BUILD_OPTS\
     -DCMAKE_INSTALL_PREFIX=/usr \

--- a/ci/generic-build-debian.sh
+++ b/ci/generic-build-debian.sh
@@ -10,16 +10,6 @@ sudo apt-get install -q devscripts equivs
 mk-build-deps ./ci/control --install --root-cmd=sudo --remove
 sudo apt-get --allow-unauthenticated install -f
 
-# Xenial finds webview header but not the library:
-if [ "$OCPN_TARGET" = "xenial" ]; then
-    WEBVIEW_OPT="-DOCPN_USE_WEBVIEW:BOOL=OFF"
-fi
-
-if [[ "$EXTRA_BUILD_OPTS" == *OCPN_FORCE_GTK3=ON* ]]; then
-    sudo update-alternatives --set wx-config \
-        /usr/lib/*-linux-*/wx/config/gtk3-unicode-3.0
-fi
-
 rm -rf build && mkdir build && cd build
 cmake $WEBVIEW_OPT  $EXTRA_BUILD_OPTS\
     -DCMAKE_INSTALL_PREFIX=/usr \


### PR DESCRIPTION
Update the ci builds to match the 5.8.0 ubuntu targets jammy and focal. 

Jammy will need further work to use wx 3.2

