### PR TITLE
Handle reverse deps on global variables in libs (#3161)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -874,6 +874,7 @@ set(
   include/chartdb.h
   include/chartdbs.h
   include/chartimg.h
+  include/chart_ctx_factory.h
   include/chcanv.h
   include/ChInfoWin.h
   include/color_handler.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -934,6 +934,7 @@ set(
   include/navutil.h
   include/navutil_base.h
   include/NMEALogWindow.h
+  include/nmea_ctx_factory.h
   include/ocpCursor.h
   include/ocpn_frame.h
   include/ocpndc.h

--- a/include/chart_ctx_factory.h
+++ b/include/chart_ctx_factory.h
@@ -1,0 +1,45 @@
+/***************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  Wrapper for creating a ChartCtx based on global vars
+ * Author:   Alec Leamas
+ *
+ ***************************************************************************
+ *   Copyright (C) 2023 by Alec Leamas
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+#ifndef _CHART_CTX_FACTORY_H__
+#define _CHART_CTX_FACTORY_H__
+
+#include "s52plib.h"
+
+extern bool g_bopengl;
+
+#ifdef ocpnUSE_GL
+extern GLenum g_texture_rectangle_format;
+
+/** Return a ChartCtx reflecting caller's opengl context */
+static ChartCtx ChartCtxFactory() {
+   return ChartCtx(g_bopengl, g_texture_rectangle_format);
+}
+#else
+
+/** Return a ChartCtx reflecting caller's context not using opengl */
+static ChartCtx ChartCtxFactory() { return ChartCtx(g_bopengl); }
+#endif
+
+#endif   //  _CHART_CTX_FACTORY_H__

--- a/include/comm_decoder.h
+++ b/include/comm_decoder.h
@@ -34,8 +34,10 @@
 #include <wx/string.h>
 
 #include "comm_appmsg.h"
+#include "config_vars.h"
 #include "nmea0183.h"
 #include "N2KParser.h"
+
 
 
 

--- a/include/comm_decoder.h
+++ b/include/comm_decoder.h
@@ -51,9 +51,18 @@ typedef struct{
   int SID;
 } NavData;
 
+extern int g_NMEAAPBPrecision;
+
+static NmeaContext NmeaCtxFactory() {
+  NmeaContext ctx;
+  ctx.get_talker_id = []() { return  g_TalkerIdText; };
+  ctx.get_apb_precision = []() {return g_NMEAAPBPrecision; };
+  return ctx;
+}
+
 class CommDecoder {
 public:
-  CommDecoder(){};
+  CommDecoder() : m_NMEA0183(NmeaCtxFactory()) {};
   ~CommDecoder(){};
 
   // NMEA0183 decoding, by sentence.

--- a/include/comm_decoder.h
+++ b/include/comm_decoder.h
@@ -37,8 +37,7 @@
 #include "config_vars.h"
 #include "nmea0183.h"
 #include "N2KParser.h"
-
-
+#include "nmea_ctx_factory.h"
 
 
 typedef struct{
@@ -53,14 +52,6 @@ typedef struct{
   int SID;
 } NavData;
 
-extern int g_NMEAAPBPrecision;
-
-static NmeaContext NmeaCtxFactory() {
-  NmeaContext ctx;
-  ctx.get_talker_id = []() { return  g_TalkerIdText; };
-  ctx.get_apb_precision = []() {return g_NMEAAPBPrecision; };
-  return ctx;
-}
 
 class CommDecoder {
 public:

--- a/include/config_vars.h
+++ b/include/config_vars.h
@@ -43,6 +43,7 @@ extern int sat_watchdog_timeout_ticks;
 
 extern wxString g_GPS_Ident;
 extern wxString g_hostname;
+extern wxString g_TalkerIdText;
 
 wxConfigBase* TheBaseConfig();
 void InitBaseConfig(wxConfigBase* cfg);

--- a/include/config_vars.h
+++ b/include/config_vars.h
@@ -36,6 +36,7 @@ extern bool g_bWplUsePosition;
 extern double g_UserVar;
 
 extern int g_maxWPNameLength;
+extern int g_NMEAAPBPrecision;
 extern int g_nNMEADebug;
 extern int gps_watchdog_timeout_ticks;
 extern int sat_watchdog_timeout_ticks;

--- a/include/nmea_ctx_factory.h
+++ b/include/nmea_ctx_factory.h
@@ -1,0 +1,39 @@
+/***************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  Wrapper for creating an NmeaContext based on global vars
+ * Author:   Alec Leamas
+ *
+ ***************************************************************************
+ *   Copyright (C) 2023 by Alec Leamas
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+#ifndef _NMEA_CTX_FACTORY_H__
+#define _NMEA_CTX_FACTORY_H__
+
+#include "nmea0183.h"
+#include "config_vars.h"
+
+static NmeaContext NmeaCtxFactory() {
+  NmeaContext ctx;
+  ctx.get_talker_id = []() { return  g_TalkerIdText; };
+  ctx.get_apb_precision = []() { return g_NMEAAPBPrecision; };
+  return ctx;
+}
+
+#endif

--- a/libs/nmea0183/src/Response.hpp
+++ b/libs/nmea0183/src/Response.hpp
@@ -46,7 +46,7 @@ class NMEA0183;
 class RESPONSE
 {
 
-   private:
+   protected:
 
       NMEA0183 *container_p;
 

--- a/libs/nmea0183/src/apb.cpp
+++ b/libs/nmea0183/src/apb.cpp
@@ -148,7 +148,7 @@ bool APB::Write( SENTENCE& sentence )
 
    int NmeaApbPrecision = 3;
    if (container_p) {
-     NmeaApbPrecision = container_p->context.get_apb_precision();
+     NmeaApbPrecision = container_p->caller_ctx.get_apb_precision();
    }
 
    sentence += IsLoranBlinkOK;

--- a/libs/nmea0183/src/apb.cpp
+++ b/libs/nmea0183/src/apb.cpp
@@ -40,8 +40,6 @@
 ** You can use it any way you like.
 */
 
-extern int              g_NMEAAPBPrecision;
-
 
 APB::APB()
 {
@@ -148,9 +146,14 @@ bool APB::Write( SENTENCE& sentence )
 
    RESPONSE::Write( sentence );
 
+   int NmeaApbPrecision = 3;
+   if (container_p) {
+     NmeaApbPrecision = container_p->context.get_apb_precision();
+   }
+
    sentence += IsLoranBlinkOK;
    sentence += IsLoranCCycleLockOK;
-   sentence.Add( CrossTrackErrorMagnitude, g_NMEAAPBPrecision);
+   sentence.Add( CrossTrackErrorMagnitude, NmeaApbPrecision);
 
    if(DirectionToSteer == Left)
        sentence += _T("L");
@@ -160,12 +163,12 @@ bool APB::Write( SENTENCE& sentence )
    sentence += CrossTrackUnits;
    sentence += IsArrivalCircleEntered;
    sentence += IsPerpendicular;
-   sentence.Add( BearingOriginToDestination, g_NMEAAPBPrecision);
+   sentence.Add( BearingOriginToDestination, NmeaApbPrecision);
    sentence += BearingOriginToDestinationUnits;
    sentence += To;
-   sentence.Add( BearingPresentPositionToDestination, g_NMEAAPBPrecision );
+   sentence.Add( BearingPresentPositionToDestination, NmeaApbPrecision );
    sentence += BearingPresentPositionToDestinationUnits;
-   sentence.Add( HeadingToSteer, g_NMEAAPBPrecision );
+   sentence.Add( HeadingToSteer, NmeaApbPrecision );
    sentence += HeadingToSteerUnits;
 
    sentence.Finish();

--- a/libs/nmea0183/src/nmea0183.cpp
+++ b/libs/nmea0183/src/nmea0183.cpp
@@ -44,6 +44,7 @@
 WX_DEFINE_LIST(MRL);
 
 
+NMEA0183::NMEA0183() : NMEA0183(NmeaContext()) {}
 NMEA0183::NMEA0183(const NmeaContext& ctx) : caller_ctx(ctx)
 {
    initialize();

--- a/libs/nmea0183/src/nmea0183.cpp
+++ b/libs/nmea0183/src/nmea0183.cpp
@@ -44,7 +44,7 @@
 WX_DEFINE_LIST(MRL);
 
 
-NMEA0183::NMEA0183(const NmeaContext& ctx) : context(ctx)
+NMEA0183::NMEA0183(const NmeaContext& ctx) : caller_ctx(ctx)
 {
    initialize();
 

--- a/libs/nmea0183/src/nmea0183.cpp
+++ b/libs/nmea0183/src/nmea0183.cpp
@@ -44,7 +44,7 @@
 WX_DEFINE_LIST(MRL);
 
 
-NMEA0183::NMEA0183()
+NMEA0183::NMEA0183(const NmeaContext& ctx) : context(ctx)
 {
    initialize();
 

--- a/libs/nmea0183/src/nmea0183.h
+++ b/libs/nmea0183/src/nmea0183.h
@@ -150,8 +150,6 @@ typedef enum
       WorkingRoute
 } ROUTE_TYPE;
 
-extern wxString g_TalkerIdText;   /* FIXME(leamas) pesky global. */
-
 /*
 ** Misc Function Prototypes
 */

--- a/libs/nmea0183/src/nmea0183.h
+++ b/libs/nmea0183/src/nmea0183.h
@@ -41,6 +41,8 @@
 ** You can use it any way you like.
 */
 
+#include   <functional>
+
 //    Include wxWindows stuff
 //#include "wx/wxprec.h"
 
@@ -62,6 +64,15 @@
 
 #define CARRIAGE_RETURN 0x0D
 #define LINE_FEED       0x0A
+
+class NmeaContext {
+public:
+  std::function<wxString()> get_talker_id;
+  std::function<int()> get_apb_precision;
+  NmeaContext()
+      : get_talker_id([]() { return ""; }),
+        get_apb_precision( []() { return 3; }) {}
+};
 
 
 typedef enum _NMEA0183_BOOLEAN

--- a/libs/nmea0183/src/nmea0183.hpp
+++ b/libs/nmea0183/src/nmea0183.hpp
@@ -148,8 +148,12 @@ class NMEA0183
       void sort_response_table( void );
 
    public:
-
+      /** For use in main opencpn with access to globals. */
       NMEA0183(const NmeaContext& ctx);
+
+      /** For use in plugins without access to globals. */
+      NMEA0183();
+
       virtual ~NMEA0183();
 
       const NmeaContext caller_ctx;

--- a/libs/nmea0183/src/nmea0183.hpp
+++ b/libs/nmea0183/src/nmea0183.hpp
@@ -146,10 +146,11 @@ class NMEA0183
 
       void set_container_pointers( void );
       void sort_response_table( void );
+      const NmeaContext context;
 
    public:
 
-      NMEA0183();
+      NMEA0183(const NmeaContext& ctx);
       virtual ~NMEA0183();
 
       wxArrayString GetRecognizedArray(void);

--- a/libs/nmea0183/src/nmea0183.hpp
+++ b/libs/nmea0183/src/nmea0183.hpp
@@ -152,7 +152,7 @@ class NMEA0183
       NMEA0183(const NmeaContext& ctx);
       virtual ~NMEA0183();
 
-      const NmeaContext context;
+      const NmeaContext caller_ctx;
 
       wxArrayString GetRecognizedArray(void);
 

--- a/libs/nmea0183/src/nmea0183.hpp
+++ b/libs/nmea0183/src/nmea0183.hpp
@@ -146,12 +146,13 @@ class NMEA0183
 
       void set_container_pointers( void );
       void sort_response_table( void );
-      const NmeaContext context;
 
    public:
 
       NMEA0183(const NmeaContext& ctx);
       virtual ~NMEA0183();
+
+      const NmeaContext context;
 
       wxArrayString GetRecognizedArray(void);
 

--- a/libs/nmea0183/src/response.cpp
+++ b/libs/nmea0183/src/response.cpp
@@ -40,8 +40,6 @@
 ** You can use it any way you like.
 */
 
-wxString g_TalkerIdText;
-
 RESPONSE::RESPONSE()
 {
    Talker.Empty();
@@ -75,14 +73,15 @@ bool RESPONSE::Write( SENTENCE& sentence )
 
     sentence  = _T("$");
 
-    if(NULL == container_p)
-          sentence.Sentence.Append(_T("--"));
+    if (NULL == container_p)
+        sentence.Sentence.Append("--");
     else {
-        if ( g_TalkerIdText.length() == 0) {
-          sentence.Sentence.Append(container_p->TalkerID);
+        wxString talker_id = container_p->context.get_talker_id();
+        if ( talker_id.length() == 0) {
+            sentence.Sentence.Append(container_p->TalkerID);
         }
         else {
-            sentence.Sentence.Append( g_TalkerIdText );
+            sentence.Sentence.Append( talker_id );
         }
     }
 

--- a/libs/nmea0183/src/response.cpp
+++ b/libs/nmea0183/src/response.cpp
@@ -76,7 +76,7 @@ bool RESPONSE::Write( SENTENCE& sentence )
     if (NULL == container_p)
         sentence.Sentence.Append("--");
     else {
-        wxString talker_id = container_p->context.get_talker_id();
+        wxString talker_id = container_p->caller_ctx.get_talker_id();
         if ( talker_id.length() == 0) {
             sentence.Sentence.Append(container_p->TalkerID);
         }

--- a/libs/nmea0183/src/xte.cpp
+++ b/libs/nmea0183/src/xte.cpp
@@ -40,9 +40,6 @@
 ** You can use it any way you like.
 */
 
-extern int              g_NMEAXTEPrecision;
-
-
 XTE::XTE()
 {
    Mnemonic = _T("XTE");

--- a/libs/s52plib/src/chartsymbols.cpp
+++ b/libs/s52plib/src/chartsymbols.cpp
@@ -56,8 +56,6 @@
 
 #include "s52plib.h"
 
-extern bool g_bopengl;
-
 #ifdef ocpnUSE_GL
 extern GLenum g_texture_rectangle_format;
 #endif
@@ -728,14 +726,15 @@ bool ChartSymbols::LoadConfigFile(s52plib *plibArg,
 
   return true;
 }
-void ChartSymbols::SetColorTableIndex(int index) {
+void ChartSymbols::SetColorTableIndex(int index, bool flush, bool use_opengl) {
   ColorTableIndex = index;
-  LoadRasterFileForColorTable(ColorTableIndex);
+  LoadRasterFileForColorTable(ColorTableIndex, flush, use_opengl);
 }
 
-int ChartSymbols::LoadRasterFileForColorTable(int tableNo, bool flush) {
+int ChartSymbols::LoadRasterFileForColorTable(int tableNo, bool flush,
+                                              bool use_opengl) {
   if (tableNo == rasterSymbolsLoadedColorMapNumber && !flush) {
-    if (g_bopengl) {
+    if (use_opengl) {
       if (rasterSymbolsTexture) return true;
 #ifdef ocpnUSE_GL
       else if (!g_texture_rectangle_format && rasterSymbols.IsOk())
@@ -754,7 +753,7 @@ int ChartSymbols::LoadRasterFileForColorTable(int tableNo, bool flush) {
   if (rasterFileImg.LoadFile(filename, wxBITMAP_TYPE_PNG)) {
 #ifdef ocpnUSE_GL
     /* for opengl mode, load the symbols into a texture */
-    if (g_bopengl && g_texture_rectangle_format) {
+    if (use_opengl && g_texture_rectangle_format) {
       int w = rasterFileImg.GetWidth();
       int h = rasterFileImg.GetHeight();
 

--- a/libs/s52plib/src/chartsymbols.cpp
+++ b/libs/s52plib/src/chartsymbols.cpp
@@ -56,10 +56,6 @@
 
 #include "s52plib.h"
 
-#ifdef ocpnUSE_GL
-extern GLenum g_texture_rectangle_format;
-#endif
-
 //--------------------------------------------------------------------------------------
 
 ChartSymbols::ChartSymbols(void) {}
@@ -726,18 +722,19 @@ bool ChartSymbols::LoadConfigFile(s52plib *plibArg,
 
   return true;
 }
-void ChartSymbols::SetColorTableIndex(int index, bool flush, bool use_opengl) {
+void ChartSymbols::SetColorTableIndex(int index, bool flush,
+                                      const ChartCtx& ctx) {
   ColorTableIndex = index;
-  LoadRasterFileForColorTable(ColorTableIndex, flush, use_opengl);
+  LoadRasterFileForColorTable(ColorTableIndex, flush, ctx);
 }
 
 int ChartSymbols::LoadRasterFileForColorTable(int tableNo, bool flush,
-                                              bool use_opengl) {
+                                              const ChartCtx& ctx) {
   if (tableNo == rasterSymbolsLoadedColorMapNumber && !flush) {
-    if (use_opengl) {
+    if (ctx.m_use_opengl) {
       if (rasterSymbolsTexture) return true;
 #ifdef ocpnUSE_GL
-      else if (!g_texture_rectangle_format && rasterSymbols.IsOk())
+      if (!ctx.m_texture_rectangle_format && rasterSymbols.IsOk())
         return true;
 #endif
     }
@@ -753,7 +750,7 @@ int ChartSymbols::LoadRasterFileForColorTable(int tableNo, bool flush,
   if (rasterFileImg.LoadFile(filename, wxBITMAP_TYPE_PNG)) {
 #ifdef ocpnUSE_GL
     /* for opengl mode, load the symbols into a texture */
-    if (use_opengl && g_texture_rectangle_format) {
+    if (ctx.m_use_opengl && ctx.m_texture_rectangle_format) {
       int w = rasterFileImg.GetWidth();
       int h = rasterFileImg.GetHeight();
 
@@ -776,11 +773,11 @@ int ChartSymbols::LoadRasterFileForColorTable(int tableNo, bool flush,
       }
       if (!rasterSymbolsTexture) glGenTextures(1, &rasterSymbolsTexture);
 
-      glBindTexture(g_texture_rectangle_format, rasterSymbolsTexture);
+      glBindTexture(ctx.m_texture_rectangle_format, rasterSymbolsTexture);
 
       /* unfortunately this texture looks terrible with compression */
       GLuint format = GL_RGBA;
-      glTexImage2D(g_texture_rectangle_format, 0, format, w, h, 0, GL_RGBA,
+      glTexImage2D(ctx.m_texture_rectangle_format, 0, format, w, h, 0, GL_RGBA,
                    GL_UNSIGNED_BYTE, e);
 
       //             glTexParameteri( g_texture_rectangle_format,
@@ -788,14 +785,14 @@ int ChartSymbols::LoadRasterFileForColorTable(int tableNo, bool flush,
       //             g_texture_rectangle_format, GL_TEXTURE_MIN_FILTER,
       //             GL_NEAREST );
 
-      glTexParameteri(g_texture_rectangle_format, GL_TEXTURE_WRAP_S,
+      glTexParameteri(ctx.m_texture_rectangle_format, GL_TEXTURE_WRAP_S,
                       GL_CLAMP_TO_EDGE);
-      glTexParameteri(g_texture_rectangle_format, GL_TEXTURE_WRAP_T,
+      glTexParameteri(ctx.m_texture_rectangle_format, GL_TEXTURE_WRAP_T,
                       GL_CLAMP_TO_EDGE);
 
-      glTexParameteri(g_texture_rectangle_format, GL_TEXTURE_MAG_FILTER,
+      glTexParameteri(ctx.m_texture_rectangle_format, GL_TEXTURE_MAG_FILTER,
                       GL_NEAREST);  // No mipmapping
-      glTexParameteri(g_texture_rectangle_format, GL_TEXTURE_MIN_FILTER,
+      glTexParameteri(ctx.m_texture_rectangle_format, GL_TEXTURE_MIN_FILTER,
                       GL_NEAREST);
 
       rasterSymbolsTextureSize = wxSize(w, h);

--- a/libs/s52plib/src/chartsymbols.h
+++ b/libs/s52plib/src/chartsymbols.h
@@ -120,6 +120,23 @@ public:
   wxString HPGL;
 };
 
+#ifdef ocpnUSE_GL
+struct ChartCtx {
+  const  bool m_use_opengl;
+  const GLenum m_texture_rectangle_format;
+  ChartCtx(bool use_opengl, GLenum rect_format)
+    : m_use_opengl(use_opengl), m_texture_rectangle_format(rect_format) {}
+};
+
+#else
+struct ChartCtx {
+  const  bool m_use_opengl;
+  ChartCtx(bool use_opengl) : m_use_opengl(use_opengl) {}
+};
+#endif
+
+
+
 class ChartSymbol {
 public:
   wxString name;
@@ -151,9 +168,9 @@ public:
   unsigned int GetGLTextureRect(wxRect &rect, const char *symbolName);
   wxSize GLTextureSize();
   void SetTextureFormat( int format){ m_texture_rectangle_format = format; }
-  int LoadRasterFileForColorTable(int tableNo, bool flush,
-                                  bool use_opengl);
-  void SetColorTableIndex(int index, bool flush, bool use_opengl);
+  int LoadRasterFileForColorTable(int table_nr, bool flush,
+                                  const ChartCtx& ctx);
+  void SetColorTableIndex(int index, bool flush, const ChartCtx& ctx);
 
   wxArrayPtrVoid m_colorTables;
   unsigned int rasterSymbolsTexture;

--- a/libs/s52plib/src/chartsymbols.h
+++ b/libs/s52plib/src/chartsymbols.h
@@ -142,7 +142,6 @@ public:
 
   void InitializeTables(void);
   void DeleteGlobals(void);
-  int LoadRasterFileForColorTable(int tableNo, bool flush = false);
   int FindColorTable(const wxString &tableName);
   S52color *GetColor(const char *colorName, int fromTable);
   wxColor GetwxColor(const wxString &colorName, int fromTable);
@@ -151,8 +150,10 @@ public:
   wxImage GetImage(const char *symbolName);
   unsigned int GetGLTextureRect(wxRect &rect, const char *symbolName);
   wxSize GLTextureSize();
-  void SetColorTableIndex(int index);
   void SetTextureFormat( int format){ m_texture_rectangle_format = format; }
+  int LoadRasterFileForColorTable(int tableNo, bool flush,
+                                  bool use_opengl);
+  void SetColorTableIndex(int index, bool flush, bool use_opengl);
 
   wxArrayPtrVoid m_colorTables;
   unsigned int rasterSymbolsTexture;

--- a/libs/s52plib/src/chartsymbols.h
+++ b/libs/s52plib/src/chartsymbols.h
@@ -120,20 +120,18 @@ public:
   wxString HPGL;
 };
 
-#ifdef ocpnUSE_GL
+/** Generic method argument wrapping differences using opengl or not */
 struct ChartCtx {
+#ifdef ocpnUSE_GL
   const  bool m_use_opengl;
   const GLenum m_texture_rectangle_format;
   ChartCtx(bool use_opengl, GLenum rect_format)
     : m_use_opengl(use_opengl), m_texture_rectangle_format(rect_format) {}
-};
-
 #else
-struct ChartCtx {
   const  bool m_use_opengl;
   ChartCtx(bool use_opengl) : m_use_opengl(use_opengl) {}
-};
 #endif
+};
 
 
 

--- a/libs/s52plib/src/s52plib.cpp
+++ b/libs/s52plib/src/s52plib.cpp
@@ -1253,8 +1253,8 @@ void s52plib::DestroyRules(RuleHash *rh) {
   delete rh;
 }
 
-void s52plib::FlushSymbolCaches(void) {
-  m_chartSymbols.LoadRasterFileForColorTable(m_colortable_index, true);
+void s52plib::FlushSymbolCaches(bool use_opengl) {
+  m_chartSymbols.LoadRasterFileForColorTable(m_colortable_index, true, use_opengl);
 
   RuleHash *rh = _symb_sym;
 
@@ -1373,7 +1373,7 @@ LUPrec *s52plib::S52_LUPLookup(LUPname LUP_Name, const char *objectName,
   return LUP;
 }
 
-void s52plib::SetPLIBColorScheme(ColorScheme cs) {
+void s52plib::SetPLIBColorScheme(ColorScheme cs, bool use_opengl) {
   wxString SchemeName;
   switch (cs) {
     case GLOBAL_COLOR_SCHEME_DAY:
@@ -1390,10 +1390,10 @@ void s52plib::SetPLIBColorScheme(ColorScheme cs) {
       break;
   }
 
-  SetPLIBColorScheme(SchemeName);
+  SetPLIBColorScheme(SchemeName, use_opengl);
 }
 
-void s52plib::SetPLIBColorScheme(wxString scheme) {
+void s52plib::SetPLIBColorScheme(wxString scheme, bool use_opengl) {
   wxString str_find;
   str_find = scheme;
   m_colortable_index = 0;  // default is the first color in the table
@@ -1406,7 +1406,7 @@ void s52plib::SetPLIBColorScheme(wxString scheme) {
   }
   m_colortable_index = m_chartSymbols.FindColorTable(scheme);
 
-  m_chartSymbols.SetColorTableIndex(m_colortable_index);
+  m_chartSymbols.SetColorTableIndex(m_colortable_index, false, use_opengl);
 
   m_ColorScheme = scheme;
 }

--- a/libs/s52plib/src/s52plib.cpp
+++ b/libs/s52plib/src/s52plib.cpp
@@ -1253,9 +1253,8 @@ void s52plib::DestroyRules(RuleHash *rh) {
   delete rh;
 }
 
-void s52plib::FlushSymbolCaches(bool use_opengl) {
-  m_chartSymbols.LoadRasterFileForColorTable(m_colortable_index, true, use_opengl);
-
+void s52plib::FlushSymbolCaches(const ChartCtx& ctx) {
+  m_chartSymbols.LoadRasterFileForColorTable(m_colortable_index, true, ctx);
   RuleHash *rh = _symb_sym;
 
   if (!rh) return;
@@ -1373,7 +1372,7 @@ LUPrec *s52plib::S52_LUPLookup(LUPname LUP_Name, const char *objectName,
   return LUP;
 }
 
-void s52plib::SetPLIBColorScheme(ColorScheme cs, bool use_opengl) {
+void s52plib::SetPLIBColorScheme(ColorScheme cs, const ChartCtx& ctx) {
   wxString SchemeName;
   switch (cs) {
     case GLOBAL_COLOR_SCHEME_DAY:
@@ -1390,10 +1389,10 @@ void s52plib::SetPLIBColorScheme(ColorScheme cs, bool use_opengl) {
       break;
   }
 
-  SetPLIBColorScheme(SchemeName, use_opengl);
+  SetPLIBColorScheme(SchemeName, ctx);
 }
 
-void s52plib::SetPLIBColorScheme(wxString scheme, bool use_opengl) {
+void s52plib::SetPLIBColorScheme(wxString scheme, const ChartCtx& ctx) {
   wxString str_find;
   str_find = scheme;
   m_colortable_index = 0;  // default is the first color in the table
@@ -1406,7 +1405,7 @@ void s52plib::SetPLIBColorScheme(wxString scheme, bool use_opengl) {
   }
   m_colortable_index = m_chartSymbols.FindColorTable(scheme);
 
-  m_chartSymbols.SetColorTableIndex(m_colortable_index, false, use_opengl);
+  m_chartSymbols.SetColorTableIndex(m_colortable_index, false, ctx);
 
   m_ColorScheme = scheme;
 }

--- a/libs/s52plib/src/s52plib.h
+++ b/libs/s52plib/src/s52plib.h
@@ -206,8 +206,8 @@ public:
   void GenerateStateHash();
   long GetStateHash() { return m_state_hash; }
 
-  void SetPLIBColorScheme(wxString scheme);
-  void SetPLIBColorScheme(ColorScheme cs);
+  void SetPLIBColorScheme(wxString scheme, bool use_opengl);
+  void SetPLIBColorScheme(ColorScheme cs, bool use_opengl);
   wxString GetPLIBColorScheme(void) { return m_ColorScheme; }
 
   void SetGLRendererString(const wxString &renderer);
@@ -242,7 +242,7 @@ public:
   void AdjustTextList(int dx, int dy, int screenw, int screenh);
   void ClearTextList(void);
   int SetLineFeaturePriority(ObjRazRules *rzRules, int npriority);
-  void FlushSymbolCaches();
+  void FlushSymbolCaches(bool use_openpgl);
 
   //    For DC's
   int RenderObjectToDC(wxDC *pdc, ObjRazRules *rzRules);

--- a/libs/s52plib/src/s52plib.h
+++ b/libs/s52plib/src/s52plib.h
@@ -206,8 +206,8 @@ public:
   void GenerateStateHash();
   long GetStateHash() { return m_state_hash; }
 
-  void SetPLIBColorScheme(wxString scheme, bool use_opengl);
-  void SetPLIBColorScheme(ColorScheme cs, bool use_opengl);
+  void SetPLIBColorScheme(wxString scheme, const ChartCtx& ctx);
+  void SetPLIBColorScheme(ColorScheme cs, const ChartCtx& ctx);
   wxString GetPLIBColorScheme(void) { return m_ColorScheme; }
 
   void SetGLRendererString(const wxString &renderer);
@@ -242,7 +242,7 @@ public:
   void AdjustTextList(int dx, int dy, int screenw, int screenh);
   void ClearTextList(void);
   int SetLineFeaturePriority(ObjRazRules *rzRules, int npriority);
-  void FlushSymbolCaches(bool use_openpgl);
+  void FlushSymbolCaches(const ChartCtx& ctx);
 
   //    For DC's
   int RenderObjectToDC(wxDC *pdc, ObjRazRules *rzRules);

--- a/libs/sound/src/SystemCmdSound.cpp
+++ b/libs/sound/src/SystemCmdSound.cpp
@@ -29,9 +29,6 @@
 
 #include "SystemCmdSound.h"
 
-extern bool g_bquiting;     // Flag tells us O is shutting down
-
-
 #ifdef _WIN32
 #include <windows.h>
 

--- a/libs/texcmp/squish/squish.cpp
+++ b/libs/texcmp/squish/squish.cpp
@@ -38,8 +38,6 @@
 #include "twocolourfitfast.h"
 #include <wx/thread.h>
 
-extern bool g_throttle_squish;
-
 namespace squish {
 
 static int FixFlags( int flags )

--- a/plugins/chartdldr_pi/data/doc-src/.~lock.index.odt#
+++ b/plugins/chartdldr_pi/data/doc-src/.~lock.index.odt#
@@ -1,1 +1,0 @@
-,mk,hemulen,28.12.2022 08:59,file:///home/mk/.config/libreoffice/4;

--- a/plugins/chartdldr_pi/data/doc-src/.~lock.index.odt#
+++ b/plugins/chartdldr_pi/data/doc-src/.~lock.index.odt#
@@ -1,0 +1,1 @@
+,mk,hemulen,28.12.2022 08:59,file:///home/mk/.config/libreoffice/4;

--- a/src/ConfigMgr.cpp
+++ b/src/ConfigMgr.cpp
@@ -103,6 +103,7 @@ extern wxString g_UserPresLibData;
 
 extern wxString *pInit_Chart_Dir;
 extern wxString gWorldMapLocation;
+extern wxString  g_TalkerIdText;
 
 extern bool s_bSetSystemTime;
 extern bool g_bDisplayGrid;  // Flag indicating if grid is to be displayed

--- a/src/androidUTIL.cpp
+++ b/src/androidUTIL.cpp
@@ -64,6 +64,7 @@
 #include "nav_object_database.h"
 #include "navutil.h"
 #include "nmea0183.h"
+#include "nmea_ctx_factory.h"
 #include "OCPNPlatform.h"
 #include "ocpn_plugin.h"
 #include "options.h"
@@ -1149,7 +1150,7 @@ JNIEXPORT jint JNICALL Java_org_opencpn_OCPNNativeLib_processSailTimer(
       // true_windSpeed << true_windDirection;
 
       if (s_pAndroidNMEAMessageConsumer) {
-        NMEA0183 parser;
+        NMEA0183 parser(NmeaCtxFactory());
 
         // Now make some NMEA messages
         // We dont want to pass the incoming MWD message thru directly, since it

--- a/src/comm_n0183_output.cpp
+++ b/src/comm_n0183_output.cpp
@@ -47,6 +47,7 @@
 #include "conn_params.h"
 #include "gui_lib.h"
 #include "nmea0183.h"
+#include "nmea_ctx_factory.h"
 #include "route.h"
 #include "NMEALogWindow.h"
 
@@ -297,13 +298,6 @@ std::shared_ptr<AbstractCommDriver> CreateOutputConnection(const wxString &com_n
       }
   }
   return driver;
-}
-
-static NmeaContext  NmeaCtxFactory() {
-  NmeaContext ctx;
-  ctx.get_talker_id = []() { return  g_TalkerIdText; };
-  ctx.get_apb_precision = []() {return g_NMEAAPBPrecision; };
-  return ctx;
 }
 
 int SendRouteToGPS_N0183(Route *pr, const wxString &com_name,

--- a/src/comm_n0183_output.cpp
+++ b/src/comm_n0183_output.cpp
@@ -299,6 +299,12 @@ std::shared_ptr<AbstractCommDriver> CreateOutputConnection(const wxString &com_n
   return driver;
 }
 
+static NmeaContext  NmeaCtxFactory() {
+  NmeaContext ctx;
+  ctx.get_talker_id = []() { return  g_TalkerIdText; };
+  ctx.get_apb_precision = []() {return g_NMEAAPBPrecision; };
+  return ctx;
+}
 
 int SendRouteToGPS_N0183(Route *pr, const wxString &com_name,
                                 bool bsend_waypoints/*, SendToGpsDlg *dialog*/) {
@@ -468,7 +474,7 @@ int SendRouteToGPS_N0183(Route *pr, const wxString &com_name,
 #if 1
   {
     SENTENCE snt;
-      NMEA0183 oNMEA0183;
+      NMEA0183 oNMEA0183(NmeaCtxFactory());
       oNMEA0183.TalkerID = _T ( "EC" );
 
       int nProg = pr->pRoutePointList->GetCount() + 1;
@@ -634,7 +640,7 @@ int SendRouteToGPS_N0183(Route *pr, const wxString &com_name,
            max_wp))  // Do we need split sentences?
       {
         // Make a route with zero waypoints to get tare load.
-        NMEA0183 tNMEA0183;
+        NMEA0183 tNMEA0183(NmeaCtxFactory());
         SENTENCE tsnt;
         tNMEA0183.TalkerID = _T ( "EC" );
 
@@ -996,7 +1002,7 @@ int SendWaypointToGPS_N0183(RoutePoint *prp, const wxString &com_name/*,SendToGp
   {  // Standard NMEA mode
 
     SENTENCE snt;
-    NMEA0183 oNMEA0183;
+    NMEA0183 oNMEA0183(NmeaCtxFactory());
     oNMEA0183.TalkerID = _T ( "EC" );
 
 //FIXME     if (dialog && dialog->GetProgressGauge())

--- a/src/config_vars.cpp
+++ b/src/config_vars.cpp
@@ -30,6 +30,7 @@ bool g_bWplUsePosition;
 double g_UserVar = 0.0;
 
 int g_maxWPNameLength;
+int g_NMEAAPBPrecision = 3;
 int g_nNMEADebug = 0;
 int gps_watchdog_timeout_ticks = 0;
 int sat_watchdog_timeout_ticks = 12;

--- a/src/config_vars.cpp
+++ b/src/config_vars.cpp
@@ -37,6 +37,7 @@ int sat_watchdog_timeout_ticks = 12;
 
 wxString g_GPS_Ident;
 wxString g_hostname;
+wxString g_TalkerIdText;
 
 static wxConfigBase* the_base_config = 0;
 

--- a/src/connections_dialog.cpp
+++ b/src/connections_dialog.cpp
@@ -54,6 +54,7 @@
 #include "config_vars.h"
 #include "conn_params_panel.h"
 #include "NMEALogWindow.h"
+#include "nmea_ctx_factory.h"
 #include "OCPNPlatform.h"
 #include "ocpn_plugin.h"    // FIXME for GetOCPNScaledFont_PlugIn
 #include "options.h"
@@ -2067,14 +2068,6 @@ void ConnectionsDialog::OnPriorityDialog(wxCommandEvent &event){
   pdlg->ShowModal();
 
 }
-
-static NmeaContext  NmeaCtxFactory() {
-  NmeaContext ctx;
-  ctx.get_talker_id = []() { return  g_TalkerIdText; };
-  ctx.get_apb_precision = []() {return g_NMEAAPBPrecision; };
-  return ctx;
-}
-
 
 SentenceListDlg::SentenceListDlg(wxWindow* parent, FilterDirection dir,
                                  ListType type, const wxArrayString& list)

--- a/src/connections_dialog.cpp
+++ b/src/connections_dialog.cpp
@@ -2067,6 +2067,13 @@ void ConnectionsDialog::OnPriorityDialog(wxCommandEvent &event){
 
 }
 
+static NmeaContext  NmeaCtxFactory() {
+  NmeaContext ctx;
+  ctx.get_talker_id = []() { return  g_TalkerIdText; };
+  ctx.get_apb_precision = []() {return g_NMEAAPBPrecision; };
+  return ctx;
+}
+
 
 SentenceListDlg::SentenceListDlg(wxWindow* parent, FilterDirection dir,
                                  ListType type, const wxArrayString& list)
@@ -2074,7 +2081,7 @@ SentenceListDlg::SentenceListDlg(wxWindow* parent, FilterDirection dir,
                wxSize(280, 420)),
       m_type(type),
       m_dir(dir),
-      m_sentences(NMEA0183().GetRecognizedArray()) {
+      m_sentences(NMEA0183(NmeaCtxFactory()).GetRecognizedArray()) {
   wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
   wxBoxSizer* secondSizer = new wxBoxSizer(wxHORIZONTAL);
   wxStaticBox* pclbBox = new wxStaticBox(this, wxID_ANY, GetBoxLabel());

--- a/src/connections_dialog.cpp
+++ b/src/connections_dialog.cpp
@@ -69,6 +69,7 @@ extern int g_COGFilterSec;
 extern int g_SOGFilterSec;
 extern int g_NMEAAPBPrecision;
 extern OCPNPlatform* g_Platform;
+extern wxString g_TalkerIdText;
 
 wxString StringArrayToString(wxArrayString arr) {
   wxString ret = wxEmptyString;

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -127,8 +127,6 @@ Select* pSelectAIS;
 
 /* comm_bridge context. */
 
-int g_NMEAAPBPrecision;
-
 Select* pSelect;
 double g_n_arrival_circle_radius;
 double g_PlanSpeed;

--- a/src/garmin_protocol_mgr.cpp
+++ b/src/garmin_protocol_mgr.cpp
@@ -61,6 +61,7 @@
 #include <setupapi.h>
 #endif
 
+#include "config_vars.h"
 #include "dychart.h"
 #include "garmin_wrapper.h"
 #include "garmin_protocol_mgr.h"
@@ -86,6 +87,15 @@ extern bool g_benableUDPNullHeader;
 DEFINE_GUID(GARMIN_GUID1, 0x2c9c45c2L, 0x8e7d, 0x4c08, 0xa1, 0x2d, 0x81, 0x6b,
             0xba, 0xe7, 0x22, 0xc0);
 #endif
+
+
+static NmeaContext  NmeaCtxFactory() {
+  NmeaContext ctx;
+  ctx.get_talker_id = []() { return  g_TalkerIdText; };
+  ctx.get_apb_precision = []() {return g_NMEAAPBPrecision; };
+  return ctx;
+}
+
 
 //----------------------------------------------------------------------------
 // Garmin Device Management
@@ -779,7 +789,7 @@ void *GARMIN_Serial_Thread::Entry() {
         if ((mypvt.fix) >= 2 && (mypvt.fix <= 5)) {
           // Synthesize an NMEA GMRMC message
           SENTENCE snt;
-          NMEA0183 oNMEA0183;
+          NMEA0183 oNMEA0183(NmeaCtxFactory());
           oNMEA0183.TalkerID = _T ( "GM" );
 
           if (mypvt.lat < 0.)
@@ -912,7 +922,7 @@ void *GARMIN_USB_Thread::Entry() {
 
       // Synthesize an NMEA GMGSV message
       SENTENCE snt;
-      NMEA0183 oNMEA0183;
+      NMEA0183 oNMEA0183(NmeaCtxFactory());
       oNMEA0183.TalkerID = _T ( "GM" );
       oNMEA0183.Gsv.SatsInView = m_nSats;
 
@@ -940,7 +950,7 @@ void *GARMIN_USB_Thread::Entry() {
       if ((ppvt->fix) >= 2 && (ppvt->fix <= 5)) {
         // Synthesize an NMEA GMRMC message
         SENTENCE snt;
-        NMEA0183 oNMEA0183;
+        NMEA0183 oNMEA0183(NmeaCtxFactory());
         oNMEA0183.TalkerID = _T ( "GM" );
 
         if (ppvt->lat < 0.)

--- a/src/garmin_protocol_mgr.cpp
+++ b/src/garmin_protocol_mgr.cpp
@@ -61,12 +61,13 @@
 #include <setupapi.h>
 #endif
 
+#include "comm_drv_n0183_serial.h"
 #include "config_vars.h"
 #include "dychart.h"
 #include "garmin_wrapper.h"
 #include "garmin_protocol_mgr.h"
 #include "nmea0183.h"
-#include "comm_drv_n0183_serial.h"
+#include "nmea_ctx_factory.h"
 
 #ifdef __ANDROID__
 #include "androidUTIL.h"
@@ -87,14 +88,6 @@ extern bool g_benableUDPNullHeader;
 DEFINE_GUID(GARMIN_GUID1, 0x2c9c45c2L, 0x8e7d, 0x4c08, 0xa1, 0x2d, 0x81, 0x6b,
             0xba, 0xe7, 0x22, 0xc0);
 #endif
-
-
-static NmeaContext  NmeaCtxFactory() {
-  NmeaContext ctx;
-  ctx.get_talker_id = []() { return  g_TalkerIdText; };
-  ctx.get_apb_precision = []() {return g_NMEAAPBPrecision; };
-  return ctx;
-}
 
 
 //----------------------------------------------------------------------------

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -1396,7 +1396,7 @@ void glChartCanvas::OnPaint(wxPaintEvent &event) {
   if (!m_bsetup) {
     SetupOpenGL();
 
-    if (ps52plib) ps52plib->FlushSymbolCaches();
+    if (ps52plib) ps52plib->FlushSymbolCaches(g_bopengl);
 
     m_bsetup = true;
     //        g_bDebugOGL = true;

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -186,7 +186,7 @@ extern bool g_bShowChartBar;
 extern glTextureManager *g_glTextureManager;
 extern bool b_inCompressAllCharts;
 
-GLenum g_texture_rectangle_format;
+extern GLenum g_texture_rectangle_format;
 
 extern int g_memCacheLimit;
 extern ColorScheme global_color_scheme;
@@ -329,6 +329,15 @@ static void print_region(OCPNRegion &Region)
         upd.NextRect();
     }
 }
+
+#endif
+
+#ifdef ocpnUSE_GL
+static ChartCtx ChartCtxFactory() {
+   return ChartCtx(g_bopengl, g_texture_rectangle_format);
+}
+#else
+static ChartCtx ChartCtxFactory() { return ChartCtx(g_bopengl); }
 #endif
 
 GLboolean QueryExtension(const char *extName) {
@@ -1396,7 +1405,7 @@ void glChartCanvas::OnPaint(wxPaintEvent &event) {
   if (!m_bsetup) {
     SetupOpenGL();
 
-    if (ps52plib) ps52plib->FlushSymbolCaches(g_bopengl);
+    if (ps52plib) ps52plib->FlushSymbolCaches(ChartCtxFactory());
 
     m_bsetup = true;
     //        g_bDebugOGL = true;

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -62,6 +62,7 @@
 #include "chartbase.h"
 #include "chartdb.h"
 #include "chartimg.h"
+#include "chart_ctx_factory.h"
 #include "chcanv.h"
 #include "ChInfoWin.h"
 #include "cm93.h"  // for chart outline draw
@@ -330,14 +331,6 @@ static void print_region(OCPNRegion &Region)
     }
 }
 
-#endif
-
-#ifdef ocpnUSE_GL
-static ChartCtx ChartCtxFactory() {
-   return ChartCtx(g_bopengl, g_texture_rectangle_format);
-}
-#else
-static ChartCtx ChartCtxFactory() { return ChartCtx(g_bopengl); }
 #endif
 
 GLboolean QueryExtension(const char *extName) {

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -124,6 +124,7 @@ extern wxString g_winPluginDir;
 
 extern wxString g_SENCPrefix;
 extern wxString g_UserPresLibData;
+extern wxString g_TalkerIdText;
 
 extern wxString *pInit_Chart_Dir;
 extern wxString gWorldMapLocation;

--- a/src/ocpn_app.cpp
+++ b/src/ocpn_app.cpp
@@ -753,7 +753,6 @@ bool g_bUIexpert;
 int g_chart_zoom_modifier_raster;
 int g_chart_zoom_modifier_vector;
 
-int g_NMEAAPBPrecision;
 
 bool g_bAdvanceRouteWaypointOnArrivalOnly;
 

--- a/src/ocpn_frame.cpp
+++ b/src/ocpn_frame.cpp
@@ -84,6 +84,7 @@
 
 #include "OCPN_AUIManager.h"
 #include "chartbase.h"
+#include "chart_ctx_factory.h"
 #include "georef.h"
 #include "glChartCanvas.h"
 #include "plugin_loader.h"
@@ -490,16 +491,6 @@ void appendOSDirSlash(wxString *pString);
 void InitializeUserColors(void);
 void DeInitializeUserColors(void);
 void SetSystemColors(ColorScheme cs);
-
-#ifdef ocpnUSE_GL
-static ChartCtx ChartCtxFactory() {
-   return ChartCtx(g_bopengl, g_texture_rectangle_format);
-}
-#else
-
-static ChartCtx ChartCtxFactory() { return ChartCtx(g_bopengl); }
-#endif
-
 
 static bool LoadAllPlugIns(bool load_enabled) {
   g_Platform->ShowBusySpinner();

--- a/src/ocpn_frame.cpp
+++ b/src/ocpn_frame.cpp
@@ -252,6 +252,10 @@ extern ColorScheme global_color_scheme;
 extern options *g_pOptions;
 extern options *g_options;
 
+#ifdef ocpnUSE_GL
+GLenum g_texture_rectangle_format;
+#endif
+
 #if wxUSE_XLOCALE || !wxCHECK_VERSION(3, 0, 0)
 extern wxLocale *plocale_def_lang;
 #endif
@@ -486,6 +490,16 @@ void appendOSDirSlash(wxString *pString);
 void InitializeUserColors(void);
 void DeInitializeUserColors(void);
 void SetSystemColors(ColorScheme cs);
+
+#ifdef ocpnUSE_GL
+static ChartCtx ChartCtxFactory() {
+   return ChartCtx(g_bopengl, g_texture_rectangle_format);
+}
+#else
+
+static ChartCtx ChartCtxFactory() { return ChartCtx(g_bopengl); }
+#endif
+
 
 static bool LoadAllPlugIns(bool load_enabled) {
   g_Platform->ShowBusySpinner();
@@ -1109,7 +1123,7 @@ void MyFrame::SetAndApplyColorScheme(ColorScheme cs) {
     }
   }
 
-  if (ps52plib) ps52plib->SetPLIBColorScheme(SchemeName, g_bopengl);
+  if (ps52plib) ps52plib->SetPLIBColorScheme(SchemeName, ChartCtxFactory());
 
   //    Set up a pointer to the proper hash table
   pcurrent_user_color_hash =
@@ -6914,7 +6928,7 @@ void MyFrame::applySettingsString(wxString settings) {
 
   if (rr & S52_CHANGED) {
     if (ps52plib) {
-      ps52plib->FlushSymbolCaches(g_bopengl);
+      ps52plib->FlushSymbolCaches(ChartCtxFactory());
       ps52plib
           ->ClearCNSYLUPArray();  // some CNSY depends on renderer (e.g. CARC)
       ps52plib->GenerateStateHash();
@@ -8547,7 +8561,7 @@ void LoadS57() {
     }
 
     pConfig->LoadS57Config();
-    ps52plib->SetPLIBColorScheme(global_color_scheme, g_bopengl);
+    ps52plib->SetPLIBColorScheme(global_color_scheme, ChartCtxFactory());
 
     if (gFrame){
       ps52plib->SetPPMM(g_BasePlatform->GetDisplayDPmm());

--- a/src/ocpn_frame.cpp
+++ b/src/ocpn_frame.cpp
@@ -1109,7 +1109,7 @@ void MyFrame::SetAndApplyColorScheme(ColorScheme cs) {
     }
   }
 
-  if (ps52plib) ps52plib->SetPLIBColorScheme(SchemeName);
+  if (ps52plib) ps52plib->SetPLIBColorScheme(SchemeName, g_bopengl);
 
   //    Set up a pointer to the proper hash table
   pcurrent_user_color_hash =
@@ -6914,7 +6914,7 @@ void MyFrame::applySettingsString(wxString settings) {
 
   if (rr & S52_CHANGED) {
     if (ps52plib) {
-      ps52plib->FlushSymbolCaches();
+      ps52plib->FlushSymbolCaches(g_bopengl);
       ps52plib
           ->ClearCNSYLUPArray();  // some CNSY depends on renderer (e.g. CARC)
       ps52plib->GenerateStateHash();
@@ -8547,7 +8547,7 @@ void LoadS57() {
     }
 
     pConfig->LoadS57Config();
-    ps52plib->SetPLIBColorScheme(global_color_scheme);
+    ps52plib->SetPLIBColorScheme(global_color_scheme, g_bopengl);
 
     if (gFrame){
       ps52plib->SetPPMM(g_BasePlatform->GetDisplayDPmm());

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -81,6 +81,7 @@
 #ifdef ocpnUSE_GL
 #include "glChartCanvas.h"
 extern GLuint g_raster_format;
+extern GLenum g_texture_rectangle_format;
 #endif
 
 #include "chartdbs.h"
@@ -470,7 +471,15 @@ static int lang_list[] = {
     wxLANGUAGE_YIDDISH, wxLANGUAGE_YORUBA, wxLANGUAGE_ZHUANG, wxLANGUAGE_ZULU};
 #endif
 
-#ifdef __OCPN__ANDROID__
+#ifdef ocpnUSE_GL
+static ChartCtx ChartCtxFactory() {
+   return ChartCtx(g_bopengl, g_texture_rectangle_format);
+}
+#else
+static ChartCtx ChartCtxFactory() { return ChartCtx(g_bopengl); }
+#endif
+
+#ifdef __ANDROID__
 void prepareSlider(wxSlider* slider) {
   slider->GetHandle()->setStyleSheet(
       prepareAndroidSliderStyleSheet(slider->GetSize().x));
@@ -7237,7 +7246,7 @@ void options::OnApplyClick(wxCommandEvent& event) {
     if (m_returnChanges & GL_CHANGED) {
       // Do this now to handle the screen refresh that is automatically
       // generated on Windows at closure of the options dialog...
-      ps52plib->FlushSymbolCaches(g_bopengl);
+      ps52plib->FlushSymbolCaches(ChartCtxFactory());
       // some CNSY depends on renderer (e.g. CARC)
       ps52plib->ClearCNSYLUPArray();
       ps52plib->GenerateStateHash();

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -81,7 +81,6 @@
 #ifdef ocpnUSE_GL
 #include "glChartCanvas.h"
 extern GLuint g_raster_format;
-extern GLenum g_texture_rectangle_format;
 #endif
 
 #include "chartdbs.h"
@@ -99,6 +98,7 @@ extern GLenum g_texture_rectangle_format;
 #include "wx28compat.h"
 #include "routeman.h"
 #include "chcanv.h"
+#include "chart_ctx_factory.h"
 #include "MarkInfo.h"
 
 #include "ais.h"
@@ -469,14 +469,6 @@ static int lang_list[] = {
     wxLANGUAGE_UZBEK_CYRILLIC, wxLANGUAGE_UZBEK_LATIN, wxLANGUAGE_VIETNAMESE,
     wxLANGUAGE_VOLAPUK, wxLANGUAGE_WELSH, wxLANGUAGE_WOLOF, wxLANGUAGE_XHOSA,
     wxLANGUAGE_YIDDISH, wxLANGUAGE_YORUBA, wxLANGUAGE_ZHUANG, wxLANGUAGE_ZULU};
-#endif
-
-#ifdef ocpnUSE_GL
-static ChartCtx ChartCtxFactory() {
-   return ChartCtx(g_bopengl, g_texture_rectangle_format);
-}
-#else
-static ChartCtx ChartCtxFactory() { return ChartCtx(g_bopengl); }
 #endif
 
 #ifdef __ANDROID__

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -7237,7 +7237,7 @@ void options::OnApplyClick(wxCommandEvent& event) {
     if (m_returnChanges & GL_CHANGED) {
       // Do this now to handle the screen refresh that is automatically
       // generated on Windows at closure of the options dialog...
-      ps52plib->FlushSymbolCaches();
+      ps52plib->FlushSymbolCaches(g_bopengl);
       // some CNSY depends on renderer (e.g. CARC)
       ps52plib->ClearCNSYLUPArray();
       ps52plib->GenerateStateHash();

--- a/src/routeman.cpp
+++ b/src/routeman.cpp
@@ -128,7 +128,8 @@ void appendOSDirSlash(wxString *pString);
 //--------------------------------------------------------------------------------
 
 Routeman::Routeman(struct RoutePropDlgCtx ctx,
-                   std::function<void()> dlg_update_list_ctrl) {
+                   std::function<void()> dlg_update_list_ctrl)
+   : m_NMEA0183(NmeaCtxFactory()) {
   m_prop_dlg_ctx = ctx;
   m_route_mgr_dlg_update_list_ctrl = dlg_update_list_ctrl;
   pActiveRoute = NULL;

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -385,16 +385,16 @@ void s57chart::SetColorScheme(ColorScheme cs, bool bApplyImmediate) {
 
   switch (cs) {
     case GLOBAL_COLOR_SCHEME_DAY:
-      ps52plib->SetPLIBColorScheme(_T("DAY"));
+      ps52plib->SetPLIBColorScheme("DAY", g_bopengl);
       break;
     case GLOBAL_COLOR_SCHEME_DUSK:
-      ps52plib->SetPLIBColorScheme(_T("DUSK"));
+      ps52plib->SetPLIBColorScheme("DUSK", g_bopengl);
       break;
     case GLOBAL_COLOR_SCHEME_NIGHT:
-      ps52plib->SetPLIBColorScheme(_T("NIGHT"));
+      ps52plib->SetPLIBColorScheme("NIGHT", g_bopengl);
       break;
     default:
-      ps52plib->SetPLIBColorScheme(_T("DAY"));
+      ps52plib->SetPLIBColorScheme("DAY", g_bopengl);
       break;
   }
 
@@ -3069,7 +3069,7 @@ bool s57chart::BuildThumbnail(const wxString &bmpname) {
 
   //      set the color scheme
   ps52plib->SaveColorScheme();
-  ps52plib->SetPLIBColorScheme(_T("DAY"));
+  ps52plib->SetPLIBColorScheme("DAY", g_bopengl);
   //      Do the render
   DoRenderViewOnDC(memdc, vp, DC_RENDER_ONLY, true);
 

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -87,6 +87,7 @@
 
 #include "ssl/sha1.h"
 #include "shaders.h"
+#include "chart_ctx_factory.h"
 
 #ifdef __MSVC__
 #define strncasecmp(x, y, z) _strnicmp(x, y, z)
@@ -112,10 +113,6 @@ extern bool g_b_overzoom_x;
 extern bool g_b_EnableVBO;
 extern OCPNPlatform *g_Platform;
 extern SENCThreadManager *g_SencThreadManager;
-
-#ifdef ocpnUSE_GL
-extern GLenum g_texture_rectangle_format;
-#endif
 
 int g_SENC_LOD_pixels;
 
@@ -192,16 +189,6 @@ static unsigned int hash_fast32(const void *buf, size_t len,
 unsigned long connector_key::hash() const {
   return hash_fast32(k, sizeof k, 0);
 }
-
-#ifdef ocpnUSE_GL
-static ChartCtx ChartCtxFactory() {
-   return ChartCtx(g_bopengl, g_texture_rectangle_format);
-}
-#else
-
-static ChartCtx ChartCtxFactory() { return ChartCtx(g_bopengl); }
-#endif
-
 
 
 //----------------------------------------------------------------------------------

--- a/src/s57chart.cpp
+++ b/src/s57chart.cpp
@@ -113,6 +113,10 @@ extern bool g_b_EnableVBO;
 extern OCPNPlatform *g_Platform;
 extern SENCThreadManager *g_SencThreadManager;
 
+#ifdef ocpnUSE_GL
+extern GLenum g_texture_rectangle_format;
+#endif
+
 int g_SENC_LOD_pixels;
 
 static jmp_buf env_ogrf;  // the context saved by setjmp();
@@ -188,6 +192,17 @@ static unsigned int hash_fast32(const void *buf, size_t len,
 unsigned long connector_key::hash() const {
   return hash_fast32(k, sizeof k, 0);
 }
+
+#ifdef ocpnUSE_GL
+static ChartCtx ChartCtxFactory() {
+   return ChartCtx(g_bopengl, g_texture_rectangle_format);
+}
+#else
+
+static ChartCtx ChartCtxFactory() { return ChartCtx(g_bopengl); }
+#endif
+
+
 
 //----------------------------------------------------------------------------------
 //      render_canvas_parms Implementation
@@ -385,16 +400,16 @@ void s57chart::SetColorScheme(ColorScheme cs, bool bApplyImmediate) {
 
   switch (cs) {
     case GLOBAL_COLOR_SCHEME_DAY:
-      ps52plib->SetPLIBColorScheme("DAY", g_bopengl);
+      ps52plib->SetPLIBColorScheme("DAY", ChartCtxFactory());
       break;
     case GLOBAL_COLOR_SCHEME_DUSK:
-      ps52plib->SetPLIBColorScheme("DUSK", g_bopengl);
+      ps52plib->SetPLIBColorScheme("DUSK", ChartCtxFactory());
       break;
     case GLOBAL_COLOR_SCHEME_NIGHT:
-      ps52plib->SetPLIBColorScheme("NIGHT", g_bopengl);
+      ps52plib->SetPLIBColorScheme("NIGHT", ChartCtxFactory());
       break;
     default:
-      ps52plib->SetPLIBColorScheme("DAY", g_bopengl);
+      ps52plib->SetPLIBColorScheme("DAY", ChartCtxFactory());
       break;
   }
 
@@ -3069,7 +3084,7 @@ bool s57chart::BuildThumbnail(const wxString &bmpname) {
 
   //      set the color scheme
   ps52plib->SaveColorScheme();
-  ps52plib->SetPLIBColorScheme("DAY", g_bopengl);
+  ps52plib->SetPLIBColorScheme("DAY", ChartCtxFactory());
   //      Do the render
   DoRenderViewOnDC(memdc, vp, DC_RENDER_ONLY, true);
 

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -76,8 +76,6 @@ void* g_pi_manager = reinterpret_cast<void*>(1L);
 wxString g_compatOS = PKG_TARGET;
 wxString g_compatOsVersion = PKG_TARGET_VERSION;
 
-int g_NMEAAPBPrecision;
-
 Select* pSelect;
 double g_n_arrival_circle_radius;
 double g_PlanSpeed;


### PR DESCRIPTION
Remove all references to OpenCPN core global variables in libs.

Some has been discovered being unused and are thus just remoged. Other are replaces with callbacks or parameters.

If/when Håkan has time he might do some testing in opencpn-libs. 


Closes: #3161