### PR TITLE
Fix a memory corruption due to incorrect buffer size calculation

### DIFF
--- a/src/ocpndc.cpp
+++ b/src/ocpndc.cpp
@@ -963,10 +963,10 @@ void ocpnDC::DrawRoundedRectangle(wxCoord x, wxCoord y, wxCoord w, wxCoord h,
     ConfigurePen();
 
     //  Grow the work buffer as necessary
-    size_t bufReq = (steps+1) * 8 * 2 * sizeof(float);  // large, to be sure
+    size_t bufReq = (steps+1) * 8 * 2;  // large, to be sure
 
     if (workBufSize < bufReq) {
-      workBuf = (float *)realloc(workBuf, bufReq);
+      workBuf = (float *)realloc(workBuf, bufReq * sizeof(float));
       workBufSize = bufReq;
     }
     workBufIndex = 0;


### PR DESCRIPTION
This memory corruption has been observed when following a track point by point in the 'Track details' dialog, but it can probably occur in many scenarios, as long as a rounded rectangle is drawn somewhere.

This fixes my issue reported initially here:
https://www.cruisersforum.com/forums/f134/opencpn-version-5-8-2-released-275428-11.html#post3787568