### PR TITLE
Correct Info line position when ChartBar not displayed

### DIFF
--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -2336,6 +2336,8 @@ void GRIBOverlayFactory::DrawMessageWindow(wxString msg, int x, int y,
                                            wxFont *mfont) {
   if (msg.empty()) return;
 
+  int ScaleBare_H = 30;//futur : get the position/size from API?
+
   if (m_pdc) {
     wxDC &dc = *m_pdc;
     dc.SetFont(*mfont);
@@ -2345,7 +2347,7 @@ void GRIBOverlayFactory::DrawMessageWindow(wxString msg, int x, int y,
     int w, h;
     dc.GetMultiLineTextExtent(msg, &w, &h);
     h += 2;
-    int yp = y - (2 * GetChartbarHeight() + h);
+    int yp = y - (ScaleBare_H + GetChartbarHeight() + h);
 
     int label_offset = 10;
     int wdraw = w + (label_offset * 2);
@@ -2366,7 +2368,7 @@ void GRIBOverlayFactory::DrawMessageWindow(wxString msg, int x, int y,
       int wdraw = w + (label_offset * 2);
       wdraw *= g_ContentScaleFactor;
       h *= g_ContentScaleFactor;
-      int yp = y - (2 * GetChartbarHeight() + h);
+      int yp = y - (ScaleBare_H + GetChartbarHeight() + h);
 
       m_oDC->DrawRectangle(0, yp, wdraw, h);
       m_oDC->DrawText(msg, label_offset, yp);


### PR DESCRIPTION
When The ChartBar in hidden, the "GetChartbarHeight()" return 0;
So we have to evaluate the ScaleBar height to ovoid the line to be written above it.
It would be better to can get the position and size of the ScaleBar from the API,