### PR TITLE
Grib plugin fixes

### DIFF
--- a/plugins/grib_pi/src/CustomGrid.cpp
+++ b/plugins/grib_pi/src/CustomGrid.cpp
@@ -64,17 +64,21 @@ CustomGrid::CustomGrid(wxWindow* parent, wxWindowID id, const wxPoint& pos,
   // init labels attr
   wxFont labelfont = GetOCPNGUIScaledFont_PlugIn(_T("Dialog")).MakeBold();
   SetLabelFont(labelfont);
-  wxColour colour;
-  GetGlobalColor(_T("DILG0"), &colour);
+  wxColour colour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
+  if(colour.Red() > 128) {
+    GetGlobalColor(_T("DILG0"), &colour);
+    GetGlobalColor(_T("GREEN1"), &m_greenColour);
+    GetGlobalColor(_T("DILG1"), &m_greyColour);
+  } else {
+    GetGlobalColor(_T("GREEN2"), &m_greenColour);
+    m_greyColour = colour;
+  }
   SetLabelBackgroundColour(colour);
   // set row label size
   int w;
   GetTextExtent(_T("Ab"), &w, NULL, 0, 0, &labelfont);
   double x = (double)w * 6.5;
   SetRowLabelSize((int)x);
-  // colour settings
-  GetGlobalColor(_T("GREEN1"), &m_greenColour);
-  GetGlobalColor(_T("DILG1"), &m_greyColour);
 
 #ifdef __WXOSX__
   m_bLeftDown = false;

--- a/plugins/grib_pi/src/GribRequestDialog.cpp
+++ b/plugins/grib_pi/src/GribRequestDialog.cpp
@@ -444,7 +444,7 @@ void GribRequestSetting::ApplyRequestConfig(unsigned rs, unsigned it,
   m_pWind->SetValue(!IsRTOFS);
   m_pPress->SetValue(!IsRTOFS);
   m_pWaves->SetValue(m_RequestConfigBase.GetChar(8) == 'X' && IsGFS);
-  m_pWaves->Enable(IsGFS && m_pTimeRange->GetCurrentSelection() <
+  m_pWaves->Enable(IsECMWF || IsGFS && m_pTimeRange->GetCurrentSelection() <
                                 7);  // gfs & time range less than 8 days
   m_pRainfall->SetValue(m_RequestConfigBase.GetChar(9) == 'X' &&
                         (IsGFS || IsHRRR));
@@ -858,7 +858,7 @@ wxString GribRequestSetting::WriteMail() {
       _T("SFCTMP"), _T("GUST"), _T(""), _T(""), _T(""),
       _T("WIND500,HGT500"), _T("")},
       //parametres ECMWF
-      {_T(""), _T(""), _T("TEMP"), _T(""),
+      {_T(""), _T(""), _T("TEMP"), _T("WAVES"),
       _T(""), _T(""), _T(""), _T(""), _T(""),
       _T("WIND500,HGT500"), _T("")},
       // parameters GFS from zygrib
@@ -1016,6 +1016,9 @@ wxString GribRequestSetting::WriteMail() {
           r_parameters.Append(s[m_pMailTo->GetCurrentSelection()] +
             p[ECMWF][9]);
       }
+      if (m_pWaves->IsChecked())
+        r_parameters.Append(s[m_pMailTo->GetCurrentSelection()] +
+                            p[ECMWF][3]);
       break;
   }
   if (!IsZYGRIB && m_cMovingGribEnabled->IsChecked())  // moving grib


### PR DESCRIPTION
- Add WAVES option to the ECMWF request. Fixes #3132
- Fix the meteotable colors on systems with dark theme
Old colors:
![old_colors](https://user-images.githubusercontent.com/249856/233648052-c5a89e25-afe2-4815-8b1d-7bc9313e07d4.png)
New colors:
![new_colors](https://user-images.githubusercontent.com/249856/233648124-43217ff7-30e6-4ff3-83d2-51f1cc1f31e5.png)
