### PR TITLE
ocpn_plugin.h warnings, part 2

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -424,7 +424,7 @@ public:
 
   virtual void ShowPreferencesDialog(wxWindow *parent);
 
-  virtual bool RenderOverlay(wxMemoryDC *pmdc, PlugIn_ViewPort *vp);
+  virtual bool RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp);
   virtual void SetCursorLatLon(double lat, double lon);
   virtual void SetCurrentViewPort(PlugIn_ViewPort &vp);
 
@@ -459,7 +459,7 @@ public:
   using opencpn_plugin::RenderOverlay;
   virtual ~opencpn_plugin_16();
 
-  virtual bool RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp);
+  bool RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp) override;
 
   virtual void SetPluginMessage(wxString &message_id, wxString &message_body);
 };
@@ -470,7 +470,7 @@ public:
   virtual ~opencpn_plugin_17();
 
   using opencpn_plugin::RenderOverlay;
-  virtual bool RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp);
+  bool RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp) override;
   virtual bool RenderGLOverlay(wxGLContext *pcontext, PlugIn_ViewPort *vp);
 
   virtual void SetPluginMessage(wxString &message_id, wxString &message_body);
@@ -481,7 +481,7 @@ public:
   opencpn_plugin_18(void *pmgr);
   virtual ~opencpn_plugin_18();
   using opencpn_plugin::RenderOverlay;
-  virtual bool RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp);
+  bool RenderOverlay(wxDC &dc, PlugIn_ViewPort *vp) override;
   virtual bool RenderGLOverlay(wxGLContext *pcontext, PlugIn_ViewPort *vp);
   virtual void SetPluginMessage(wxString &message_id, wxString &message_body);
   virtual void SetPositionFixEx(PlugIn_Position_Fix_Ex &pfix);

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -8716,7 +8716,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
       if (b_start_rollover)
         m_RolloverPopupTimer.Start(m_rollover_popup_timer_msec,
                                    wxTIMER_ONE_SHOT);
-      Route *tail, *current;
+      Route *tail = 0, *current;
       bool appending = false;
       bool inserting = false;
       int connect = 0;

--- a/src/ocpn_plugin.cpp
+++ b/src/ocpn_plugin.cpp
@@ -126,7 +126,7 @@ void opencpn_plugin::OnToolbarToolCallback(int id) {}
 
 void opencpn_plugin::OnContextMenuItemCallback(int id) {}
 
-bool opencpn_plugin::RenderOverlay(wxMemoryDC* dc, PlugIn_ViewPort* vp) {
+bool opencpn_plugin::RenderOverlay(wxDC& dc, PlugIn_ViewPort* vp) {
   return false;
 }
 


### PR DESCRIPTION
As discussed in  https://shorturl.at/sF238 last part of silencing the compiler warnings for ocpn_plugin.h when compiling plugins.

Theoretically, this might break both API and  ABI for plugins using an API level < 1.16. However, I don't  think we have such plugins around, and even if the changes "should" work.

While on it, fix an annoying uninitialized variable.