### PR TITLE
libs: observable: Add EvtVarListener interface class

### DIFF
--- a/libs/observable/include/observable_evtvar.h
+++ b/libs/observable/include/observable_evtvar.h
@@ -65,7 +65,6 @@
  *      ObservableListener change_listener;
  *    }
  */
-
 class EventVar : public Observable {
 public:
   EventVar() : Observable(Autokey()) {}

--- a/manual/modules/ROOT/pages/plugin-messaging.adoc
+++ b/manual/modules/ROOT/pages/plugin-messaging.adoc
@@ -10,7 +10,48 @@ as earlier.
 However, the new system can be used also for nmea0183 where it offers more
 flexibility and performance.
 
-== Receiving messages
+== Simplified receiving using ObsListener
+
+From 5.10 a new ObsListener class offers a simpler way to listen to
+messages. The simplified approach:
+
+. Declare a ObsListener listener object
+. Declare a method which handles the message.
+. Initiate the listener to invoke the method  when message arrives.
+
+The ObsListener object normally lives in the class context, like:
+----
+
+        class Dlg : public ShipDriverBase {
+        public:
+            ...
+        private:
+            ObsListener  listener;
+            ...
+
+----
+The method is declared something like below.
+----
+       static void HandleGPGA(ObservedEvt ev) {
+            NMEA0183Id id("GPGGA");
+            std::string payload = GetN0183Payload(id, ev)
+            ...
+----
+There are other ids for NMEA2000 and SignalK messages available.
+Likewise, there are similar methods to access the payload.
+See the *ocpn_plugin.h* header file.
+
+To invoke this method when a GPGGA message arrives, initiate the
+ObsListener like:
+----
+        listener.Init(NMEA0183Id("GPGGA"),
+                      [&](ObservedEvt ev) { HandleGPGA(ev); });
+----
+The last line is a lambda expression which could be used to much more than
+to just invoke a method, see <<using-lambda>> below.
+
+
+== Receiving messages the legacy 5.8 way.
 
 Receiving messages is done in six steps:
 
@@ -85,8 +126,9 @@ Notes:
     the _EVT_SHIPDRIVER_ arrives.  From this point all incoming GPGGA
     messages will land in the `HandleGPGGA()` method and be processed.
 
+[#using-lambda]
 
-=== Epilog: Using the lambda
+== Epilog: Using the lambda
 
 The last step above was
 `Bind(EVT_SHIPDRIVER [](wxCommandEvent ev) { HandleGPGA(ev); })`.
@@ -106,7 +148,7 @@ To get the feeling one need to experiment.
 But then again, C++ lambdas is a complex step which is not necessary
 to get something running.
 
-=== Receiving SignalK messages
+== Receiving SignalK messages
 
 Handling signalk messages goes like
 ```
@@ -123,7 +165,7 @@ Handling signalk messages goes like
 * "Context": string, message context.
 * "ContextSelf": string, own ship context.
 
-Since the map is const, expressions like `msg["Data"]` are not possible 
+Since the map is const, expressions like `msg["Data"]` are not possible
 (the [] operator is not const since it potentially inserts data into the
 map if the index does not exist). Use `msg.ItemAt("Data")` instead.
 


### PR DESCRIPTION
Currently, listening to an Observable item is a but messy involving defining an event type, start listening to this event and define how to handle the event.

The goal for this PR is to simplify this process. The first step is the new class EvtVarListener which completely hides details about event types, Bind() and listening when listening to an EventVar. User just defines an action to be performed when a given EventVar is notified, and that's it.

It should be possible to generalize this to other contexts like message listening. 

EDIT:

Closes: #3467

The initial PR is updated so it can be applied to anything which can be listened to, more exactly anything implementing the dead simple KeyProvider interface. This includes NavMsg (messages common denominator), EvtVar, ConfigVar and GlobalVar.