### PR TITLE
CMakeLists, appdata: Add required timestamp to appdata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -552,9 +552,10 @@ set(PREFIX_LIB "${CMAKE_INSTALL_FULL_LIBDIR}")
 #
 include(${CMAKE_SOURCE_DIR}/VERSION.cmake)
 
+string(TIMESTAMP VERSION_DATE "%Y-%m-%d")
+string(TIMESTAMP UNIX_TIMESTAMP "%s")
 if (OCPN_CI_BUILD)
   include(Utils)
-  today(DATE)
   commit_id(COMMIT)
   build_num(BUILD_NUMBER)
   if (NOT "${OCPN_RELEASE}" STREQUAL "")
@@ -564,8 +565,7 @@ if (OCPN_CI_BUILD)
   if (NOT "${BUILD_NUMBER}" STREQUAL "")
     set(VERSION_TAIL "-${BUILD_NUMBER}${VERSION_TAIL}")
   endif ()
-  string(STRIP "{DATE}" VERSION_DATE)
-endif (OCPN_CI_BUILD)
+endif ()
 
 set(
   PACKAGE_VERSION

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -1,18 +1,3 @@
-MACRO (TODAY RESULT)
-    IF (CMAKE_HOST_WIN32)
-        EXECUTE_PROCESS(COMMAND "cmd" "/C" "date /T" OUTPUT_VARIABLE ${RESULT})
-        string(REGEX REPLACE "(..)/(..)/(....).*" "\\3-\\2-\\1"
-               ${RESULT} ${${RESULT}})
-    ELSEIF(UNIX OR MINGW)
-        EXECUTE_PROCESS(COMMAND "date" "-u" "+%d/%m/%Y" OUTPUT_VARIABLE ${RESULT})
-        string(REGEX REPLACE "(..)/(..)/(....).*" "\\3-\\2-\\1"
-               ${RESULT} ${${RESULT}})
-    ELSE ()
-        MESSAGE(SEND_ERROR "date not implemented")
-        SET(${RESULT} 000000)
-    ENDIF ()
-ENDMACRO (TODAY)
-
 MACRO (COMMIT_ID RESULT)
     # Get the latest abbreviated commit hash of the working branch
     execute_process(

--- a/data/opencpn.appdata.xml.in
+++ b/data/opencpn.appdata.xml.in
@@ -33,7 +33,8 @@
     </p>
   </description>
   <releases>
-    <release version="@PACKAGE_VERSION@" date="@VERSION_DATE@">
+      <release version="@PACKAGE_VERSION@" date="@VERSION_DATE@"
+          timestamp="@UNIX_TIMESTAMP@">
       <description>
         <p>The latest upstream commit.</p>
       </description>


### PR DESCRIPTION
The appdata.xml generation requires that VERSION_DATE always is available as a cmake variable. However, as of current this is only created when OCPN_CI_BUILD is on.  The variable is also setup in a needlessly complicated way which also seems to fail in some circimstances.

Use CMAKE's string command to set up VERSION_DATE instead of complicated code
Add a timestamp field to the appdata _Release_ section to cover up if Date for some reason is no set in a reasonable way.

This patch is applied to the Flatpak (beta) packaging.