### PR TITLE
Make the prepare all ENCs dialog window modal on macOS. Fixes #3142

### DIFF
--- a/src/ocpn_frame.cpp
+++ b/src/ocpn_frame.cpp
@@ -8747,7 +8747,11 @@ void ParseAllENC(wxWindow *parent) {
     // prog->SetSize( sz );
 
     DimeControl(prog);
+    #ifdef __WXOSX__
+    prog->ShowWindowModal();
+    #else
     prog->Show();
+    #endif
   }
 
   // parse targets


### PR DESCRIPTION
I don't particularly like this solution, but it does the job without the need of larger refactoring that could break the other platforms.