### PR TITLE
Add  a slider for Windows users to adjust Grib_pi Icons size

### DIFF
--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -2131,6 +2131,21 @@ GribPreferencesDialogBase::GribPreferencesDialogBase(
   m_rbTimeFormat->SetSelection(1);
   fgSizer6->Add(m_rbTimeFormat, 0, wxALL | wxEXPAND, 5);
 
+#ifdef __WXMSW__
+  wxFlexGridSizer * fgSizer47;
+  fgSizer47 = new wxFlexGridSizer(0, 2, 0, 0);
+  fgSizer47->SetFlexibleDirection(wxBOTH);
+  fgSizer47->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
+  wxStaticText * text = new wxStaticText(this, wxID_ANY, _("Icons Size Factor")
+    , wxDefaultPosition, wxDefaultSize);
+  fgSizer47->Add(text, 0, wxALL | wxEXPAND, 5);
+  m_sIconSizeFactor =
+    new wxSlider(this, wxID_ANY, 0, -8, 8, wxDefaultPosition,
+      wxDefaultSize, wxSL_BOTTOM | wxSL_HORIZONTAL | wxSL_LABELS);
+  fgSizer47->Add(m_sIconSizeFactor, 0, wxALL | wxEXPAND, 5);
+  fgSizer6->Add(fgSizer47, 0, wxALL | wxEXPAND, 5);
+#endif
+
   wxStdDialogButtonSizer* m_sdbSizer2;
   wxButton* m_sdbSizer2OK;
   wxButton* m_sdbSizer2Cancel;

--- a/plugins/grib_pi/src/GribUIDialogBase.h
+++ b/plugins/grib_pi/src/GribUIDialogBase.h
@@ -342,6 +342,9 @@ public:
   wxRadioBox* m_rbLoadOptions;
   wxRadioBox* m_rbStartOptions;
   wxRadioBox* m_rbTimeFormat;
+#ifdef __WXMSW__
+  wxSlider* m_sIconSizeFactor;
+#endif
 
   GribPreferencesDialogBase(wxWindow* parent, wxWindowID id = wxID_ANY,
                             const wxString& title = _("Preferences"),

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -244,6 +244,10 @@ void grib_pi::ShowPreferencesDialog(wxWindow *parent) {
   Pref->m_rbTimeFormat->SetSelection(m_bTimeZone);
   Pref->m_rbLoadOptions->SetSelection(m_bLoadLastOpenFile);
   Pref->m_rbStartOptions->SetSelection(m_bStartOptions);
+#ifdef __WXMSW__
+  int val = (m_GribIconsScaleFactor * 10.) - 10;
+  Pref->m_sIconSizeFactor->SetValue(val);
+#endif
 
 #ifdef __OCPN__ANDROID__
   if (m_parent_window) {
@@ -267,6 +271,10 @@ void grib_pi::UpdatePrefs(GribPreferencesDialog *Pref) {
   m_bLoadLastOpenFile = Pref->m_rbLoadOptions->GetSelection();
   m_bDrawBarbedArrowHead = Pref->m_cbDrawBarbedArrowHead->GetValue();
   m_bZoomToCenterAtInit = Pref->m_cZoomToCenterAtInit->GetValue();
+#ifdef __WXMSW__
+  double val = Pref->m_sIconSizeFactor->GetValue();
+  m_GribIconsScaleFactor = 1. + (val / 10);
+#endif
 
   if (m_pGRIBOverlayFactory)
     m_pGRIBOverlayFactory->SetSettings(m_bGRIBUseHiDef, m_bGRIBUseGradualColors,
@@ -381,6 +389,9 @@ void grib_pi::OnToolbarToolCallback(int id) {
   bool starting = false;
 
   double scale_factor = GetOCPNGUIToolScaleFactor_PlugIn() * OCPN_GetWinDIPScaleFactor();
+#ifdef __WXMSW__
+  scale_factor *= m_GribIconsScaleFactor;
+#endif
   if (scale_factor != m_GUIScaleFactor) starting = true;
 
   if (!m_pGribCtrlBar) {
@@ -723,6 +734,9 @@ bool grib_pi::LoadConfig(void) {
   pConf->Read(_T( "GRIBTimeZone" ), &m_bTimeZone, 1);
   pConf->Read(_T( "CopyFirstCumulativeRecord" ), &m_bCopyFirstCumRec, 1);
   pConf->Read(_T( "CopyMissingWaveRecord" ), &m_bCopyMissWaveRec, 1);
+#ifdef __WXMSW__
+  pConf->Read(_T("GribIconsScaleFactor"), &m_GribIconsScaleFactor, 1);
+#endif
 
   m_CtrlBar_Sizexy.x = pConf->Read(_T ( "GRIBCtrlBarSizeX" ), 1400L);
   m_CtrlBar_Sizexy.y = pConf->Read(_T ( "GRIBCtrlBarSizeY" ), 800L);
@@ -755,6 +769,9 @@ bool grib_pi::SaveConfig(void) {
   pConf->Write(_T ( "CopyMissingWaveRecord" ), m_bCopyMissWaveRec);
   pConf->Write(_T ( "DrawBarbedArrowHead" ), m_bDrawBarbedArrowHead);
   pConf->Write(_T ( "ZoomToCenterAtInit"), m_bZoomToCenterAtInit);
+#ifdef __WXMSW__
+  pConf->Write(_T("GribIconsScaleFactor"), m_GribIconsScaleFactor);
+#endif
 
   pConf->Write(_T ( "GRIBCtrlBarSizeX" ), m_CtrlBar_Sizexy.x);
   pConf->Write(_T ( "GRIBCtrlBarSizeY" ), m_CtrlBar_Sizexy.y);

--- a/plugins/grib_pi/src/grib_pi.h
+++ b/plugins/grib_pi/src/grib_pi.h
@@ -172,7 +172,9 @@ private:
   wxString m_ZyGribLogin;
   wxString m_ZyGribCode;
   double m_GUIScaleFactor;
-
+ #ifdef __WXMSW__
+  double m_GribIconsScaleFactor;
+ #endif
   bool m_bGRIBShowIcon;
 
   bool m_bShowGrib;


### PR DESCRIPTION
As there is no immediate solution to fix this size problem, I propose to add a slider to allow Windows users to adjust themselves the icon's size.
It should be suitable for many of the different screen scaled, the different definition etc…that could exist.