### PR TITLE
DB: Scale depth graph for all platforms.

### DIFF
--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -801,7 +801,7 @@ void dashboard_pi::Notify() {
   if (mWTP_Watchdog <= 0) {
     mPriWTP = 99;
     SendSentenceToAllInstruments(OCPN_DBP_STC_TMP, NAN, "-");
-    mWTP_Watchdog = gps_watchdog_timeout_ticks;
+    mWTP_Watchdog = no_nav_watchdog_timeout_ticks;
   }
   mRSA_Watchdog--;
   if (mRSA_Watchdog <= 0) {
@@ -1241,7 +1241,7 @@ void dashboard_pi::SetNMEASentence(wxString &sentence) {
               OCPN_DBP_STC_TMP,
               toUsrTemp_Plugin(m_NMEA0183.Mtw.Temperature, g_iDashTempUnit),
               getUsrTempUnit_Plugin(g_iDashTempUnit));
-          mWTP_Watchdog = gps_watchdog_timeout_ticks;
+          mWTP_Watchdog = no_nav_watchdog_timeout_ticks;
         }
       }
 


### PR DESCRIPTION
Last fix(?). Get rid of all hard coded draw positions. Rely all on system font sizes instead. Would fit all platforms wo specials for WIN.  (Hopefully Android is happy as well.)