### PR TITLE
macOS - support for multi architecture plugins

### DIFF
--- a/cmake/in-files/config.h.in
+++ b/cmake/in-files/config.h.in
@@ -52,9 +52,6 @@
 // The os version compatible plugins are are built for
 #define PKG_TARGET_VERSION "${PKG_TARGET_VERSION}"
 
-// The architecture compatible plugins are built for
-#define PKG_TARGET_ARCH "${ARCH}"
-
 // Command line to play a sound in system(3), like "aplay %s".
 #define OCPN_SOUND_CMD  ${OCPN_SOUND_CMD}
 

--- a/include/macutils.h
+++ b/include/macutils.h
@@ -33,6 +33,9 @@ extern "C" bool ValidateSerialPortName(const char* pPortName,
                                        int iMaxNamesToSearch);
 extern "C" int GetMacMonitorSize();
 
+extern "C"  int ProcessIsTranslated();
+extern "C"  int IsAppleSilicon();
+
 #endif  // __WXOSX__
 
 #endif  // MACUTILS_H_INCLUDED_H__

--- a/src/base_platform.cpp
+++ b/src/base_platform.cpp
@@ -551,6 +551,18 @@ bool BasePlatform::DetectOSDetail(OCPN_OSDetail* detail) {
   if (arch == wxARCH_32) detail->osd_arch = std::string("armhf");
 #endif
 
+#ifdef __WXOSX__
+  if (IsAppleSilicon() == 1) {
+    if (ProcessIsTranslated() != 1) {
+      detail->osd_arch = std::string("arm64");
+    } else {
+      detail->osd_arch = std::string("x86_64");
+    }
+  } else {
+    detail->osd_arch = std::string("x86_64");
+  }
+#endif
+
   return true;
 }
 

--- a/src/macutils.c
+++ b/src/macutils.c
@@ -34,6 +34,7 @@
 #include <sys/param.h>
 #include <sys/select.h>
 #include <sys/time.h>
+#include <sys/sysctl.h>
 #include <time.h>
 #include <stdlib.h>
 #include <AvailabilityMacros.h>
@@ -242,6 +243,32 @@ bool ValidateSerialPortName(char* pPortName, int iMaxNamestoSearch) {
 int GetMacMonitorSize() {
   CGSize displayPhysicalSize = CGDisplayScreenSize(CGMainDisplayID());  // mm
   return displayPhysicalSize.width;
+}
+
+/**
+ * Determines whether we run as a translated binary under Rosetta
+ * See https://developer.apple.com/documentation/apple-silicon/about-the-rosetta-translation-environment#Determine-Whether-Your-App-Is-Running-as-a-Translated-Binary 
+ */
+int ProcessIsTranslated() {
+   int ret = 0;
+   size_t size = sizeof(ret);
+   if (sysctlbyname("sysctl.proc_translated", &ret, &size, NULL, 0) == -1) 
+   {
+      if (errno == ENOENT)
+         return 0;
+      return -1;
+   }
+   return ret;
+}
+
+int IsAppleSilicon() {
+    int ret = 0;
+    size_t size = sizeof(ret);
+    
+    if (sysctlbyname("hw.optional.arm64", &ret, &size, NULL, 0) == -1) {        
+        return -1;
+    }
+    return ret;
 }
 
 #endif  //__WXOSX__

--- a/src/plugin_handler.cpp
+++ b/src/plugin_handler.cpp
@@ -128,8 +128,8 @@ static std::vector<std::string> glob_dir(const std::string& dir_path,
   wxDir dir(dir_path);
   auto match = dir.GetFirst(&s, pattern);
   while (match) {
-    static const std::string SEP
-        = wxString(wxFileName::GetPathSeparator()).ToStdString();
+    static const std::string SEP =
+        wxString(wxFileName::GetPathSeparator()).ToStdString();
     found.push_back(dir_path + SEP + s.ToStdString());
     match = dir.GetNext(&s);
   }
@@ -261,7 +261,7 @@ public:
         "debian-armhf;12;ubuntu-armhf;23.04",
         "debian-armhf;12;ubuntu-armhf;23.10",
         "debian-armhf;12;ubuntu-armhf;24.04",
-        "debian-armhf;sid;ubuntu-armhf;24.04"}; //clang-format: on
+        "debian-armhf;sid;ubuntu-armhf;24.04"};  // clang-format: on
 
     if (ocpn::startswith(plugin.abi(), "debian")) {
       wxLogDebug("Checking for debian plugin on a ubuntu host");
@@ -339,8 +339,7 @@ PluginHandler::PluginHandler() {}
 bool PluginHandler::isCompatible(const PluginMetadata& metadata, const char* os,
                                  const char* os_version) {
   static const std::vector<std::string> simple_abis = {
-      "msvc",        "msvc-wx32",     "darwin",
-      "darwin-wx32", "android-armhf", "android-arm64"};
+      "msvc", "msvc-wx32", "android-armhf", "android-arm64"};
 
   Plugin plugin(metadata);
   if (plugin.abi() == "all") {
@@ -365,8 +364,15 @@ bool PluginHandler::isCompatible(const PluginMetadata& metadata, const char* os,
     rv = true;
     wxLogDebug("Found Debian version matching Ubuntu host");
   }
-  DEBUG_LOG << "Plugin compatibility check Final: "
-            << (rv ? "ACCEPTED: " : "REJECTED: ") << metadata.name;
+  if (plugin.abi() == "darwin-wx32") {
+    OCPN_OSDetail *detail = g_BasePlatform->GetOSDetail();
+    auto found = metadata.target_arch.find(detail->osd_arch);
+    if(found != std::string::npos) {
+      rv = true;
+    }
+  }
+    DEBUG_LOG << "Plugin compatibility check Final: "
+              << (rv ? "ACCEPTED: " : "REJECTED: ") << metadata.name;
   return rv;
 }
 
@@ -380,7 +386,8 @@ std::string PluginHandler::versionPath(std::string name) {
   return pluginsConfigDir() + SEP + name + ".version";
 }
 
-std::string PluginHandler::ImportedMetadataPath(std::string name) {;
+std::string PluginHandler::ImportedMetadataPath(std::string name) {
+  ;
   std::transform(name.begin(), name.end(), name.begin(), ::tolower);
   return importsDir() + SEP + name + ".xml";
 }
@@ -770,7 +777,7 @@ bool PluginHandler::explodeTarball(struct archive* src, struct archive* dest,
       continue;
     }
     if (!is_metadata && only_metadata) {
-        continue;
+      continue;
     }
     if (!is_metadata) {
       filelist.append(std::string(archive_entry_pathname(entry)) + "\n");
@@ -911,7 +918,7 @@ bool PluginHandler::InstallPlugin(const std::string& path,
     last_error_msg = os.str();
     return false;
   }
-  if (only_metadata)  {
+  if (only_metadata) {
     return true;
   }
   struct CatalogCtx ctx;
@@ -939,7 +946,6 @@ std::string PluginHandler::getMetadataPath() {
   return metadataPath;
 }
 
-
 const std::map<std::string, int> PluginHandler::getCountByTarget() {
   auto plugins = getInstalled();
   auto a = getAvailable();
@@ -959,11 +965,9 @@ const std::map<std::string, int> PluginHandler::getCountByTarget() {
   return count_by_target;
 }
 
-
 std::vector<std::string> PluginHandler::GetImportPaths() {
   return glob_dir(importsDir(), "*.xml");
 }
-
 
 void PluginHandler::cleanupFiles(const std::string& manifestFile,
                                  const std::string& plugname) {
@@ -1069,14 +1073,13 @@ const std::vector<PluginMetadata> PluginHandler::getInstalled() {
 }
 
 void PluginHandler::SetInstalledMetadata(const PluginMetadata& pm) {
-   auto loader = PluginLoader::getInstance();
-   ssize_t ix =  PlugInIxByName(pm.name, loader->GetPlugInArray());
-   if (ix == -1) return;  // no such plugin
+  auto loader = PluginLoader::getInstance();
+  ssize_t ix = PlugInIxByName(pm.name, loader->GetPlugInArray());
+  if (ix == -1) return;  // no such plugin
 
-   auto plugins = *loader->GetPlugInArray();
-   plugins[ix]->m_managed_metadata = pm;
+  auto plugins = *loader->GetPlugInArray();
+  plugins[ix]->m_managed_metadata = pm;
 }
-
 
 bool PluginHandler::installPlugin(PluginMetadata plugin, std::string path) {
   std::string filelist;
@@ -1203,7 +1206,7 @@ static std::string FindMatchingDataDir(std::regex name_re) {
     auto token = tokens.GetNextToken();
     wxFileName path(token);
     wxDir dir(path.GetFullPath());
-    if (dir.IsOpened()){
+    if (dir.IsOpened()) {
       wxString filename;
       bool cont = dir.GetFirst(&filename, "", wxDIR_DIRS);
       while (cont) {


### PR DESCRIPTION
Detect architecture at runtime and check plugin compatibility based on `target-arch` metadata.
The plugin can provide either a single platform (`x86_64` or `arm64`) or a list in case of universal build (`x86_64;arm64`)

The plugin side counterpart may look like https://github.com/nohal/nsk_pi/commit/7b3512e250f02e0af0874dbb6e06e147c5e0c03b