### PR TITLE
plugin_loader: Don't use metadata version (#3374).

### DIFF
--- a/src/plugin_loader.cpp
+++ b/src/plugin_loader.cpp
@@ -145,8 +145,6 @@ std::string PluginLoader::GetPluginVersion(
         v_major, v_minor, p->GetPlugInVersionPatch(), p->GetPlugInVersionPost(),
         p->GetPlugInVersionPre(), p->GetPlugInVersionBuild());
     return v.to_string() + import_suffix;
-  } else if (metadata.version != "") {
-    return metadata.version + import_suffix;
   } else {
     return SemanticVersion(v_major, v_minor, -1).to_string() + import_suffix;
   }


### PR DESCRIPTION
More cleanup after #3103, as discussed in
https://github.com/OpenCPN/OpenCPN/issues/3374#issuecomment-1666539373

We cannot reliably match available metadata to an existing plugin pre API 117 since plugin only carries major + minor. This means that a metadata change like 1.1.1 -> 1.1.2 is not reflected in what's available from the plugin.

Eventually, this means that if metadata is updated (catalog update) the metadata will not match the plugin if it's not updated.

So: just just plugin major + minor for installed plugins which don't have any more info i. e., is <= API 116.