### PR TITLE
Workaround the wrongly calculated scale on Retina displays

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -5397,8 +5397,18 @@ bool ChartCanvas::SetViewPoint(double lat, double lon, double scale_ppm,
     else if (VPoint.chart_scale <= 100000.)
       round_factor = 1000.;
 
+    // Fixme: Workaround the wrongly calculated scale on Retina displays (#3117)
+    double retina_coef = 1;
+    #ifdef ocpnUSE_GL
+    #ifdef __WXOSX__
+    if (g_bopengl) {
+      retina_coef = GetContentScaleFactor();;
+    }
+    #endif
+    #endif
+
     double true_scale_display =
-        wxRound(VPoint.chart_scale / round_factor) * round_factor;
+        wxRound(VPoint.chart_scale / round_factor) * round_factor * retina_coef;
     wxString text;
 
     m_displayed_scale_factor = VPoint.ref_scale / VPoint.chart_scale;


### PR DESCRIPTION
Implements the workaround for the *2 wrong scale displayed in the MUI bar in GL mode on Retina displays described in #3117