### PR TITLE
Extend the plugin API for layered rendering of plugin overlays

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -66,7 +66,7 @@ class wxGLContext;
 //    PlugIns conforming to API Version less then the most modern will also
 //    be correctly supported.
 #define API_VERSION_MAJOR 1
-#define API_VERSION_MINOR 17
+#define API_VERSION_MINOR 18
 
 //    Fwd Definitions
 class wxFileConfig;
@@ -103,6 +103,16 @@ class wxGLCanvas;
 #define WANTS_MOUSE_EVENTS 0x00080000
 #define WANTS_VECTOR_CHART_OBJECT_INFO 0x00100000
 #define WANTS_KEYBOARD_EVENTS 0x00200000
+
+//---------------------------------------------------------------------------------------------------------
+//
+//    Overlay priorities
+//
+//---------------------------------------------------------------------------------------------------------
+#define OVERLAY_LEGACY 0
+#define OVERLAY_OVER_SHIPS 64
+#define OVERLAY_OVER_EMBOSS 96
+#define OVERLAY_OVER_UI 128
 
 //----------------------------------------------------------------------------------------------------------
 //    Some PlugIn API interface object class definitions
@@ -565,6 +575,31 @@ public:
 
   /*Provide active leg data to plugins*/
   virtual void SetActiveLegInfo(Plugin_Active_Leg_Info &leg_info);
+};
+
+class DECL_EXP opencpn_plugin_118 : public opencpn_plugin_117 {
+public:
+  opencpn_plugin_118(void *pmgr);
+  /// Render plugin overlay over chart canvas in OpenGL mode
+  ///
+  /// \param pcontext Pointer to the OpenGL context
+  /// \param vp Pointer to the Viewport
+  /// \param canvasIndex Index of the chart canvas, 0 for the first canvas
+  /// \param priority Priority, plugins only upgrading from older API versions should draw only
+  /// when priority is OVERLAY_LEGACY (0)
+  /// \return true if overlay was rendered, false otherwise
+  virtual bool RenderGLOverlayMultiCanvas(wxGLContext *pcontext,
+                                          PlugIn_ViewPort *vp, int canvasIndex, int priority = -1);
+  /// Render plugin overlay over chart canvas in non-OpenGL mode
+  ///
+  /// \param dc Reference to the "device context"
+  /// \param vp Pointer to the Viewport
+  /// \param canvasIndex Index of the chart canvas, 0 for the first canvas
+  /// \param priority Priority, plugins only upgrading from older API versions should draw only
+  /// when priority is OVERLAY_LEGACY (0)
+  /// \return true if overlay was rendered, false otherwise
+  virtual bool RenderOverlayMultiCanvas(wxDC &dc, PlugIn_ViewPort *vp,
+                                        int canvasIndex, int priority = -1);
 };
 //------------------------------------------------------------------
 //      Route and Waypoint PlugIn support

--- a/include/pluginmanager.h
+++ b/include/pluginmanager.h
@@ -186,9 +186,10 @@ public:
   virtual ~PlugInManager();
 
   bool RenderAllCanvasOverlayPlugIns(ocpnDC &dc, const ViewPort &vp,
-                                     int canvasIndex);
+                                     int canvasIndex, int priority);
   bool RenderAllGLCanvasOverlayPlugIns(wxGLContext *pcontext,
-                                       const ViewPort &vp, int canvasIndex);
+                                       const ViewPort &vp, int canvasIndex,
+                                       int priority);
   void SendCursorLatLonToAllPlugIns(double lat, double lon);
   void SendViewPortToRequestingPlugIns(ViewPort &vp);
   void PrepareAllPluginContextMenus();

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -11583,12 +11583,10 @@ void ChartCanvas::DrawOverlayObjects(ocpnDC &dc, const wxRegion &ru) {
 
   if (g_pi_manager) {
     g_pi_manager->SendViewPortToRequestingPlugIns(GetVP());
-    g_pi_manager->RenderAllCanvasOverlayPlugIns(dc, GetVP(), m_canvasIndex);
+    g_pi_manager->RenderAllCanvasOverlayPlugIns(dc, GetVP(), m_canvasIndex, OVERLAY_LEGACY);
   }
 
   AISDrawAreaNotices(dc, GetVP(), this);
-  DrawEmboss(dc, EmbossDepthScale());
-  DrawEmboss(dc, EmbossOverzoomIndicator(dc));
 
   wxDC *pdc = dc.GetDC();
   if (pdc) {
@@ -11617,6 +11615,15 @@ void ChartCanvas::DrawOverlayObjects(ocpnDC &dc, const wxRegion &ru) {
   RenderShipToActive(dc, false);
   ScaleBarDraw(dc);
   s57_DrawExtendedLightSectors(dc, VPoint, extendedSectorLegs);
+  if (g_pi_manager) {
+    g_pi_manager->RenderAllCanvasOverlayPlugIns(dc, GetVP(), m_canvasIndex, OVERLAY_OVER_SHIPS);
+  }
+
+  DrawEmboss(dc, EmbossDepthScale());
+  DrawEmboss(dc, EmbossOverzoomIndicator(dc));
+  if (g_pi_manager) {
+    g_pi_manager->RenderAllCanvasOverlayPlugIns(dc, GetVP(), m_canvasIndex, OVERLAY_OVER_EMBOSS);
+  }
 
   if (m_pTrackRolloverWin) {
     m_pTrackRolloverWin->Draw(dc);
@@ -11631,6 +11638,10 @@ void ChartCanvas::DrawOverlayObjects(ocpnDC &dc, const wxRegion &ru) {
   if (m_pAISRolloverWin) {
     m_pAISRolloverWin->Draw(dc);
     m_brepaint_piano = true;
+  }
+  
+  if (g_pi_manager) {
+    g_pi_manager->RenderAllCanvasOverlayPlugIns(dc, GetVP(), m_canvasIndex, OVERLAY_OVER_UI);
   }
 }
 

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -2652,7 +2652,7 @@ void glChartCanvas::DrawFloatingOverlayObjects(ocpnDC &dc) {
   if (g_pi_manager) {
     g_pi_manager->SendViewPortToRequestingPlugIns(vp);
     g_pi_manager->RenderAllGLCanvasOverlayPlugIns(
-        m_pcontext, vp, m_pParentCanvas->m_canvasIndex);
+        m_pcontext, vp, m_pParentCanvas->m_canvasIndex, OVERLAY_LEGACY);
   }
 
   // all functions called with m_pParentCanvas-> are still slow because they go
@@ -2671,6 +2671,10 @@ void glChartCanvas::DrawFloatingOverlayObjects(ocpnDC &dc) {
   m_pParentCanvas->ScaleBarDraw(dc);
   s57_DrawExtendedLightSectors(dc, m_pParentCanvas->VPoint,
                                m_pParentCanvas->extendedSectorLegs);
+  if (g_pi_manager) {
+    g_pi_manager->RenderAllGLCanvasOverlayPlugIns(
+        m_pcontext, vp, m_pParentCanvas->m_canvasIndex, OVERLAY_OVER_SHIPS);
+  }
 }
 
 void glChartCanvas::DrawChartBar(ocpnDC &dc) {
@@ -4359,6 +4363,13 @@ void glChartCanvas::Render() {
   DrawEmboss(m_gldc, m_pParentCanvas->EmbossDepthScale());
   DrawEmboss(m_gldc, m_pParentCanvas->EmbossOverzoomIndicator(gldc));
 
+  if (g_pi_manager) {
+    ViewPort &vp = m_pParentCanvas->GetVP();
+    g_pi_manager->SendViewPortToRequestingPlugIns(vp);
+    g_pi_manager->RenderAllGLCanvasOverlayPlugIns(
+        m_pcontext, vp, m_pParentCanvas->m_canvasIndex, OVERLAY_OVER_EMBOSS);
+  }
+
   if (m_pParentCanvas->m_pTrackRolloverWin)
     m_pParentCanvas->m_pTrackRolloverWin->Draw(gldc);
 
@@ -4428,6 +4439,13 @@ void glChartCanvas::Render() {
 
   RenderGLAlertMessage();
 #endif
+
+  if (g_pi_manager) {
+    ViewPort &vp = m_pParentCanvas->GetVP();
+    g_pi_manager->SendViewPortToRequestingPlugIns(vp);
+    g_pi_manager->RenderAllGLCanvasOverlayPlugIns(
+        m_pcontext, vp, m_pParentCanvas->m_canvasIndex, OVERLAY_OVER_UI);
+  }
 
   // quiting?
   if (g_bquiting) DrawQuiting();

--- a/src/ocpn_plugin.cpp
+++ b/src/ocpn_plugin.cpp
@@ -275,3 +275,19 @@ const char* opencpn_plugin_117::GetPlugInVersionPre() { return ""; };
 const char* opencpn_plugin_117::GetPlugInVersionBuild() { return ""; };
 
 void opencpn_plugin_117::SetActiveLegInfo(Plugin_Active_Leg_Info& leg_info) {}
+
+//    Opencpn_Plugin_118 Implementation
+opencpn_plugin_118::opencpn_plugin_118(void* pmgr) : opencpn_plugin_117(pmgr) {}
+
+bool opencpn_plugin_118::RenderGLOverlayMultiCanvas(wxGLContext* pcontext,
+                                                    PlugIn_ViewPort* vp,
+                                                    int max_canvas,
+						    int priority) {
+  return false;
+}
+
+bool opencpn_plugin_118::RenderOverlayMultiCanvas(wxDC& dc, PlugIn_ViewPort* vp,
+                                                  int max_canvas,
+						  int priority) {
+  return false;
+}

--- a/src/plugin_loader.cpp
+++ b/src/plugin_loader.cpp
@@ -1364,6 +1364,16 @@ PlugInContainer* PluginLoader::LoadPlugIn(wxString plugin_file,
                             p->GetPlugInVersionBuild());
       } while (false);
       break;
+    case 118:
+      pic->m_pplugin = dynamic_cast<opencpn_plugin_118*>(plug_in);
+      do /* force a local scope */ {
+        auto p = dynamic_cast<opencpn_plugin_118*>(plug_in);
+        pi_ver =
+            SemanticVersion(pi_major, pi_minor, p->GetPlugInVersionPatch(),
+                            p->GetPlugInVersionPost(), p->GetPlugInVersionPre(),
+                            p->GetPlugInVersionBuild());
+      } while (false);
+      break;
 
     default:
       break;

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -1378,6 +1378,7 @@ bool PlugInManager::CallLateInit(void) {
       case 115:
       case 116:
       case 117:
+      case 118:
         ProcessLateInit(pic);
         break;
     }
@@ -1448,7 +1449,8 @@ void PlugInManager::SendVectorChartObjectInfo(const wxString &chart,
           case 114:
           case 115:
           case 116:
-          case 117: {
+          case 117:
+          case 118: {
             opencpn_plugin_112 *ppi =
                 dynamic_cast<opencpn_plugin_112 *>(pic->m_pplugin);
             if (ppi)
@@ -1778,7 +1780,7 @@ bool PlugInManager::CheckBlacklistedPlugin(wxString name, int major, int minor) 
 
 bool PlugInManager::RenderAllCanvasOverlayPlugIns(ocpnDC &dc,
                                                   const ViewPort &vp,
-                                                  int canvasIndex) {
+                                                  int canvasIndex, int priority) {
   auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer *pic = plugin_array->Item(i);
@@ -1791,12 +1793,16 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns(ocpnDC &dc,
         {
           switch (pic->m_api_version) {
             case 106: {
+              if (priority > 0)
+                break;
               opencpn_plugin_16 *ppi =
                   dynamic_cast<opencpn_plugin_16 *>(pic->m_pplugin);
               if (ppi) ppi->RenderOverlay(*pdc, &pivp);
               break;
             }
             case 107: {
+              if (priority > 0)
+                break;
               opencpn_plugin_17 *ppi =
                   dynamic_cast<opencpn_plugin_17 *>(pic->m_pplugin);
               if (ppi) ppi->RenderOverlay(*pdc, &pivp);
@@ -1810,6 +1816,8 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns(ocpnDC &dc,
             case 113:
             case 114:
             case 115: {
+              if (priority > 0)
+                break;
               opencpn_plugin_18 *ppi =
                   dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
               if (ppi) ppi->RenderOverlay(*pdc, &pivp);
@@ -1817,6 +1825,8 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns(ocpnDC &dc,
             }
             case 116:
             case 117: {
+              if (priority > 0)
+                break;
               opencpn_plugin_18 *ppi =
                   dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
               if (ppi) {
@@ -1826,6 +1836,20 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns(ocpnDC &dc,
                   dynamic_cast<opencpn_plugin_116 *>(pic->m_pplugin);
               if (ppi116)
                 ppi116->RenderOverlayMultiCanvas(*pdc, &pivp, canvasIndex);
+              break;
+            }
+            case 118: {
+              if (priority <= 0) {
+                opencpn_plugin_18 *ppi =
+                    dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
+                if (ppi) {
+                  ppi->RenderOverlay(*pdc, &pivp);
+                }
+              }
+              opencpn_plugin_118 *ppi118 =
+                  dynamic_cast<opencpn_plugin_118 *>(pic->m_pplugin);
+              if (ppi118)
+                ppi118->RenderOverlayMultiCanvas(*pdc, &pivp, canvasIndex, priority);
               break;
             }
             default:
@@ -1849,12 +1873,16 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns(ocpnDC &dc,
 
           switch (pic->m_api_version) {
             case 106: {
+              if (priority > 0)
+                break;
               opencpn_plugin_16 *ppi =
                   dynamic_cast<opencpn_plugin_16 *>(pic->m_pplugin);
               if (ppi) b_rendered = ppi->RenderOverlay(mdc, &pivp);
               break;
             }
             case 107: {
+              if (priority > 0)
+                break;
               opencpn_plugin_17 *ppi =
                   dynamic_cast<opencpn_plugin_17 *>(pic->m_pplugin);
               if (ppi) b_rendered = ppi->RenderOverlay(mdc, &pivp);
@@ -1868,6 +1896,8 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns(ocpnDC &dc,
             case 113:
             case 114:
             case 115: {
+              if (priority > 0)
+                break;
               opencpn_plugin_18 *ppi =
                   dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
               if (ppi) b_rendered = ppi->RenderOverlay(*pdc, &pivp);
@@ -1875,6 +1905,8 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns(ocpnDC &dc,
             }
             case 116:
             case 117: {
+              if (priority > 0)
+                break;
               opencpn_plugin_18 *ppi =
                   dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
               if (ppi) {
@@ -1885,6 +1917,22 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns(ocpnDC &dc,
               if (ppi116)
                 b_rendered = ppi116->RenderOverlayMultiCanvas(*pdc, &pivp,
                                                               g_canvasConfig);
+              break;
+            }
+            case 118: {
+              if (priority <= 0) {
+                opencpn_plugin_18 *ppi =
+                    dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
+                if (ppi) {
+                  b_rendered = ppi->RenderOverlay(*pdc, &pivp);
+                }
+              }
+              opencpn_plugin_118 *ppi118 =
+                  dynamic_cast<opencpn_plugin_118 *>(pic->m_pplugin);
+              if (ppi118)
+                b_rendered = ppi118->RenderOverlayMultiCanvas(*pdc, &pivp,
+                                                              g_canvasConfig,
+                                                              priority);
               break;
             }
             default: {
@@ -1912,7 +1960,7 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns(ocpnDC &dc,
 
 bool PlugInManager::RenderAllGLCanvasOverlayPlugIns(wxGLContext *pcontext,
                                                     const ViewPort &vp,
-                                                    int canvasIndex) {
+                                                    int canvasIndex, int priority) {
   auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer *pic = plugin_array->Item(i);
@@ -1922,6 +1970,8 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns(wxGLContext *pcontext,
 
         switch (pic->m_api_version) {
           case 107: {
+            if (priority > 0)
+                break;
             opencpn_plugin_17 *ppi =
                 dynamic_cast<opencpn_plugin_17 *>(pic->m_pplugin);
             if (ppi) ppi->RenderGLOverlay(pcontext, &pivp);
@@ -1936,6 +1986,8 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns(wxGLContext *pcontext,
           case 113:
           case 114:
           case 115: {
+            if (priority > 0)
+                break;
             opencpn_plugin_18 *ppi =
                 dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
             if (ppi) ppi->RenderGLOverlay(pcontext, &pivp);
@@ -1943,6 +1995,8 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns(wxGLContext *pcontext,
           }
           case 116:
           case 117: {
+            if (priority > 0)
+                break;
             opencpn_plugin_18 *ppi =
                 dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
             if (ppi) {
@@ -1952,6 +2006,21 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns(wxGLContext *pcontext,
                 dynamic_cast<opencpn_plugin_116 *>(pic->m_pplugin);
             if (ppi116) {
               ppi116->RenderGLOverlayMultiCanvas(pcontext, &pivp, canvasIndex);
+            }
+            break;
+          }
+          case 118: {
+            if (priority <= 0) {
+              opencpn_plugin_18 *ppi =
+                dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
+              if (ppi) {
+                ppi->RenderGLOverlay(pcontext, &pivp);
+              }
+            }
+            opencpn_plugin_118 *ppi118 =
+                dynamic_cast<opencpn_plugin_118 *>(pic->m_pplugin);
+            if (ppi118) {
+              ppi118->RenderGLOverlayMultiCanvas(pcontext, &pivp, canvasIndex, priority);
             }
             break;
           }
@@ -1978,7 +2047,8 @@ bool PlugInManager::SendMouseEventToPlugins(wxMouseEvent &event) {
           case 114:
           case 115:
           case 116:
-          case 117: {
+          case 117:
+          case 118: {
             opencpn_plugin_112 *ppi =
                 dynamic_cast<opencpn_plugin_112 *>(pic->m_pplugin);
             if (ppi)
@@ -2008,7 +2078,8 @@ bool PlugInManager::SendKeyEventToPlugins(wxKeyEvent &event) {
             case 114:
             case 115:
             case 116:
-            case 117: {
+            case 117:
+            case 118: {
               opencpn_plugin_113 *ppi =
                   dynamic_cast<opencpn_plugin_113 *>(pic->m_pplugin);
               if (ppi && ppi->KeyboardEventHook(event)) bret = true;
@@ -2062,7 +2133,8 @@ void NotifySetupOptionsPlugin(const PlugInContainer *pic) {
         case 114:
         case 115:
         case 116:
-        case 117: {
+        case 117:
+        case 118: {
           opencpn_plugin_19 *ppi =
               dynamic_cast<opencpn_plugin_19 *>(pic->m_pplugin);
           if (ppi) {
@@ -2275,7 +2347,8 @@ void PlugInManager::SendMessageToAllPlugins(const wxString &message_id,
           case 114:
           case 115:
           case 116:
-          case 117: {
+          case 117:
+          case 118: {
             opencpn_plugin_18 *ppi =
                 dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
             if (ppi)
@@ -2350,7 +2423,8 @@ void PlugInManager::SendPositionFixToAllPlugIns(GenericPosDatEx *ppos) {
           case 114:
           case 115:
           case 116:
-          case 117: {
+          case 117:
+          case 118: {
             opencpn_plugin_18 *ppi =
                 dynamic_cast<opencpn_plugin_18 *>(pic->m_pplugin);
             if (ppi) ppi->SetPositionFixEx(pfix_ex);
@@ -2387,7 +2461,8 @@ void PlugInManager::SendActiveLegInfoToAllPlugIns(const ActiveLegDat *leg_info) 
           case 115:
           case 116:
             break;
-          case 117: {
+          case 117:
+          case 118: {
             opencpn_plugin_117 *ppi =
                 dynamic_cast<opencpn_plugin_117 *>(pic->m_pplugin);
             if (ppi) ppi->SetActiveLegInfo(leg);
@@ -2430,7 +2505,8 @@ void PlugInManager::PrepareAllPluginContextMenus() {
       if (pic->m_cap_flag & INSTALLS_CONTEXTMENU_ITEMS) {
         switch (pic->m_api_version) {
           case 116:
-          case 117: {
+          case 117:
+          case 118: {
             opencpn_plugin_116 *ppi =
                 dynamic_cast<opencpn_plugin_116 *>(pic->m_pplugin);
             if (ppi) ppi->PrepareContextMenu(canvasIndex);


### PR DESCRIPTION
Implement API 1.18 adding plugin overlay rendering in multiple phases of the rendering pipeline

Plugins using older API versions up to 1.17 are unaffected.

Plugins using API 1.18 get a call to `RenderOverlayMultiCanvas`/`RenderGLOverlayMultiCanvas` with a new parameter priority, letting them decide whether they want to render something in the respective overlay layer or not.

This allows plugins to render scene like bellow instead of the current behavior where the plugin overlays are always under ships and UI elements (Which makes the functionality of https://github.com/nohal/dashboardsk_pi impossible to implement properly).
![image](https://user-images.githubusercontent.com/249856/204894461-12c40356-bd22-424a-9ecf-186b9de12315.png)