### PR TITLE
Macos: Handle bundled mp3 libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2589,6 +2589,15 @@ if (WIN32 AND NOT UNIX)
   endif (BUNDLE_LIBARCHIVEDLLS)
 endif (WIN32 AND NOT UNIX)
 
+if (APPLE)
+  find_library(MPG123 NAMES mpg123 REQUIRED)
+  target_link_libraries(${PACKAGE_NAME} PUBLIC ${MPG123})
+  message(STATUS "MPG123: ${MPG123}")
+  find_library(MP3LAME NAMES mp3lame lame REQUIRED)
+  target_link_libraries(${PACKAGE_NAME} PUBLIC ${MP3LAME})
+  message(STATUS "MP3LAME: ${MP3LAME}")
+endif ()
+
 if (MSVC AND OCPN_USE_CRASHREPORT)
   install(
     FILES ${CMAKE_SOURCE_DIR}/cache/buildwin/crashrpt/CrashRpt1403.dll

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2906,10 +2906,10 @@ install(CODE "
 )
 
 #  For unknown reasons, fixup_bundle copies the wrong version of liblzma.5.dylib into the bundle.
-#  So, fix that here by grabbing the correct version as installed by macports.
+#  So, fix that here by grabbing the correct version  actually used.
 install(CODE "
   include(BundleUtilities)
-  copy_resolved_item_into_bundle(\"/opt/local/lib/liblzma.5.dylib\" \"\${CMAKE_INSTALL_PREFIX}/bin/OpenCPN.app/Contents/Frameworks\")
+  copy_resolved_item_into_bundle(\"${LIBLZMA_LIBRARIES}\" \"\${CMAKE_INSTALL_PREFIX}/bin/OpenCPN.app/Contents/Frameworks\")
   "
   COMPONENT Runtime
 )

--- a/ci/macos-deps
+++ b/ci/macos-deps
@@ -1,7 +1,9 @@
 # brew packages installed in macos ci build
 cmake
 gettext
+lame
 libexif
+mpg123
 python
 wget
 libarchive


### PR DESCRIPTION
This removes both libmpg123.0.dylib and libmp3lame.0.dylib from the list of libraries bundled in the dmg image. 

The header file _lame.h_ is nowhere included in OpenCPN and the build is just fine without these libraries, so removing this should be ok.

This might break some obscure plugin which has depended on this library to be available. However, the general contract is that plugins which uses libraries not used by main OpenCPN should bundle such libs in the plugin tarball.