### PR TITLE
Fix grib plugin problems related to non-GL display

### DIFF
--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -273,16 +273,16 @@ GRIBOverlayFactory::GRIBOverlayFactory(GRIBUICtrlBar &dlg)
     LineBuffer &arrow = m_WindArrowCache[i];
 
     arrow.pushLine(dec, 0, dec + windArrowSize, 0);                  // hampe
-    arrow.pushLine(dec, 0, dec + pointerLength, pointerLength / 2);  // flèche
+    arrow.pushLine(dec, 0, dec + pointerLength, pointerLength / 2);  // fleche
     arrow.pushLine(dec, 0, dec + pointerLength,
-                   -(pointerLength / 2));  // flèche
+                   -(pointerLength / 2));  // fleche
   }
 
   int featherPosition = windArrowSize / 6;
 
   int b1 =
-      dec + windArrowSize - featherPosition;  // position de la 1ère barbule
-  int b2 = dec + windArrowSize;  // position de la 1ère barbule si >= 10 noeuds
+      dec + windArrowSize - featherPosition;  // position de la 1ere barbule
+  int b2 = dec + windArrowSize;  // position de la 1ere barbule si >= 10 noeuds
 
   int lpetite = windArrowSize / 5;
   int lgrande = lpetite * 2;
@@ -354,15 +354,15 @@ GRIBOverlayFactory::GRIBOverlayFactory(GRIBUICtrlBar &dlg)
     dec = -arrowSize / 2;
 
     m_SingleArrow[i].pushLine(dec, 0, dec + arrowSize, 0);
-    m_SingleArrow[i].pushLine(dec - 2, 0, dec + dec1, dec1 + 1);     // flèche
-    m_SingleArrow[i].pushLine(dec - 2, 0, dec + dec1, -(dec1 + 1));  // flèche
+    m_SingleArrow[i].pushLine(dec - 2, 0, dec + dec1, dec1 + 1);     // fleche
+    m_SingleArrow[i].pushLine(dec - 2, 0, dec + dec1, -(dec1 + 1));  // fleche
     m_SingleArrow[i].Finalize();
 
     m_DoubleArrow[i].pushLine(dec, -dec2, dec + arrowSize, -dec2);
     m_DoubleArrow[i].pushLine(dec, dec2, dec + arrowSize, +dec2);
 
-    m_DoubleArrow[i].pushLine(dec - 2, 0, dec + dec1, dec1 + 1);     // flèche
-    m_DoubleArrow[i].pushLine(dec - 2, 0, dec + dec1, -(dec1 + 1));  // flèche
+    m_DoubleArrow[i].pushLine(dec - 2, 0, dec + dec1, dec1 + 1);     // fleche
+    m_DoubleArrow[i].pushLine(dec - 2, 0, dec + dec1, -(dec1 + 1));  // fleche
     m_DoubleArrow[i].Finalize();
   }
 }
@@ -419,7 +419,12 @@ bool GRIBOverlayFactory::RenderGLGribOverlay(wxGLContext *pcontext,
 
   // qDebug() << "RenderGLGribOverlay" << sw.GetTime();
 
-  if (!m_oDC) m_oDC = new pi_ocpnDC();
+  if (!m_oDC || !m_oDC->UsesGL()) {
+    if (m_oDC) {
+      delete m_oDC;
+    }
+    m_oDC = new pi_ocpnDC();
+  }
 
   m_oDC->SetVP(vp);
   m_oDC->SetDC(NULL);
@@ -434,12 +439,17 @@ bool GRIBOverlayFactory::RenderGLGribOverlay(wxGLContext *pcontext,
 }
 
 bool GRIBOverlayFactory::RenderGribOverlay(wxDC &dc, PlugIn_ViewPort *vp) {
-  if (!m_oDC) m_oDC = new pi_ocpnDC();
+  if (!m_oDC || m_oDC->UsesGL()) {
+    if (m_oDC) {
+      delete m_oDC;
+    }
+    m_oDC = new pi_ocpnDC(dc);
+  }
 
   m_oDC->SetVP(vp);
   m_oDC->SetDC(&dc);
 
-  m_pdc = NULL;
+  m_pdc = &dc;
 #if 0
 #if wxUSE_GRAPHICS_CONTEXT
     wxMemoryDC *pmdc;

--- a/plugins/grib_pi/src/pi_ocpndc.cpp
+++ b/plugins/grib_pi/src/pi_ocpndc.cpp
@@ -93,7 +93,7 @@ int NextPow2(int size) {
 //----------------------------------------------------------------------------
 /* pass the dc to the constructor, or NULL to use opengl */
 pi_ocpnDC::pi_ocpnDC(wxGLCanvas &canvas)
-    : glcanvas(&canvas), dc(NULL), m_pen(wxNullPen), m_brush(wxNullBrush) {
+    : glcanvas(&canvas), dc(NULL), m_pen(wxNullPen), m_brush(wxNullBrush), m_buseGL(true) {
 #if wxUSE_GRAPHICS_CONTEXT
   pgc = NULL;
 #endif
@@ -120,7 +120,7 @@ pi_ocpnDC::pi_ocpnDC(wxGLCanvas &canvas)
 }
 
 pi_ocpnDC::pi_ocpnDC(wxDC &pdc)
-    : glcanvas(NULL), dc(&pdc), m_pen(wxNullPen), m_brush(wxNullBrush) {
+    : glcanvas(NULL), dc(&pdc), m_pen(wxNullPen), m_brush(wxNullBrush), m_buseGL(false) {
 #if wxUSE_GRAPHICS_CONTEXT
   pgc = NULL;
   wxMemoryDC *pmdc = wxDynamicCast(dc, wxMemoryDC);
@@ -139,7 +139,7 @@ pi_ocpnDC::pi_ocpnDC(wxDC &pdc)
 }
 
 pi_ocpnDC::pi_ocpnDC()
-    : glcanvas(NULL), dc(NULL), m_pen(wxNullPen), m_brush(wxNullBrush) {
+    : glcanvas(NULL), dc(NULL), m_pen(wxNullPen), m_brush(wxNullBrush), m_buseGL(true) {
 #if wxUSE_GRAPHICS_CONTEXT
   pgc = NULL;
 #endif
@@ -165,7 +165,9 @@ pi_ocpnDC::~pi_ocpnDC() {
 
 void pi_ocpnDC::SetVP(PlugIn_ViewPort *vp) {
 //#ifdef __OCPN__ANDROID__
-  configureShaders(vp->pix_width, vp->pix_height);
+  if ( m_buseGL ) {
+    configureShaders(vp->pix_width, vp->pix_height);
+  }
 //#endif
   m_vpSize = wxSize(vp->pix_width, vp->pix_height);
 }

--- a/plugins/grib_pi/src/pi_ocpndc.h
+++ b/plugins/grib_pi/src/pi_ocpndc.h
@@ -135,6 +135,7 @@ public:
   GLUtesselator *m_tobj;
 
 #endif
+  bool UsesGL() { return m_buseGL; };
 
 protected:
   bool ConfigurePen();
@@ -167,6 +168,7 @@ protected:
   unsigned int workBufIndex;
 
   wxSize m_vpSize;
+  bool m_buseGL;
 };
 
 #endif


### PR DESCRIPTION
- Fix crash when starting with OpenGL disabled and activating grib plugin
- Reinitialize the context when GL/non-GL mode is switched