### PR TITLE
Rapid JSON headers needed before ais_decoder.h

### DIFF
--- a/src/ais_decoder.cpp
+++ b/src/ais_decoder.cpp
@@ -46,6 +46,9 @@
 #include <wx/timer.h>
 #include <wx/tokenzr.h>
 
+#include "rapidjson/document.h"
+#include "rapidjson/writer.h"
+#include "rapidjson/stringbuffer.h"
 #include "ais_decoder.h"
 #include "meteo_points.h"
 #include "ais_target_data.h"
@@ -57,9 +60,6 @@
 #include "multiplexer.h"
 #include "navutil_base.h"
 #include "own_ship.h"
-#include "rapidjson/document.h"
-#include "rapidjson/writer.h"
-#include "rapidjson/stringbuffer.h"
 #include "route_point.h"
 #include "select.h"
 #include "SoundFactory.h"


### PR DESCRIPTION
I think the JSON library headers need to come before the "rapidjson/fwd.h" file is included by "ais_decoder.h".  Otherwise, I see declaration errors in "ais_decoder.cpp" when building locally on Windows.