### PR TITLE
fix mmsi-properties convert AIVDM to AIVDO (only 0183)

### DIFF
--- a/src/ais_decoder.cpp
+++ b/src/ais_decoder.cpp
@@ -1967,14 +1967,21 @@ AisError AisDecoder::DecodeN0183(const wxString &str) {
 
               gps_watchdog_timeout_ticks =
                   60;  // increase watchdog time up to 1 minute
-              // add the changed sentence into nmea stream
+              // add the changed sentence into nmea message system
+              std::string full_sentence = aivdostr.ToStdString();
+              std::string identifier("AIVDO");
+              // We notify based on full message, including the Talker ID
+              // notify message listener and also "ALL" N0183 messages, to support plugin
+              // API using original talker id
+              auto address = std::make_shared<NavAddr0183>("virtual");
+              auto msg =
+              std::make_shared<const Nmea0183Msg>(identifier, full_sentence, address);
+              auto msg_all = std::make_shared<const Nmea0183Msg>(*msg, "ALL");
 
-              //FIXME (dave) What is this all about?
-//               OCPN_DataStreamEvent event(wxEVT_OCPN_DATASTREAM, 0);
-//               std::string s = std::string(aivdostr.mb_str());
-//               event.SetNMEAString(s);
-//               event.SetStream(NULL);
-//               g_pMUX->AddPendingEvent(event);
+              auto &msgbus = NavMsgBus::GetInstance();
+
+              msgbus.Notify(std::move(msg));
+              msgbus.Notify(std::move(msg_all));
             }
           }
           return AIS_NoError;


### PR DESCRIPTION
Converting an AIVDM to an AIVDO sentence for targets in the mmsi-properties was broken. This will fix it if the original sentence was a 0183.