### PR TITLE
Only run notify_setup_options() once.

### DIFF
--- a/include/plugin_loader.h
+++ b/include/plugin_loader.h
@@ -68,6 +68,7 @@ public:
 
   PlugInData();
 
+  bool m_has_setup_options;          //!< Has run NotifySetupOptionsPlugin()
   bool m_enabled;
   bool m_init_state;
   bool m_toolbox_panel;

--- a/src/plugin_loader.cpp
+++ b/src/plugin_loader.cpp
@@ -156,7 +156,8 @@ PlugInContainer::PlugInContainer()
     : PlugInData(), m_pplugin(nullptr), m_library(), m_destroy_fn(nullptr) {}
 
 PlugInData::PlugInData()
-    : m_enabled(false),
+    : m_has_setup_options(false),
+      m_enabled(false),
       m_init_state(false),
       m_toolbox_panel(false),
       m_cap_flag(0),
@@ -288,6 +289,8 @@ void PluginLoader::ShowPreferencesDialog(const PlugInData& pd,
 void PluginLoader::NotifySetupOptionsPlugin(const PlugInData* pd) {
   auto pic = GetContainer(*pd, *GetPlugInArray());
   if (!pic) return;
+  if (pic->m_has_setup_options) return;
+  pic->m_has_setup_options = true;
   if (pic->m_enabled && pic->m_init_state) {
     if (pic->m_cap_flag & INSTALLS_TOOLBOX_PAGE) {
       switch (pic->m_api_version) {


### PR DESCRIPTION
More clean up after #3258

As discussed in https://github.com/OpenCPN/OpenCPN/issues/3374#issuecomment-1663856174, new code invokes `PluginLoader::NotifySetupOptionsPlugin(...)` multiple times which plugins are are not prepared to handle. Add a simple check ensuring that only the first call is actually executed.

This is one of many things which not are defined. With  NotifySetupOptionsPlugin() calls spread all over the place it's IMHO just luck that this has not happened before.