### PR TITLE
Signalk comm API getter function (#3381)

### DIFF
--- a/include/comm_navmsg.h
+++ b/include/comm_navmsg.h
@@ -303,8 +303,6 @@ public:
   std::string context;
   std::string raw_message;
 
-  std::vector<std::string> errors;
-  std::vector<std::string> warnings;
   std::string key() const { return std::string("signalK"); };
 };
 

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -1701,6 +1701,24 @@ extern DECL_EXP std::vector<uint8_t> GetN2000Payload(NMEA2000Id id,
                                                      ObservedEvt ev);
 
 /**
+ *  Get SignalK status payload after receiving a message.
+ *  @return pointer to a wxJSONValue map object. Typical usage:
+ *
+ *      auto ptr = GetSignalkPayload(ev);
+ *      const auto msg = *std::static_pointer_cast<const wxJSONValue>(payload);
+ *
+ *  The map contains the following entries:
+ *  - "Data": the parsed json message
+ *  - "ErrorCount": int, the number of parsing errors
+ *  - "WarningCount": int, the number of parsing warnings
+ *  - "Errors": list of strings, error messages.
+ *  - "Warnings": list of strings, warning messages..
+ *  - "Context": string, message context
+ *  - "ContextSelf": string, own ship context.
+ */
+std::shared_ptr<void> GetSignalkPayload(ObservedEvt ev);
+
+/**
  * Return source identifier (iface) of a received n2000 message of type id
  * in ev.
  */

--- a/manual/modules/ROOT/pages/plugin-messaging.adoc
+++ b/manual/modules/ROOT/pages/plugin-messaging.adoc
@@ -22,12 +22,12 @@ Receiving messages is done in six steps:
 . Handle the messages as they arrives.
 
 
-The code handling messages must live in a wxEventClass instance. 
+The code handling messages must live in a wxEventClass instance.
 In almost all cases this means that the code should be implemented in a wxWindow.
-If there is a wxWindow available with a suitable lifespan, this could be used. 
+If there is a wxWindow available with a suitable lifespan, this could be used.
 If there is no such window, it needs to be created (it can be hidden) or an
 existing one can be modified to alwasy exist, using Show()/Hide() to enable and
-disable. 
+disable.
 
 As an example, the *ShipDrivergui_impl*  class is used.
 First, in the header declare a listener on the class level, here with the shipdriver
@@ -50,8 +50,8 @@ message, something like this:
 ----
 Then, still in the .cpp file, set up the listening in the window constructor:
 ----
-         Dlg::Dlg(wxWindow* parent, ...) 
-        
+         Dlg::Dlg(wxWindow* parent, ...)
+
          {
          ...
      ①   NMEA0183Id id("GPGGA");
@@ -105,6 +105,27 @@ something which otherwise is a problem.
 To get the feeling one need to experiment.
 But then again, C++ lambdas is a complex step which is not necessary
 to get something running.
+
+=== Receiving SignalK messages
+
+Handling signalk messages goes like
+```
+    auto payload = GetSignalkPayload(ev);
+    const auto msg = *std::static_pointer_cast<const wxJSONValue>(payload);
+```
+`msg` is a const json map containing at least
+
+* "Data": the parsed json message.
+* "ErrorCount": int, the number of parsing errors.
+* "WarningCount": int, the number of parsing warnings.
+* "Errors": list of strings, error messages.
+* "Warnings": list of strings, warning messages.
+* "Context": string, message context.
+* "ContextSelf": string, own ship context.
+
+Since the map is const, expressions like `msg["Data"]` are not possible 
+(the [] operator is not const since it potentially inserts data into the
+map if the index does not exist). Use `msg.ItemAt("Data")` instead.
 
 == Sending messages
 

--- a/manual/site.yml
+++ b/manual/site.yml
@@ -6,7 +6,7 @@ site:
 content:
   sources:
     - url: ..
-      branches: [master] 
+      branches: [HEAD] 
       start_path: manual
 
 ui:   


### PR DESCRIPTION
Tentative fix for #3381. This is raw code which needs review and testing.

One open issue I'm aware of is the `context_self` and `context` strings in the internal signalK message defined in *comm_navmg.h*. Should these be visible in the API? As of  this PR they are not.
