### PR TITLE
Load The latest grib file without reloading OpenCPN (Issue 2773)

### DIFF
--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -416,14 +416,19 @@ void grib_pi::OnToolbarToolCallback(int id) {
     m_pGribCtrlBar->OpenFile(m_bLoadLastOpenFile == 0);
   }
 
-  if (m_pGribCtrlBar->GetFont() != *OCPNGetFont(_("Dialog"), 10))
-    starting = true;
-
   // Toggle GRIB overlay display
   m_bShowGrib = !m_bShowGrib;
 
   //    Toggle dialog?
   if (m_bShowGrib) {
+    //A new file could have been added since grib plugin opened
+    if (!starting && m_bLoadLastOpenFile == 0) {
+      m_pGribCtrlBar->OpenFile(true);
+      starting = true;
+    }
+    //the dialog font could have been changed since grib plugin opened
+    if (m_pGribCtrlBar->GetFont() != *OCPNGetFont(_("Dialog"), 10))
+      starting = true;
     if (starting) {
       m_pGRIBOverlayFactory->SetMessageFont();
       SetDialogFont(m_pGribCtrlBar);


### PR DESCRIPTION
Load a new Grib file added to the repository while O is opened and the Grib_pi is already activated