### PR TITLE
Get rid of atrifact next to IDL on the GSHHG basemap. Fixes #3288

### DIFF
--- a/src/gshhs.cpp
+++ b/src/gshhs.cpp
@@ -450,11 +450,8 @@ void GshhsPolyCell::DrawPolygonFilledGL(ocpnDC &pnt, contour_list *p, float_2Dpt
             // that have a discontiguous date line
 
             if (idl && ccp.x == 180) {
-              if (vp.m_projection_type == PROJECTION_MERCATOR ||
-                  vp.m_projection_type == PROJECTION_EQUIRECTANGULAR)
-                q.m_x -=
-                    40058986 * 4096.0;  // 360 degrees in normalized viewport
-              else
+              if (vp.m_projection_type != PROJECTION_MERCATOR &&
+                  vp.m_projection_type != PROJECTION_EQUIRECTANGULAR)
                 q.m_x -= 360;  // lat/lon coordinates
             }
           }


### PR DESCRIPTION
Effect of the patch:

![image](https://github.com/OpenCPN/OpenCPN/assets/249856/2ebf8800-7948-45d1-95b2-dec830662b68)
