### PR TITLE
Do not dime window if system theme is dark

### DIFF
--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -3487,6 +3487,11 @@ void DimeControl(wxWindow *ctrl) {
   return;  // this is seriously broken on wxqt
 #endif
 
+  if(wxSystemSettings::GetColour(wxSystemColour::wxSYS_COLOUR_WINDOW).Red() < 128) {
+    // Dark system color themes usually do better job than we do on diming UI controls, do not fight with them
+    return;
+  }
+
   if (NULL == ctrl) return;
 
   wxColour col, window_back_color, gridline, uitext, udkrd, ctrl_back_color,


### PR DESCRIPTION
Dark system themes nowadays make a better job than we do at saving the eyes on all the platforms.
If we want to revisit this in the future, we should use different logic at least for dark themes and only make bright colors less bright instead of using a custom palette, something like

```c++
#define LUMIMOSITY_NIGHT (-0.8)
#define LUMIMOSITY_DUSK (-0.5)

wxColor GetDimedColor(const wxColor& c, int color_scheme) const
{
    switch (color_scheme) {
    case NIGHT:
        return (
            wxColor(wxMax(0, wxMin(c.Red() + c.Red() * LUMIMOSITY_NIGHT, 255)),
                wxMax(0, wxMin(c.Green() + c.Green() * LUMIMOSITY_NIGHT, 255)),
                wxMax(0, wxMin(c.Blue() + c.Blue() * LUMIMOSITY_NIGHT, 255))));
    case DUSK:
        return (
            wxColor(wxMax(0, wxMin(c.Red() + c.Red() * LUMIMOSITY_DUSK, 255)),
                wxMax(0, wxMin(c.Green() + c.Green() * LUMIMOSITY_DUSK, 255)),
                wxMax(0, wxMin(c.Blue() + c.Blue() * LUMIMOSITY_DUSK, 255))));
    default:
        return c;
    }
}
```