### PR TITLE
Correct Split merge routes processes

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -8928,9 +8928,13 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
         FinishRoute();
       }
       if (inserting) {
+        pSelect->DeleteAllSelectableRoutePoints(current);
+        pSelect->DeleteAllSelectableRouteSegments(current);
         for (int i = 1; i < connect; i++) {  // numbering in the tail route
           current->InsertPointAndSegment(tail->GetPoint(i), i - 1, false);
         }
+        pSelect->AddAllSelectableRouteSegments(current);
+        pSelect->AddAllSelectableRoutePoints(current);
         current->FinalizeForRendering();
         current->m_bIsBeingEdited = false;
       }
@@ -9131,9 +9135,13 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
             FinishRoute();
           }
           if (inserting) {
+            pSelect->DeleteAllSelectableRoutePoints(current);
+            pSelect->DeleteAllSelectableRouteSegments(current);
             for (int i = 1; i < connect; i++) {  // numbering in the tail route
               current->InsertPointAndSegment(tail->GetPoint(i), i - 1, false);
             }
+            pSelect->AddAllSelectableRouteSegments(current);
+            pSelect->AddAllSelectableRoutePoints(current);
             current->FinalizeForRendering();
             current->m_bIsBeingEdited = false;
           }

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -8925,6 +8925,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
         }
         current->FinalizeForRendering();
         current->m_bIsBeingEdited = false;
+        FinishRoute();
       }
       if (inserting) {
         for (int i = 1; i < connect; i++) {  // numbering in the tail route

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -8926,6 +8926,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
         current->FinalizeForRendering();
         current->m_bIsBeingEdited = false;
         FinishRoute();
+        g_pRouteMan->DeleteRoute(tail, NavObjectChanges::getInstance());
       }
       if (inserting) {
         pSelect->DeleteAllSelectableRoutePoints(current);
@@ -8937,6 +8938,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
         pSelect->AddAllSelectableRoutePoints(current);
         current->FinalizeForRendering();
         current->m_bIsBeingEdited = false;
+        g_pRouteMan->DeleteRoute(tail, NavObjectChanges::getInstance());
       }
 
       //    Update the RouteProperties Dialog, if currently shown
@@ -9133,6 +9135,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
             current->FinalizeForRendering();
             current->m_bIsBeingEdited = false;
             FinishRoute();
+            g_pRouteMan->DeleteRoute(tail, NavObjectChanges::getInstance());
           }
           if (inserting) {
             pSelect->DeleteAllSelectableRoutePoints(current);
@@ -9144,6 +9147,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
             pSelect->AddAllSelectableRoutePoints(current);
             current->FinalizeForRendering();
             current->m_bIsBeingEdited = false;
+            g_pRouteMan->DeleteRoute(tail, NavObjectChanges::getInstance());
           }
 
           //    Update the RouteProperties Dialog, if currently shown

--- a/src/route.cpp
+++ b/src/route.cpp
@@ -127,7 +127,7 @@ void Route::CloneRoute(Route *psourceroute, int start_nPoint, int end_nPoint,
       RoutePoint *psourcepoint = psourceroute->GetPoint(i);
       RoutePoint *ptargetpoint = new RoutePoint(
         psourcepoint->m_lat, psourcepoint->m_lon, psourcepoint->GetIconName(),
-        psourcepoint->GetName(), wxEmptyString, false);
+        psourcepoint->GetName(), wxEmptyString, true);
       ptargetpoint->m_bShowName =
         psourcepoint->m_bShowName;  // do not change new wpt's name visibility
       AddPoint(ptargetpoint, false);


### PR DESCRIPTION
1) Crash when merging two routes and click on the resulting route. (process appending)
2) Legs not selectable after merging (process inserting)
3) First point of the second route after a "split at waypoint" not selectable as "nearby point"
4) Delete the unuseful  "tail" part of the route after  merge