### PR TITLE
Do not attempt to resize zero area canvas

### DIFF
--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -6609,6 +6609,8 @@ void ChartCanvas::ToggleCPAWarn() {
 void ChartCanvas::OnActivate(wxActivateEvent &event) { ReloadVP(); }
 
 void ChartCanvas::OnSize(wxSizeEvent &event) {
+  if ((event.m_size.GetWidth() < 1) || (event.m_size.GetHeight() < 1))
+    return;
   GetClientSize(&m_canvas_width, &m_canvas_height);
 
 #ifdef __WXOSX__


### PR DESCRIPTION
ChartCanvas should not attempt to build a canvas view when one of the window size parameters is zero. Eventually, when the canvas has an area > 0 then we will rebuild it.