### PR TITLE
Miscellanour, notably 3497

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3295,3 +3295,5 @@ if (QT_ANDROID)
 
     add_definitions(-DMG_ENABLE_OPENSSL)
 endif (QT_ANDROID)
+
+add_custom_target(print-model-files COMMAND cmake -E echo ${MODEL_SRC})

--- a/include/cmdline.h
+++ b/include/cmdline.h
@@ -22,6 +22,9 @@
  * Global variables reflecting command line options and arguments.
  */
 
+#ifndef _CMDLINE_H__
+#define _CMDLINE_H__
+
 #include <vector>
 #include <string>
 
@@ -33,3 +36,5 @@ extern bool g_parse_all_enc;
 extern bool g_bportable;
 extern bool g_bdisable_opengl;
 extern std::vector<std::string> g_params;
+
+#endif  // _CMDLINE_H__

--- a/include/config_vars.h
+++ b/include/config_vars.h
@@ -35,6 +35,9 @@ extern bool g_bWplUsePosition;
 
 extern double g_UserVar;
 
+extern int g_iDistanceFormat;
+extern int g_iSpeedFormat;
+extern int g_iSDMMFormat;
 extern int g_iWindSpeedFormat;
 extern int g_iTempFormat;
 extern int g_maxWPNameLength;
@@ -48,6 +51,7 @@ extern wxString g_GPS_Ident;
 extern wxString g_hostname;
 extern wxString g_TalkerIdText;
 extern wxString g_android_Device_Model;
+extern wxString g_winPluginDir;   // Base plugin directory on Windows.
 
 wxConfigBase* TheBaseConfig();
 void InitBaseConfig(wxConfigBase* cfg);

--- a/libs/sound/src/PortAudioSound.cpp
+++ b/libs/sound/src/PortAudioSound.cpp
@@ -155,11 +155,13 @@ PortAudioSound::PortAudioSound()
     : m_soundLoader(SoundLoaderFactory()),
     m_lock(ATOMIC_FLAG_INIT)
 {
+    if (!getenv("OCPN_DEBUG_ALSA")) freopen("/dev/null","w",stderr);
     m_stream = NULL;
     m_isAsynch = false;
     m_isPaInitialized = false;
     PaError err = Pa_Initialize();
     if (err != paNoError) {
+        freopen("/dev/tty","w",stderr);
         wxLogError("PortAudio; cannot initialize: %s", Pa_GetErrorText(err));
         return;
     }
@@ -167,8 +169,9 @@ PortAudioSound::PortAudioSound()
     SetDeviceIndex(-1);
     for (int i = 0; i < DeviceCount(); i += 1) {
         const PaDeviceInfo* info = Pa_GetDeviceInfo(i);
-	wxLogDebug("Device: %d: %s", i, info->name);
+        wxLogDebug("Device: %d: %s", i, info->name);
     }
+    freopen("/dev/tty","w",stderr);
 }
 
 

--- a/libs/wxservdisc/CMakeLists.txt
+++ b/libs/wxservdisc/CMakeLists.txt
@@ -19,7 +19,7 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
   target_compile_options(
     WXSERVDISC PRIVATE $<$<COMPILE_LANGUAGE:C>:-Wno-pointer-sign>
   )
-  target_compile_options(WXSERVDISC PRIVATE -Wno-pointer-sign -Wno-parentheses)
+  target_compile_options(WXSERVDISC PRIVATE -Wno-parentheses)
 endif ()
 
 if (WIN32)

--- a/src/ConfigMgr.cpp
+++ b/src/ConfigMgr.cpp
@@ -129,9 +129,6 @@ extern int g_nAWDefault;
 extern int g_nAWMax;
 extern int g_nTrackPrecision;
 
-extern int g_iSDMMFormat;
-extern int g_iDistanceFormat;
-extern int g_iSpeedFormat;
 extern int g_iWindSpeedFormat;
 
 extern int g_nframewin_x;

--- a/src/OCPNPlatform.cpp
+++ b/src/OCPNPlatform.cpp
@@ -119,7 +119,6 @@ extern sigjmp_buf env;  // the context saved by sigsetjmp();
 #endif
 
 extern OCPNPlatform *g_Platform;
-extern wxString g_winPluginDir;
 extern bool g_bFirstRun;
 extern bool g_bUpgradeInProcess;
 

--- a/src/ais_decoder.cpp
+++ b/src/ais_decoder.cpp
@@ -100,8 +100,6 @@ extern bool g_bInlandEcdis;
 extern int g_WplAction;
 extern bool g_bAIS_CPA_Alert;
 extern bool g_bAIS_CPA_Alert_Audio;
-extern int g_iDistanceFormat;
-extern int g_iSpeedFormat;
 
 extern ArrayOfMmsiProperties g_MMSI_Props_Array;
 extern Route *pAISMOBRoute;

--- a/src/androidUTIL.cpp
+++ b/src/androidUTIL.cpp
@@ -219,10 +219,6 @@ extern double g_TrackDeltaDistance;
 extern double g_TrackDeltaDistance;
 extern int g_nTrackPrecision;
 
-extern int g_iSDMMFormat;
-extern int g_iDistanceFormat;
-extern int g_iSpeedFormat;
-
 extern bool g_bAdvanceRouteWaypointOnArrivalOnly;
 
 extern int g_cm93_zoom_factor;

--- a/src/base_platform.cpp
+++ b/src/base_platform.cpp
@@ -57,6 +57,7 @@
 
 #include "base_platform.h"
 #include "cmdline.h"
+#include "config_vars.h"
 #include "logger.h"
 #include "ocpn_utils.h"
 #include "ocpn_plugin.h"
@@ -81,7 +82,6 @@ static const char* const DEFAULT_XDG_DATA_DIRS =
 
 void appendOSDirSlash(wxString* pString);
 
-extern wxString g_winPluginDir;
 
 extern bool g_btouch;
 extern float g_selection_radius_mm;

--- a/src/chcanv.cpp
+++ b/src/chcanv.cpp
@@ -189,7 +189,6 @@ extern double AnchorPointMinDist;
 extern bool AnchorAlertOn1;
 extern bool AnchorAlertOn2;
 extern int g_nAWMax;
-extern int g_iDistanceFormat;
 
 extern RouteManagerDialog *pRouteManagerDialog;
 extern GoToPositionDialog *pGoToPositionDialog;

--- a/src/config_vars.cpp
+++ b/src/config_vars.cpp
@@ -28,7 +28,9 @@ bool g_bGarminHostUpload;
 bool g_bWplUsePosition;
 
 double g_UserVar = 0.0;
-
+int g_iDistanceFormat = 0;
+int g_iSDMMFormat = 0;
+int g_iSpeedFormat = 0;
 int g_iWindSpeedFormat = 0;
 int g_iTempFormat = 0;
 int g_maxWPNameLength;
@@ -41,6 +43,7 @@ int sat_watchdog_timeout_ticks = 12;
 wxString g_GPS_Ident;
 wxString g_hostname;
 wxString g_TalkerIdText;
+wxString g_winPluginDir;
 
 static wxConfigBase* the_base_config = 0;
 

--- a/src/console.cpp
+++ b/src/console.cpp
@@ -77,7 +77,6 @@ class Multiplexer;
 class Select;
 
 BasePlatform* g_BasePlatform = 0;
-wxString g_winPluginDir;
 void* g_pi_manager = reinterpret_cast<void*>(1L);
 wxString g_compatOS = PKG_TARGET;
 wxString g_compatOsVersion = PKG_TARGET_VERSION;
@@ -166,11 +165,6 @@ static void InitRouteman() {
   auto RouteMgrDlgUpdateListCtrl = [&]() {};
   g_pRouteMan = new Routeman(ctx, RouteMgrDlgUpdateListCtrl);
 }
-
-// navutil_base context
-int g_iDistanceFormat = 0;
-int g_iSDMMFormat = 0;
-int g_iSpeedFormat = 0;
 
 namespace safe_mode {
 bool get_mode() { return false; }

--- a/src/navutil.cpp
+++ b/src/navutil.cpp
@@ -158,9 +158,6 @@ extern int g_nAWDefault;
 extern int g_nAWMax;
 extern int g_nTrackPrecision;
 
-extern int g_iSDMMFormat;
-extern int g_iDistanceFormat;
-extern int g_iSpeedFormat;
 extern int g_iTempFormat;
 
 extern int g_nframewin_x;

--- a/src/navutil_base.cpp
+++ b/src/navutil_base.cpp
@@ -39,9 +39,6 @@
 #include "navutil_base.h"
 #include "vector2D.h"
 
-extern int g_iSDMMFormat;
-extern int g_iSpeedFormat;
-extern int g_iDistanceFormat;
 extern int g_nDepthUnitDisplay;
 extern int g_iTempFormat;
 

--- a/src/ocpn_app.cpp
+++ b/src/ocpn_app.cpp
@@ -65,22 +65,24 @@
 #include <wx/artprov.h>
 #include <wx/aui/aui.h>
 #include <wx/clrpicker.h>
+#include <wx/cmdline.h>
 #include <wx/dialog.h>
 #include <wx/dialog.h>
 #include <wx/dir.h>
+#include <wx/display.h>
+#include <wx/dynlib.h>
 #include <wx/image.h>
 #include <wx/intl.h>
 #include <wx/ipc.h>
 #include <wx/jsonreader.h>
 #include <wx/listctrl.h>
+#include <wx/power.h>
 #include <wx/printdlg.h>
 #include <wx/print.h>
 #include <wx/progdlg.h>
 #include <wx/settings.h>
 #include <wx/stdpaths.h>
 #include <wx/tokenzr.h>
-#include <wx/cmdline.h>
-#include <wx/display.h>
 
 
 #include "AboutFrameImpl.h"
@@ -920,7 +922,6 @@ BEGIN_EVENT_TABLE(MyApp, wxApp)
 EVT_ACTIVATE_APP(MyApp::OnActivateApp)
 END_EVENT_TABLE()
 
-#include <wx/dynlib.h>
 
 #if wxUSE_CMDLINE_PARSER
 void MyApp::OnInitCmdLine(wxCmdLineParser &parser) {
@@ -2141,7 +2142,6 @@ Track* MyApp::TrackOff(void) {
     return nullptr;
 }
 
-#include <wx/power.h>
 
 
 

--- a/src/ocpn_app.cpp
+++ b/src/ocpn_app.cpp
@@ -921,29 +921,30 @@ void MyApp::OnInitCmdLine(wxCmdLineParser &parser) {
   //    Add some OpenCPN specific command line options
   parser.AddSwitch("h", "help", _("Show usage syntax."),
                    wxCMD_LINE_OPTION_HELP);
-  parser.AddSwitch("p", wxEmptyString, _("Run in portable mode."));
-  parser.AddSwitch("fullscreen", wxEmptyString,
+  parser.AddSwitch("p", "portable", _("Run in portable mode."));
+  parser.AddSwitch("f", "fullscreen",
                    _("Switch to full screen mode on start."));
   parser.AddSwitch(
-      "no_opengl", wxEmptyString,
+      "G", "no_opengl",
       _("Disable OpenGL video acceleration. This setting will be remembered."));
-  parser.AddSwitch("rebuild_gl_raster_cache", wxEmptyString,
+  parser.AddSwitch("g", "rebuild_gl_raster_cache",
                    _("Rebuild OpenGL raster cache on start."));
   parser.AddSwitch(
-      "parse_all_enc", wxEmptyString,
+      "P", "parse_all_enc",
       _("Convert all S-57 charts to OpenCPN's internal format on start."));
   parser.AddOption(
       "l", "loglevel",
       "Amount of logging: error, warning, message, info, debug or trace");
-  parser.AddOption("unit_test_1", wxEmptyString,
+  parser.AddOption("u", "unit_test_1",
                    _("Display a slideshow of <num> charts and then exit. Zero "
                      "or negative <num> specifies no limit."),
                    wxCMD_LINE_VAL_NUMBER);
-  parser.AddSwitch("unit_test_2");
+  parser.AddSwitch("U", "unit_test_2");
   parser.AddParam("import GPX files", wxCMD_LINE_VAL_STRING,
                   wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE);
-  parser.AddLongSwitch("unit_test_2");
-  parser.AddSwitch("safe_mode");
+  parser.AddSwitch(
+      "s", "safe_mode",
+     _("Run without plugins, opengl and other \"dangerous\" stuff"));
 }
 
 /** Parse --loglevel and set up logging, falling back to defaults. */

--- a/src/ocpn_app.cpp
+++ b/src/ocpn_app.cpp
@@ -270,7 +270,6 @@ wxString ChartListFileName;
 wxString AISTargetNameFileName;
 wxString gWorldMapLocation, gDefaultWorldMapLocation;
 wxString *pInit_Chart_Dir;
-wxString g_winPluginDir;  // Base plugin directory on Windows.
 wxString g_csv_locn;
 wxString g_SENCPrefix;
 wxString g_UserPresLibData;
@@ -341,10 +340,6 @@ bool g_bAutoHideToolbar;
 
 bool g_bPermanentMOBIcon;
 bool g_bTempShowMenuBar;
-
-int g_iSDMMFormat;
-int g_iDistanceFormat;
-int g_iSpeedFormat;
 
 int g_iNavAidRadarRingsNumberVisible;
 float g_fNavAidRadarRingsStep;

--- a/src/ocpn_app.cpp
+++ b/src/ocpn_app.cpp
@@ -364,8 +364,6 @@ int g_maxzoomin;
 // Set default color scheme
 ColorScheme global_color_scheme = GLOBAL_COLOR_SCHEME_DAY;
 
-int Usercolortable_index;
-wxArrayPtrVoid *UserColorTableArray;
 wxArrayPtrVoid *UserColourHashTableArray;
 wxColorHashMap *pcurrent_user_color_hash;
 

--- a/src/ocpn_frame.cpp
+++ b/src/ocpn_frame.cpp
@@ -319,8 +319,6 @@ extern std::vector<OcpnSound *> bells_sound;
 extern char bells_sound_file_name[2][12];
 extern int g_sticky_chart;
 extern int g_sticky_projection;
-extern int Usercolortable_index;
-extern wxArrayPtrVoid *UserColorTableArray;
 extern wxArrayPtrVoid *UserColourHashTableArray;
 extern wxColorHashMap *pcurrent_user_color_hash;
 
@@ -393,6 +391,8 @@ DWORD color_inactiveborder;
 static const long long lNaN = 0xfff8000000000000;
 #define NAN (*(double *)&lNaN)
 #endif
+
+static wxArrayPtrVoid *UserColorTableArray = 0;
 
 //    Some static helpers
 void appendOSDirSlash(wxString *pString);
@@ -659,9 +659,7 @@ static void onBellsFinishedCB(void *ptr) {
 // My frame constructor
 MyFrame::MyFrame(wxFrame *frame, const wxString &title, const wxPoint &pos,
                  const wxSize &size, long style)
-    : wxFrame(frame, -1, title, pos, size,
-              style)  // wxSIMPLE_BORDER | wxCLIP_CHILDREN | wxRESIZE_BORDER)
-      // wxCAPTION | wxSYSTEM_MENU | wxRESIZE_BORDER
+    : wxFrame(frame, -1, title, pos, size, style)
       {
   m_last_track_rotation_ts = 0;
   m_ulLastNMEATicktime = 0;
@@ -1014,7 +1012,7 @@ void MyFrame::SetAndApplyColorScheme(ColorScheme cs) {
   g_StyleManager->GetCurrentStyle()->SetColorScheme(cs);
 
   // Search the user color table array to find the proper hash table
-  Usercolortable_index = 0;
+  unsigned Usercolortable_index = 0;
   for (unsigned int i = 0; i < UserColorTableArray->GetCount(); i++) {
     colTable *ct = (colTable *)UserColorTableArray->Item(i);
     if (SchemeName.IsSameAs(*ct->tableName)) {
@@ -7560,8 +7558,8 @@ void InitializeUserColors(void) {
 }
 
 void DeInitializeUserColors(void) {
-  unsigned int i;
-  for (i = 0; i < UserColorTableArray->GetCount(); i++) {
+  if (!UserColorTableArray) return;
+  for (unsigned i = 0; i < UserColorTableArray->GetCount(); i++) {
     colTable *ct = (colTable *)UserColorTableArray->Item(i);
 
     for (unsigned int j = 0; j < ct->color->GetCount(); j++) {
@@ -7577,7 +7575,7 @@ void DeInitializeUserColors(void) {
 
   delete UserColorTableArray;
 
-  for (i = 0; i < UserColourHashTableArray->GetCount(); i++) {
+  for (unsigned i = 0; i < UserColourHashTableArray->GetCount(); i++) {
     wxColorHashMap *phash = (wxColorHashMap *)UserColourHashTableArray->Item(i);
     delete phash;
   }

--- a/src/ocpn_frame.cpp
+++ b/src/ocpn_frame.cpp
@@ -1880,6 +1880,7 @@ void MyFrame::OnCloseWindow(wxCloseEvent &event) {
   wxTheApp->OnExit();
 #endif
 #endif
+  wxTheApp->ExitMainLoop();
 }
 
 void MyFrame::OnMove(wxMoveEvent &event) {

--- a/src/options.cpp
+++ b/src/options.cpp
@@ -249,9 +249,6 @@ extern double g_TrackDeltaDistance;
 extern int g_nTrackPrecision;
 extern wxColour g_colourTrackLineColour;
 
-extern int g_iSDMMFormat;
-extern int g_iDistanceFormat;
-extern int g_iSpeedFormat;
 extern int g_iTempFormat;
 
 extern bool g_bAdvanceRouteWaypointOnArrivalOnly;

--- a/src/plugin_handler.cpp
+++ b/src/plugin_handler.cpp
@@ -58,6 +58,7 @@ typedef __LA_INT64_T la_int64_t;  //  "older" libarchive versions support
 #include "base_platform.h"
 #include "catalog_handler.h"
 #include "catalog_parser.h"
+#include "config_vars.h"
 #include "cmdline.h"
 #include "config.h"
 #include "downloader.h"
@@ -81,7 +82,6 @@ static std::string SEP("/");
 #endif
 
 extern BasePlatform* g_BasePlatform;
-extern wxString g_winPluginDir;
 extern MyConfig* pConfig;
 
 extern wxString g_compatOS;

--- a/src/pluginmanager.cpp
+++ b/src/pluginmanager.cpp
@@ -227,8 +227,6 @@ extern unsigned int g_canvasConfig;
 
 extern wxString g_CmdSoundString;
 
-extern int g_iSDMMFormat;
-
 unsigned int gs_plib_flags;
 wxString g_lastPluginMessage;
 extern ChartCanvas* g_focusCanvas;

--- a/test/n2k_tests.cpp
+++ b/test/n2k_tests.cpp
@@ -134,7 +134,6 @@ extern int g_nCOMPortCheck;
 extern bool g_benableUDPNullHeader;
 
 extern BasePlatform* g_BasePlatform;
-extern wxString g_winPluginDir;
 extern void* g_pi_manager;
 extern wxString g_compatOS;
 extern wxString g_compatOsVersion;

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -72,7 +72,6 @@ int g_nCOMPortCheck = 32;
 bool g_benableUDPNullHeader;
 
 BasePlatform* g_BasePlatform = 0;
-wxString g_winPluginDir;
 void* g_pi_manager = reinterpret_cast<void*>(1L);
 wxString g_compatOS = PKG_TARGET;
 wxString g_compatOsVersion = PKG_TARGET_VERSION;
@@ -126,10 +125,6 @@ Select* pSelectAIS;
 
 
 // navutil_base context
-
-int g_iDistanceFormat = 0;
-int g_iSDMMFormat = 0;
-int g_iSpeedFormat = 0;
 
 wxDEFINE_EVENT(EVT_FOO, ObservedEvt);
 wxDEFINE_EVENT(EVT_BAR, ObservedEvt);


### PR DESCRIPTION
Still preparations for  #3409 and #3349. Here is
  - The fix described in #3497. This breaks the current CLI interface.
  - A fix needed to make an "early exit" from cli commands: add51a3f1. Scary stuff, see below.
  - Some clean up: misplaced #include,  disable noisy cli debug logging on linux, missing #include guards, handling of  UserColorTableArray in ocpn_frame The latter probably results of the split ocpn_frame and ocpn_app. 
  - Some really boring work reducing the number of extern declarations using config_vars

Regarding  add51a3f:
  - It is the right thing to do. Closing the top window should also exit the main loop.
  - I have made smoke tests on Linux, Windows and MacOS without noticing anything peculiar.

