### PR TITLE
Flatpak patches (#2992 update)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ build
 cscope.out
 *~
 *.kdev*
-*.patch
 crowdin.yaml
 buildwin/NSIS_Unicode/Include/Langstrings_*.nsh
 buildwin/crashrpt/CrashRpt1402.dll

--- a/flatpak/patches/0002-flatpak-Add-a-shell-wrapper.patch
+++ b/flatpak/patches/0002-flatpak-Add-a-shell-wrapper.patch
@@ -1,0 +1,25 @@
+From 0ef7d9ef5f4ce1d8c03294ea198f54a18f826e63 Mon Sep 17 00:00:00 2001
+From: Alec Leamas <leamas@nowhere.net>
+Date: Fri, 3 Aug 2018 18:50:08 +0200
+Subject: [PATCH] flatpak: Add a shell wrapper.
+
+---
+data/opencpn.sh | 7 +++++++
+ 1 file changed, 7 insertions(+)
+ create mode 100644 data/opencpn.sh
+
+diff --git a/data/opencpn.sh b/data/opencpn.sh
+new file mode 100644
+index 000000000..fca02ad9c
+--- /dev/null
++++ b/data/opencpn.sh
+@@ -0,0 +1,7 @@
++#!/bin/sh
++
++export XDG_DATA_DIRS=$XDG_DATA_DIRS:/app/extensions/share
++export GDK_BACKEND=x11
++export OPENCPN_PLUGIN_DIRS=/app/extensions/lib/opencpn:/app/lib/opencpn
++
++exec opencpn $@
+-- 
+2.38.1

--- a/flatpak/patches/0101-Add-wxDEPRECATED_EXPORT_CORE-macro-for-wxTransformMa.patch
+++ b/flatpak/patches/0101-Add-wxDEPRECATED_EXPORT_CORE-macro-for-wxTransformMa.patch
@@ -1,0 +1,88 @@
+From 2d939a36653a7ea015c82c841a30dfd22f90cdad Mon Sep 17 00:00:00 2001
+From: Vadim Zeitlin <vadim@wxwidgets.org>
+Date: Sun, 18 Sep 2022 18:27:04 +0200
+Subject: [PATCH] Add wxDEPRECATED_EXPORT_CORE() macro for wxTransformMatrix
+
+wxDEPRECATED_MSG() and WXDLLIMPEXP_CORE can't be used together in the
+same declaration when the former uses the standard attribute ([[...]])
+and the latter uses a legacy one (__attribute__((....))), at least not
+with gcc 12.
+
+Work around this problem by defining a special new macro that combines
+both attributes in a working way.
+
+This is rather ugly, as it would seem to be better to just always define
+WXDLLIMPEXP_CORE using the standard attribute, but unfortunately this
+doesn't work as the standard attribute must be placed before the
+function and variable declarations, while we currently use our DLL
+export macros in the middle of the declaration. Maybe we can change all
+the declarations doing this later, but for now this is the simplest
+solution to the immediate problem.
+
+See #22790.
+---
+ include/wx/defs.h   | 30 ++++++++++++++++++++++++++++++
+ include/wx/matrix.h |  6 ++----
+ 2 files changed, 32 insertions(+), 4 deletions(-)
+
+diff --git a/include/wx/defs.h b/include/wx/defs.h
+index 102e8c9950..01b7c228a1 100644
+--- a/include/wx/defs.h
++++ b/include/wx/defs.h
+@@ -697,6 +697,36 @@ typedef short int WXTYPE;
+ #   define wxDEPRECATED_BUT_USED_INTERNALLY(x) wxDEPRECATED(x)
+ #endif
+ 
++/*
++    Some gcc versions choke on __has_cpp_attribute(gnu::visibility) due to the
++    presence of the colon, but we only need this macro in C++ code, so just
++    don't define it when using C.
++ */
++#ifdef __cplusplus
++
++/*
++    Special macro used for the classes that are exported and deprecated.
++    It exists because standard [[deprecated]] attribute can't be combined with
++    legacy __attribute__((visibility)), but we can't use [[visibility]] instead
++    of the latter because it can't be use in the same place in the declarations
++    where we use WXDLLIMPEXP_CORE. So we define this special macro which uses
++    the standard visibility attribute just where we can't do otherwise.
++ */
++/* #ifdef wxHAS_DEPRECATED_ATTR */
++/*    #if __has_cpp_attribute(gnu::visibility) */
++        #define wxDEPRECATED_EXPORT_CORE(msg) \
++           __attribute__((visibility("default")))
++/*    #endif */
++/* #endif  */
++
++#ifndef wxDEPRECATED_EXPORT_CORE
++    /* Fall back when nothing special is needed or available. */
++    #define wxDEPRECATED_EXPORT_CORE(msg) \
++        wxDEPRECATED_MSG(msg) WXDLLIMPEXP_CORE
++#endif
++
++#endif /* __cplusplus */
++
+ /*
+    Macros to suppress and restore gcc warnings, requires g++ >= 4.6 and don't
+    do anything otherwise.
+diff --git a/include/wx/matrix.h b/include/wx/matrix.h
+index d18a0d2321..3b3225d3fa 100644
+--- a/include/wx/matrix.h
++++ b/include/wx/matrix.h
+@@ -38,10 +38,8 @@
+ //  At all times m_isIdentity is set if the matrix itself is an Identity matrix.
+ //  It is used where possible to optimize calculations.
+ class
+-#ifndef WXBUILDING
+-wxDEPRECATED_MSG("use wxAffineMatrix2D instead")
+-#endif
+-WXDLLIMPEXP_CORE wxTransformMatrix: public wxObject
++wxDEPRECATED_EXPORT_CORE("use wxAffineMatrix2D instead")
++wxTransformMatrix: public wxObject
+ {
+ public:
+     wxTransformMatrix();
+-- 
+2.38.1
+


### PR DESCRIPTION
Adding two missing patch files related to #2992

This went under the radar because .gitignore lists .patch files, probably since old times where we had no  patches in the sources. Fix that.