### PR TITLE
Make no data watchdog reconnection optional

### DIFF
--- a/include/conn_params.h
+++ b/include/conn_params.h
@@ -94,6 +94,7 @@ public:
   wxString Port;
   wxString socketCAN_port;
   int Baudrate;
+  bool NoDataReconnect;
   bool ChecksumCheck;
   bool Garmin;
   bool GarminUpload;

--- a/src/comm_drv_n0183_net.cpp
+++ b/src/comm_drv_n0183_net.cpp
@@ -331,9 +331,16 @@ void CommDriverN0183Net::OpenNetworkGPSD() {
 void CommDriverN0183Net::OnSocketReadWatchdogTimer(wxTimerEvent& event) {
   m_dog_value--;
   if (m_dog_value <= 0) {  // No receive in n seconds, assume connection lost
-    wxLogMessage(
-        wxString::Format(_T("    TCP NetworkDataStream watchdog timeout: %s"),
-                         GetPort().c_str()));
+    wxString log = wxString::Format(_T("    TCP NetworkDataStream watchdog timeout: %s."),
+      GetPort().c_str());
+    if (!GetParams().NoDataReconnect) {
+      log.Append(wxString::Format(_T(" Reconnection is disabled, waiting another %d seconds."),
+        N_DOG_TIMEOUT));
+      m_dog_value = N_DOG_TIMEOUT;
+      wxLogMessage(log);
+      return;
+    }
+    wxLogMessage(log);
 
     if (GetProtocol() == TCP) {
       wxSocketClient* tcp_socket = dynamic_cast<wxSocketClient*>(GetSock());

--- a/src/conn_params.cpp
+++ b/src/conn_params.cpp
@@ -105,6 +105,9 @@ void ConnectionParams::Deserialize(const wxString &configStr) {
   if (prms.Count() >= 21) {
     socketCAN_port = prms[20];
   }
+  if (prms.Count() >= 22) {
+    NoDataReconnect = wxAtoi(prms[21]);
+  }
 }
 
 wxString ConnectionParams::Serialize() const {
@@ -119,11 +122,12 @@ wxString ConnectionParams::Serialize() const {
     ostcs.Append(OutputSentenceList[i]);
   }
   wxString ret = wxString::Format(
-      _T("%d;%d;%s;%d;%d;%s;%d;%d;%d;%d;%s;%d;%s;%d;%d;%d;%d;%d;%s;%d;%s"), Type,
+      _T("%d;%d;%s;%d;%d;%s;%d;%d;%d;%d;%s;%d;%s;%d;%d;%d;%d;%d;%s;%d;%s;%d"), Type,
       NetProtocol, NetworkAddress.c_str(), NetworkPort, Protocol, Port.c_str(),
       Baudrate, ChecksumCheck, IOSelect, InputSentenceListType, istcs.c_str(),
       OutputSentenceListType, ostcs.c_str(), Priority, Garmin, GarminUpload,
-      FurunoGP3X, bEnabled, UserComment.c_str(), AutoSKDiscover, socketCAN_port.c_str());
+      FurunoGP3X, bEnabled, UserComment.c_str(), AutoSKDiscover, socketCAN_port.c_str(),
+      NoDataReconnect);
 
   return ret;
 }
@@ -148,6 +152,7 @@ ConnectionParams::ConnectionParams() {
   b_IsSetup = false;
   m_optionsPanel = NULL;
   AutoSKDiscover = false;
+  NoDataReconnect = false;
 }
 
 ConnectionParams::~ConnectionParams() {

--- a/src/connections_dialog.cpp
+++ b/src/connections_dialog.cpp
@@ -1401,7 +1401,6 @@ void ConnectionsDialog::SetDSFormRWStates(void) {
     m_rbOAccept->Enable(FALSE);
     m_rbOIgnore->Enable(FALSE);
     UpdateDiscoverStatus(wxEmptyString);
-
   } else {
     if (m_tNetPort->GetValue() == wxEmptyString)
       m_tNetPort->SetValue(_T("10110"));


### PR DESCRIPTION
As https://github.com/OpenCPN/OpenCPN/issues/2824 points out, there are use cases where the fact that no data is received over a TCP connection for long periods of time does not mean a problem on the data source side and we should simply keep the connection open and wait.
This patch allows disabling the reconnection function of the watchdog.
We might also consider progressively increasing the watchdog period to limit flooding the logfile with frequent messages.