### PR TITLE
Windows build: refactor and bugfixes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,14 +10,4 @@ crowdin.yaml
 buildwin/NSIS_Unicode/Include/Langstrings_*.nsh
 buildwin/crashrpt/CrashRpt1402.dll
 buildwin/crashrpt/CrashSender1402.exe
-buildwin/expat*/
-buildwin/gtk*/
-buildwin/libcurl.dll
-buildwin/vc/
-buildwin/wxWidgets/
-buildwin/include/
-buildwin/*.dll
-buildwin/*.lib
-buildwin/*.exe
-buildwin/*.crt
 .DS_Store

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -759,24 +759,6 @@ if (NOT QT_ANDROID)
   endif (MSYS)
   include(${wxWidgets_USE_FILE})
 
-  if (wxWidgets_VERSION_STRING VERSION_GREATER_EQUAL "3.1.6")
-    add_definitions("-DWX316PLUS")
-  endif()
-
-
-  # As of cmake 3.11.2, these libraries are missing in list despite that we
-  # looked for them. This is a nasty fix which might fail miserably. Assumption:
-  # All builds using GTK uses unicode and wxWidgets 3.0
-  if (GTK3_FOUND AND CMAKE_VERSION VERSION_LESS 3.12)
-    if (NOT wxWidgets_VERSION_STRING VERSION_GREATER "3.0")
-      message (STATUS " Patching ${wxWidgets_LIBRARIES}")
-      list(APPEND wxWidgets_LIBRARIES "-lwx_gtk3u_aui-3.0")
-      if (OPENGL_FOUND)
-        list(APPEND wxWidgets_LIBRARIES "-lwx_gtk3u_gl-3.0")
-      endif ()
-    endif ()
-  endif ()
-
   message(STATUS "Found wxWidgets...")
   message(STATUS " wxWidgets Include: ${wxWidgets_INCLUDE_DIRS}")
   message(STATUS " wxWidgets Libraries: ${wxWidgets_LIBRARIES}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -562,7 +562,7 @@ if (OCPN_CI_BUILD)
   if (NOT "${BUILD_NUMBER}" STREQUAL "")
     set(VERSION_TAIL "-${BUILD_NUMBER}${VERSION_TAIL}")
   endif ()
-  set(VERSION_DATE "${DATE}")
+  string(STRIP "{DATE}" VERSION_DATE)
 endif (OCPN_CI_BUILD)
 
 set(
@@ -692,8 +692,10 @@ if (OPENGL_FOUND)
     #list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/buildwin/include/glew")
     #find_package(GLEW REQUIRED)
     #message(STATUS "+++GLEW: " ${GLEW_INCLUDE_DIRS})
-    include_directories("${CMAKE_CURRENT_SOURCE_DIR}/buildwin/include/glew")
-    link_libraries(${CMAKE_SOURCE_DIR}/buildwin/glew32.lib )
+    include_directories(
+      "${CMAKE_CURRENT_SOURCE_DIR}/cache/buildwin/include/glew"
+    )
+    link_libraries(${CMAKE_SOURCE_DIR}/cache/buildwin/glew32.lib )
   else (CMAKE_HOST_WIN32)
     if (NOT APPLE)
       find_package(GLEW REQUIRED)
@@ -1427,8 +1429,12 @@ endif (UNIX)
 
 # check for lzma support for reading compressed charts
 if (CMAKE_HOST_WIN32)
-  list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/buildwin")
-  list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_SOURCE_DIR}/buildwin/include")
+  list(APPEND CMAKE_PREFIX_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/cache/buildwin"
+  )
+  list(APPEND CMAKE_PREFIX_PATH
+    "${CMAKE_CURRENT_SOURCE_DIR}/cache/buildwin/include"
+  )
 endif (CMAKE_HOST_WIN32)
 if (OCPN_USE_LZMA)
   find_package(LibLZMA)
@@ -1444,15 +1450,15 @@ if (OCPN_USE_CURL)
   if (CMAKE_HOST_WIN32)
     install(
       FILES
-        "${CMAKE_SOURCE_DIR}/buildwin/curl-ca-bundle.crt"
-        "${CMAKE_SOURCE_DIR}/buildwin/libeay32.dll"
-        "${CMAKE_SOURCE_DIR}/buildwin/ssleay32.dll"
+        "${CMAKE_SOURCE_DIR}/cache/buildwin/curl-ca-bundle.crt"
+        "${CMAKE_SOURCE_DIR}/cache/buildwin/libeay32.dll"
+        "${CMAKE_SOURCE_DIR}/cache/buildwin/ssleay32.dll"
       DESTINATION "."
     )
     if (MSVC)
       set(CURL_LIBRARIES "${CMAKE_SOURCE_DIR}/buildwin/libcurl.lib")
-      install(FILES "buildwin/libcurl.dll" DESTINATION ".")
-      install(FILES "buildwin/zlib1.dll" DESTINATION ".")
+      install(FILES "cache/buildwin/libcurl.dll" DESTINATION ".")
+      install(FILES "cache/buildwin/zlib1.dll" DESTINATION ".")
     endif (MSVC)
   else (CMAKE_HOST_WIN32)
     set(OCPN_USE_EXTERN_CURL ON)
@@ -1527,12 +1533,12 @@ if (OCPN_USE_SVG)
       include(OcpnFindExpat)
       if (CMAKE_HOST_WIN32)
         # On Windows, we have our own expat and cairo
-        file(GLOB gtkdll_files "${CMAKE_CURRENT_SOURCE_DIR}/buildwin/gtk/*.dll")
+        file(GLOB gtkdll_files "${CMAKE_CURRENT_SOURCE_DIR}/cache/buildwin/gtk/*.dll")
         install(FILES ${gtkdll_files} DESTINATION ".")
         file(
           GLOB
             expatdll_files
-            "${CMAKE_CURRENT_SOURCE_DIR}/buildwin/expat-2.2.5/*.dll"
+            "${CMAKE_CURRENT_SOURCE_DIR}/cache/buildwin/expat-2.2.5/*.dll"
         )
         install(FILES ${expatdll_files} DESTINATION ".")
         message(STATUS "GTK and Expat DLLs bundled into the installer package...")
@@ -1673,8 +1679,8 @@ add_subdirectory(libs/pugixml)
 target_link_libraries(${PACKAGE_NAME} PRIVATE ocpn::pugixml)
 
 if (MSVC)
-  install(FILES "buildwin/libssl-3.dll" DESTINATION ".")
-  install(FILES "buildwin/libcrypto-3.dll" DESTINATION ".")
+  install(FILES "cache/buildwin/libssl-3.dll" DESTINATION ".")
+  install(FILES "cache/buildwin/libcrypto-3.dll" DESTINATION ".")
 endif (MSVC)
 
 message(STATUS "S57 ENC support: enabled")
@@ -2543,35 +2549,31 @@ endif (APPLE)
 # directory
 #
 if (WIN32 AND NOT UNIX)
-  message(STATUS "wxWidgets DLLs bundled into the installer package: ...")
-
-  list(GET wxWidgets_LIBRARIES 1 first_file)
-  message(STATUS "first_file: ${first_file}")
-  get_filename_component(dll_dir ${first_file} DIRECTORY)
-
-  message(STATUS "dll_dir: ${dll_dir}")
-
-  file(
-      GLOB wxdll_files "${dll_dir}/wx*u_*.dll"
-  )
-  message(STATUS "wxdll_files: ${wxdll_files}")
-  install(FILES ${wxdll_files} DESTINATION ".")
-
-
+  if (OCPN_BUNDLE_WXDLLS)
+    file(GLOB wxdll_files
+      "${wxWidgets_LIB_DIR}/wxmsw32u_*.dll"
+      "${wxWidgets_LIB_DIR}/wxbase32u_*.dll"
+    )
+    install(FILES ${wxdll_files} DESTINATION ".")
+    list(LENGTH "${wxdll_files}" wxdll_count)
+    message(STATUS
+      "${wxdll_count} wxWidgets DLLs bundled into the installer package..."
+    )
+  endif ()
   if (OCPN_BUNDLE_VCDLLS)
-    file(GLOB vcdll_files "${CMAKE_CURRENT_SOURCE_DIR}/buildwin/vc/*.dll")
+    file(GLOB vcdll_files "${CMAKE_CURRENT_SOURCE_DIR}/cache/buildwin/vc/*.dll")
     install(FILES ${vcdll_files} DESTINATION ".")
     message(
       STATUS "MSVC redistributable DLLs bundled into the installer package..."
     )
-  endif (OCPN_BUNDLE_VCDLLS)
+  endif ()
   if (BUNDLE_LIBARCHIVEDLLS)
     file(
       GLOB
         libarchivedll_files
-        "${CMAKE_CURRENT_SOURCE_DIR}/buildwin/archive.dll"
-        "${CMAKE_CURRENT_SOURCE_DIR}/buildwin/liblzma.dll"
-        "${CMAKE_CURRENT_SOURCE_DIR}/buildwin/zlib1.dll"
+        "${CMAKE_CURRENT_SOURCE_DIR}/cache/buildwin/archive.dll"
+        "${CMAKE_CURRENT_SOURCE_DIR}/cache/buildwin/liblzma.dll"
+        "${CMAKE_CURRENT_SOURCE_DIR}/cache/buildwin/zlib1.dll"
     )
     install(FILES ${libarchivedll_files} DESTINATION ".")
     message(STATUS "LibArchive DLLs bundled into the installer package...")
@@ -2580,19 +2582,19 @@ endif (WIN32 AND NOT UNIX)
 
 if (MSVC AND OCPN_USE_CRASHREPORT)
   install(
-    FILES ${CMAKE_SOURCE_DIR}/buildwin/crashrpt/CrashRpt1403.dll
+    FILES ${CMAKE_SOURCE_DIR}/cache/buildwin/crashrpt/CrashRpt1403.dll
     DESTINATION ${PREFIX_PKGDATA}
   )
   install(
-    FILES ${CMAKE_SOURCE_DIR}/buildwin/crashrpt/CrashSender1403.exe
+    FILES ${CMAKE_SOURCE_DIR}/cache/buildwin/crashrpt/CrashSender1403.exe
     DESTINATION ${PREFIX_PKGDATA}
   )
   install(
-    FILES ${CMAKE_SOURCE_DIR}/buildwin/crashrpt/crashrpt_lang.ini
+    FILES ${CMAKE_SOURCE_DIR}/cache/buildwin/crashrpt/crashrpt_lang.ini
     DESTINATION ${PREFIX_PKGDATA}
   )
   install(
-    FILES ${CMAKE_SOURCE_DIR}/buildwin/crashrpt/dbghelp.dll
+    FILES ${CMAKE_SOURCE_DIR}/cache/buildwin/crashrpt/dbghelp.dll
     DESTINATION ${PREFIX_PKGDATA}
   )
   install(
@@ -2605,7 +2607,7 @@ endif (MSVC AND OCPN_USE_CRASHREPORT)
 # Install glew dll
 if (MSVC AND OCPN_USE_GL)
   install(
-    FILES ${CMAKE_SOURCE_DIR}/buildwin/glew32.dll
+    FILES ${CMAKE_SOURCE_DIR}/cache/buildwin/glew32.dll
     DESTINATION ${PREFIX_PKGDATA}
   )
 endif ()
@@ -3063,15 +3065,15 @@ if (NOT WIN32)
 else (NOT WIN32)
     target_include_directories(
       opencpn-cmd
-      PRIVATE ${CMAKE_SOURCE_DIR}/buildwin/include/openssl
+      PRIVATE ${CMAKE_SOURCE_DIR}/cache/buildwin/include/openssl
     )
     target_link_libraries(
       opencpn-cmd
-      PRIVATE ${CMAKE_SOURCE_DIR}/buildwin/libssl.lib
+      PRIVATE ${CMAKE_SOURCE_DIR}/cache/buildwin/libssl.lib
     )
    target_link_libraries(
       opencpn-cmd
-      PRIVATE ${CMAKE_SOURCE_DIR}/buildwin/libcrypto.lib
+      PRIVATE ${CMAKE_SOURCE_DIR}/cache/buildwin/libcrypto.lib
     )
 endif (NOT WIN32)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,81 +7,20 @@ image:
   - Visual Studio 2022
 
 platform:
-  # - x64
   - Win32
 
 configuration: RelWithDebInfo
-test: OFF
 
 install:
   - set "VS_BASE=C:\Program Files\Microsoft Visual Studio\2022"
   - call "%VS_BASE%\Community\VC\Auxiliary\Build\vcvars32.bat"
 
-  - cmd: SET PATH=%PATH%;C:\Program Files (x86)\Poedit\Gettexttools\bin
-  - cmd: SET PATH=%PATH%;C:\Program Files\Git\bin;c:\cygwin\bin
   - cmd: python --version
 
-  # install dependencies:
-  - choco install poedit
-  - choco install git
-
-  # - choco install nsis-3.04 -x86
-
-  # Download and unzip wxwidgets, version 3.2.1
-  - wget --version > null 2>&1 || choco install wget
-  - set "GITHUB_DL=https://github.com/wxWidgets/wxWidgets/releases/download"
-  - wget -nv %GITHUB_DL%/v3.2.1/wxMSW-3.2.1_vc14x_Dev.7z
-  - 7z x -y -oC:\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_Dev.7z
-  - wget -nv %GITHUB_DL%/v3.2.1/wxWidgets-3.2.1-headers.7z
-  - 7z x -y -oC:\wxWidgets-3.2.1 wxWidgets-3.2.1-headers.7z
-  - wget %GITHUB_DL%/v3.2.1/wxMSW-3.2.1_vc14x_ReleaseDLL.7z
-  - 7z x -y -oC:\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_ReleaseDLL.7z
-
-  # set environment variables
-  - set WXWIN=C:\wxWidgets-3.2.1
-  # Add path to resolve wxWidgets runtime deps
-  - set PATH=%PATH%;%WXWIN%\lib\vc14x_dll
-
-  - ps: >
-      Start-FileDownload
-      https://download.opencpn.org/s/54HsBDLNzRZLL6i/download
-      -FileName nsis-3.04-setup.exe
-  - nsis-3.04-setup.exe /S
-
-before_build:
-  - cd c:\project\opencpn
-  - mkdir build
-  - cd build
-  - ps: >
-      Start-FileDownload
-      https://github.com/OpenCPN/OCPNWindowsCoreBuildSupport/archive/refs/tags/v0.3.zip
-      -FileName OCPNWindowsCoreBuildSupport.zip
-  - 7z x OCPNWindowsCoreBuildSupport.zip -oc:\project\opencpn\buildwintemp
-  - mkdir c:\projects\opencpn\buildwin
-  - >
-    XCOPY
-    c:\project\opencpn\buildwintemp\OCPNWindowsCoreBuildSupport-0.3\buildwin
-    c:\project\opencpn\buildwin /s /y /q
-  - >
-    cmake -T v143
-    -DCMAKE_GENERATOR_PLATFORM=Win32
-    -A Win32 -G "Visual Studio 17 2022"
-    -DwxWidgets_ROOT_DIR=%WXWIN%
-    -DwxWidgets_LIB_DIR=%WXWIN%\lib\vc14x_dll
-    -DwxWidgets_CONFIGURATION=mswu
-    -DCMAKE_BUILD_TYPE=Release
-    -DOCPN_CI_BUILD=ON
-    -DOCPN_BUILD_TEST=OFF
-    ..
-  # Add runtime test path
-  - cmd: SET PATH=%PATH%;c:\project\opencpn\buildwin
-
 build_script:
-  # - cmake --build . --config debug
-  - cmake --build . --target opencpn --config Release
-  - SET PATH=..\buildwin;%PATH%
-  - cmake --build . --target package --config Release
+  - call ci\appveyor.bat
+
 deploy_script:
   - |
-      cd %APPVEYOR_BUILD_FOLDER%\ci
-      "\Program Files\Git\bin\bash" appveyor-upload.sh
+    cd %APPVEYOR_BUILD_FOLDER%\ci
+    "\Program Files\Git\bin\bash" appveyor-upload.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,24 +1,24 @@
+---
 clone_folder: c:\project\opencpn
 shallow_clone: false
 clone_depth: 10
 
 image:
-- Visual Studio 2022
+  - Visual Studio 2022
 
 platform:
-# - x64
-- Win32
+  # - x64
+  - Win32
 
 configuration: RelWithDebInfo
 test: OFF
 
 install:
-  # VS2015 and earlier version - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x86'
-  #- call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvars32.bat"
-  - call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars32.bat"
-  #- call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
+  - set "VS_BASE=C:\Program Files\Microsoft Visual Studio\2022"
+  - call "%VS_BASE%\Community\VC\Auxiliary\Build\vcvars32.bat"
 
-  - cmd: SET PATH=%PATH%;C:\Program Files (x86)\Poedit\Gettexttools\bin;C:\Program Files\Git\bin;c:\cygwin\bin
+  - cmd: SET PATH=%PATH%;C:\Program Files (x86)\Poedit\Gettexttools\bin
+  - cmd: SET PATH=%PATH%;C:\Program Files\Git\bin;c:\cygwin\bin
   - cmd: python --version
 
   # install dependencies:
@@ -31,38 +31,38 @@ install:
   - wget --version > null 2>&1 || choco install wget
   - set "GITHUB_DL=https://github.com/wxWidgets/wxWidgets/releases/download"
   - wget -nv %GITHUB_DL%/v3.2.1/wxMSW-3.2.1_vc14x_Dev.7z
-  - 7z x -oC:\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_Dev.7z
+  - 7z x -y -oC:\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_Dev.7z
   - wget -nv %GITHUB_DL%/v3.2.1/wxWidgets-3.2.1-headers.7z
-  - 7z x -oC:\wxWidgets-3.2.1 wxWidgets-3.2.1-headers.7z
+  - 7z x -y -oC:\wxWidgets-3.2.1 wxWidgets-3.2.1-headers.7z
   - wget %GITHUB_DL%/v3.2.1/wxMSW-3.2.1_vc14x_ReleaseDLL.7z
-  - 7z x -oC:\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_ReleaseDLL.7z
+  - 7z x -y -oC:\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_ReleaseDLL.7z
 
   # set environment variables
   - set WXWIN=C:\wxWidgets-3.2.1
   # Add path to resolve wxWidgets runtime deps
   - set PATH=%PATH%;%WXWIN%\lib\vc14x_dll
 
-  - ps: Start-FileDownload https://download.opencpn.org/s/54HsBDLNzRZLL6i/download -FileName nsis-3.04-setup.exe
-  - cmd: nsis-3.04-setup.exe /S
-
-  # some debugging information
-  # - set   Displays sensitive password!
-  # - cmake --help
-
-  # build wxWidgets - Disabled as we provide prebuilt WX to save time
-  #- cmd: cd %WXWIN%\build\msw\
-  #- cmd: nmake -f makefile.vc BUILD=release SHARED=1 CFLAGS=/D_USING_V120_SDK71_ CXXFLAGS=/D_USING_V120_SDK71_
-  #- cmd: nmake -f makefile.vc BUILD=debug SHARED=1 CFLAGS=/D_USING_V120_SDK71_ CXXFLAGS=/D_USING_V120_SDK71_
+  - ps: >
+      Start-FileDownload
+      https://download.opencpn.org/s/54HsBDLNzRZLL6i/download
+      -FileName nsis-3.04-setup.exe
+  - nsis-3.04-setup.exe /S
 
 before_build:
   - cd c:\project\opencpn
   - mkdir build
   - cd build
-  - ps: Start-FileDownload https://github.com/OpenCPN/OCPNWindowsCoreBuildSupport/archive/refs/tags/v0.3.zip -FileName OCPNWindowsCoreBuildSupport.zip
-  - cmd: 7z x OCPNWindowsCoreBuildSupport.zip -oc:\project\opencpn\buildwintemp
-  - cmd: mkdir c:\projects\opencpn\buildwin
-  - cmd: XCOPY c:\project\opencpn\buildwintemp\OCPNWindowsCoreBuildSupport-0.3\buildwin c:\project\opencpn\buildwin /s /y /q
-  ->
+  - ps: >
+      Start-FileDownload
+      https://github.com/OpenCPN/OCPNWindowsCoreBuildSupport/archive/refs/tags/v0.3.zip
+      -FileName OCPNWindowsCoreBuildSupport.zip
+  - 7z x OCPNWindowsCoreBuildSupport.zip -oc:\project\opencpn\buildwintemp
+  - mkdir c:\projects\opencpn\buildwin
+  - >
+    XCOPY
+    c:\project\opencpn\buildwintemp\OCPNWindowsCoreBuildSupport-0.3\buildwin
+    c:\project\opencpn\buildwin /s /y /q
+  - >
     cmake -T v143
     -DCMAKE_GENERATOR_PLATFORM=Win32
     -A Win32 -G "Visual Studio 17 2022"
@@ -73,8 +73,9 @@ before_build:
     -DOCPN_CI_BUILD=ON
     -DOCPN_BUILD_TEST=OFF
     ..
-  # Add runtime test path:
+  # Add runtime test path
   - cmd: SET PATH=%PATH%;c:\project\opencpn\buildwin
+
 build_script:
   # - cmake --build . --config debug
   - cmake --build . --target opencpn --config Release
@@ -84,4 +85,3 @@ deploy_script:
   - |
       cd %APPVEYOR_BUILD_FOLDER%\ci
       "\Program Files\Git\bin\bash" appveyor-upload.sh
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,24 +29,18 @@ install:
   - choco install poedit
   - choco install git
 
-  - choco install nsis
-  #- ps: Start-FileDownload https://download.opencpn.org/s/54HsBDLNzRZLL6i/download -FileName nsis-3.04-setup.exe
-  #- cmd: nsis-3.04-setup.exe /S
+  # - choco install nsis-3.04 -x86
 
   # Download and unzip wxwidgets, version 3.2.1
-  #- ps: Start-FileDownload https://download.opencpn.org/s/mKn7bczRPSJXBtF/download -FileName wxWidgets-3.2.1.7z
-  #- cmd: 7z x wxWidgets-3.2.1.7z -oC:\wxWidgets-3.2.1
+  - wget --version > null 2>&1 || choco install wget
+  - set "GITHUB_DL=https://github.com/wxWidgets/wxWidgets/releases/download"
+  - wget -nv %GITHUB_DL%/v3.2.1/wxMSW-3.2.1_vc14x_Dev.7z
+  - 7z x -oC:\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_Dev.7z
+  - wget -nv %GITHUB_DL%/v3.2.1/wxWidgets-3.2.1-headers.7z
+  - 7z x -oC:\wxWidgets-3.2.1 wxWidgets-3.2.1-headers.7z
 
-  - cmd: wget --version > nul 2>&1 || choco install -y wget
-
-  - cmd: wget -nv https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.1/wxMSW-3.2.1_vc14x_Dev.7z
-  - cmd: 7z x -oC:\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_Dev.7z
-
-  - cmd: wget -nv https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.1/wxMSW-3.2.1_vc14x_ReleaseDLL.7z
-  - cmd: 7z x -oC:\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_ReleaseDLL.7z -y
-
-  - cmd: wget -nv https://github.com/wxWidgets/wxWidgets/releases/download/v3.2.1/wxWidgets-3.2.1-headers.7z
-  - cmd: 7z x -oC:\wxWidgets-3.2.1 wxWidgets-3.2.1-headers.7z
+  - ps: Start-FileDownload https://download.opencpn.org/s/54HsBDLNzRZLL6i/download -FileName nsis-3.04-setup.exe
+  - cmd: nsis-3.04-setup.exe /S
 
   # some debugging information
   # - set   Displays sensitive password!

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,11 +18,7 @@ install:
   - call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars32.bat"
   #- call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars32.bat"
 
-  # set environment variables for wxWidgets
-  - set WXWIN=C:\wxWidgets-3.2.1
-  - set wxWidgets_ROOT_DIR=%WXWIN%
-  - set wxWidgets_LIB_DIR=%WXWIN%\lib\vc_dll
-  - cmd: SET PATH=%PATH%;%WXWIN%;%wxWidgets_LIB_DIR%;C:\Program Files (x86)\Poedit\Gettexttools\bin;C:\Program Files\Git\bin;c:\cygwin\bin
+  - cmd: SET PATH=%PATH%;C:\Program Files (x86)\Poedit\Gettexttools\bin;C:\Program Files\Git\bin;c:\cygwin\bin
   - cmd: python --version
 
   # install dependencies:
@@ -38,6 +34,13 @@ install:
   - 7z x -oC:\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_Dev.7z
   - wget -nv %GITHUB_DL%/v3.2.1/wxWidgets-3.2.1-headers.7z
   - 7z x -oC:\wxWidgets-3.2.1 wxWidgets-3.2.1-headers.7z
+  - wget %GITHUB_DL%/v3.2.1/wxMSW-3.2.1_vc14x_ReleaseDLL.7z
+  - 7z x -oC:\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_ReleaseDLL.7z
+
+  # set environment variables
+  - set WXWIN=C:\wxWidgets-3.2.1
+  # Add path to resolve wxWidgets runtime deps
+  - set PATH=%PATH%;%WXWIN%\lib\vc14x_dll
 
   - ps: Start-FileDownload https://download.opencpn.org/s/54HsBDLNzRZLL6i/download -FileName nsis-3.04-setup.exe
   - cmd: nsis-3.04-setup.exe /S
@@ -59,16 +62,23 @@ before_build:
   - cmd: 7z x OCPNWindowsCoreBuildSupport.zip -oc:\project\opencpn\buildwintemp
   - cmd: mkdir c:\projects\opencpn\buildwin
   - cmd: XCOPY c:\project\opencpn\buildwintemp\OCPNWindowsCoreBuildSupport-0.3\buildwin c:\project\opencpn\buildwin /s /y /q
-
-  - cmake -T v143 -DOCPN_CI_BUILD=ON -DCMAKE_GENERATOR_PLATFORM=Win32 -DOCPN_BUILD_TEST=OFF ..
+  ->
+    cmake -T v143
+    -DCMAKE_GENERATOR_PLATFORM=Win32
+    -A Win32 -G "Visual Studio 17 2022"
+    -DwxWidgets_ROOT_DIR=%WXWIN%
+    -DwxWidgets_LIB_DIR=%WXWIN%\lib\vc14x_dll
+    -DwxWidgets_CONFIGURATION=mswu
+    -DCMAKE_BUILD_TYPE=Release
+    -DOCPN_CI_BUILD=ON
+    -DOCPN_BUILD_TEST=OFF
+    ..
   # Add runtime test path:
   - cmd: SET PATH=%PATH%;c:\project\opencpn\buildwin
 build_script:
   # - cmake --build . --config debug
-  - cmake --build . --target opencpn --config RelWithDebInfo
+  - cmake --build . --target opencpn --config Release
   - SET PATH=..\buildwin;%PATH%
-  #- cmake --build . --target run-tests --config RelWithDebInfo
-  #- cmake --build . --target package --config RelWithDebInfo
   - cmake --build . --target package --config Release
 deploy_script:
   - |

--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -1,0 +1,61 @@
+:: Download OpenCPN prebuilt dependencies
+::
+@echo off
+setlocal enabledelayedexpansion
+
+:: Install Poedit if required
+msgmerge --version >nul 2>&1
+if errorlevel 1 (
+  choco install -y poedit
+  set "PATH=%PATH%;C:\Program Files (x86)\Poedit\Gettexttools\bin"
+)
+
+:: Install git if required.
+git --version >nul 2>&1
+if errorlevel 1 (
+  choco install -y git
+  set "PATH=%PATH%;C:\Program Files\Git\bin"
+)
+
+:: install wget as required
+wget --version >nul 2>&1 || choco install -y wget
+
+:: If needed, download wxWidgets binary build.
+set "CACHE_DIR=%~dp0..\cache"
+if not exist !CACHE_DIR! (mkdir !CACHE_DIR!)
+if not exist cache\wxWidgets-3.2.1 (
+  set "GITHUB_DL=https://github.com/wxWidgets/wxWidgets/releases/download"
+  wget -nv %GITHUB_DL%/v3.2.1/wxMSW-3.2.1_vc14x_Dev.7z
+  7z x -y -o!CACHE_DIR!\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_Dev.7z
+  wget -nv !GITHUB_DL!/v3.2.1/wxWidgets-3.2.1-headers.7z
+  7z x -y -o%CACHE_DIR%\wxWidgets-3.2.1 wxWidgets-3.2.1-headers.7z
+  wget %GITHUB_DL%/v3.2.1/wxMSW-3.2.1_vc14x_ReleaseDLL.7z
+  7z x -y -o!CACHE_DIR!\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_ReleaseDLL.7z
+)
+
+:: Create cache\wx-config.bat, paths to downloaded wxWidgets.
+set "WXWIN=!CACHE_DIR!\wxWidgets-3.2.1"
+echo set "wxWidgets_ROOT_DIR=%WXWIN%" > %CACHE_DIR%\wx-config.bat
+echo set "wxWidgets_LIB_DIR=%WXWIN%\lib\vc14x_dll" >> %CACHE_DIR%\wx-config.bat
+
+
+if not exist C:\ProgramData\chocolatey\lib\nsis (
+  echo Installing nsis tools using choco
+  choco install -y nsis
+)
+
+:: Make sure the pre-compiled libraries are in place
+if not exist !CACHE_DIR!\buildwin\libcurl.dll (
+  set "GH_DL_BASE=https://github.com/OpenCPN/OCPNWindowsCoreBuildSupport"
+  wget -nv -O !CACHE_DIR!\OCPNWindowsCoreBuildSupport.zip ^
+      %GH_DL_BASE%/archive/refs/tags/v0.3.zip
+  7z x -y !CACHE_DIR!\OCPNWindowsCoreBuildSupport.zip ^
+      -o%CACHE_DIR%\buildwintemp
+  if not exist !CACHE_DIR!\buildwin (mkdir !CACHE_DIR!\buildwin)
+  xcopy ^
+    !CACHE_DIR!\buildwintemp\OCPNWindowsCoreBuildSupport-0.3\buildwin ^
+    !CACHE_DIR!\buildwin /s /y /q
+  if exist !CACHE_DIR!\buildwin\wxWidgets (
+    rmdir !CACHE_DIR!\buildwin\wxWidgets /s /q
+  )
+)

--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -1,6 +1,6 @@
 :: Download OpenCPN prebuilt dependencies
 ::
-@echo off
+@echo on
 setlocal enabledelayedexpansion
 
 :: Install Poedit if required
@@ -23,14 +23,14 @@ wget --version >nul 2>&1 || choco install -y wget
 :: If needed, download wxWidgets binary build.
 set "CACHE_DIR=%~dp0..\cache"
 if not exist !CACHE_DIR! (mkdir !CACHE_DIR!)
+set "GITHUB_DL=https://github.com/wxWidgets/wxWidgets/releases/download"
 if not exist cache\wxWidgets-3.2.1 (
-  set "GITHUB_DL=https://github.com/wxWidgets/wxWidgets/releases/download"
   wget -nv %GITHUB_DL%/v3.2.1/wxMSW-3.2.1_vc14x_Dev.7z
-  7z x -y -o!CACHE_DIR!\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_Dev.7z
-  wget -nv !GITHUB_DL!/v3.2.1/wxWidgets-3.2.1-headers.7z
+  7z x -y -o%CACHE_DIR%\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_Dev.7z
+  wget -nv %GITHUB_DL%/v3.2.1/wxWidgets-3.2.1-headers.7z
   7z x -y -o%CACHE_DIR%\wxWidgets-3.2.1 wxWidgets-3.2.1-headers.7z
-  wget %GITHUB_DL%/v3.2.1/wxMSW-3.2.1_vc14x_ReleaseDLL.7z
-  7z x -y -o!CACHE_DIR!\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_ReleaseDLL.7z
+  wget -nv %GITHUB_DL%/v3.2.1/wxMSW-3.2.1_vc14x_ReleaseDLL.7z
+  7z x -y -o%CACHE_DIR%\wxWidgets-3.2.1 wxMSW-3.2.1_vc14x_ReleaseDLL.7z
 )
 
 :: Create cache\wx-config.bat, paths to downloaded wxWidgets.
@@ -45,8 +45,8 @@ if not exist C:\ProgramData\chocolatey\lib\nsis (
 )
 
 :: Make sure the pre-compiled libraries are in place
-if not exist !CACHE_DIR!\buildwin\libcurl.dll (
-  set "GH_DL_BASE=https://github.com/OpenCPN/OCPNWindowsCoreBuildSupport"
+set "GH_DL_BASE=https://github.com/OpenCPN/OCPNWindowsCoreBuildSupport"
+if not exist %CACHE_DIR%\buildwin\libcurl.dll (
   wget -nv -O !CACHE_DIR!\OCPNWindowsCoreBuildSupport.zip ^
       %GH_DL_BASE%/archive/refs/tags/v0.3.zip
   7z x -y !CACHE_DIR!\OCPNWindowsCoreBuildSupport.zip ^

--- a/ci/appveyor.bat
+++ b/ci/appveyor.bat
@@ -1,0 +1,43 @@
+:: Build and upload OpenCPN artifacts
+@echo on
+
+setlocal enabledelayedexpansion
+
+if "%CONFIGURATION%" == "" (set CONFIGURATION=Release)
+if "%APPVEYOR_BUILD_FOLDER%" == "" (set "APPVEYOR_BUILD_FOLDER=%~dp0..")
+
+where dumpbin.exe >nul 2>&1
+if errorlevel 1 (
+  set "VS_BASE=C:\Program Files\Microsoft Visual Studio\2022"
+  call "%VS_BASE%\Community\VC\Auxiliary\Build\vcvars32.bat"
+)
+
+call %APPVEYOR_BUILD_FOLDER%\buildwin\win_deps.bat
+call %APPVEYOR_BUILD_FOLDER%\cache\wx-config.bat
+
+where wxmsw32u_qa_vc14x.dll >nul 2>&1
+if errorlevel 1 (
+  set "PATH=%PATH%;%wxWidgets_LIB_DIR%"
+  echo Appending %wxWidgets_LIB_DIR% to PATH
+)
+
+cd %APPVEYOR_BUILD_FOLDER%
+
+if exist build (rmdir /q /s build)
+mkdir build && cd build
+
+cmake -T v143 ^
+    -DCMAKE_GENERATOR_PLATFORM=Win32 ^
+    -A Win32 -G "Visual Studio 17 2022" ^
+    -DwxWidgets_ROOT_DIR=%wxWidgets_ROOT_DIR% ^
+    -DwxWidgets_LIB_DIR=%wxWidgets_LIB_DIR% ^
+    -DwxWidgets_CONFIGURATION=mswu ^
+    -DCMAKE_BUILD_TYPE=%CONFIGURATION% ^
+    -DCMAKE_LIBRARY_PATH=%~dp0..\cache\buildwin ^
+    -DCMAKE_INCLUDE_PATH=%~dp0..\cache\buildwin\include ^
+    -DOCPN_CI_BUILD=ON ^
+    -DOCPN_BUNDLE_WXDLLS=ON ^
+    -DOCPN_BUILD_TEST=OFF ^
+    ..
+
+cmake --build . --target package --config %CONFIGURATION%

--- a/cmake/Curl.cmake
+++ b/cmake/Curl.cmake
@@ -19,33 +19,33 @@ IF (CURL_FOUND)
 ENDIF ()
 
 IF(CMAKE_HOST_WIN32)
-  if (NOT EXISTS ${PROJECT_SOURCE_DIR}/buildwin/libcurl.lib)
+  if (NOT EXISTS ${PROJECT_SOURCE_DIR}/cache/buildwin/libcurl.lib)
       message(FATAL_ERROR "Cannot find bundled windows files.")
   endif ()
   ADD_LIBRARY(WIN32_LIBCURL SHARED IMPORTED)
   SET_TARGET_PROPERTIES(WIN32_LIBCURL PROPERTIES
-      IMPORTED_IMPLIB ${PROJECT_SOURCE_DIR}/buildwin/libcurl.lib
-      IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/buildwin/libcurl.dll
+      IMPORTED_IMPLIB ${PROJECT_SOURCE_DIR}/cache/buildwin/libcurl.lib
+      IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/cache/buildwin/libcurl.dll
   )
   ADD_LIBRARY(WIN32_ZLIB1 SHARED IMPORTED)
   SET_TARGET_PROPERTIES(WIN32_ZLIB1 PROPERTIES
-      IMPORTED_IMPLIB ${PROJECT_SOURCE_DIR}/buildwin/zlib1.lib
-      IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/buildwin/zlib1.dll
+      IMPORTED_IMPLIB ${PROJECT_SOURCE_DIR}/cache/buildwin/zlib1.lib
+      IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/cache/buildwin/zlib1.dll
   )
   IF(MSVC)
-    INSTALL(FILES "buildwin/libcurl.dll" DESTINATION ".")
-    INSTALL(FILES "buildwin/zlib1.dll" DESTINATION ".")
-    #INSTALL(FILES "buildwin/libeay32.dll" DESTINATION ".")
-    #INSTALL(FILES "buildwin/ssleay32.dll" DESTINATION ".")
-    #INSTALL(FILES "buildwin/curl-ca-bundle.crt" DESTINATION ".")
+    INSTALL(FILES "cache/buildwin/libcurl.dll" DESTINATION ".")
+    INSTALL(FILES "cache/buildwin/zlib1.dll" DESTINATION ".")
+    #INSTALL(FILES "cache/buildwin/libeay32.dll" DESTINATION ".")
+    #INSTALL(FILES "cache/buildwin/ssleay32.dll" DESTINATION ".")
+    #INSTALL(FILES "cache/buildwin/curl-ca-bundle.crt" DESTINATION ".")
     SET(CURL_LIBRARIES WIN32_LIBCURL WIN32_ZLIB1)
   ELSE(MSVC)
     # mingw
     SET(CURL_LIBRARIES WIN32_LIBCURL)
-    INSTALL(FILES "buildwin/libcurl.dll" DESTINATION ".")
+    INSTALL(FILES "cache/buildwin/libcurl.dll" DESTINATION ".")
   ENDIF(MSVC)
 
-  set(CURL_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/buildwin/include)
+  set(CURL_INCLUDE_DIRS ${PROJECT_SOURCE_DIR}/cache/buildwin/include)
   SET(CURL_FOUND 1)
 ENDIF(CMAKE_HOST_WIN32)
 

--- a/cmake/OcpnFindCairo.cmake
+++ b/cmake/OcpnFindCairo.cmake
@@ -8,7 +8,7 @@ if (CAIRO_INCLUDE_DIRS)
 endif ()
 
 if (CMAKE_HOST_WIN32)
-  set(CAIRO_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/buildwin/gtk/include)
+  set(CAIRO_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/cache/buildwin/gtk/include)
 else (CMAKE_HOST_WIN32)
   set(CAIRO_INC_LOOK_PATHS /usr/local/include /usr/include)
   if (APPLE)
@@ -28,8 +28,8 @@ message(STATUS " Cairo includes: ${CAIRO_INCLUDE_DIRS}")
 
 if (CMAKE_HOST_WIN32)
   set(CAIRO_LIBRARIES
-    ${CMAKE_SOURCE_DIR}/buildwin/gtk/cairo.lib
-    ${CMAKE_SOURCE_DIR}/buildwin/archive.lib
+    ${CMAKE_SOURCE_DIR}/cache/buildwin/gtk/cairo.lib
+    ${CMAKE_SOURCE_DIR}/cache/buildwin/archive.lib
   )
   set(CAIRO_FOUND 1)
 else (CMAKE_HOST_WIN32)

--- a/libs/mongoose/CMakeLists.txt
+++ b/libs/mongoose/CMakeLists.txt
@@ -35,15 +35,15 @@ if (NOT WIN32)
 else (NOT WIN32)
     target_include_directories(
       MONGOOSE
-      PRIVATE ${CMAKE_SOURCE_DIR}/buildwin/include/openssl
+      PRIVATE ${CMAKE_SOURCE_DIR}/cache/buildwin/include/openssl
     )
     target_link_libraries(
       MONGOOSE
-      PRIVATE ${CMAKE_SOURCE_DIR}/buildwin/libssl.lib
+      PRIVATE ${CMAKE_SOURCE_DIR}/cache/buildwin/libssl.lib
     )
    target_link_libraries(
       MONGOOSE
-      PRIVATE ${CMAKE_SOURCE_DIR}/buildwin/libcrypto.lib
+      PRIVATE ${CMAKE_SOURCE_DIR}/cache/buildwin/libcrypto.lib
     )
 endif (NOT WIN32)
 
@@ -63,6 +63,6 @@ target_include_directories(
 
 if (MSVC)
 target_include_directories(
-  MONGOOSE PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../buildwin/include
+  MONGOOSE PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../../cache/buildwin/include
 )
 endif (MSVC)

--- a/plugins/chartdldr_pi/CMakeLists.txt
+++ b/plugins/chartdldr_pi/CMakeLists.txt
@@ -112,8 +112,8 @@ if (APPLE)
 endif ()
 
 if (CMAKE_HOST_WIN32)
-  list(APPEND CMAKE_PREFIX_PATH "../../buildwin/include")
-  list(APPEND CMAKE_PREFIX_PATH "../../buildwin")
+  list(APPEND CMAKE_PREFIX_PATH "../../cache/buildwin/include")
+  list(APPEND CMAKE_PREFIX_PATH "../../cache/buildwin")
 endif ()
 
 option(OCPN_USE_CHART_LIST "Use wxDATAVIEWLISTCTRL for chart downloader" OFF)

--- a/plugins/grib_pi/CMakeLists.txt
+++ b/plugins/grib_pi/CMakeLists.txt
@@ -144,7 +144,7 @@ if (NOT UNIX)
   )
   add_library(LIB_BZIP STATIC ${SRC_BZIP})
 
-  include_directories(${CMAKE_SOURCE_DIR}/buildwin/include)
+  include_directories(${CMAKE_SOURCE_DIR}/cache/buildwin/include)
   include_directories(${PLUGIN_SOURCE_DIR}/src/bzip2)
 endif (NOT UNIX)
 
@@ -160,7 +160,7 @@ if (QT_ANDROID)
   )
   set(SRC_GRIB ${SRC_GRIB} ${SRC_BZIP_ANDROID})
 
-  include_directories(${CMAKE_SOURCE_DIR}/buildwin/include)
+  include_directories(${CMAKE_SOURCE_DIR}/cache/buildwin/include)
   include_directories(${PLUGIN_SOURCE_DIR}/src/bzip2)
 
   message(STATUS ${SRC_GRIB})
@@ -191,7 +191,7 @@ endif ()
 if (WIN32)
   if (MSVC)
     target_link_libraries(
-      ${PACKAGE_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/buildwin/zlib1.lib"
+      ${PACKAGE_NAME} PRIVATE "${CMAKE_SOURCE_DIR}/cache/buildwin/zlib1.lib"
                               "GLU_static"
     )
   else (MSVC)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -99,15 +99,15 @@ if (NOT WIN32)
 else (NOT WIN32)
     target_include_directories(
       tests
-      PRIVATE ${CMAKE_SOURCE_DIR}/buildwin/include/openssl
+      PRIVATE ${CMAKE_SOURCE_DIR}/cache/buildwin/include/openssl
     )
     target_link_libraries(
       tests
-      PRIVATE ${CMAKE_SOURCE_DIR}/buildwin/libssl.lib
+      PRIVATE ${CMAKE_SOURCE_DIR}/cache/buildwin/libssl.lib
     )
    target_link_libraries(
       tests
-      PRIVATE ${CMAKE_SOURCE_DIR}/buildwin/libcrypto.lib
+      PRIVATE ${CMAKE_SOURCE_DIR}/cache/buildwin/libcrypto.lib
     )
 endif (NOT WIN32)
 


### PR DESCRIPTION
build: windows: re-factor to use separate scripts.

Create a separate script buildwin/win_deps.bat which downloads pre-built dependencies. This script can also be run when doing manual builds.

Move the downloaded stuff from buildwin to a new directory cache/. Adding files to a directory mamaged by git is just not the way to do it. Clean up .gitignore, modify paths to libs spread out over the place.

Make sure the wxWidgets libraries are installed when creating the installer.

Fix a long-standing bug when using CI_BUILDS causing a bad  multiline constant in config.h

With these changes, the process to build OpenCPN on Windows should become much simplified.
