### PR TITLE
Change dependency for wxWidgets language files. Closes #3164

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -43,7 +43,7 @@ Homepage: http://www.opencpn.org
 
 Package: opencpn
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, wx3.0-i18n
+Depends: ${shlibs:Depends}, ${misc:Depends}, wx-i18n
 Breaks: opencpn-gshhs-crude (<< ${source:Version}),
  opencpn-tcdata (<< ${source:Version})
 Provides: opencpn-plugin-wmm, opencpn-plugin-chartdldr


### PR DESCRIPTION
Changes the dependency of the Debian package to the `wx-i18n` virtual package which should pull in the correct version on every release.

https://packages.debian.org/buster/wx-i18n
https://packages.debian.org/bullseye/wx-i18n
https://packages.debian.org/bookworm/wx-i18n
https://packages.ubuntu.com/bionic/wx-i18n
https://packages.ubuntu.com/jammy/wx-i18n
https://packages.ubuntu.com/kinetic/wx-i18n
https://packages.ubuntu.com/lunar/wx-i18n