### PR TITLE
Fixes for plugins. 

### DIFF
--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -4669,6 +4669,10 @@ void PluginPanel::SetSelected(bool selected) {
         break;
     }
     SetActionLabel(label);
+    const auto plugin_name = m_plugin.m_common_name.ToStdString();
+    if (ocpn::exists(PluginHandler::ImportedMetadataPath(plugin_name))) {
+       m_pButtonAction->Hide();
+    }
 
     Layout();
   } else {


### PR DESCRIPTION
More clean  up after #3258 as discussed in #3374. 
  - Use the installation data version.  That this was not used is what's in Swedish is called a "brain drop". 
  - Hide the Action (typically Reinstall) button for imported plugins.
  - Take care handling versions like v3.2.1  or r1.2.3