### PR TITLE
Ais meteo update

### DIFF
--- a/include/meteo_points.h
+++ b/include/meteo_points.h
@@ -47,10 +47,10 @@
   int water_lev_trend;  // NAN = 3
   double current;       // kn NAN = 255(25.5)
   int curr_dir;         // NAN = 360
-  double wave_hight;    // m NAN=255(25.5)
+  double wave_height;    // m NAN=255(25.5)
   int wave_period;      // s NAN = 63
   int wave_dir;         // NAN = 360
-  double swell_hight;   // m NAN = 255 (25.5)
+  double swell_height;   // m NAN = 255 (25.5)
   int swell_per;        // s NAN = 63
   int swell_dir;        // NAN=360
   int seastate;         // Bf NAN=13

--- a/include/meteo_points.h
+++ b/include/meteo_points.h
@@ -47,10 +47,10 @@
   int water_lev_trend;  // NAN = 3
   double current;       // kn NAN = 255(25.5)
   int curr_dir;         // NAN = 360
-  double wave_height;    // m NAN=255(25.5)
+  double wave_height;   // m NAN=255(25.5)
   int wave_period;      // s NAN = 63
   int wave_dir;         // NAN = 360
-  double swell_height;   // m NAN = 255 (25.5)
+  double swell_height;  // m NAN = 255 (25.5)
   int swell_per;        // s NAN = 63
   int swell_dir;        // NAN=360
   int seastate;         // Bf NAN=13
@@ -60,8 +60,9 @@
   int ice;              // NAN=3
 };
 
-
-
+ /**
+ * Add a new point to the list of Meteo stations
+ */
 class AisMeteoPoint {
 public:
   const int mmsi;
@@ -76,8 +77,8 @@ public:
  * List of Meteo stations, a singleton.
  * Since several nations have chose not to use individual mmsi ID
  * for each station but the same for all we need to separate them
- * by its position. Every station is allocated a unik fake ID.
- * This list collect them and is used to identify each update to whom it belongs.
+ * by its position. Every station is allocated a unique Meteo ID.
+ * This list collect them and is used to destine each update to whom it belongs.
  */
 class AisMeteoPoints {
 public:

--- a/src/ais_decoder.cpp
+++ b/src/ais_decoder.cpp
@@ -3284,10 +3284,10 @@ bool AisDecoder::Parse_VDXBitstring(AisBitstring *bstr,
             ptd->met_data.water_lev_trend = bstr->GetInt(214, 2);
             ptd->met_data.current = bstr->GetInt(216, 8) / 10.;
             ptd->met_data.curr_dir = bstr->GetInt(224, 9);
-            ptd->met_data.wave_hight = bstr->GetInt(277, 8) / 10.;
+            ptd->met_data.wave_height = bstr->GetInt(277, 8) / 10.;
             ptd->met_data.wave_period = bstr->GetInt(285, 6);
             ptd->met_data.wave_dir = bstr->GetInt(291, 9);
-            ptd->met_data.swell_hight = bstr->GetInt(300, 8) / 10;
+            ptd->met_data.swell_height = bstr->GetInt(300, 8) / 10;
             ptd->met_data.swell_per = bstr->GetInt(308, 6);
             ptd->met_data.swell_dir = bstr->GetInt(314, 9);
             ptd->met_data.seastate = bstr->GetInt(323, 4);

--- a/src/ais_decoder.cpp
+++ b/src/ais_decoder.cpp
@@ -168,7 +168,7 @@ static inline double MS2KNOTS(double ms) {
   return ms * 1.9438444924406;
 }
 
-int AisMeteoNewMmsi(int, int, int, double, double);
+int AisMeteoNewMmsi(int, int, int);
 
 void AISshipNameCache(AisTargetData *pTargetData,
                       AIS_Target_Name_Hash *AISTargetNamesC,
@@ -1914,6 +1914,20 @@ AisError AisDecoder::DecodeN0183(const wxString &str) {
     //  Extract the MMSI
     if (!mmsi) mmsi = strbit.GetInt(9, 30);
     long mmsi_long = mmsi;
+
+    // Ais8_001_31 (class AIS_METEO) test for a possible new mmsi ID
+    int origin_mmsi = 0;
+    int messID = strbit.GetInt(1, 6);
+    int dac = strbit.GetInt(41, 10);
+    int fi = strbit.GetInt(51, 6);
+    if (messID == 8 && dac == 001 && fi == 31) {
+      int met_lon = strbit.GetInt(57, 25);
+      int met_lat = strbit.GetInt(82, 24);
+      origin_mmsi = mmsi;
+      mmsi = AisMeteoNewMmsi(mmsi, met_lat, met_lon);
+      mmsi_long = mmsi;
+    }
+
     //  Search the current AISTargetList for an MMSI match
     auto it = AISTargetList.find(mmsi);
     if (it == AISTargetList.end())  // not found
@@ -1921,36 +1935,13 @@ AisError AisDecoder::DecodeN0183(const wxString &str) {
       pTargetData = AisTargetDataMaker::GetInstance().GetTargetData();
       bnewtarget = true;
       m_n_targets++;
+
+      if (origin_mmsi) {  // New mmsi allocated for a Meteo station
+        pTargetData->MMSI = mmsi;
+        pTargetData->met_data.original_mmsi = origin_mmsi;
+      }
     } else {
       pTargetData = it->second;    // find current entry
-
-      //Ais8_001_31 (class AIS_METEO) test for a possible new mmsi ID
-      int messID = strbit.GetInt(1, 6);
-      int dac = strbit.GetInt(41, 10);
-      int fi = strbit.GetInt(51, 6);
-      if (messID == 8 && dac == 001 && fi == 31) { //Ais8_001_31
-        int met_lon = strbit.GetInt(57, 25);
-        int met_lat = strbit.GetInt(82, 24);
-        //Compare message position with already present in TargetData
-        int new_mmsi = AisMeteoNewMmsi(mmsi, met_lat, met_lon, pTargetData->Lat,
-                                       pTargetData->Lon);
-        if (mmsi != new_mmsi) {
-          int origin_mmsi = mmsi;
-          mmsi = new_mmsi;
-          mmsi_long = new_mmsi;
-          pTargetData.reset();
-          it = AISTargetList.find(mmsi);
-          if (it == AISTargetList.end()) {  // not found
-            pTargetData = AisTargetDataMaker::GetInstance().GetTargetData();
-            bnewtarget = true;
-            m_n_targets++;
-            pTargetData->MMSI = mmsi;
-            pTargetData->met_data.original_mmsi = origin_mmsi;
-          } else {
-            pTargetData = it->second;
-          }
-        }
-      }
 
       if(!bnewtarget) pStaleTarget = pTargetData;  // save a pointer to stale data
     }
@@ -4224,8 +4215,8 @@ wxString GetShipNameFromFile(int nmmsi) {
   return name;
 }
 
-int AisMeteoNewMmsi(int m_mmsi, int m_lat, int m_lon, double pt_Lat,
-                    double pt_Lon) {
+  // Assign a unique meteo mmsi related to position
+int AisMeteoNewMmsi(int m_mmsi, int m_lat, int m_lon) {
   if (m_lon & 0x01000000)  // negative?
     m_lon |= 0xFE000000;
   double lon_tentative = m_lon / 60000.;
@@ -4234,45 +4225,39 @@ int AisMeteoNewMmsi(int m_mmsi, int m_lat, int m_lon, double pt_Lat,
     m_lat |= 0xFF000000;
   double lat_tentative = m_lat / 60000.;
 
-    // Since buoys can move we set position to separate ~50 m
-    // to be able to compare previous message.
-  wxString sLON = wxString::Format("%0.3f", pt_Lon);
+    // Since buoys can move we use position precision not better
+    // than 50 m to be able to compare previous messages
   wxString slon = wxString::Format("%0.3f", lon_tentative);
-  wxString sLAT = wxString::Format("%0.3f", pt_Lat);
   wxString slat = wxString::Format("%0.3f", lat_tentative);
 
-  if (sLON.IsSameAs(slon) && sLAT.IsSameAs(slat)) {  // Same position - continue
-    return m_mmsi;
-  } else {  // Change mmsi number
-    // Some countries use one mmsi for all meteo stations.
-    // Create our own fake mmsi to separate them.
-    // 199 is INMARSAT-A MID, should not occur ever in AIS stream.
-    // 1992 to 1993 are already used so here we use 1994+
-    static int nextMeteommsi = 199400000;
-    bool found = false;
-    int new_mmsi = 0;
-
-    auto& points = AisMeteoPoints::GetInstance().GetPoints();
-
-    if (points.size()) {
-      wxString t_lat, t_lon;
-      for (const auto& point: points) {
-        // Does this station position exist
-        if (slat.IsSameAs(point.lat) &&
-            slon.IsSameAs(point.lon)) {
-          // Created before. Continue
-          new_mmsi = point.mmsi;
-          found = true;
-          break;
-        }
+  // Change mmsi number
+  // Some countries use one equal mmsi for all meteo stations.
+  // Others use the same mmsi for a meteo station and a nearby AtoN
+  // So we create our own fake mmsi to separate them.
+  // 199 is INMARSAT-A MID, should not occur ever in AIS stream.
+  // 1992 to 1993 are already used so here we use 1994+
+  static int nextMeteommsi = 199400000;
+  bool found = false;
+  int new_mmsi = 0;
+  auto& points = AisMeteoPoints::GetInstance().GetPoints();
+  if (points.size()) {
+    wxString t_lat, t_lon;
+    for (const auto& point: points) {
+      // Does this station position exist
+      if (slat.IsSameAs(point.lat) &&
+          slon.IsSameAs(point.lon)) {
+        // Created before. Continue
+        new_mmsi = point.mmsi;
+        found = true;
+        break;
       }
     }
-    if (!found) {
-      // Create a new post
-      nextMeteommsi++;
-      points.push_back(AisMeteoPoint(nextMeteommsi, slat, slon));
-      new_mmsi = nextMeteommsi;
-    }
-    return new_mmsi;
   }
+  if (!found) {
+    // Create a new post
+    nextMeteommsi++;
+    points.push_back(AisMeteoPoint(nextMeteommsi, slat, slon));
+    new_mmsi = nextMeteommsi;
+  }
+  return new_mmsi;
 }

--- a/src/ais_target_data.cpp
+++ b/src/ais_target_data.cpp
@@ -270,10 +270,10 @@ AisTargetData::AisTargetData(AisTargetCallbacks cb ) : m_callbacks(cb)  {
   int met_water_lev_trend = 3;
   double met_current = 25.5;
   int met_curr_dir = 360;
-  double met_wave_hight = 25.5;
+  double met_wave_height = 25.5;
   int met_wave_period = 63;
   int met_wave_dir = 360;
-  double met_swell_hight = 25.5;
+  double met_swell_height = 25.5;
   int met_swell_per = 63;
   int met_swell_dir = 360;
   int met_seastate = 13;
@@ -864,24 +864,24 @@ wxString AisTargetData::BuildQueryResult(void) {
              << current << rowEnd;
     }
 
-    if (met_data.wave_hight < 25. || met_data.swell_hight < 25.) {
-      double userwave = toUsrDepth(met_data.wave_hight);
+    if (met_data.wave_height < 25. || met_data.swell_height < 25.) {
+      double userwave = toUsrDepth(met_data.wave_height);
         wxString wave =
             wxString::Format("%.1f %s %d%c %d %s", userwave, getUsrDepthUnit(),
                              met_data.wave_dir, 0x00B0,
                              met_data.wave_period, _("s"));
-      if (met_data.wave_hight >= 25.) wave = wxEmptyString;
+      if (met_data.wave_height >= 25.) wave = wxEmptyString;
 
-      double userswell = toUsrDepth(met_data.swell_hight);
+      double userswell = toUsrDepth(met_data.swell_height);
       wxString swell =
           wxString::Format("%.1f %s %d%c %d %s", userswell, getUsrDepthUnit(),
                            met_data.swell_dir, 0x00B0,
                            met_data.swell_per, _("s"));
-      if (met_data.swell_hight >= 25.) swell = wxEmptyString;
+      if (met_data.swell_height >= 25.) swell = wxEmptyString;
 
-      html << vertSpacer << rowStart << _("Waves hight & period")
+      html << vertSpacer << rowStart << _("Waves height & period")
            << _T("</font></td><td align=right><font size=-2>")
-           << _("Swell hight & period ")
+           << _("Swell height & period ")
            << _T("</font></td></tr>") << rowStartH << _T("<b>") << wave
            << _T("</b></td><td align=right><b>") << swell << rowEnd;
     }
@@ -1114,10 +1114,10 @@ wxString AisTargetData::GetRolloverString(void) {
       result << wxString::Format(": %s%.1f ", sign, met_data.current) << _("kts")
              << wxString::Format(" %d%c ", met_data.curr_dir, 0x00B0);
     }
-    if (met_data.wave_hight < 25.) {
+    if (met_data.wave_height < 25.) {
       if (result.Len()) result << "\n";
-      double userwh = toUsrDepth(met_data.wave_hight);
-      result << _("Wave high");
+      double userwh = toUsrDepth(met_data.wave_height);
+      result << _("Wave height");
       result << wxString::Format(": %.1f %s", userwh, getUsrDepthUnit()) << " "
              << _("Period") << wxString::Format(": %d ", met_data.wave_period)
              << _("s");

--- a/src/ais_target_data.cpp
+++ b/src/ais_target_data.cpp
@@ -451,6 +451,17 @@ wxString AisTargetData::BuildQueryResult(void) {
          << _T("</b></td><td>&nbsp;</td><td align=right><b>") << IMOstr
          << rowEnd << _T("</table></td></tr>");
 
+  else if (Class == AIS_METEO) {
+    MMSIstr = wxString::Format(_T("%09d"), abs(met_data.original_mmsi));
+    html << _T("<tr><td colspan=2><table width=100% border=0 cellpadding=0 ")
+            _T("cellspacing=0>")
+         << rowStart << _("MMSI")
+         << _T("</font></td><td>&nbsp;</td><td align=right><font size=-2>")
+         << _("Class") << _T("</font></td></tr>") << rowStartH << _T("<b>")
+         << MMSIstr << _T("</b></td><td>&nbsp;</td><td align=right><b>")
+         << _T("<font size=-1>") << ClassStr << rowEnd << rowStart << _T("ID: ")
+         << MMSI << rowEnd << _T("</table></td></tr>");
+  }
   else
     html << _T("<tr><td colspan=2><table width=100% border=0 cellpadding=0 ")
             _T("cellspacing=0>")
@@ -829,7 +840,7 @@ wxString AisTargetData::BuildQueryResult(void) {
   }
 
   if (Class == AIS_METEO) {
-    if (met_data.wind_kn < 127) {
+    if (met_data.wind_kn < 126) {
       double userwindspeed = toUsrWindSpeed(met_data.wind_kn);
       wxString wspeed = wxString::Format("%.0f %s %d%c", userwindspeed, getUsrWindSpeedUnit(),
                            met_data.wind_dir, 0x00B0);
@@ -837,7 +848,7 @@ wxString AisTargetData::BuildQueryResult(void) {
       double userwindgustspeed = toUsrWindSpeed(met_data.wind_gust_kn);
       wxString wspeedGust = wxString::Format("%.0f %s %d%c", userwindgustspeed,
                            getUsrWindSpeedUnit(), met_data.wind_gust_dir, 0x00B0);
-      if (met_data.wind_gust_kn >= 127) wspeedGust = wxEmptyString;
+      if (met_data.wind_gust_kn >= 126) wspeedGust = wxEmptyString;
 
       html << vertSpacer << rowStart << _("Wind speed")
            << _T("</font></td><td align=right><font size=-2>")
@@ -859,7 +870,7 @@ wxString AisTargetData::BuildQueryResult(void) {
 
         html << vertSpacer << rowStart << _("Water level deviation")
              << _T("</font></td><td align=right><font size=-2>")
-             << _("Current ") << _T("</font></td></tr>") << rowStartH
+             << _("Surface current ") << _T("</font></td></tr>") << rowStartH
              << _T("<b>") << level << _T("</b></td><td align=right><b>")
              << current << rowEnd;
     }
@@ -1092,7 +1103,7 @@ wxString AisTargetData::GetRolloverString(void) {
            << _T(" ") << _("min");
   }
   if (Class == AIS_METEO) {
-    if (met_data.wind_kn < 127) {
+    if (met_data.wind_kn < 126) {
       if (result.Len()) result << "\n";
       int userwindspeed = toUsrWindSpeed(met_data.wind_kn);
       result << _("Wind speed");
@@ -1242,7 +1253,7 @@ wxString AisTargetData::Get_class_string(bool b_short) {
     case AIS_APRS:
       return b_short ? _("APRS") : _("APRS Position Report");
     case AIS_METEO:
-      return b_short ? _("Meteo") : _("Meteorologic and Hydrographic");
+      return b_short ? _("Meteo") : _("Meteorologic station");
 
     default:
       return b_short ? _("Unk") : _("Unknown");


### PR DESCRIPTION
Update the logic to change mmsi-ID for received ais8dac001fi3 Meteo stations.
Initially we changed the mmsi when the same mmsi was used for all station from one country.
We tried to check if the mmsi was unique and thus keep it.
After helpful tests from Irish users it turned out Ireland used the same mmsi for Meteo and a nearby AtoN. Leading to clashes.
Since IMO lack of rules for mmsi assignment for these targets it can happen similar assignments are used also by other countries.
The logic is hereby changed so every Meteo station get a met-mmsi to avoid clashes. It also implies code simplification with less conditions.
Also a small edit of AIS Target query to show both the origin MMSI and the used meteo ID.

![bild](https://github.com/OpenCPN/OpenCPN/assets/7202854/9a942fd4-f77f-42b9-b434-52f296df3802)
