### PR TITLE
.gitignore: Add missing cache directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+cache
 cscope.files
 tags
 index.sh


### PR DESCRIPTION
As discussed in zulip "Master 5.8.8 (was: comms)".  The cache directory contains various temporary large files which should not be part of the git repo.

IMHO, pretty urgent to merge to avoid getting large amounts of junk in the git history.