### PR TITLE
Meteo;  Include  data from (US) AIS 8 Dac 367 Fi 33 and other adjustments

### DIFF
--- a/include/meteo_points.h
+++ b/include/meteo_points.h
@@ -34,7 +34,7 @@
   int minute;           // UTC 60
   int pos_acc;          // low = 0 GNSS
   int wind_kn;          // NAN=127
-  int wind_gust_kn;     // kn NAN=127
+  int wind_gust_kn;     // kn NAN=127/122
   int wind_dir;         // NAN=360
   int wind_gust_dir;    // NAN=360
   double air_temp;      // C NAN = -102.4
@@ -43,11 +43,12 @@
   int airpress;         // value+799 hPa NAN = 511(1310)
   int airpress_tend;    // NAN = 3
   double hor_vis;       // NAN = 127(12.7)
-  double water_level;   // m Water level(incl.tide) NAN = 4001
+  double water_lev_dev; // Water level deviation (incl.tide) NAN = 30
+  double water_level;   // Water level NAN = -32,768
   int water_lev_trend;  // NAN = 3
   double current;       // kn NAN = 255(25.5)
   int curr_dir;         // NAN = 360
-  double wave_height;   // m NAN=255(25.5)
+  double wave_height;   // m NAN=255(24.5)
   int wave_period;      // s NAN = 63
   int wave_dir;         // NAN = 360
   double swell_height;  // m NAN = 255 (25.5)
@@ -56,7 +57,7 @@
   int seastate;         // Bf NAN=13
   double water_temp;    // C NAN = 501(50.1)
   int precipitation;    // type NAN=7
-  double salinity;      // ‰ NAN=510(51.0)
+  double salinity;      // ‰ NAN=510(50.0)
   int ice;              // NAN=3
 };
 
@@ -68,9 +69,10 @@ public:
   const int mmsi;
   const wxString lat;
   const wxString lon;
+  const int siteID;
   AisMeteoPoint(int mmsi, const wxString& lat,
-                const wxString& lon) :
-   mmsi(mmsi), lat(lat), lon(lon) {}
+                const wxString& lon, int siteID) :
+   mmsi(mmsi), lat(lat), lon(lon), siteID(siteID) {}
 };
 
 /**

--- a/include/meteo_points.h
+++ b/include/meteo_points.h
@@ -22,11 +22,12 @@
 #define _METEO_POINTS_H__
 
 /** Meteo points are Meteorological and Hydrographic data received
- ** by NMEA0183 (AIS) VDM message 8 dac:001 fi: 31.
- ** Structure and content as described in IMO SN.1/Circ.289 **/
+ ** by NMEA0183 (AIS) VDM message 8 dac:001 fi: 31 or Ais8_367_33.
+ ** Structure and content as described in IMO SN.1/Circ.289 or
+ ** DAC367_FI33_em_version_release_3-23mar15_0**/
 
  struct AisMeteoData {
-   // Ais8_001_31 Meteo data
+   // Ais8_001_31, Ais8_367_33 Meteo data
   int original_mmsi;
   int month;            // UTC 0
   int day;              // UTC 0
@@ -59,7 +60,8 @@
   int precipitation;    // type NAN=7
   double salinity;      // ‰ NAN=510(50.0)
   int ice;              // NAN=3
-};
+  int vertical_ref;     // NAN=14
+ };
 
  /**
  * Add a new point to the list of Meteo stations
@@ -70,9 +72,10 @@ public:
   const wxString lat;
   const wxString lon;
   const int siteID;
-  AisMeteoPoint(int mmsi, const wxString& lat,
-                const wxString& lon, int siteID) :
-   mmsi(mmsi), lat(lat), lon(lon), siteID(siteID) {}
+  const int orig_mmsi;
+  AisMeteoPoint(int mmsi, const wxString& lat, const wxString& lon, int siteID,
+                int orig_mmsi)
+      : mmsi(mmsi), lat(lat), lon(lon), siteID(siteID), orig_mmsi(orig_mmsi) {}
 };
 
 /**
@@ -80,7 +83,7 @@ public:
  * Since several nations have chose not to use individual mmsi ID
  * for each station but the same for all we need to separate them
  * by its position. Every station is allocated a unique Meteo ID.
- * This list collect them and is used to destine each update to whom it belongs.
+ * This list collect them and is used to destine each data update to whom it belongs.
  */
 class AisMeteoPoints {
 public:

--- a/src/AISTargetQueryDialog.cpp
+++ b/src/AISTargetQueryDialog.cpp
@@ -323,6 +323,7 @@ void AISTargetQueryDialog::UpdateText() {
     m_createWptBtn->Enable(td->b_positionOnceValid);
     m_createTrkBtn->Enable(td->b_show_track);
 
+    AdjustBestSize(td.get());
     RenderHTMLQuery(td.get());
   }
 

--- a/src/ais_decoder.cpp
+++ b/src/ais_decoder.cpp
@@ -168,7 +168,7 @@ static inline double MS2KNOTS(double ms) {
   return ms * 1.9438444924406;
 }
 
-int AisMeteoNewMmsi(int, int, int);
+int AisMeteoNewMmsi(int, int, int, int, int);
 
 void AISshipNameCache(AisTargetData *pTargetData,
                       AIS_Target_Name_Hash *AISTargetNamesC,
@@ -1915,17 +1915,42 @@ AisError AisDecoder::DecodeN0183(const wxString &str) {
     if (!mmsi) mmsi = strbit.GetInt(9, 30);
     long mmsi_long = mmsi;
 
-    // Ais8_001_31 (class AIS_METEO) test for a possible new mmsi ID
+    // Ais8_001_31 || ais8_367_33 (class AIS_METEO) test for a new mmsi ID
     int origin_mmsi = 0;
     int messID = strbit.GetInt(1, 6);
     int dac = strbit.GetInt(41, 10);
     int fi = strbit.GetInt(51, 6);
-    if (messID == 8 && dac == 001 && fi == 31) {
-      int met_lon = strbit.GetInt(57, 25);
-      int met_lat = strbit.GetInt(82, 24);
-      origin_mmsi = mmsi;
-      mmsi = AisMeteoNewMmsi(mmsi, met_lat, met_lon);
-      mmsi_long = mmsi;
+    if (messID == 8) {
+      int met_lon, met_lat;
+      if (dac == 001 && fi == 31) {
+        origin_mmsi = mmsi;
+        met_lon = strbit.GetInt(57, 25);
+        met_lat = strbit.GetInt(82, 24);
+        mmsi = AisMeteoNewMmsi(mmsi, met_lat, met_lon, 25, 0);
+        mmsi_long = mmsi;
+
+      } else if (dac == 367 && fi == 33) { // ais8_367_33
+        int mes_type = strbit.GetInt(57, 4);
+        int site_ID = strbit.GetInt(77, 7);
+        if (mes_type == 0) { // Location
+          origin_mmsi = mmsi;
+          met_lon = strbit.GetInt(90, 28);
+          met_lat = strbit.GetInt(118, 27);
+          mmsi = AisMeteoNewMmsi(mmsi, met_lat, met_lon, 28, site_ID);
+          mmsi_long = mmsi;
+        } else { // Other messsage types without position.
+            // We need a previously received type 0, position message
+            // to get use of any sensor report.
+          int x_mmsi = AisMeteoNewMmsi(mmsi, 91, 181, 0, site_ID);
+          if (x_mmsi) {
+            origin_mmsi = mmsi;
+            mmsi = x_mmsi;
+            mmsi_long = mmsi;
+          } else // So far no use for this report.
+            return AIS_GENERIC_ERROR;
+
+        }
+      }
     }
 
     //  Search the current AISTargetList for an MMSI match
@@ -1944,6 +1969,10 @@ AisError AisDecoder::DecodeN0183(const wxString &str) {
       pTargetData = it->second;    // find current entry
 
       if(!bnewtarget) pStaleTarget = pTargetData;  // save a pointer to stale data
+      if (origin_mmsi) {  // Meteo point
+        pTargetData->MMSI = mmsi;
+        pTargetData->met_data.original_mmsi = origin_mmsi;
+      }
     }
     for (unsigned int i = 0; i < g_MMSI_Props_Array.GetCount(); i++) {
       MmsiProperties *props = g_MMSI_Props_Array[i];
@@ -2603,7 +2632,7 @@ bool AisDecoder::Parse_VDXBitstring(AisBitstring *bstr,
   int message_ID = bstr->GetInt(1, 6);  // Parse on message ID
   ptd->MID = message_ID;
 
-    // Save for Ais8_001_31 (class AIS_METEO)
+    // Save for Ais8_001_31 and ais8_367_33 (class AIS_METEO)
   int met_mmsi = ptd->MMSI;
 
     // MMSI is always in the same spot in the bitstream
@@ -3105,6 +3134,7 @@ bool AisDecoder::Parse_VDXBitstring(AisBitstring *bstr,
     {
       int dac = bstr->GetInt(41, 10);
       int fi = bstr->GetInt(51, 6);
+
       if (dac == 200)  // European inland
       {
         if (fi == 10)  // "Inland ship static and voyage related data"
@@ -3271,7 +3301,7 @@ bool AisDecoder::Parse_VDXBitstring(AisBitstring *bstr,
             ptd->met_data.hor_vis = bstr->GetInt(194, 8) / 10.;
             //int MSB = bstr->GetInt(194, 8) < 0;
 
-            ptd->met_data.water_level = (bstr->GetInt(202, 12) / 100.) - 10.;
+            ptd->met_data.water_lev_dev = (bstr->GetInt(202, 12) / 100.) - 10.;
             ptd->met_data.water_lev_trend = bstr->GetInt(214, 2);
             ptd->met_data.current = bstr->GetInt(216, 8) / 10.;
             ptd->met_data.curr_dir = bstr->GetInt(224, 9);
@@ -3306,6 +3336,150 @@ bool AisDecoder::Parse_VDXBitstring(AisBitstring *bstr,
             parse_result = true;
           }
         }
+        break;
+      }
+
+      if (dac == 367 && fi == 33) {  //  ais8_367_33
+          // US data acording to DAC367_FI33_em_version_release_3-23mar15_0
+          // We use only the parts as of ais8_001_31 for these reports.
+          // Also is only slot 1 used.
+        int size = bstr->GetBitCount();
+        if (size >= 168) {
+            //  Change to meteo mmsi-ID
+          if (met_mmsi != 666) ptd->MMSI = met_mmsi;
+          int type = bstr->GetInt(57, 4);
+          ptd->met_data.hour = bstr->GetInt(66, 5);
+          ptd->met_data.minute = bstr->GetInt(71, 6);
+          int Site_ID = bstr->GetInt(77, 7);
+            // Name the station acc to site ID until message type 1
+          if (!ptd->b_nameValid) {
+            wxString nameID = "METEO Site: ";
+            nameID << Site_ID;
+            strncpy(ptd->ShipName, nameID, SHIP_NAME_LEN - 1);
+            ptd->b_nameValid = true;
+          }
+
+          if (type == 0) { //Location
+            int lon = bstr->GetInt(90, 28);
+            if (lon & 0x08000000)  // negative?
+              lon |= 0xf0000000;
+            ptd->Lon = lon / 600000.;
+
+            int lat = bstr->GetInt(118, 27);
+            if (lat & 0x04000000)  // negative?
+              lat |= 0xf8000000;
+            ptd->Lat = lat / 600000.;
+            ptd->b_positionOnceValid = true;
+
+          } else if (type == 1) {  // Name
+            bstr->GetStr(84, 84, &ptd->ShipName[0], SHIP_NAME_LEN);
+            ptd->b_nameValid = true;
+
+          } else if (type == 2) {  // Wind
+              // Description 1 and 2 are real time values.
+            int descr = bstr->GetInt(116, 3);
+            if (descr == 1 || descr == 2) {
+              ptd->met_data.wind_kn = bstr->GetInt(84, 7);
+              ptd->met_data.wind_gust_kn = bstr->GetInt(91, 7);
+              ptd->met_data.wind_dir = bstr->GetInt(98, 9);
+              ptd->met_data.wind_gust_dir = bstr->GetInt(107, 9);
+            }
+
+          } else if (type == 3) {  // Water level
+            // Description 1 and 2 are real time values.
+            int descr = bstr->GetInt(108, 3);
+            if (descr == 1 || descr == 2) {
+              int wltype = bstr->GetInt(84, 1); //0 = rel to datum; 1 = water depth.
+              int wl = bstr->GetInt(85, 16); // cm
+              if (wl & 0x00004000)  // negative?
+                wl |= 0xffff0000;
+              if (wltype == 1)
+                ptd->met_data.water_level = wl/100.; // m
+              else
+                ptd->met_data.water_lev_dev = wl / 100.;  // m
+            }
+            ptd->met_data.water_lev_trend = bstr->GetInt(101, 2);
+            int verticalDatum = bstr->GetInt(103, 5);
+
+          } else if (type == 6) {  //  Horizontal Current Profil
+            int readbearing = bstr->GetInt(84, 9);
+            int readdistance = bstr->GetInt(93, 9);
+            ptd->met_data.current = bstr->GetInt(102, 8) / 10.0;
+            ptd->met_data.curr_dir = bstr->GetInt(110, 9);
+            int readLevel = bstr->GetInt(119, 9);
+
+          } else if (type == 7) {  // Sea state
+            int swell_descr = bstr->GetInt(111, 3);  // Use 1 || 2 real data
+            if (swell_descr == 1 || swell_descr == 2) {
+              ptd->met_data.swell_height = bstr->GetInt(84, 8) / 10.0;
+              ptd->met_data.swell_per = bstr->GetInt(92, 6);
+              ptd->met_data.swell_dir = bstr->GetInt(98, 9);
+            }
+            ptd->met_data.seastate = bstr->GetInt(107, 4); // Bf
+            int wt_descr = bstr->GetInt(131, 3);
+            if (wt_descr == 1 || wt_descr == 2)
+              ptd->met_data.water_temp = bstr->GetInt(114, 10) / 10. - 10.;
+
+            int wawe_descr = bstr->GetInt(157, 3);
+            if (wawe_descr == 1 || wawe_descr == 2) { // Only real data
+              ptd->met_data.wave_height = bstr->GetInt(134, 8) / 10.0;
+              ptd->met_data.wave_period = bstr->GetInt(142, 6);
+              ptd->met_data.wave_dir = bstr->GetInt(148, 9);
+            }
+            ptd->met_data.salinity = bstr->GetInt(160, 9 / 10.0);
+
+          } else if (type == 8) {  // Salinity
+            ptd->met_data.water_temp = bstr->GetInt(84, 10) / 10.0 - 10.0;
+            ptd->met_data.salinity = bstr->GetInt(120, 9) / 10.0;
+
+          } else if (type == 9) {  // Weather
+            int tmp = bstr->GetInt(84, 11);
+            if (tmp & 0x00000400)  // negative?
+              tmp |= 0xFFFFF800;
+            ptd->met_data.air_temp = tmp / 10.;
+            int pp , precip = bstr->GetInt(98, 2);
+            switch (precip) { // Adapt to IMO precipitation
+            case 0:
+              pp = 1;
+            case 1:
+              pp = 5;
+            case 2:
+              pp = 4;
+            case 3:
+              pp = 7;
+            }
+            ptd->met_data.precipitation = pp;
+            ptd->met_data.hor_vis = bstr->GetInt(100, 8) / 10.0;
+            ptd->met_data.dew_point = bstr->GetInt(108, 10) / 10.0 - 20.0;
+            ptd->met_data.airpress = bstr->GetInt(121, 9) + 799;
+            ptd->met_data.airpress_tend = bstr->GetInt(130, 2);
+            ptd->met_data.salinity = bstr->GetInt(135, 9) / 10.0;
+
+          } else if (type == 11) {  // Wind V2
+            // Description 1 and 2 are real time values.
+            int descr = bstr->GetInt(113, 3);
+            if (descr == 1 || descr == 2) {
+            ptd->met_data.wind_kn = bstr->GetInt(84, 7);
+            ptd->met_data.wind_gust_kn = bstr->GetInt(91, 7);
+            ptd->met_data.wind_dir = bstr->GetInt(98, 9);
+            }
+          }
+
+          if (ptd->b_positionOnceValid) {
+            ptd->Class = AIS_METEO;
+            ptd->b_NoTrack = true;
+            ptd->b_show_track = false;
+            ptd->b_positionDoubtful = false;
+            b_posn_report = true;
+            ptd->PositionReportTicks = now.GetTicks();
+            ptd->b_nameValid = true;
+            ptd->b_show_AIS_CPA = false;
+            ptd->bCPA_Valid = false;
+
+            parse_result = true;
+          }
+        }
+        break;
       }
       break;
     }
@@ -4216,14 +4390,45 @@ wxString GetShipNameFromFile(int nmmsi) {
 }
 
   // Assign a unique meteo mmsi related to position
-int AisMeteoNewMmsi(int m_mmsi, int m_lat, int m_lon) {
-  if (m_lon & 0x01000000)  // negative?
-    m_lon |= 0xFE000000;
-  double lon_tentative = m_lon / 60000.;
+int AisMeteoNewMmsi(int m_mmsi, int m_lat,int m_lon, int lon_bits = 0, int siteID = 0) {
+  bool found = false;
+  int new_mmsi = 0;
+  if (!lon_bits && siteID) {
+    auto &points = AisMeteoPoints::GetInstance().GetPoints();
+    if (points.size()) {
+      for (const auto &point : points) {
+        // Does this station ID exist
+        if (siteID == point.siteID) {
+          // Created before. Continue
+          new_mmsi = point.mmsi;
+          found = true;
+          break;
+        }
+      }
+    }
+    if (!found) return 0;
+  }
+  double lon_tentative = 181.;
+  double lat_tentative = 91.;
 
-  if (m_lat & 0x00800000)  // negative?
-    m_lat |= 0xFF000000;
-  double lat_tentative = m_lat / 60000.;
+  if (lon_bits == 25) {
+    if (m_lon & 0x01000000)  // negative?
+      m_lon |= 0xFE000000;
+    lon_tentative = m_lon / 60000.;
+
+    if (m_lat & 0x00800000)  // negative?
+      m_lat |= 0xFF000000;
+    lat_tentative = m_lat / 60000.;
+
+  } else if (lon_bits == 28) {
+    if (m_lon & 0x08000000)  // negative?
+      m_lon |= 0xf0000000;
+    lon_tentative = m_lon / 600000.;
+
+    if (m_lat & 0x04000000)  // negative?
+      m_lat |= 0xf8000000;
+    lat_tentative = m_lat / 600000.;
+  }
 
     // Since buoys can move we use position precision not better
     // than 50 m to be able to compare previous messages
@@ -4237,8 +4442,6 @@ int AisMeteoNewMmsi(int m_mmsi, int m_lat, int m_lon) {
   // 199 is INMARSAT-A MID, should not occur ever in AIS stream.
   // 1992 to 1993 are already used so here we use 1994+
   static int nextMeteommsi = 199400000;
-  bool found = false;
-  int new_mmsi = 0;
   auto& points = AisMeteoPoints::GetInstance().GetPoints();
   if (points.size()) {
     wxString t_lat, t_lon;
@@ -4256,7 +4459,7 @@ int AisMeteoNewMmsi(int m_mmsi, int m_lat, int m_lon) {
   if (!found) {
     // Create a new post
     nextMeteommsi++;
-    points.push_back(AisMeteoPoint(nextMeteommsi, slat, slon));
+    points.push_back(AisMeteoPoint(nextMeteommsi, slat, slon, siteID));
     new_mmsi = nextMeteommsi;
   }
   return new_mmsi;

--- a/src/ais_decoder.cpp
+++ b/src/ais_decoder.cpp
@@ -3769,7 +3769,8 @@ void AisDecoder::UpdateAllAlarms(void) {
         }
 
         if ((td->CPA < g_CPAWarn_NM) && (td->TCPA > 0) &&
-            (td->Class != AIS_ATON) && (td->Class != AIS_BASE)) {
+            (td->Class != AIS_ATON) && (td->Class != AIS_BASE) &&
+            (td->Class != AIS_METEO)) {
           if (g_bTCPA_Max) {
             if (td->TCPA < g_TCPA_Max) {
               if (td->b_isFollower)

--- a/src/ais_target_data.cpp
+++ b/src/ais_target_data.cpp
@@ -1211,6 +1211,14 @@ wxString AisTargetData::GetRolloverString(void) {
              << " / " << met_data.wave_period << " " << _("s");
     }
 
+    if (met_data.water_temp < 50.) {
+      if (result.Len()) result << "\n";
+      double usertemp = toUsrTemp(met_data.water_temp);
+      result << _("Water temp");
+      result << wxString::Format(": %.1f%c", usertemp, 0x00B0)
+             << getUsrTempUnit();
+    }
+
     if (met_data.air_temp != -102.4) {
       if (result.Len()) result << "\n";
       double usertemp = toUsrTemp(met_data.air_temp);


### PR DESCRIPTION
- According to spec. "DAC367_FI33_em_version_release_3-23mar15_0." 

- Some adjustments to the overall Meteo handling including resize of Target query dialog after a data update from another station.  -> Q - commit: "Adjust size after updated Ais query dialog"  does add "AdjustBestSize()" commented out above by df0dcd6 back in 2015. Are there some obstacle I don't understand implementing it again?