### PR TITLE
Gtest : use system libraries if available (#2799)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1879,6 +1879,7 @@ if (UNIX)
 endif (UNIX)
 
 if (OCPN_BUILD_TEST)
+  add_subdirectory(libs/gtest)
   add_subdirectory(test)
   add_custom_target(run-tests
     COMMAND ctest  -C $<CONFIG> -E tests

--- a/libs/gtest/CMakeLists.txt
+++ b/libs/gtest/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.12)
+
+if (TARGET ocpn::gtest)
+    return ()
+endif ()
+
+if (NOT CMAKE_MODULE_PATH)
+  set (CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/../../cmake)
+endif ()
+
+add_library(_OCPN_GTEST_IF INTERFACE)
+add_library(ocpn::gtest ALIAS _OCPN_GTEST_IF)
+
+find_library(GTEST_LIB gtest)
+find_library(GTEST_MAIN gtest_main)
+find_path(GTEST_HDR NAME gtest PATH_SUFFIXES gtest)
+
+if (GTEST_LIB AND GTEST_MAIN AND GTEST_HDR)
+  message(STATUS "Using system gtest libraries")
+  target_include_directories(_OCPN_GTEST_IF INTERFACE ${GTEST_HDR})
+  target_link_libraries(_OCPN_GTEST_IF INTERFACE ${GTEST_LIB})
+  target_link_libraries(_OCPN_GTEST_IF INTERFACE ${GTEST_MAIN})
+else ()
+  message(STATUS "Downloading and building gtest from source")
+  include(FetchContent)
+  set(CMAKE_CXX_STANDARD 14)
+  FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG release-1.12.1
+  )
+  set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+  FetchContent_MakeAvailable(googletest)
+  target_link_libraries(_OCPN_GTEST_IF GTest::gtest_main)
+endif ()  

--- a/libs/gtest/CMakeLists.txt
+++ b/libs/gtest/CMakeLists.txt
@@ -21,15 +21,29 @@ if (GTEST_LIB AND GTEST_MAIN AND GTEST_HDR)
   target_link_libraries(_OCPN_GTEST_IF INTERFACE ${GTEST_LIB})
   target_link_libraries(_OCPN_GTEST_IF INTERFACE ${GTEST_MAIN})
 else ()
-  message(STATUS "Downloading and building gtest from source")
-  include(FetchContent)
-  set(CMAKE_CXX_STANDARD 14)
-  FetchContent_Declare(
-    googletest
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.12.1
+  find_path(GTEST_SRC_LOCATION
+    NAMES googlemock/src/gmock-all.cc googletest/src/gtest-all.cc
+    HINTS ENV GTEST_SRC_ROOT
+    PATHS "/usr/src/googletest"
+    NO_DEFAULT_PATH
   )
+  include(FetchContent)
+  if (GTEST_SRC_LOCATION)
+    message(STATUS "Building gtest from installed sources")
+    FetchContent_Declare(
+      googletest
+      URL ${GTEST_SRC_LOCATION}
+    )
+  else ()
+    message(STATUS "Downloading and building gtest from source")
+    FetchContent_Declare(
+      googletest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG release-1.12.1
+    )
+  endif ()
+  set(CMAKE_CXX_STANDARD 14)
   set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
   FetchContent_MakeAvailable(googletest)
-  target_link_libraries(_OCPN_GTEST_IF GTest::gtest_main)
-endif ()  
+  target_link_libraries(_OCPN_GTEST_IF INTERFACE GTest::gtest_main)
+endif ()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,16 +1,10 @@
 cmake_minimum_required(VERSION 3.14)
 
-
 project(opencpn_tests)
 set(CMAKE_CXX_STANDARD 14)
-include(FetchContent)
-FetchContent_Declare(
-  googletest
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG release-1.12.1
-)
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
-FetchContent_MakeAvailable(googletest)
+message(STATUS "Building tests")
+
 
 enable_testing ()
 
@@ -112,7 +106,7 @@ else (NOT WIN32)
 endif (NOT WIN32)
 
 
-target_link_libraries(tests PRIVATE GTest::gtest_main)
+target_link_libraries(tests PRIVATE ocpn::gtest)
 include(GoogleTest)
 gtest_discover_tests(tests)
 


### PR DESCRIPTION
If packaged version of the gtest libraries are available use them instead of downloading sources from github. Likewise, if installed gtest sources (like on Debian) are available, use these instead of downloading.

First patch is applied to pending Flatpak beta release.