### PR TITLE
plugin_loader: Drop resurrected jailing code  (#2516)

### DIFF
--- a/include/plugin_blacklist.h
+++ b/include/plugin_blacklist.h
@@ -77,10 +77,20 @@ public:
   virtual plug_status get_status(const plug_data pd)  = 0;
 
   /** Best effort attempt to get data for a library file. */
-  virtual plug_data get_library_data(const std::string library_file) = 0;
+  virtual plug_data get_library_data(const std::string& library_file) = 0;
 
-  /** Given a path, mark filename as unloadable. */
-  virtual void mark_unloadable(const std::string& path) = 0;
+  /**
+   *  Given a path, mark filename as unloadable.
+   *  @return true if filename was already marked, else false.
+   */
+  virtual bool mark_unloadable(const std::string& path) = 0;
+
+  /**
+   *  Given plugin name and version mark it as unloadable.
+   *  @return true if plugin was already marked, else false.
+   **/
+  virtual bool mark_unloadable(const std::string& name,
+		               int major, int minor) = 0;
 
   /** Return true iff plugin (a path) is loadable. */
   virtual bool is_loadable(const std::string path) = 0;

--- a/include/plugin_loader.h
+++ b/include/plugin_loader.h
@@ -37,6 +37,7 @@
 #include "catalog_parser.h"
 #include "observable_evtvar.h"
 #include "ocpn_plugin.h"
+#include "plugin_blacklist.h"
 #include "semantic_vers.h"
 
 
@@ -51,19 +52,6 @@ typedef struct {
                    // plugin
   bool mute_dialog;  // if true, don't warn the user by dialog.
 } BlackListedPlugin;
-
-const BlackListedPlugin PluginBlacklist[] = {
-    {_T("aisradar_pi"), 0, 95, true, true},
-    {_T("radar_pi"), 0, 95, true, true},  // GCC alias for aisradar_pi
-    {_T("watchdog_pi"), 1, 00, true, true},
-    {_T("squiddio_pi"), 0, 2, true, true},
-    {_T("objsearch_pi"), 0, 3, true, true},
-#ifdef __WXOSX__
-    {_T("s63_pi"), 0, 6, true, true},
-#endif
-    {_T("oesenc_pi"), 4, 2, true, true},
-
-};
 
 
 enum class PluginStatus {
@@ -189,12 +177,12 @@ public:
   ArrayOfPlugIns* GetPlugInArray() { return &plugin_array; }
   bool IsPlugInAvailable(wxString commonName);
   bool CheckPluginCompatibility(wxString plugin_file);
-  bool CheckBlacklistedPlugin(opencpn_plugin* plugin);
 
 private:
   PluginLoader();
   bool LoadPlugInDirectory(const wxString &plugin_dir, bool load_enabled);
   bool LoadPluginCandidate(wxString file_name, bool load_enabled);
+  std::unique_ptr<AbstractBlacklist> m_blacklist;
   ArrayOfPlugIns plugin_array;
   wxString m_last_error_string;
   wxString m_plugin_location;

--- a/src/ocpn_frame.cpp
+++ b/src/ocpn_frame.cpp
@@ -4886,9 +4886,10 @@ void MyFrame::OnInitTimer(wxTimerEvent &event) {
       //   Notify all the AUI PlugIns so that they may syncronize with the
       //   Perspective
       g_pi_manager->NotifyAuiPlugIns();
-      g_pi_manager
-          ->ShowDeferredBlacklistMessages();  //  Give the use dialog on any
-                                              //  blacklisted PlugIns
+
+      //  Give the user dialog on any blacklisted PlugIns
+      g_pi_manager ->ShowDeferredBlacklistMessages();
+
       g_pi_manager->CallLateInit();
 
       //  If any PlugIn implements PlugIn Charts, we need to re-run the initial

--- a/src/plugin_blacklist.cpp
+++ b/src/plugin_blacklist.cpp
@@ -173,12 +173,16 @@ private:
     return m_blocks.end();
   }
 
-  void update_block(const std::string& name, int major, int minor) {
-    if (m_blocks.find(name) == m_blocks.end())
+  bool update_block(const std::string& name, int major, int minor) {
+    bool  new_block = false;
+    if (m_blocks.find(name) == m_blocks.end()) {
       m_blocks[name] = block(major, minor);
+      new_block = true;
+    }
     m_blocks[name].status = plug_status::unloadable;
     m_blocks[name].major = major;
     m_blocks[name].minor = minor;
+    return new_block;
   }
 
   /** Avoid pulling in wx libraries in low-level model code. */
@@ -197,7 +201,7 @@ private:
 
 public:
 
-  virtual plug_data get_library_data(const std::string library_file) {
+  virtual plug_data get_library_data(const std::string& library_file) {
     std::string filename(normalize_lib(library_file));
     auto found = find_block(filename);
     if (found == m_blocks.end()) return plug_data("", -1, -1);
@@ -214,12 +218,18 @@ public:
     return get_status(pd.name, pd.major, pd.minor);
   }
 
-  void mark_unloadable(const std::string& path) {
+  virtual bool mark_unloadable(const std::string& name,
+		               int major, int minor) {
+    return update_block(name, major, minor);
+  }
+
+  /** Given a path, mark filename as unloadable. */
+  bool mark_unloadable(const std::string& path) {
     auto filename(path);
     auto slashpos = filename.rfind(SEP);
     if (slashpos != std::string::npos)
       filename = filename.substr(slashpos + 1);
-    update_block(filename, -1, -1);
+    return update_block(filename, -1, -1);
   }
 
   bool is_loadable(const std::string path) {


### PR DESCRIPTION
Re-factor mark_unloadable in new blacklist to return status, review and re-factor GUI messages.

Basically, restore things as they were before the failed rebase related to the plugin_manager -> plugin_loader refactoring + polish after more testing.

Closes: #2516