### PR TITLE
glTextureManager: Don't delete pointer before last use (#2696)

### DIFF
--- a/src/glTextureManager.cpp
+++ b/src/glTextureManager.cpp
@@ -890,12 +890,12 @@ void glTextureManager::OnEvtThread(OCPN_CompressionThreadEvent &event) {
     tnode = tnode->GetNext();
   }
 
-  delete ticket;
-
   if (g_raster_format != GL_COMPRESSED_RGB_FXT1_3DFX) {
     running_list.DeleteObject(ticket);
     StartTopJob();
   }
+
+  delete ticket;
 }
 
 void glTextureManager::OnTimer(wxTimerEvent &event) {


### PR DESCRIPTION
This is a simple point  fix for #2696. I have had  ambitions to do something more about this code which generally certainly could be improved. However, no time, defaulting to the obvious, simple fix.

Closes: #2696