### PR TITLE
Fix mbtiles zoom modifier bug

### DIFF
--- a/src/mbtiles.cpp
+++ b/src/mbtiles.cpp
@@ -1053,7 +1053,7 @@ bool ChartMBTiles::RenderRegionViewOnGL(const wxGLContext &glc,
                                         const OCPNRegion &RectRegion,
                                         const LLRegion &Region) {
   // Do not render if significantly underzoomed
-  if (VPoint.chart_scale > (20 * OSM_zoomScale[m_minZoom])) {
+if (VPoint.chart_scale > (20 * OSM_zoomScale[m_minZoom])) {
     if (m_nTiles > 500) {
       return true;
     }
@@ -1078,7 +1078,7 @@ bool ChartMBTiles::RenderRegionViewOnGL(const wxGLContext &glc,
 
   int viewZoom = m_maxZoom;
   // Set zoom modifier according to Raster Zoom Modifier settings from display preference pane
-  double zoomMod = 2 * pow(2, g_chart_zoom_modifier_raster / 3.0);
+  double zoomMod = 2 * pow(2, -g_chart_zoom_modifier_raster / 3.0);
 
   for (int kz = m_minZoom; kz <= 19; kz++) {
     double db_mpp = OSM_zoomMPP[kz];
@@ -1247,7 +1247,7 @@ bool ChartMBTiles::RenderRegionViewOnGL(const wxGLContext &glc,
 
   glDisable(GL_TEXTURE_2D);
 
-  m_zoomScaleFactor = 2.0 * OSM_zoomMPP[maxrenZoom] * VPoint.view_scale_ppm;
+  m_zoomScaleFactor = 2.0 * OSM_zoomMPP[maxrenZoom] * VPoint.view_scale_ppm / zoomMod;
 
   glChartCanvas::DisableClipRegion();
 


### PR DESCRIPTION
A few month ago, I implemented the zoom modifier setting for MBTILES, reading the raster zoom modifier and changing the MBTILE map level accordingly. But I did two errors :

1 - I inverted the silder : positive values where actually reducing details while it should have been the opposite.
2 - I did not take into account the modifier when returning the current map scale, leading to incorrect over/underzoom flags being raised.

Both problems are fixed in this pull request.