### PR TITLE
Update the Windows application manifest to support new DPI awareness features

### DIFF
--- a/app.manifest
+++ b/app.manifest
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
-    <application xmlns="urn:schemas-microsoft-com:asm.v3">
-        <windowsSettings>
-            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">True/PM</dpiAware>
-        </windowsSettings>
-    </application>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+    <assemblyIdentity type="win32" name="MyApplication" version="1.0.0.0" processorArchitecture="amd64"/>
+
+    <asmv3:application>
+        <asmv3:windowsSettings>
+            <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware> <!-- fallback for Windows 7 and 8 -->
+            <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness> <!-- adding v1 as fallback would result in v2 not being applied to dialogs on capable systems -->
+            <gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">true</gdiScaling> <!-- enables GDI DPI scaling -->
+        </asmv3:windowsSettings>
+    </asmv3:application>
 </assembly>


### PR DESCRIPTION
This should activate all the state of the art DPI awareness features on all Windows versions, we should aim to require zero user configuration with this manifest and default sizing settings even on Hi-DPI and multi monitor systems.
It does not seem to break the current state on my system (which is not HiDPI and not multi monitor)