### PR TITLE
debian/rules: Use default portaudio sound

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -12,7 +12,6 @@ override_dh_auto_configure:
 ifeq ($(DEB_BUILD_ARCH_CPU), arm)
 	dh_auto_configure -- \
 	    -DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH) \
-            -DOCPN_ENABLE_SYSTEM_CMD_SOUND:BOOL=ON     \
             -DCMAKE_INSTALL_LIBDIR=lib                 \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo          \
             -DDEB_VERSION=$(DEB_VERSION)               \
@@ -21,7 +20,6 @@ ifeq ($(DEB_BUILD_ARCH_CPU), arm)
 else ifeq ($(DEB_BUILD_ARCH_CPU), arm64)
 	dh_auto_configure -- \
 	    -DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH) \
-            -DOCPN_ENABLE_SYSTEM_CMD_SOUND:BOOL=ON     \
             -DCMAKE_INSTALL_LIBDIR=lib                 \
             -DCMAKE_BUILD_TYPE=RelWithDebInfo          \
             -DDEB_VERSION=$(DEB_VERSION)               \

--- a/debian/rules
+++ b/debian/rules
@@ -18,15 +18,6 @@ ifeq ($(DEB_BUILD_ARCH_CPU), arm)
             -DDEB_VERSION=$(DEB_VERSION)               \
             -DDEB_DISTRIBUTION=$(DEB_DISTRIBUTION)     \
             -DOCPN_BUILD_TEST=OFF
-else ifeq ($(DEB_BUILD_ARCH_CPU), aarch64)
-	dh_auto_configure -- \
-	    -DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH) \
-            -DOCPN_ENABLE_SYSTEM_CMD_SOUND:BOOL=ON     \
-            -DCMAKE_INSTALL_LIBDIR=lib                 \
-            -DCMAKE_BUILD_TYPE=RelWithDebInfo          \
-            -DDEB_VERSION=$(DEB_VERSION)               \
-            -DDEB_DISTRIBUTION=$(DEB_DISTRIBUTION)     \
-            -DOCPN_BUILD_TEST=OFF
 else ifeq ($(DEB_BUILD_ARCH_CPU), arm64)
 	dh_auto_configure -- \
 	    -DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH) \


### PR DESCRIPTION
Always use the default portaudio sound system, also on arm architectures. Makes for consistent sound usage, avoiding the problems related to using external programs to run sounds.

While on it, remove an unused if branch.
    
Closes: #3285 

EDIT: Updated bug reference.
