### PR TITLE
Fix default settings for waypoints

### DIFF
--- a/src/MarkInfo.cpp
+++ b/src/MarkInfo.cpp
@@ -93,6 +93,7 @@ extern wxColour g_colourWaypointRangeRingsColour;
 
 extern int g_iWpt_ScaMin;
 extern bool g_bUseWptScaMin;
+extern bool g_bShowWptName;
 
 WX_DECLARE_LIST(wxBitmap, BitmapList);
 #include <wx/listimpl.cpp>
@@ -1395,7 +1396,7 @@ void MarkInfoDlg::DefautlBtnClicked(wxCommandEvent& event) {
         g_bUseWptScaMin = m_checkBoxScaMin->GetValue();
       }
       if (m_SaveDefaultDlg->NameCB->GetValue()) {
-        g_iWpt_ScaMin = m_checkBoxShowName->GetValue();
+        g_bShowWptName = m_checkBoxShowName->GetValue();
       }
     }
     m_SaveDefaultDlg = NULL;

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -143,6 +143,7 @@ int g_iWaypointRangeRingsNumber;
 int g_iWaypointRangeRingsStepUnits;
 wxColour g_colourWaypointRangeRingsColour;
 bool g_bUseWptScaMin;
+bool g_bShowWptName;
 int g_iWpt_ScaMin;
 int g_LayerIdx;
 bool g_bOverruleScaMin;

--- a/src/route_point.cpp
+++ b/src/route_point.cpp
@@ -59,6 +59,7 @@ extern float g_ChartScaleFactorExp;
 extern int g_iWpt_ScaMin;
 extern bool g_bUseWptScaMin;
 extern bool g_bOverruleScaMin;
+extern bool g_bShowWptName;
 
 WX_DEFINE_LIST(RoutePointList);
 
@@ -115,6 +116,7 @@ RoutePoint::RoutePoint() {
   m_iWaypointRangeRingsStepUnits = g_iWaypointRangeRingsStepUnits;
   m_wxcWaypointRangeRingsColour = g_colourWaypointRangeRingsColour;
   m_ScaMin = g_iWpt_ScaMin;
+  m_bShowName = g_bShowWptName;
   m_ScaMax = 0;
   b_UseScamin = g_bUseWptScaMin;
 
@@ -269,6 +271,7 @@ RoutePoint::RoutePoint(double lat, double lon, const wxString &icon_ident,
   m_ScaMin = g_iWpt_ScaMin;
   m_ScaMax = 0;
   b_UseScamin = g_bUseWptScaMin;
+  m_bShowName = g_bShowWptName;
 
   m_bDrawDragHandle = false;
   m_dragIconTexture = 0;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -92,6 +92,7 @@ int g_iWaypointRangeRingsStepUnits;
 wxColour g_colourWaypointRangeRingsColour;
 bool g_bUseWptScaMin;
 int g_iWpt_ScaMin;
+bool g_bShowWptName;
 int g_LayerIdx;
 bool g_bOverruleScaMin;
 int g_nTrackPrecision;


### PR DESCRIPTION
- Fixes #3209 
- Fixes the related problem with persistence of name visibility settings and it's application on new waypoints

Both should be backported to 5.8.4