### PR TITLE
cmake/TargetSetup: macos: Fix illegal target darwin-wx321

### DIFF
--- a/cmake/TargetSetup.cmake
+++ b/cmake/TargetSetup.cmake
@@ -35,7 +35,7 @@ elseif (MSVC)
         set(PKG_TARGET_VERSION 10)
     endif ()
 elseif (APPLE)
-    set(PKG_TARGET "darwin-wx321")
+    set(PKG_TARGET "darwin-wx32")
     execute_process(COMMAND "sw_vers" "-productVersion"
                     OUTPUT_VARIABLE PKG_TARGET_VERSION)
 elseif (UNIX)


### PR DESCRIPTION
The auto-computed target for macos is plain wrong,  hereby fixed.