### PR TITLE
Revert "plugin_loader: Fix bad typo leading to crash."

### DIFF
--- a/src/plugin_loader.cpp
+++ b/src/plugin_loader.cpp
@@ -284,7 +284,8 @@ void PluginLoader::NotifySetupOptionsPlugin(const PlugInData* pd) {
         case 117:
         case 118: {
           if (pic->m_pplugin) {
-            auto ppi = dynamic_cast<opencpn_plugin_118*>(pic->m_pplugin);
+            opencpn_plugin_19 *ppi =
+                dynamic_cast<opencpn_plugin_19 *>(pic->m_pplugin);
             if (ppi) {
               ppi->OnSetupOptions();
               auto loader = PluginLoader::getInstance();


### PR DESCRIPTION
More clean up after #3258

This reverts commit d2ce0c583d7320828d2266a9cb93ce0930f21efb. This was a misconception from my side leading to that the chartdownloader tab disappears as discussed in #3374