### PR TITLE
Fix broken .gitignore (#2936)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,6 @@ cscope.out
 *.kdev*
 *.patch
 crowdin.yaml
-buildwin
 buildwin/NSIS_Unicode/Include/Langstrings_*.nsh
 buildwin/crashrpt/CrashRpt1402.dll
 buildwin/crashrpt/CrashSender1402.exe


### PR DESCRIPTION
Quick fix after merging #2936 which basically excluded the _buildwin/_ directory from the git repo, I presume by accident.