### PR TITLE
ci: GA: windows: Make CLOUDSMITH_REPO usable (#3096)

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -57,3 +57,4 @@ jobs:
         run: ci/generic-upload.sh
         env:
           CLOUDSMITH_API_KEY: ${{ secrets.CLOUDSMITH_API_KEY }}
+          CLOUDSMITH_REPO: ${{ secrets.CLOUDSMITH_REPO }}


### PR DESCRIPTION
The upload script is designed to allow uploading to other cloudsmith repos then the hardcoded default. This is an important test hook.

Relocating is done using the CLOUDSMITH_REPO environment variable. On GA, make sure that this is visible in the windows build script

See: #3096