### PR TITLE
editorconfig: Update charset to utf-8 (#2874)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,7 +1,7 @@
 root = true
 [*.{cpp,h,c,cmake}]
 insert_final_newline = true
-charset = latin1
+charset = utf-8
 indent_style = space
 indent_size = 2
 trim_trailing_whitespace = true


### PR DESCRIPTION
As discussed in #2874, the `charset: latin1` setting in  _.editorconfig_ is plain wrong, should be utf-8. 

Hereby fixed. 