### PR TITLE
Add toggle CPA alarm to canvas menu

### DIFF
--- a/src/canvasMenu.cpp
+++ b/src/canvasMenu.cpp
@@ -93,6 +93,7 @@ extern void pupHandler_PasteTrack();
 extern void pupHandler_PasteWaypoint();
 
 extern AisDecoder *g_pAIS;
+extern bool g_bCPAWarn;
 extern bool g_bShowAreaNotices;
 extern bool bGPSValid;
 extern Routeman *g_pRouteMan;
@@ -178,6 +179,7 @@ enum {
   ID_WP_MENU_SET_ANCHORWATCH,
   ID_WP_MENU_CLEAR_ANCHORWATCH,
   ID_DEF_MENU_AISTARGETLIST,
+  ID_DEF_MENU_AIS_CPAWARNING,
 
   ID_RC_MENU_SCALE_IN,
   ID_RC_MENU_SCALE_OUT,
@@ -668,9 +670,14 @@ void CanvasMenuHandler::CanvasPopupMenu(int x, int y, int seltype) {
         }
 
         menuFocus = menuAIS;
-      } else
+      } else {
         MenuAppend1(contextMenu, ID_DEF_MENU_AISTARGETLIST,
                     _("AIS target list") + _T("..."));
+
+        wxString nextCPAstatus = g_bCPAWarn ? _("OFF") : _("ON");
+        MenuAppend1(contextMenu, ID_DEF_MENU_AIS_CPAWARNING,
+                    _menuText(_("CPA alarm ") + "--> " + nextCPAstatus, "W"));
+      }
     }
   }
 
@@ -1198,6 +1205,10 @@ void CanvasMenuHandler::PopupMenuHandler(wxCommandEvent &event) {
 
     case ID_DEF_MENU_AISTARGETLIST:
       parent->ShowAISTargetList();
+      break;
+
+    case ID_DEF_MENU_AIS_CPAWARNING:
+      parent->ToggleCPAWarn();
       break;
 
     case ID_WP_MENU_GOTO: {


### PR DESCRIPTION
I know new features would not be implemented close to 5.8 release so please reject if desired.
I was asked to add the key shortcut "W" function to the canvas menu for a non keyboard use.
To not jeopardize Crowdin translations with new strings I've only reused what's already there so gettext will find it.
This reuse of strings also made the menu slightly possible to misunderstand. I find it clear enough. If you judge it misleading I can redo, to "Toggle CPA alarms", and PR it after 5.8 instead?

Picture: The menu click will now toggle to "ON"   (Will print "OFF"  on next turn)

![bild](https://user-images.githubusercontent.com/7202854/227523409-fbc59c24-74d0-462c-9c95-ba1bca5e8398.png)
