### PR TITLE
Fix logic error in persistent track deletion.

### DIFF
--- a/src/ocpn_frame.cpp
+++ b/src/ocpn_frame.cpp
@@ -1232,7 +1232,7 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, const wxPoint &pos,
          "A Persistent track recording will therefore be restarted for this target.\n\n"
          "Do you instead want to stop Persistent tracking for this target?"),
        _("OpenCPN Info"), wxYES_NO | wxCENTER, 60);
-    return r == wxID_OK;
+    return r == wxID_YES;
   };
   g_pAIS = new AisDecoder(ais_callbacks);
 


### PR DESCRIPTION
Found a bug in AIS target track deletion.  The YES/NO dialog box needs to be tested for wxID_YES not wxID_OK.