### PR TITLE
Allow control of 'echo to self' for serial ports

### DIFF
--- a/include/conn_params.h
+++ b/include/conn_params.h
@@ -95,6 +95,7 @@ public:
   wxString socketCAN_port;
   int Baudrate;
   bool NoDataReconnect;
+  bool DisableEcho;
   bool ChecksumCheck;
   bool Garmin;
   bool GarminUpload;

--- a/src/conn_params.cpp
+++ b/src/conn_params.cpp
@@ -108,6 +108,9 @@ void ConnectionParams::Deserialize(const wxString &configStr) {
   if (prms.Count() >= 22) {
     NoDataReconnect = wxAtoi(prms[21]);
   }
+  if (prms.Count() >= 23) {
+    DisableEcho = wxAtoi(prms[22]);
+  }
 }
 
 wxString ConnectionParams::Serialize() const {
@@ -122,12 +125,12 @@ wxString ConnectionParams::Serialize() const {
     ostcs.Append(OutputSentenceList[i]);
   }
   wxString ret = wxString::Format(
-      _T("%d;%d;%s;%d;%d;%s;%d;%d;%d;%d;%s;%d;%s;%d;%d;%d;%d;%d;%s;%d;%s;%d"), Type,
+      _T("%d;%d;%s;%d;%d;%s;%d;%d;%d;%d;%s;%d;%s;%d;%d;%d;%d;%d;%s;%d;%s;%d;%d"), Type,
       NetProtocol, NetworkAddress.c_str(), NetworkPort, Protocol, Port.c_str(),
       Baudrate, ChecksumCheck, IOSelect, InputSentenceListType, istcs.c_str(),
       OutputSentenceListType, ostcs.c_str(), Priority, Garmin, GarminUpload,
       FurunoGP3X, bEnabled, UserComment.c_str(), AutoSKDiscover, socketCAN_port.c_str(),
-      NoDataReconnect);
+      NoDataReconnect, DisableEcho);
 
   return ret;
 }
@@ -153,6 +156,7 @@ ConnectionParams::ConnectionParams() {
   m_optionsPanel = NULL;
   AutoSKDiscover = false;
   NoDataReconnect = false;
+  DisableEcho = false;
 }
 
 ConnectionParams::~ConnectionParams() {

--- a/src/multiplexer.cpp
+++ b/src/multiplexer.cpp
@@ -280,7 +280,7 @@ void Multiplexer::HandleN0183(std::shared_ptr<const Nmea0183Msg> n0183_msg) {
       //  Allow re-transmit on same port (if type is SERIAL),
       //  or any any other NMEA0183 port supporting output
       //  But, do not echo to the source network interface.  This will likely recurse...
-        if (params.Type == SERIAL || driver->iface != source_iface) {
+        if ((!params.DisableEcho && params.Type == SERIAL) || driver->iface != source_iface) {
           if (params.IOSelect == DS_TYPE_INPUT_OUTPUT ||
               params.IOSelect == DS_TYPE_OUTPUT)
           {


### PR DESCRIPTION
If I understand the discussions correctly, this addresses the issue raised in https://github.com/OpenCPN/OpenCPN/issues/2954 and again in https://github.com/OpenCPN/OpenCPN/issues/3516

There is no GUI change as there wasn't for other similar changes allowing to tune the connection parameters. But we probably need to have a look at the way connections are configured as at 20+ parameters the current CSV format is probably way over the limit of its convenient usability. TOML/YAML/JSON?