### PR TITLE
Correct console display sizing

### DIFF
--- a/src/concanv.cpp
+++ b/src/concanv.cpp
@@ -48,6 +48,7 @@
 #include "wx28compat.h"
 #include "route.h"
 #include "ocpn_frame.h"
+#include "OCPNPlatform.h"
 
 extern Routeman* g_pRouteMan;
 extern MyFrame* gFrame;
@@ -55,6 +56,7 @@ extern bool g_bShowActiveRouteHighway;
 extern double gCog;
 extern double gSog;
 extern bool g_bShowTrue, g_bShowMag;
+extern BasePlatform* g_BasePlatform;
 
 bool g_bShowRouteTotal;
 
@@ -516,6 +518,10 @@ void AnnunText::CalculateMinSize(void) {
 
   if (m_pvalueFont)
     GetTextExtent(_T("123.4567"), &wv, &hv, NULL, NULL, m_pvalueFont);
+
+  double pdifactor = g_BasePlatform->GetDisplayDPIMult(gFrame);
+  wl *= pdifactor; hl *= pdifactor;
+  wv *= pdifactor; hv *= pdifactor;
 
   wxSize min;
   min.x = wl + wv;

--- a/src/concanv.cpp
+++ b/src/concanv.cpp
@@ -534,6 +534,13 @@ void AnnunText::CalculateMinSize(void) {
   min.y = (int)((hl + hv) * 1.2);
 
   SetMinSize(min);
+
+  //resize background to the necessary size
+  ocpnStyle::Style* style = g_StyleManager->GetCurrentStyle();
+  if (style->consoleTextBackground.IsOk()) {
+    wxImage img = style->consoleTextBackground.ConvertToImage();
+    style->consoleTextBackground = wxBitmap(img.Rescale(min.x, min.y));
+  }
 }
 
 void AnnunText::SetColorScheme(ColorScheme cs) {

--- a/src/styles.cpp
+++ b/src/styles.cpp
@@ -699,13 +699,10 @@ void Style::SetColorScheme(ColorScheme cs) {
     wxBitmap bm = graphics->GetSubBitmap(
         wxRect(consoleTextBackgroundLoc, consoleTextBackgroundSize));
 
-    // The background bitmap in the icons file may be too small, so will grow it
-    // arbitrailly
-    wxImage image = bm.ConvertToImage();
-    image.Rescale(consoleTextBackgroundSize.GetX() * 2,
-                  consoleTextBackgroundSize.GetY() * 2, wxIMAGE_QUALITY_NORMAL);
-    wxBitmap bn(image);
-    consoleTextBackground = SetBitmapBrightness(bn, cs);
+    // The background bitmap in the icons file may be too small but it's better to resize it
+    // when we use it
+
+    consoleTextBackground = SetBitmapBrightness(bm, cs);
   }
 }
 


### PR DESCRIPTION
Adapt to wxWidgets 3.2.1 for MSW and suppress white lines (partial rectangle) visible when using big font size for values and/or legends 