### PR TITLE
Adjust AIS prediction circle size for less critical targets

### DIFF
--- a/src/ais.cpp
+++ b/src/ais.cpp
@@ -1149,10 +1149,7 @@ static void AISDrawTarget(AisTargetData *td, ocpnDC &dc, ViewPort &vp,
 
         if (dc.GetDC()) {
           dc.SetBrush(target_brush);
-          if (targetscale >= 75)
-            dc.StrokeCircle(PredPoint.x, PredPoint.y, 5);
-          else
-            dc.StrokeCircle(PredPoint.x, PredPoint.y, 2);
+          dc.StrokeCircle(PredPoint.x, PredPoint.y, 5* targetscale / 100);
         } else {
 #ifdef ocpnUSE_GL
 
@@ -1196,7 +1193,7 @@ static void AISDrawTarget(AisTargetData *td, ocpnDC &dc, ViewPort &vp,
 
           dc.SetBrush(target_brush);
           dc.StrokeCircle(PredPoint.x, PredPoint.y,
-                          AIS_intercept_bar_circle_diameter * AIS_user_scale_factor);
+                          AIS_intercept_bar_circle_diameter * AIS_user_scale_factor* targetscale / 100);
 #endif
 #endif
         }


### PR DESCRIPTION
If an AIS target is reduced in size, also reduce the size of the prediction circle.

//TODO The line from target to pred.circle is in non OpenGL mode dotted, but in OpenGL mode it is not. I prefer the dotted line, but don't know how to set this in GL mode.
![Screenshot_20230128_111629](https://user-images.githubusercontent.com/2668258/215261780-43dc5196-c90a-405e-9939-41118a37ce42.png)
![Screenshot_20230128_111522](https://user-images.githubusercontent.com/2668258/215261784-803b25d7-529f-4e1d-9ad8-96d36797a82e.png)

