### PR TITLE
Update windows.adoc

### DIFF
--- a/manual/modules/ROOT/pages/windows.adoc
+++ b/manual/modules/ROOT/pages/windows.adoc
@@ -1,4 +1,4 @@
-= Compiling on Windows
+= Compiling on Windows using Visual Studio 2022
 
 == 5.8.0 Fast Track
 
@@ -8,59 +8,22 @@ provided by the procedure described from next section.
 
 Steps to to make a build:
 
-. Get Visual Studio Community 2022,  either the command line tools or the
-  complete environment, from https://visualstudio.microsoft.com/vs/community/
-. Install the choco package manager, https://chocolatey.org/install
-. Clone the sources and move into them: +
-
-       > git clone https://github.com/OpenCPN/OpenCPN.git
-       > cd OpenCPN
-
-. Run the script _buildwin\win_deps.bat_. First time script installs programs
-  and should be invoked with administrative privileges using the Visual Studio
-  Command Line Interface. Following runs can (i. e., should) be run as a
-  regular user.
-. Run the script _ci\appveyor.bat_. This will configure the project using
-  cmake and make an initial build.
-
-After the first build, new builds can be done using in the _build_ directory
-using:
-```
-    > cmake --build . --target opencpn --config Release
-```
-
-*Notes:*
-
-* `--target opencpn` creates the main executable. Other targets which can be
-  built includes
-
-** `--target opencpn-cmd` -- Command line tool
-** `--target tests` -- Command line unit tests
-** `--target package` -- NSIS installer
-
-* It is perfectly possible to use `--config Debug` to create an executable with
-  debugging symbols etc. However, doing so might make the plugins in the
-  catalog incompatible if it is not possible to load optimized libraries into
-  a opencpn debug build. FIXME(leamas): what is the situation?
-* _win_deps.bat_ stores files in the _cache_ directory. This can be removed
-  safely,  it is re-created from scratch by _win_deps.bat_
-* The correct options to invoke cmake manually can be found  in
-  _ci\appveyor.bat_
-* Both _win_deps.bat_ and _appveyor.bat_ are used in the ci builds and should
-  thus be reasonably tested. However, user environment (in particular PATH))
-  can make them fail.
-
-== Prerequisities
-
-NOTE: These instructions has yet not been updated for using VS 2022  and
-wxWidgets 3.2, tools used to  build from 5.8.0.
-
-* for OpenCPN v5.0.0
-* with wxWidgets v3.1.2
-* xref:pm-plugin-api-versions.adoc[Plugin
-API] starts with API 1.16 (Supports plugins with earlier API but they
-must be compiled again for OpenCPN v5.0 due to the change in wxWidgets.)
-* Highest chance of success if these steps are followed exactly.
+- Install Visual Studio 2022
+- Install git
+- Install cmake
+- Install Chocolatey  (https://chocolatey.org/install#individual)  - powershell with administrative rights 
+- Install 7-Zip and add to the path the installation directory:  C:\Program Files\7-Zip
+- Install GNU gettext https://sourceforge.net/projects/gnuwin32/ and add C:\Program Files (x86)\GnuWin32\bin to your PATH
+- Clone OpenCPN sources into desired directory (git clone https://github.com/OpenCPN/OpenCPN.git)
+- Open CMD as administrator, go to the directory you downloaded opencpn
+- Execute buildwin\win_deps.bat   (this installs NSIS, Wxwidgets, and all remaining dependencies required)
+- Execute ci\appveyor.bat   (this generates the VS solution and projects and builds everything for the first time including an installation pack)
+- Start Visual Studio 2022 and the OpenCPN-solution file in the build folder. (For Example: C:\Opencpn\build\opencpn.sln)
+- Inside Visual studio, set the opencpn Target as your startup project ( do not use ALL_BUILD) then build (use release, debug or relwithdebinfo, your choice) 
+- in the build folder run opencpn_5.7.1+f9abd77fb_setup exe ( this is a one-ff step the first time)
+- go to the installation folder  C:\Program Files (x86)\openCPN copy everything and paste them in your Release folder ( example : C:\OpenCPN\build\Release)
+this step ( this is a one-ff step the first time)
+skip all ducpilcate files when you copy them 
 
 === Visual Studio 2017
 


### PR DESCRIPTION
detailed instructions for building opencpn on Windows with Visual studio 2022 IDE. I suspect there is an automated way to copy paste the dependencies after building ( Dan's UTILS ? ) 
