### PR TITLE
Fix noisy and mostly trivial warnings

### DIFF
--- a/include/comm_drv_signalk_net.h
+++ b/include/comm_drv_signalk_net.h
@@ -47,8 +47,6 @@
 #define N_DOG_TIMEOUT 5             // seconds
 #define N_DOG_TIMEOUT_RECONNECT 10  // seconds
 
-#define TIMER_SOCKET 9006
-
 static const double ms_to_knot_factor = 1.9438444924406;
 
 class WebSocketThread;

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -455,6 +455,8 @@ typedef void destroy_t(opencpn_plugin *);
 class DECL_EXP opencpn_plugin_16 : public opencpn_plugin {
 public:
   opencpn_plugin_16(void *pmgr);
+
+  using opencpn_plugin::RenderOverlay;
   virtual ~opencpn_plugin_16();
 
   virtual bool RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp);
@@ -467,6 +469,7 @@ public:
   opencpn_plugin_17(void *pmgr);
   virtual ~opencpn_plugin_17();
 
+  using opencpn_plugin::RenderOverlay;
   virtual bool RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp);
   virtual bool RenderGLOverlay(wxGLContext *pcontext, PlugIn_ViewPort *vp);
 
@@ -477,7 +480,7 @@ class DECL_EXP opencpn_plugin_18 : public opencpn_plugin {
 public:
   opencpn_plugin_18(void *pmgr);
   virtual ~opencpn_plugin_18();
-
+  using opencpn_plugin::RenderOverlay;
   virtual bool RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp);
   virtual bool RenderGLOverlay(wxGLContext *pcontext, PlugIn_ViewPort *vp);
   virtual void SetPluginMessage(wxString &message_id, wxString &message_body);
@@ -580,6 +583,7 @@ public:
 class DECL_EXP opencpn_plugin_118 : public opencpn_plugin_117 {
 public:
   opencpn_plugin_118(void *pmgr);
+  using opencpn_plugin_116::RenderGLOverlayMultiCanvas;
   /// Render plugin overlay over chart canvas in OpenGL mode
   ///
   /// \param pcontext Pointer to the OpenGL context
@@ -591,6 +595,7 @@ public:
   virtual bool RenderGLOverlayMultiCanvas(wxGLContext *pcontext,
                                           PlugIn_ViewPort *vp, int canvasIndex,
                                           int priority = -1);
+  using opencpn_plugin_116::RenderOverlayMultiCanvas;
   /// Render plugin overlay over chart canvas in non-OpenGL mode
   ///
   /// \param dc Reference to the "device context"

--- a/include/shaders.h
+++ b/include/shaders.h
@@ -70,7 +70,7 @@ public:
         GLint logLength = 0;
         glGetShaderiv(shaderId, GL_INFO_LOG_LENGTH, &logLength);
         if (logLength > 0) {
-          auto log = std::unique_ptr<char>(new char[logLength]);
+          auto log = std::unique_ptr<char[]>(new char[logLength]);
           glGetShaderInfoLog(shaderId, logLength, &logLength, log.get());
           printf("ERROR::SHADER::COMPILATION_FAILED\n%s\n", log.get());
 #ifdef USE_ANDROID_GLES2
@@ -92,7 +92,7 @@ public:
         GLint logLength = 0;
         glGetShaderiv(programId_, GL_INFO_LOG_LENGTH, &logLength);
         if (logLength > 0) {
-          auto log = std::unique_ptr<char>(new char[logLength]);
+          auto log = std::unique_ptr<char[]>(new char[logLength]);
           glGetShaderInfoLog(programId_, logLength, &logLength, log.get());
           printf("ERROR::SHADER::LINK_FAILED\n%s\n", log.get());
         }

--- a/libs/s52plib/src/Cs52_shaders.cpp
+++ b/libs/s52plib/src/Cs52_shaders.cpp
@@ -186,8 +186,6 @@ bool loadCShaders(int index) {
   }
 
   bool ret_val = true;
-  GLint success;
-
 
   // Simple colored triangle shader
   if (!pCcolor_tri_shader_program[index]) {

--- a/libs/s52plib/src/Cs52_shaders.h
+++ b/libs/s52plib/src/Cs52_shaders.h
@@ -73,7 +73,8 @@ public:
         GLint logLength = 0;
         glGetShaderiv(shaderId, GL_INFO_LOG_LENGTH, &logLength);
         if (logLength > 0) {
-          auto log = std::unique_ptr<char>(new char[logLength]);
+          auto log = std::unique_ptr<char>(
+                  reinterpret_cast<char*>(new char[logLength]));
           glGetShaderInfoLog(shaderId, logLength, &logLength, log.get());
           printf("ERROR::SHADER::COMPILATION_FAILED\n%s\n", log.get());
 #ifdef USE_ANDROID_GLES2
@@ -94,7 +95,8 @@ public:
         GLint logLength = 0;
         glGetShaderiv(programId_, GL_INFO_LOG_LENGTH, &logLength);
         if (logLength > 0) {
-          auto log = std::unique_ptr<char>(new char[logLength]);
+          auto log = std::unique_ptr<char>(
+             reinterpret_cast<char*>(new char[logLength]));
           glGetShaderInfoLog(programId_, logLength, &logLength, log.get());
           printf("ERROR::SHADER::LINK_FAILED\n%s\n", log.get());
         }

--- a/libs/s52plib/src/Cs52_shaders.h
+++ b/libs/s52plib/src/Cs52_shaders.h
@@ -73,8 +73,7 @@ public:
         GLint logLength = 0;
         glGetShaderiv(shaderId, GL_INFO_LOG_LENGTH, &logLength);
         if (logLength > 0) {
-          auto log = std::unique_ptr<char>(
-                  reinterpret_cast<char*>(new char[logLength]));
+          auto log = std::unique_ptr<char[]>(new char[logLength]);
           glGetShaderInfoLog(shaderId, logLength, &logLength, log.get());
           printf("ERROR::SHADER::COMPILATION_FAILED\n%s\n", log.get());
 #ifdef USE_ANDROID_GLES2
@@ -95,8 +94,7 @@ public:
         GLint logLength = 0;
         glGetShaderiv(programId_, GL_INFO_LOG_LENGTH, &logLength);
         if (logLength > 0) {
-          auto log = std::unique_ptr<char>(
-             reinterpret_cast<char*>(new char[logLength]));
+          auto log = std::unique_ptr<char[]>(new char[logLength]);
           glGetShaderInfoLog(programId_, logLength, &logLength, log.get());
           printf("ERROR::SHADER::LINK_FAILED\n%s\n", log.get());
         }

--- a/libs/s52plib/src/TexFont.cpp
+++ b/libs/s52plib/src/TexFont.cpp
@@ -502,8 +502,6 @@ static const GLchar *TexFont_fragment_shader_source =
 bool TexFont::LoadTexFontShaders() {
   bool ret_val = true;
 
-  int success;
-
   // Are the shaders ready?
   if(m_TexFontShader)
     return true;

--- a/libs/s52plib/src/s52shaders.cpp
+++ b/libs/s52plib/src/s52shaders.cpp
@@ -368,7 +368,9 @@ bool loadS52Shaders() {
   //GLint success;
 
   enum Consts { INFOLOG_LEN = 512 };
+#if 0
   GLchar infoLog[INFOLOG_LEN];
+#endif
 
   // Are the shaders ready?
   if(shadersLoaded)

--- a/plugins/grib_pi/src/GribRequestDialog.cpp
+++ b/plugins/grib_pi/src/GribRequestDialog.cpp
@@ -444,8 +444,8 @@ void GribRequestSetting::ApplyRequestConfig(unsigned rs, unsigned it,
   m_pWind->SetValue(!IsRTOFS);
   m_pPress->SetValue(!IsRTOFS);
   m_pWaves->SetValue(m_RequestConfigBase.GetChar(8) == 'X' && IsGFS);
-  m_pWaves->Enable(IsECMWF || IsGFS && m_pTimeRange->GetCurrentSelection() <
-                                7);  // gfs & time range less than 8 days
+  m_pWaves->Enable(IsECMWF || (IsGFS && m_pTimeRange->GetCurrentSelection() <7));
+     // gfs & time range less than 8 days
   m_pRainfall->SetValue(m_RequestConfigBase.GetChar(9) == 'X' &&
                         (IsGFS || IsHRRR));
   m_pRainfall->Enable(IsGFS || IsHRRR);

--- a/src/TCWin.cpp
+++ b/src/TCWin.cpp
@@ -554,7 +554,7 @@ void TCWin::OnPaint(wxPaintEvent &event) {
           dc.SetPen(*pblack_2);
           dc.DrawLine(xd, m_graph_rect.y, xd,
                       m_graph_rect.y + m_graph_rect.height + 5);
-          char sbuf[5];
+          char sbuf[16];
           int hour_show = hour_start + i;
           if (hour_show >= 24) hour_show -= 24;
           sprintf(sbuf, "%02d", hour_show);

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -31,16 +31,8 @@
 #endif  // precompiled headers
 #include <wx/image.h>
 #include <wx/graphics.h>
-#include <wx/listbook.h>
 #include <wx/clipbrd.h>
 #include <wx/aui/aui.h>
-#include <wx/progdlg.h>
-
-// #if defined(__OCPN__ANDROID__)
-// #include <GLES2/gl2.h>
-// #elif defined(__WXQT__) || defined(__WXGTK__)
-// #include <GL/glew.h>
-// #endif
 
 #include "config.h"
 
@@ -106,7 +98,7 @@
 #include "route_gui.h"
 #include "line_clip.h"
 
-#ifdef __OCPN__ANDROID__
+#ifdef __ANDROID__
 #include "androidUTIL.h"
 #endif
 
@@ -8960,10 +8952,11 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
 
     else {                    // !g_btouch
       if (m_bRouteEditing) {  // End of RoutePoint drag
-        Route *tail, *current;
+        Route *tail = 0;
+        Route *current = 0;
         bool appending = false;
         bool inserting = false;
-        int connect;
+        int connect = 0;
         int index_last;
         if (m_pRoutePointEditTarget) {
           m_pRoutePointEditTarget->m_bBlink = false;

--- a/src/cm93.cpp
+++ b/src/cm93.cpp
@@ -3246,7 +3246,6 @@ S57Obj *cm93chart::CreateS57Obj(int cell_index, int iobject, int subcell,
     int *pAVI;
     char *pAVS;
     double *pAVR;
-    int nlen;
     double dival;
     int ival;
 

--- a/src/comm_drv_n0183_serial.cpp
+++ b/src/comm_drv_n0183_serial.cpp
@@ -427,7 +427,7 @@ bool CommDriverN0183SerialThread::OpenComPortPhysical(const wxString& com_name,
     m_serial.setBaudrate(baud_rate);
     m_serial.open();
     m_serial.setTimeout(250, 250, 0, 250, 0);
-  } catch (std::exception& e) {
+  } catch (std::exception&) {
     //      std::cerr << "Unhandled Exception while opening serial port: " <<
     //      e.what() << std::endl;
   }
@@ -437,7 +437,7 @@ bool CommDriverN0183SerialThread::OpenComPortPhysical(const wxString& com_name,
 void CommDriverN0183SerialThread::CloseComPortPhysical() {
   try {
     m_serial.close();
-  } catch (std::exception& e) {
+  } catch (std::exception&) {
     //      std::cerr << "Unhandled Exception while closing serial port: " <<
     //      e.what() << std::endl;
   }
@@ -513,7 +513,7 @@ void* CommDriverN0183SerialThread::Entry() {
     if (m_serial.isOpen()) {
       try {
         newdata = m_serial.read(rdata, 200);
-      } catch (std::exception& e) {
+      } catch (std::exception&) {
         //        std::cerr << "Serial read exception: " << e.what() <<
         //        std::endl;
         if (10 < retries++) {

--- a/src/comm_drv_n2k_serial.cpp
+++ b/src/comm_drv_n2k_serial.cpp
@@ -660,7 +660,7 @@ bool CommDriverN2KSerialThread::OpenComPortPhysical(const wxString& com_name,
     m_serial.setBaudrate(baud_rate);
     m_serial.open();
     m_serial.setTimeout(250, 250, 0, 250, 0);
-  } catch (std::exception& e) {
+  } catch (std::exception&) {
     // std::cerr << "Unhandled Exception while opening serial port: " <<
     // e.what() << std::endl;
   }
@@ -670,7 +670,7 @@ bool CommDriverN2KSerialThread::OpenComPortPhysical(const wxString& com_name,
 void CommDriverN2KSerialThread::CloseComPortPhysical() {
   try {
     m_serial.close();
-  } catch (std::exception& e) {
+  } catch (std::exception&) {
     // std::cerr << "Unhandled Exception while closing serial port: " <<
     // e.what() << std::endl;
   }
@@ -723,7 +723,7 @@ size_t CommDriverN2KSerialThread::WriteComPortPhysical(unsigned char *msg, size_
     ssize_t status;
     try {
       status = m_serial.write((uint8_t*)msg, length);
-    } catch (std::exception& e) {
+    } catch (std::exception&) {
 //       std::cerr << "Unhandled Exception while writing to serial port: " <<
 //       e.what() << std::endl;
       return -1;

--- a/src/comm_drv_signalk_net.cpp
+++ b/src/comm_drv_signalk_net.cpp
@@ -36,6 +36,8 @@
 #include "easywsclient.hpp"
 #include "geodesic.h"
 
+const int kTimerSocket = 9006;
+
 class CommDriverSignalKNetEvent;  // fwd
 
 class CommDriverSignalKNetThread : public wxThread {
@@ -221,7 +223,7 @@ CommDriverSignalKNet::CommDriverSignalKNet(const ConnectionParams* params,
 
   m_addr.Hostname(params->NetworkAddress);
   m_addr.Service(params->NetworkPort);
-  m_socketread_watchdog_timer.SetOwner(this, TIMER_SOCKET);
+  m_socketread_watchdog_timer.SetOwner(this, kTimerSocket);
   m_wsThread = NULL;
   m_threadActive = false;
 

--- a/src/comm_drv_signalk_net.cpp
+++ b/src/comm_drv_signalk_net.cpp
@@ -240,7 +240,9 @@ void CommDriverSignalKNet::Activate() {
 
 void CommDriverSignalKNet::Open(void) {
   wxString discoveredIP;
+#if 0
   int discoveredPort;
+#endif
 
   //if (m_useWebSocket)
   {

--- a/src/glChartCanvas.cpp
+++ b/src/glChartCanvas.cpp
@@ -1692,10 +1692,8 @@ void glChartCanvas::RenderChartOutline(ocpnDC &dc, int dbIndex, ViewPort &vp) {
   // chart is outside of viewport lat/lon bounding box
   if (box.IntersectOutGetBias(vp.GetBBox(), lon_bias)) return;
 
-  float plylat, plylon;
 
   wxColour color;
-
   if (ChartData->GetDBChartType(dbIndex) == CHART_TYPE_CM93)
     color = GetGlobalColor(_T ( "YELO1" ));
   else if (ChartData->GetDBChartFamily(dbIndex) == CHART_FAMILY_VECTOR)
@@ -1704,6 +1702,8 @@ void glChartCanvas::RenderChartOutline(ocpnDC &dc, int dbIndex, ViewPort &vp) {
     color = GetGlobalColor(_T ( "UINFR" ));
 
 #if !defined(USE_ANDROID_GLES2) && !defined(ocpnUSE_GLSL)
+  float plylat, plylon;
+
   if (g_GLOptions.m_GLLineSmoothing) glEnable(GL_LINE_SMOOTH);
 
   glColor3ub(color.Red(), color.Green(), color.Blue());

--- a/src/piano.cpp
+++ b/src/piano.cpp
@@ -368,11 +368,11 @@ void Piano::DrawGLSL(int off) {
 #ifdef ocpnUSE_GL
   unsigned int w = m_parentCanvas->GetClientSize().x * m_parentCanvas->GetContentScaleFactor();
   int h = GetHeight();
-  int endx = 0;
+  unsigned int endx = 0;
 
-  if (m_tex_piano_height != h) BuildGLTexture();
+  if (static_cast<int>(m_tex_piano_height) != h) BuildGLTexture();
 
-  if (m_tex_piano_height != h) return;
+  if (static_cast<int>(m_tex_piano_height) != h) return;
 
   int y1 = off, y2 = y1 + h;
 

--- a/src/svg_utils.cpp
+++ b/src/svg_utils.cpp
@@ -114,9 +114,9 @@ unsigned int get_px_length(const char* val) {
   int num;
   try {
     num = std::stoi(val);
-  } catch (std::invalid_argument const& ex) {
+  } catch (std::invalid_argument&) {
     return 0;
-  } catch (std::out_of_range const& ex) {
+  } catch (std::out_of_range& ) {
     return 0;
   }
   if (num < 0) {


### PR DESCRIPTION
The number of warnings has become too large to be able to work with these sources in a sane way. It's time to take care of them.

One set of warnings is non-trivial. in ocpn_plugin.h plugin_118 did hide some methods from plugin_116. The signatures are diffferent, but as the code was written ti did hide the old definitions. The fixes here makes the old 116 methods visible in 118+. 