### PR TITLE
Update SQLite and SQLiteCPP

### DIFF
--- a/libs/SQLiteCpp/CMakeLists.txt
+++ b/libs/SQLiteCpp/CMakeLists.txt
@@ -10,6 +10,7 @@ set(SRC
     src/Column.cpp
     src/Database.cpp
     src/Exception.cpp
+    src/Savepoint.cpp
     src/Statement.cpp
     src/Transaction.cpp
 )
@@ -20,6 +21,9 @@ set(INCL
     include/SQLiteCpp/Column.h
     include/SQLiteCpp/Database.h
     include/SQLiteCpp/Exception.h
+    include/SQLiteCpp/ExecuteMany.h
+    include/SQLiteCpp/Savepoint.h
+    include/SQLiteCpp/SQLiteCppExport.h
     include/SQLiteCpp/Statement.h
     include/SQLiteCpp/Transaction.h
     include/SQLiteCpp/Utils.h

--- a/libs/SQLiteCpp/include/SQLiteCpp/Assertion.h
+++ b/libs/SQLiteCpp/include/SQLiteCpp/Assertion.h
@@ -3,7 +3,7 @@
  * @ingroup SQLiteCpp
  * @brief   Definition of the SQLITECPP_ASSERT() macro.
  *
- * Copyright (c) 2012-2018 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ * Copyright (c) 2012-2023 Sebastien Rombauts (sebastien.rombauts@gmail.com)
  *
  * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
  * or copy at http://opensource.org/licenses/MIT)
@@ -11,7 +11,6 @@
 #pragma once
 
 #include <cassert>
-
 
 /**
  * SQLITECPP_ASSERT SQLITECPP_ASSERT() is used in destructors, where exceptions shall not be thrown
@@ -25,9 +24,10 @@
 // if an assert handler is provided by user code, use it instead of assert()
 namespace SQLite
 {
-    // declaration of the assert handler to define in user code
-    void assertion_failed(const char* apFile, const long apLine, const char* apFunc,
-                          const char* apExpr, const char* apMsg);
+
+// declaration of the assert handler to define in user code
+void assertion_failed(const char* apFile, const int apLine, const char* apFunc,
+                        const char* apExpr, const char* apMsg);
 
 #ifdef _MSC_VER
     #define __func__ __FUNCTION__
@@ -35,6 +35,7 @@ namespace SQLite
 // call the assert handler provided by user code
 #define SQLITECPP_ASSERT(expression, message) \
     if (!(expression))  SQLite::assertion_failed(__FILE__, __LINE__, __func__, #expression, message)
+
 } // namespace SQLite
 
 #else

--- a/libs/SQLiteCpp/include/SQLiteCpp/Exception.h
+++ b/libs/SQLiteCpp/include/SQLiteCpp/Exception.h
@@ -3,56 +3,29 @@
  * @ingroup SQLiteCpp
  * @brief   Encapsulation of the error message from SQLite3 on a std::runtime_error.
  *
- * Copyright (c) 2012-2018 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ * Copyright (c) 2012-2023 Sebastien Rombauts (sebastien.rombauts@gmail.com)
  *
  * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
  * or copy at http://opensource.org/licenses/MIT)
  */
 #pragma once
 
+#include <SQLiteCpp/SQLiteCppExport.h>
 #include <stdexcept>
 #include <string>
 
 // Forward declaration to avoid inclusion of <sqlite3.h> in a header
 struct sqlite3;
 
-/// Compatibility with non-clang compilers.
-#ifndef __has_feature
-    #define __has_feature(x) 0
-#endif
-
-// Detect whether the compiler supports C++11 noexcept exception specifications.
-#if (  defined(__GNUC__) && ((__GNUC__ == 4 && __GNUC_MINOR__ >= 7) || (__GNUC__ > 4)) \
-    && defined(__GXX_EXPERIMENTAL_CXX0X__))
-// GCC 4.7 and following have noexcept
-#elif defined(__clang__) && __has_feature(cxx_noexcept)
-// Clang 3.0 and above have noexcept
-#elif defined(_MSC_VER) && _MSC_VER > 1800
-// Visual Studio 2015 and above have noexcept
-#else
-    // Visual Studio 2013 does not support noexcept, and "throw()" is deprecated by C++11
-    #define noexcept
-#endif
-
-
 namespace SQLite
 {
-
 
 /**
  * @brief Encapsulation of the error message from SQLite3, based on std::runtime_error.
  */
-class Exception : public std::runtime_error
+class SQLITECPP_API Exception : public std::runtime_error
 {
 public:
-    /**
-     * @brief Encapsulation of the error message from SQLite3, based on std::runtime_error.
-     *
-     * @param[in] aErrorMessage The string message describing the SQLite error
-     */
-    explicit Exception(const char* aErrorMessage);
-    explicit Exception(const std::string& aErrorMessage);
-
     /**
      * @brief Encapsulation of the error message from SQLite3, based on std::runtime_error.
      *
@@ -60,7 +33,25 @@ public:
      * @param[in] ret           Return value from function call that failed.
      */
     Exception(const char* aErrorMessage, int ret);
-    Exception(const std::string& aErrorMessage, int ret);
+
+    Exception(const std::string& aErrorMessage, int ret) :
+        Exception(aErrorMessage.c_str(), ret)
+    {
+    }
+
+    /**
+     * @brief Encapsulation of the error message from SQLite3, based on std::runtime_error.
+     *
+     * @param[in] aErrorMessage The string message describing the SQLite error
+     */
+    explicit Exception(const char* aErrorMessage) :
+        Exception(aErrorMessage, -1) // 0 would be SQLITE_OK, which doesn't make sense
+    {
+    }
+    explicit Exception(const std::string& aErrorMessage) :
+        Exception(aErrorMessage.c_str(), -1) // 0 would be SQLITE_OK, which doesn't make sense
+    {
+    }
 
    /**
      * @brief Encapsulation of the error message from SQLite3, based on std::runtime_error.
@@ -78,24 +69,23 @@ public:
     Exception(sqlite3* apSQLite, int ret);
 
     /// Return the result code (if any, otherwise -1).
-    inline int getErrorCode() const noexcept // nothrow
+    int getErrorCode() const noexcept
     {
         return mErrcode;
     }
 
     /// Return the extended numeric result code (if any, otherwise -1).
-    inline int getExtendedErrorCode() const noexcept // nothrow
+    int getExtendedErrorCode() const noexcept
     {
         return mExtendedErrcode;
     }
 
     /// Return a string, solely based on the error code
-    const char* getErrorStr() const noexcept; // nothrow
+    const char* getErrorStr() const noexcept;
 
 private:
     int mErrcode;         ///< Error code value
     int mExtendedErrcode; ///< Detailed error code if any
 };
-
 
 }  // namespace SQLite

--- a/libs/SQLiteCpp/include/SQLiteCpp/ExecuteMany.h
+++ b/libs/SQLiteCpp/include/SQLiteCpp/ExecuteMany.h
@@ -1,0 +1,91 @@
+/**
+ * @file    ExecuteMany.h
+ * @ingroup SQLiteCpp
+ * @brief   Convenience function to execute a Statement with multiple Parameter sets
+ *
+ * Copyright (c) 2019 Maximilian Bachmann (contact@maxbachmann.de)
+ * Copyright (c) 2019-2023 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ *
+ * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+ * or copy at http://opensource.org/licenses/MIT)
+ */
+#pragma once
+
+#if (__cplusplus >= 201402L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++14: Visual Studio 2015
+
+#include <SQLiteCpp/Statement.h>
+#include <SQLiteCpp/VariadicBind.h>
+
+/// @cond
+#include <tuple>
+#include <utility>
+#include <initializer_list>
+
+namespace SQLite
+{
+
+/// @endcond
+
+/**
+ * \brief Convenience function to execute a Statement with multiple Parameter sets once for each parameter set given.
+ *
+ *
+ * This feature requires a c++14 capable compiler.
+ *
+ * \code{.cpp}
+ * execute_many(db, "INSERT INTO test VALUES (?, ?)",
+ *   1,
+ *   std::make_tuple(2),
+ *   std::make_tuple(3, "three")
+ * );
+ * \endcode
+ * @param aDatabase Database to use
+ * @param apQuery   Query to use with all parameter sets
+ * @param aArg      first tuple with parameters
+ * @param aParams   the following tuples with parameters
+ */
+template <typename Arg, typename... Types>
+void execute_many(Database& aDatabase, const char* apQuery, Arg&& aArg, Types&&... aParams)
+{
+    SQLite::Statement query(aDatabase, apQuery);
+    bind_exec(query, std::forward<Arg>(aArg));
+    (void)std::initializer_list<int>
+    {
+        ((void)reset_bind_exec(query, std::forward<Types>(aParams)), 0)...
+    };
+}
+
+/**
+ * \brief Convenience function to reset a statement and call bind_exec to 
+ * bind new values to the statement and execute it
+ *
+ * This feature requires a c++14 capable compiler.
+ *
+ * @param apQuery   Query to use
+ * @param aTuple    Tuple to bind
+ */
+template <typename TupleT>
+void reset_bind_exec(Statement& apQuery, TupleT&& aTuple)
+{
+    apQuery.reset();
+    bind_exec(apQuery, std::forward<TupleT>(aTuple));
+}
+
+/**
+ * \brief Convenience function to bind values a the statement and execute it
+ *
+ * This feature requires a c++14 capable compiler.
+ *
+ * @param apQuery   Query to use
+ * @param aTuple    Tuple to bind
+ */
+template <typename TupleT>
+void bind_exec(Statement& apQuery, TupleT&& aTuple)
+{
+    SQLite::bind(apQuery, std::forward<TupleT>(aTuple));
+    while (apQuery.executeStep()) {}
+}
+
+}  // namespace SQLite
+
+#endif // c++14

--- a/libs/SQLiteCpp/include/SQLiteCpp/SQLiteCpp.h
+++ b/libs/SQLiteCpp/include/SQLiteCpp/SQLiteCpp.h
@@ -5,7 +5,7 @@
  *
  * Include this main header file in your project to gain access to all functionality provided by the wrapper.
  *
- * Copyright (c) 2012-2018 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ * Copyright (c) 2012-2023 Sebastien Rombauts (sebastien.rombauts@gmail.com)
  *
  * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
  * or copy at http://opensource.org/licenses/MIT)
@@ -18,6 +18,7 @@
 
 
 // Include useful headers of SQLiteC++
+#include <SQLiteCpp/SQLiteCppExport.h>
 #include <SQLiteCpp/Assertion.h>
 #include <SQLiteCpp/Exception.h>
 #include <SQLiteCpp/Database.h>
@@ -37,6 +38,9 @@
  * The [SQLITECPP_VERSION_NUMBER] C preprocessor macro resolves to an integer
  * with the value (X*1000000 + Y*1000 + Z) where X, Y, and Z are the same
  * numbers used in [SQLITECPP_VERSION].
+ *
+ * WARNING: shall always be updated in sync with PROJECT_VERSION in CMakeLists.txt
  */
-#define SQLITECPP_VERSION           "2.02.00"   // 2.2.0
-#define SQLITECPP_VERSION_NUMBER     2002000    // 2.2.0
+#define SQLITECPP_VERSION           "3.03.01"   // 3.3.1
+#define SQLITECPP_VERSION_NUMBER     3003001    // 3.3.1
+

--- a/libs/SQLiteCpp/include/SQLiteCpp/SQLiteCppExport.h
+++ b/libs/SQLiteCpp/include/SQLiteCpp/SQLiteCppExport.h
@@ -1,0 +1,38 @@
+/**
+ * @file    SQLiteCppExport.h
+ * @ingroup SQLiteCpp
+ * @brief   File with macros needed in the generation of Windows DLLs
+ *
+ *
+ * Copyright (c) 2012-2023 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ *
+ * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
+ * or copy at http://opensource.org/licenses/MIT)
+ */
+
+#pragma once
+
+/*
+* #define SQLITECPP_COMPILE_DLL to compile a DLL under Windows
+* #define SQLITECPP_EXPORT to export symbols when creating the DLL, otherwise it defaults to importing symbols
+*/
+
+/* Windows DLL export/import */
+#if defined(_WIN32)&& !defined(__GNUC__) && defined(SQLITECPP_COMPILE_DLL)
+    #if SQLITECPP_DLL_EXPORT
+        #define SQLITECPP_API __declspec(dllexport)
+    #else
+        #define SQLITECPP_API __declspec(dllimport)
+    #endif    
+#else    
+    #if __GNUC__ >= 4
+        #define SQLITECPP_API __attribute__ ((visibility ("default")))
+    #else
+        #define SQLITECPP_API
+    #endif
+#endif
+
+#if defined(WIN32) && defined(SQLITECPP_COMPILE_DLL)
+    #pragma warning( disable : 4251 )
+    #pragma warning( disable : 4275 )
+#endif

--- a/libs/SQLiteCpp/include/SQLiteCpp/Savepoint.h
+++ b/libs/SQLiteCpp/include/SQLiteCpp/Savepoint.h
@@ -1,0 +1,98 @@
+/**
+ * @file    Savepoint.h
+ * @ingroup SQLiteCpp
+ * @brief   A Savepoint is a way to group multiple SQL statements into an atomic
+ * secured operation. Similar to a transaction while allowing child savepoints.
+ *
+ * Copyright (c) 2020 Kelvin Hammond (hammond.kelvin@gmail.com)
+ * Copyright (c) 2020-2023 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ *
+ * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt or
+ * copy at http://opensource.org/licenses/MIT)
+ */
+#pragma once
+
+#include <SQLiteCpp/SQLiteCppExport.h>
+#include <SQLiteCpp/Exception.h>
+
+namespace SQLite
+{
+
+// Forward declaration
+class Database;
+
+/**
+ * @brief RAII encapsulation of a SQLite Savepoint.
+ *
+ * SAVEPOINTs are a method of creating Transactions, similar to BEGIN and COMMIT,
+ * except that the SAVEPOINT and RELEASE commands are named and may be nested..
+ *
+ * Resource Acquisition Is Initialization (RAII) means that the Savepoint
+ * begins in the constructor and is rolled back in the destructor (unless committed before), so that there is
+ * no need to worry about memory management or the validity of the underlying SQLite Connection.
+ *
+ * This method also offers big performances improvements compared to
+ * individually executed statements.
+ *
+ * Caveats:
+ *
+ * 1) Calling COMMIT or committing a parent transaction or RELEASE on a parent
+ * savepoint will cause this savepoint to be released.
+ *
+ * 2) Calling ROLLBACK TO or rolling back a parent savepoint will cause this
+ * savepoint to be rolled back.
+ *
+ * 3) This savepoint is not saved to the database until this and all savepoints
+ * or transaction in the savepoint stack have been released or committed.
+ *
+ * See also: https://sqlite.org/lang_savepoint.html
+ *
+ * Thread-safety: a Savepoint object shall not be shared by multiple threads, because:
+ * 1) in the SQLite "Thread Safe" mode, "SQLite can be safely used by multiple threads
+ *    provided that no single database connection is used simultaneously in two or more threads."
+ * 2) the SQLite "Serialized" mode is not supported by SQLiteC++,
+ *    because of the way it shares the underling SQLite precompiled statement
+ *    in a custom shared pointer (See the inner class "Statement::Ptr").
+ */
+class SQLITECPP_API Savepoint
+{
+public:
+    /**
+     * @brief Begins the SQLite savepoint
+     *
+     * @param[in] aDatabase the SQLite Database Connection
+     * @param[in] aName the name of the Savepoint
+     *
+     * Exception is thrown in case of error, then the Savepoint is NOT
+     * initiated.
+     */
+    Savepoint(Database& aDatabase, const std::string& aName);
+
+    // Savepoint is non-copyable
+    Savepoint(const Savepoint&) = delete;
+    Savepoint& operator=(const Savepoint&) = delete;
+
+    /**
+     * @brief Safely rollback the savepoint if it has not been committed.
+     */
+    ~Savepoint();
+
+    /**
+     * @brief Commit and release the savepoint.
+     */
+    void release();
+
+    /**
+     * @brief Rollback to the savepoint, but don't release it.
+     */
+    void rollbackTo();
+    // @deprecated same as rollbackTo();
+    void rollback() { rollbackTo(); }
+
+private:
+    Database&   mDatabase;          ///< Reference to the SQLite Database Connection
+    std::string msName;             ///< Name of the Savepoint
+    bool        mbReleased = false; ///< True when release has been called
+};
+
+}  // namespace SQLite

--- a/libs/SQLiteCpp/include/SQLiteCpp/Utils.h
+++ b/libs/SQLiteCpp/include/SQLiteCpp/Utils.h
@@ -1,71 +1,31 @@
 /**
  * @file    Utils.h
  * @ingroup SQLiteCpp
- * @brief   Shared utility macros and functions.
+ * @brief   Definition of the SQLITECPP_PURE_FUNC macro.
  *
- * Copyright (c) 2013-2018 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ * Copyright (c) 2012-2023 Sebastien Rombauts (sebastien.rombauts@gmail.com)
  *
  * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
  * or copy at http://opensource.org/licenses/MIT)
  */
 #pragma once
 
-#include <cstddef>
-
-/**
- * @brief A macro to disallow the copy constructor and operator= functions.
- *
- * This should be used in the private: declarations for a class
- *
- * @param[in] TypeName  Class name to protect
- */
-#define DISALLOW_COPY_AND_ASSIGN(TypeName)  \
-    TypeName(const TypeName&);              \
-    void operator=(const TypeName&)
-
-#ifdef _MSC_VER
-#if _MSC_VER < 1600
-/// A macro to enable the use of the nullptr keyword (NULL on older MSVC compilers, as they do not accept "nullptr_t")
-#ifndef nullptr
-#define nullptr NULL
-#endif  // nullptr
-#endif  // _MSC_VER < 1600
-#elif defined(__APPLE__) // AppleClang
-#elif defined(__clang__) && __has_feature(cxx_nullptr) // Clang 3.0+
-#else // GCC or older Clang
-#if (__cplusplus < 201103L) && !defined(__GXX_EXPERIMENTAL_CXX0X__) // before C++11 on GCC4.7 and Visual Studio 2010
-#ifndef HAVE_NULLPTR
-#define HAVE_NULLPTR    ///< A macro to avoid double definition of nullptr
-/**
- * @brief nullptr_t is the type of the null pointer literal, nullptr.
-*/
-class nullptr_t {
-public:
-    template<typename T>
-    inline operator T* () const {       ///< convertible to any type of null non-member pointer...
-        return 0;
-    }
-
-    template<typename C, typename T>
-    inline operator T C::* () const {   ///< convertible to any type of null member pointer...
-        return 0;
-    }
-
-private:
-    void operator&() const;  ///< Can't take address of nullptr NOLINT
-};
-
-/**
- * @brief Better way to enable nullptr on older GCC/Clang compilers
-*/
-const nullptr_t nullptr = {};
-#endif // HAVE_NULLPTR
-#endif // (__cplusplus < 201103L) && !defined(__GXX_EXPERIMENTAL_CXX0X__)
-#endif // _MSC_VER
-
-// A macro for snprintf support in Visual Studio
-#if _MSC_VER
-#ifndef snprintf
-#define snprintf _snprintf
+// macro taken from https://github.com/nemequ/hedley/blob/master/hedley.h that was in public domain at this time
+#if defined(__GNUC__) || defined(__GNUG__) || defined(__clang__) ||\
+(defined(__INTEL_COMPILER) && __INTEL_COMPILER > 1600) ||\
+(defined(__ARMCC_VERSION) && __ARMCC_VERSION > 4010000) ||\
+(\
+    defined(__TI_COMPILER_VERSION__) && (\
+        __TI_COMPILER_VERSION__ > 8003000 ||\
+        (__TI_COMPILER_VERSION__ > 7003000 && defined(__TI_GNU_ATTRIBUTE_SUPPORT__))\
+    )\
+)
+#if defined(__has_attribute)
+#if !defined(SQLITECPP_PURE_FUNC) && __has_attribute(pure)
+#define SQLITECPP_PURE_FUNC __attribute__((pure))
 #endif
+#endif
+#endif
+#if !defined(SQLITECPP_PURE_FUNC)
+#define SQLITECPP_PURE_FUNC
 #endif

--- a/libs/SQLiteCpp/include/SQLiteCpp/VariadicBind.h
+++ b/libs/SQLiteCpp/include/SQLiteCpp/VariadicBind.h
@@ -4,16 +4,19 @@
  * @brief   Convenience function for Statement::bind(...)
  *
  * Copyright (c) 2016 Paul Dreik (github@pauldreik.se)
- * Copyright (c) 2016-2018 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ * Copyright (c) 2016-2023 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ * Copyright (c) 2019 Maximilian Bachmann (contact@maxbachmann.de)
  *
  * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
  * or copy at http://opensource.org/licenses/MIT)
  */
 #pragma once
 
-#if (__cplusplus >= 201402L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++14: Visual Studio 2015
-
 #include <SQLiteCpp/Statement.h>
+
+#if (__cplusplus >= 201402L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++14: Visual Studio 2015
+#include <tuple>
+#endif // c++14
 
 /// @cond
 #include <utility>
@@ -21,23 +24,6 @@
 
 namespace SQLite
 {
-
-/// implementation detail for variadic bind.
-namespace detail {
-template<class F, class ...Args, std::size_t ... I>
-inline void invoke_with_index(F&& f, std::integer_sequence<std::size_t, I...>, const Args& ...args)
-{
-    std::initializer_list<int> { (f(I+1, args), 0)... };
-}
-
-/// implementation detail for variadic bind.
-template<class F, class ...Args>
-inline void invoke_with_index(F&& f, const Args& ... args)
-{
-    invoke_with_index(std::forward<F>(f), std::index_sequence_for<Args...>(), args...);
-}
-
-} // namespace detail
 /// @endcond
 
 /**
@@ -45,32 +31,68 @@ inline void invoke_with_index(F&& f, const Args& ... args)
  *
  * This takes care of incrementing the index between each calls to bind.
  *
- * This feature requires a c++14 capable compiler.
+ * This feature requires a c++11 capable compiler.
  *
  * \code{.cpp}
  * SQLite::Statement stm("SELECT * FROM MyTable WHERE colA>? && colB=? && colC<?");
- * bind(stm,a,b,c);
+ * SQLite::bind(stm,a,b,c);
  * //...is equivalent to
  * stm.bind(1,a);
  * stm.bind(2,b);
  * stm.bind(3,c);
  * \endcode
- * @param s statement
- * @param args one or more args to bind.
+ * @param query     statement
+ * @param args      zero or more args to bind.
  */
 template<class ...Args>
-void bind(SQLite::Statement& s, const Args& ... args)
+void bind(SQLite::Statement& query, const Args& ... args)
 {
-    static_assert(sizeof...(args) > 0, "please invoke bind with one or more args");
-
-    auto f=[&s](std::size_t index, const auto& value)
-    {
-        s.bind(index, value);
+    int pos = 0;
+    (void)std::initializer_list<int>{
+        ((void)query.bind(++pos, std::forward<decltype(args)>(args)), 0)...
     };
-    detail::invoke_with_index(f, args...);
 }
 
-}  // namespace SQLite
+#if (__cplusplus >= 201402L) || ( defined(_MSC_VER) && (_MSC_VER >= 1900) ) // c++14: Visual Studio 2015
 
+/**
+ * \brief Convenience function for calling Statement::bind(...) once for each parameter of a tuple,
+ * by forwarding them to the variadic template
+ *
+ * This feature requires a c++14 capable compiler.
+ *
+ * \code{.cpp}
+ * SQLite::Statement stm("SELECT * FROM MyTable WHERE colA>? && colB=? && colC<?");
+ * SQLite::bind(stm, std::make_tuple(a, b, c));
+ * //...is equivalent to
+ * stm.bind(1,a);
+ * stm.bind(2,b);
+ * stm.bind(3,c);
+ * \endcode
+ * @param query     statement
+ * @param tuple     tuple with values to bind
+ */
+template <typename ... Types>
+void bind(SQLite::Statement& query, const std::tuple<Types...> &tuple)
+{
+    bind(query, tuple, std::index_sequence_for<Types...>());
+}
+
+/**
+ * \brief Convenience function for calling Statement::bind(...) once for each parameter of a tuple,
+ * by forwarding them to the variadic template. This function is just needed to convert the tuples
+ * to parameter packs
+ *
+ * This feature requires a c++14 capable compiler.
+ * 
+ * @param query     statement
+ * @param tuple     tuple with values to bind
+ */
+template <typename ... Types, std::size_t ... Indices>
+void bind(SQLite::Statement& query, const std::tuple<Types...> &tuple, std::index_sequence<Indices...>)
+{
+    bind(query, std::get<Indices>(tuple)...);
+}
 #endif // c++14
 
+} // namespace SQLite

--- a/libs/SQLiteCpp/src/Column.cpp
+++ b/libs/SQLiteCpp/src/Column.cpp
@@ -3,7 +3,7 @@
  * @ingroup SQLiteCpp
  * @brief   Encapsulation of a Column in a row of the result pointed by the prepared SQLite::Statement.
  *
- * Copyright (c) 2012-2018 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ * Copyright (c) 2012-2023 Sebastien Rombauts (sebastien.rombauts@gmail.com)
  *
  * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
  * or copy at http://opensource.org/licenses/MIT)
@@ -13,7 +13,6 @@
 #include <sqlite3.h>
 
 #include <iostream>
-
 
 namespace SQLite
 {
@@ -26,67 +25,65 @@ const int Null      = SQLITE_NULL;
 
 
 // Encapsulation of a Column in a row of the result pointed by the prepared Statement.
-Column::Column(Statement::Ptr& aStmtPtr, int aIndex) noexcept : // nothrow
+Column::Column(const Statement::TStatementPtr& aStmtPtr, int aIndex) :
     mStmtPtr(aStmtPtr),
     mIndex(aIndex)
 {
-}
-
-// Finalize and unregister the SQL query from the SQLite Database Connection.
-Column::~Column()
-{
-    // the finalization will be done by the destructor of the last shared pointer
+    if (!aStmtPtr)
+    {
+        throw SQLite::Exception("Statement was destroyed");
+    }
 }
 
 // Return the named assigned to this result column (potentially aliased)
-const char* Column::getName() const noexcept // nothrow
+const char* Column::getName() const noexcept
 {
-    return sqlite3_column_name(mStmtPtr, mIndex);
+    return sqlite3_column_name(mStmtPtr.get(), mIndex);
 }
 
 #ifdef SQLITE_ENABLE_COLUMN_METADATA
 // Return the name of the table column that is the origin of this result column
-const char* Column::getOriginName() const noexcept // nothrow
+const char* Column::getOriginName() const noexcept
 {
-    return sqlite3_column_origin_name(mStmtPtr, mIndex);
+    return sqlite3_column_origin_name(mStmtPtr.get(), mIndex);
 }
 #endif
 
 // Return the integer value of the column specified by its index starting at 0
-int Column::getInt() const noexcept // nothrow
+int32_t Column::getInt() const noexcept
 {
-    return sqlite3_column_int(mStmtPtr, mIndex);
+    return sqlite3_column_int(mStmtPtr.get(), mIndex);
 }
 
 // Return the unsigned integer value of the column specified by its index starting at 0
-unsigned Column::getUInt() const noexcept // nothrow
+uint32_t Column::getUInt() const noexcept
 {
     return static_cast<unsigned>(getInt64());
 }
 
 // Return the 64bits integer value of the column specified by its index starting at 0
-long long Column::getInt64() const noexcept // nothrow
+int64_t Column::getInt64() const noexcept
 {
-    return sqlite3_column_int64(mStmtPtr, mIndex);
+    return sqlite3_column_int64(mStmtPtr.get(), mIndex);
 }
 
 // Return the double value of the column specified by its index starting at 0
-double Column::getDouble() const noexcept // nothrow
+double Column::getDouble() const noexcept
 {
-    return sqlite3_column_double(mStmtPtr, mIndex);
+    return sqlite3_column_double(mStmtPtr.get(), mIndex);
 }
 
 // Return a pointer to the text value (NULL terminated string) of the column specified by its index starting at 0
-const char* Column::getText(const char* apDefaultValue /* = "" */) const noexcept // nothrow
+const char* Column::getText(const char* apDefaultValue /* = "" */) const noexcept
 {
-    const char* pText = reinterpret_cast<const char*>(sqlite3_column_text(mStmtPtr, mIndex));
-    return (pText?pText:apDefaultValue);
+    auto pText = reinterpret_cast<const char*>(sqlite3_column_text(mStmtPtr.get(), mIndex));
+    return (pText ? pText : apDefaultValue);
 }
 
 // Return a pointer to the blob value (*not* NULL terminated) of the column specified by its index starting at 0
-const void* Column::getBlob() const noexcept // nothrow
+const void* Column::getBlob() const noexcept
 {
-    return sqlite3_column_blob(mStmtPtr, mIndex);
+    return sqlite3_column_blob(mStmtPtr.get(), mIndex);
 }
 
 // Return a std::string to a TEXT or BLOB column
@@ -94,23 +91,26 @@ std::string Column::getString() const
 {
     // Note: using sqlite3_column_blob and not sqlite3_column_text
     // - no need for sqlite3_column_text to add a \0 on the end, as we're getting the bytes length directly
-    const char *data = static_cast<const char *>(sqlite3_column_blob(mStmtPtr, mIndex));
+    //   however, we need to call sqlite3_column_bytes() to ensure correct format. It's a noop on a BLOB
+    //   or a TEXT value with the correct encoding (UTF-8). Otherwise it'll do a conversion to TEXT (UTF-8).
+    (void)sqlite3_column_bytes(mStmtPtr.get(), mIndex);
+    auto data = static_cast<const char *>(sqlite3_column_blob(mStmtPtr.get(), mIndex));
 
     // SQLite docs: "The safest policy is to invoke… sqlite3_column_blob() followed by sqlite3_column_bytes()"
     // Note: std::string is ok to pass nullptr as first arg, if length is 0
-    return std::string(data, sqlite3_column_bytes(mStmtPtr, mIndex));
+    return std::string(data, sqlite3_column_bytes(mStmtPtr.get(), mIndex));
 }
 
 // Return the type of the value of the column
-int Column::getType() const noexcept // nothrow
+int Column::getType() const noexcept
 {
-    return sqlite3_column_type(mStmtPtr, mIndex);
+    return sqlite3_column_type(mStmtPtr.get(), mIndex);
 }
 
 // Return the number of bytes used by the text value of the column
-int Column::getBytes() const noexcept // nothrow
+int Column::getBytes() const noexcept
 {
-    return sqlite3_column_bytes(mStmtPtr, mIndex);
+    return sqlite3_column_bytes(mStmtPtr.get(), mIndex);
 }
 
 // Standard std::ostream inserter
@@ -119,6 +119,5 @@ std::ostream& operator<<(std::ostream& aStream, const Column& aColumn)
     aStream.write(aColumn.getText(), aColumn.getBytes());
     return aStream;
 }
-
 
 }  // namespace SQLite

--- a/libs/SQLiteCpp/src/Database.cpp
+++ b/libs/SQLiteCpp/src/Database.cpp
@@ -3,19 +3,19 @@
  * @ingroup SQLiteCpp
  * @brief   Management of a SQLite Database Connection.
  *
- * Copyright (c) 2012-2018 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ * Copyright (c) 2012-2023 Sebastien Rombauts (sebastien.rombauts@gmail.com)
  *
  * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
  * or copy at http://opensource.org/licenses/MIT)
  */
-#include <sqlite3.h>
-
 #include <SQLiteCpp/Database.h>
 
-#include <SQLiteCpp/Statement.h>
 #include <SQLiteCpp/Assertion.h>
+#include <SQLiteCpp/Backup.h>
 #include <SQLiteCpp/Exception.h>
+#include <SQLiteCpp/Statement.h>
 
+#include <sqlite3.h>
 #include <fstream>
 #include <string.h>
 
@@ -23,28 +23,37 @@
 #define SQLITE_DETERMINISTIC 0x800
 #endif // SQLITE_DETERMINISTIC
 
-
 namespace SQLite
 {
 
-const int   OPEN_READONLY   = SQLITE_OPEN_READONLY;
-const int   OPEN_READWRITE  = SQLITE_OPEN_READWRITE;
-const int   OPEN_CREATE     = SQLITE_OPEN_CREATE;
-const int   OPEN_URI        = SQLITE_OPEN_URI;
+const int   OK                = SQLITE_OK;
+const int   OPEN_READONLY     = SQLITE_OPEN_READONLY;
+const int   OPEN_READWRITE    = SQLITE_OPEN_READWRITE;
+const int   OPEN_CREATE       = SQLITE_OPEN_CREATE;
+const int   OPEN_URI          = SQLITE_OPEN_URI;
+const int   OPEN_MEMORY       = SQLITE_OPEN_MEMORY;
+const int   OPEN_NOMUTEX      = SQLITE_OPEN_NOMUTEX;
+const int   OPEN_FULLMUTEX    = SQLITE_OPEN_FULLMUTEX;
+const int   OPEN_SHAREDCACHE  = SQLITE_OPEN_SHAREDCACHE;
+const int   OPEN_PRIVATECACHE = SQLITE_OPEN_PRIVATECACHE;
+// check if sqlite version is >= 3.31.0 and SQLITE_OPEN_NOFOLLOW is defined
+#if SQLITE_VERSION_NUMBER >= 3031000 && defined(SQLITE_OPEN_NOFOLLOW)
+const int   OPEN_NOFOLLOW     = SQLITE_OPEN_NOFOLLOW;
+#else
+const int   OPEN_NOFOLLOW     = 0;
+#endif
 
-const int   OK              = SQLITE_OK;
-
-const char* VERSION         = SQLITE_VERSION;
-const int   VERSION_NUMBER  = SQLITE_VERSION_NUMBER;
+const char* const VERSION        = SQLITE_VERSION;
+const int         VERSION_NUMBER = SQLITE_VERSION_NUMBER;
 
 // Return SQLite version string using runtime call to the compiled library
-const char* getLibVersion() noexcept // nothrow
+const char* getLibVersion() noexcept
 {
     return sqlite3_libversion();
 }
 
 // Return SQLite version number using runtime call to the compiled library
-int getLibVersionNumber() noexcept // nothrow
+int getLibVersionNumber() noexcept
 {
     return sqlite3_libversion_number();
 }
@@ -55,15 +64,14 @@ Database::Database(const char* apFilename,
                    const int   aFlags         /* = SQLite::OPEN_READONLY*/,
                    const int   aBusyTimeoutMs /* = 0 */,
                    const char* apVfs          /* = nullptr*/) :
-    mpSQLite(nullptr),
     mFilename(apFilename)
 {
-    const int ret = sqlite3_open_v2(apFilename, &mpSQLite, aFlags, apVfs);
+    sqlite3* handle;
+    const int ret = sqlite3_open_v2(apFilename, &handle, aFlags, apVfs);
+    mSQLitePtr.reset(handle);
     if (SQLITE_OK != ret)
     {
-        const SQLite::Exception exception(mpSQLite, ret); // must create before closing
-        sqlite3_close(mpSQLite); // close is required even in case of error on opening
-        throw exception;
+        throw SQLite::Exception(handle, ret);
     }
     if (aBusyTimeoutMs > 0)
     {
@@ -71,31 +79,10 @@ Database::Database(const char* apFilename,
     }
 }
 
-// Open the provided database UTF-8 filename with SQLite::OPEN_xxx provided flags.
-Database::Database(const std::string& aFilename,
-                   const int          aFlags         /* = SQLite::OPEN_READONLY*/,
-                   const int          aBusyTimeoutMs /* = 0 */,
-                   const std::string& aVfs           /* = "" */) :
-    mpSQLite(nullptr),
-    mFilename(aFilename)
+// Deleter functor to use with smart pointers to close the SQLite database connection in an RAII fashion.
+void Database::Deleter::operator()(sqlite3* apSQLite)
 {
-    const int ret = sqlite3_open_v2(aFilename.c_str(), &mpSQLite, aFlags, aVfs.empty() ? nullptr : aVfs.c_str());
-    if (SQLITE_OK != ret)
-    {
-        const SQLite::Exception exception(mpSQLite, ret); // must create before closing
-        sqlite3_close(mpSQLite); // close is required even in case of error on opening
-        throw exception;
-    }
-    if (aBusyTimeoutMs > 0)
-    {
-        setBusyTimeout(aBusyTimeoutMs);
-    }
-}
-
-// Close the SQLite database connection.
-Database::~Database()
-{
-    const int ret = sqlite3_close(mpSQLite);
+    const int ret = sqlite3_close(apSQLite); // Calling sqlite3_close() with a nullptr argument is a harmless no-op.
 
     // Avoid unreferenced variable warning when build in release mode
     (void) ret;
@@ -105,33 +92,27 @@ Database::~Database()
     SQLITECPP_ASSERT(SQLITE_OK == ret, "database is locked");  // See SQLITECPP_ENABLE_ASSERT_HANDLER
 }
 
-/**
- * @brief Set a busy handler that sleeps for a specified amount of time when a table is locked.
- *
- *  This is useful in multithreaded program to handle case where a table is locked for writting by a thread.
- *  Any other thread cannot access the table and will receive a SQLITE_BUSY error:
- *  setting a timeout will wait and retry up to the time specified before returning this SQLITE_BUSY error.
- *  Reading the value of timeout for current connection can be done with SQL query "PRAGMA busy_timeout;".
- *  Default busy timeout is 0ms.
- *
- * @param[in] aBusyTimeoutMs    Amount of milliseconds to wait before returning SQLITE_BUSY
- *
- * @throw SQLite::Exception in case of error
- */
+// Set a busy handler that sleeps for a specified amount of time when a table is locked.
 void Database::setBusyTimeout(const int aBusyTimeoutMs)
 {
-    const int ret = sqlite3_busy_timeout(mpSQLite, aBusyTimeoutMs);
+    const int ret = sqlite3_busy_timeout(getHandle(), aBusyTimeoutMs);
     check(ret);
 }
 
 // Shortcut to execute one or multiple SQL statements without results (UPDATE, INSERT, ALTER, COMMIT, CREATE...).
+// Return the number of changes.
 int Database::exec(const char* apQueries)
 {
-    const int ret = sqlite3_exec(mpSQLite, apQueries, nullptr, nullptr, nullptr);
+    const int ret = tryExec(apQueries);
     check(ret);
 
     // Return the number of rows modified by those SQL statements (INSERT, UPDATE or DELETE only)
-    return sqlite3_changes(mpSQLite);
+    return sqlite3_changes(getHandle());
+}
+
+int Database::tryExec(const char* apQueries) noexcept
+{
+    return sqlite3_exec(getHandle(), apQueries, nullptr, nullptr, nullptr);
 }
 
 // Shortcut to execute a one step query and fetch the first column of the result.
@@ -148,7 +129,7 @@ Column Database::execAndGet(const char* apQuery)
 }
 
 // Shortcut to test if a table exists.
-bool Database::tableExists(const char* apTableName)
+bool Database::tableExists(const char* apTableName) const
 {
     Statement query(*this, "SELECT count(*) FROM sqlite_master WHERE type='table' AND name=?");
     query.bind(1, apTableName);
@@ -157,33 +138,39 @@ bool Database::tableExists(const char* apTableName)
 }
 
 // Get the rowid of the most recent successful INSERT into the database from the current connection.
-long long Database::getLastInsertRowid() const noexcept // nothrow
+int64_t Database::getLastInsertRowid() const noexcept
 {
-    return sqlite3_last_insert_rowid(mpSQLite);
+    return sqlite3_last_insert_rowid(getHandle());
+}
+
+// Get number of rows modified by last INSERT, UPDATE or DELETE statement (not DROP table).
+int Database::getChanges() const noexcept
+{
+    return sqlite3_changes(getHandle());
 }
 
 // Get total number of rows modified by all INSERT, UPDATE or DELETE statement since connection.
-int Database::getTotalChanges() const noexcept // nothrow
+int Database::getTotalChanges() const noexcept
 {
-    return sqlite3_total_changes(mpSQLite);
+    return sqlite3_total_changes(getHandle());
 }
 
 // Return the numeric result code for the most recent failed API call (if any).
-int Database::getErrorCode() const noexcept // nothrow
+int Database::getErrorCode() const noexcept
 {
-    return sqlite3_errcode(mpSQLite);
+    return sqlite3_errcode(getHandle());
 }
 
 // Return the extended numeric result code for the most recent failed API call (if any).
-int Database::getExtendedErrorCode() const noexcept // nothrow
+int Database::getExtendedErrorCode() const noexcept
 {
-    return sqlite3_extended_errcode(mpSQLite);
+    return sqlite3_extended_errcode(getHandle());
 }
 
 // Return UTF-8 encoded English language explanation of the most recent failed API call (if any).
-const char* Database::getErrorMsg() const noexcept // nothrow
+const char* Database::getErrorMsg() const noexcept
 {
-    return sqlite3_errmsg(mpSQLite);
+    return sqlite3_errmsg(getHandle());
 }
 
 // Attach a custom function to your sqlite database. Assumes UTF8 text representation.
@@ -193,16 +180,17 @@ void Database::createFunction(const char*   apFuncName,
                               bool          abDeterministic,
                               void*         apApp,
                               void        (*apFunc)(sqlite3_context *, int, sqlite3_value **),
-                              void        (*apStep)(sqlite3_context *, int, sqlite3_value **),
-                              void        (*apFinal)(sqlite3_context *),   // NOLINT(readability/casting)
-                              void        (*apDestroy)(void *))
+                              void        (*apStep)(sqlite3_context *, int, sqlite3_value **) /* = nullptr */,
+                              void        (*apFinal)(sqlite3_context *) /* = nullptr */, // NOLINT(readability/casting)
+                              void        (*apDestroy)(void *) /* = nullptr */)
 {
-    int TextRep = SQLITE_UTF8;
+    int textRep = SQLITE_UTF8;
     // optimization if deterministic function (e.g. of nondeterministic function random())
-    if (abDeterministic) {
-        TextRep = TextRep|SQLITE_DETERMINISTIC;
+    if (abDeterministic)
+    {
+        textRep = textRep | SQLITE_DETERMINISTIC;
     }
-    const int ret = sqlite3_create_function_v2(mpSQLite, apFuncName, aNbArg, TextRep,
+    const int ret = sqlite3_create_function_v2(getHandle(), apFuncName, aNbArg, textRep,
                                                apApp, apFunc, apStep, apFinal, apDestroy);
     check(ret);
 }
@@ -216,7 +204,7 @@ void Database::loadExtension(const char* apExtensionName, const char *apEntryPoi
     (void)apExtensionName;
     (void)apEntryPointName;
 
-    throw std::runtime_error("sqlite extensions are disabled");
+    throw SQLite::Exception("sqlite extensions are disabled");
 #else
 #ifdef SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION // Since SQLite 3.13 (2016-05-18):
     // Security warning:
@@ -224,13 +212,13 @@ void Database::loadExtension(const char* apExtensionName, const char *apEntryPoi
     // The use of the sqlite3_enable_load_extension() interface should be avoided to keep the SQL load_extension()
     // disabled and prevent SQL injections from giving attackers access to extension loading capabilities.
     // (NOTE: not using nullptr: cannot pass object of non-POD type 'std::__1::nullptr_t' through variadic function)
-    int ret = sqlite3_db_config(mpSQLite, SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION, 1, NULL); // NOTE: not using nullptr
+    int ret = sqlite3_db_config(getHandle(), SQLITE_DBCONFIG_ENABLE_LOAD_EXTENSION, 1, NULL); // NOTE: not using nullptr
 #else
-    int ret = sqlite3_enable_load_extension(mpSQLite, 1);
+    int ret = sqlite3_enable_load_extension(getHandle(), 1);
 #endif
     check(ret);
 
-    ret = sqlite3_load_extension(mpSQLite, apExtensionName, apEntryPointName, 0);
+    ret = sqlite3_load_extension(getHandle(), apExtensionName, apEntryPointName, 0);
     check(ret);
 #endif
 }
@@ -238,16 +226,17 @@ void Database::loadExtension(const char* apExtensionName, const char *apEntryPoi
 // Set the key for the current sqlite database instance.
 void Database::key(const std::string& aKey) const
 {
-    int pass_len = static_cast<int>(aKey.length());
+    int passLen = static_cast<int>(aKey.length());
 #ifdef SQLITE_HAS_CODEC
-    if (pass_len > 0) {
-        const int ret = sqlite3_key(mpSQLite, aKey.c_str(), pass_len);
+    if (passLen > 0)
+    {
+        const int ret = sqlite3_key(getHandle(), aKey.c_str(), passLen);
         check(ret);
     }
 #else // SQLITE_HAS_CODEC
-    if (pass_len > 0) {
-        const SQLite::Exception exception("No encryption support, recompile with SQLITE_HAS_CODEC to enable.");
-        throw exception;
+    if (passLen > 0)
+    {
+        throw SQLite::Exception("No encryption support, recompile with SQLITE_HAS_CODEC to enable.");
     }
 #endif // SQLITE_HAS_CODEC
 }
@@ -256,39 +245,195 @@ void Database::key(const std::string& aKey) const
 void Database::rekey(const std::string& aNewKey) const
 {
 #ifdef SQLITE_HAS_CODEC
-    int pass_len = aNewKey.length();
-    if (pass_len > 0) {
-        const int ret = sqlite3_rekey(mpSQLite, aNewKey.c_str(), pass_len);
+    int passLen = aNewKey.length();
+    if (passLen > 0)
+    {
+        const int ret = sqlite3_rekey(getHandle(), aNewKey.c_str(), passLen);
         check(ret);
-    } else {
-        const int ret = sqlite3_rekey(mpSQLite, nullptr, 0);
+    }
+    else
+    {
+        const int ret = sqlite3_rekey(getHandle(), nullptr, 0);
         check(ret);
     }
 #else // SQLITE_HAS_CODEC
     static_cast<void>(aNewKey); // silence unused parameter warning
-    const SQLite::Exception exception("No encryption support, recompile with SQLITE_HAS_CODEC to enable.");
-    throw exception;
+    throw SQLite::Exception("No encryption support, recompile with SQLITE_HAS_CODEC to enable.");
 #endif // SQLITE_HAS_CODEC
 }
 
 // Test if a file contains an unencrypted database.
 bool Database::isUnencrypted(const std::string& aFilename)
 {
-    if (aFilename.length() > 0) {
-        std::ifstream fileBuffer(aFilename.c_str(), std::ios::in | std::ios::binary);
-        char header[16];
-        if (fileBuffer.is_open()) {
-            fileBuffer.seekg(0, std::ios::beg);
-            fileBuffer.getline(header, 16);
-            fileBuffer.close();
-        } else {
-            const SQLite::Exception exception("Error opening file: " + aFilename);
-            throw exception;
-        }
-        return strncmp(header, "SQLite format 3\000", 16) == 0;
+    if (aFilename.empty())
+    {
+        throw SQLite::Exception("Could not open database, the aFilename parameter was empty.");
     }
-    const SQLite::Exception exception("Could not open database, the aFilename parameter was empty.");
-    throw exception;
+
+    std::ifstream fileBuffer(aFilename.c_str(), std::ios::in | std::ios::binary);
+    char header[16];
+    if (fileBuffer.is_open())
+    {
+        fileBuffer.seekg(0, std::ios::beg);
+        fileBuffer.getline(header, 16);
+        fileBuffer.close();
+    }
+    else
+    {
+        throw SQLite::Exception("Error opening file: " + aFilename);
+    }
+
+    return strncmp(header, "SQLite format 3\000", 16) == 0;
+}
+
+// Parse header data from a database.
+Header Database::getHeaderInfo(const std::string& aFilename)
+{
+    Header h;
+    unsigned char buf[100];
+    char* pBuf = reinterpret_cast<char*>(&buf[0]);
+    char* pHeaderStr = reinterpret_cast<char*>(&h.headerStr[0]);
+
+    if (aFilename.empty())
+    {
+        throw SQLite::Exception("Filename parameter is empty");
+    }
+
+    {
+        std::ifstream fileBuffer(aFilename.c_str(), std::ios::in | std::ios::binary);
+        if (fileBuffer.is_open())
+        {
+            fileBuffer.seekg(0, std::ios::beg);
+            fileBuffer.read(pBuf, 100);
+            fileBuffer.close();
+            if (fileBuffer.gcount() < 100)
+            {
+                throw SQLite::Exception("File " + aFilename + " is too short");
+            }
+        }
+        else
+        {
+            throw SQLite::Exception("Error opening file " + aFilename);
+        }
+    }
+
+    // If the "magic string" can't be found then header is invalid, corrupt or unreadable
+    memcpy(pHeaderStr, pBuf, 16);
+    pHeaderStr[15] = '\0';
+    if (strncmp(pHeaderStr, "SQLite format 3", 15) != 0)
+    {
+        throw SQLite::Exception("Invalid or encrypted SQLite header in file " + aFilename);
+    }
+
+    h.pageSizeBytes = (buf[16] << 8) | buf[17];
+    h.fileFormatWriteVersion = buf[18];
+    h.fileFormatReadVersion = buf[19];
+    h.reservedSpaceBytes = buf[20];
+    h.maxEmbeddedPayloadFrac = buf[21];
+    h.minEmbeddedPayloadFrac = buf[22];
+    h.leafPayloadFrac = buf[23];
+
+    h.fileChangeCounter =
+        (buf[24] << 24) |
+        (buf[25] << 16) |
+        (buf[26] << 8)  |
+        (buf[27] << 0);
+
+    h.databaseSizePages =
+        (buf[28] << 24) |
+        (buf[29] << 16) |
+        (buf[30] << 8)  |
+        (buf[31] << 0);
+
+    h.firstFreelistTrunkPage =
+        (buf[32] << 24) |
+        (buf[33] << 16) |
+        (buf[34] << 8)  |
+        (buf[35] << 0);
+
+    h.totalFreelistPages =
+        (buf[36] << 24) |
+        (buf[37] << 16) |
+        (buf[38] << 8)  |
+        (buf[39] << 0);
+
+    h.schemaCookie =
+        (buf[40] << 24) |
+        (buf[41] << 16) |
+        (buf[42] << 8)  |
+        (buf[43] << 0);
+
+    h.schemaFormatNumber =
+        (buf[44] << 24) |
+        (buf[45] << 16) |
+        (buf[46] << 8)  |
+        (buf[47] << 0);
+
+    h.defaultPageCacheSizeBytes =
+        (buf[48] << 24) |
+        (buf[49] << 16) |
+        (buf[50] << 8)  |
+        (buf[51] << 0);
+
+    h.largestBTreePageNumber =
+        (buf[52] << 24) |
+        (buf[53] << 16) |
+        (buf[54] << 8)  |
+        (buf[55] << 0);
+
+    h.databaseTextEncoding =
+        (buf[56] << 24) |
+        (buf[57] << 16) |
+        (buf[58] << 8)  |
+        (buf[59] << 0);
+
+    h.userVersion =
+        (buf[60] << 24) |
+        (buf[61] << 16) |
+        (buf[62] << 8)  |
+        (buf[63] << 0);
+
+    h.incrementalVaccumMode =
+        (buf[64] << 24) |
+        (buf[65] << 16) |
+        (buf[66] << 8)  |
+        (buf[67] << 0);
+
+    h.applicationId =
+        (buf[68] << 24) |
+        (buf[69] << 16) |
+        (buf[70] << 8)  |
+        (buf[71] << 0);
+
+    h.versionValidFor =
+        (buf[92] << 24) |
+        (buf[93] << 16) |
+        (buf[94] << 8)  |
+        (buf[95] << 0);
+
+    h.sqliteVersion =
+        (buf[96] << 24) |
+        (buf[97] << 16) |
+        (buf[98] << 8)  |
+        (buf[99] << 0);
+
+    return h;
+}
+
+void Database::backup(const char* apFilename, BackupType aType)
+{
+    // Open the database file identified by apFilename
+    Database otherDatabase(apFilename, SQLite::OPEN_READWRITE | SQLite::OPEN_CREATE);
+
+    // For a 'Save' operation, data is copied from the current Database to the other. A 'Load' is the reverse.
+    Database& src = (aType == BackupType::Save ? *this : otherDatabase);
+    Database& dest = (aType == BackupType::Save ? otherDatabase : *this);
+
+    // Set up the backup procedure to copy between the "main" databases of each connection
+    Backup bkp(dest, src);
+    bkp.executeStep(); // Execute all steps at once
+
+    // RAII Finish Backup an Close the other Database
 }
 
 }  // namespace SQLite

--- a/libs/SQLiteCpp/src/Exception.cpp
+++ b/libs/SQLiteCpp/src/Exception.cpp
@@ -3,7 +3,7 @@
  * @ingroup SQLiteCpp
  * @brief   Encapsulation of the error message from SQLite3 on a std::runtime_error.
  *
- * Copyright (c) 2012-2018 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ * Copyright (c) 2012-2023 Sebastien Rombauts (sebastien.rombauts@gmail.com)
  *
  * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt
  * or copy at http://opensource.org/licenses/MIT)
@@ -12,31 +12,10 @@
 
 #include <sqlite3.h>
 
-
 namespace SQLite
 {
 
-Exception::Exception(const char* aErrorMessage) :
-    std::runtime_error(aErrorMessage),
-    mErrcode(-1), // 0 would be SQLITE_OK, which doesn't make sense
-    mExtendedErrcode(-1)
-{
-}
-Exception::Exception(const std::string& aErrorMessage) :
-    std::runtime_error(aErrorMessage),
-    mErrcode(-1), // 0 would be SQLITE_OK, which doesn't make sense
-    mExtendedErrcode(-1)
-{
-}
-
 Exception::Exception(const char* aErrorMessage, int ret) :
-    std::runtime_error(aErrorMessage),
-    mErrcode(ret),
-    mExtendedErrcode(-1)
-{
-}
-
-Exception::Exception(const std::string& aErrorMessage, int ret) :
     std::runtime_error(aErrorMessage),
     mErrcode(ret),
     mExtendedErrcode(-1)
@@ -58,10 +37,9 @@ Exception::Exception(sqlite3* apSQLite, int ret) :
 }
 
 // Return a string, solely based on the error code
-const char* Exception::getErrorStr() const noexcept // nothrow
+const char* Exception::getErrorStr() const noexcept
 {
-    return "sqlite3 error\n"; //sqlite3_errstr(mErrcode);
+    return sqlite3_errstr(mErrcode);
 }
-
 
 }  // namespace SQLite

--- a/libs/SQLiteCpp/src/Savepoint.cpp
+++ b/libs/SQLiteCpp/src/Savepoint.cpp
@@ -1,0 +1,81 @@
+/**
+ * @file    Savepoint.cpp
+ * @ingroup SQLiteCpp
+ * @brief   A Savepoint is a way to group multiple SQL statements into an atomic
+ * secured operation. Similar to a transaction while allowing child savepoints.
+ *
+ * Copyright (c) 2020 Kelvin Hammond (hammond.kelvin@gmail.com)
+ * Copyright (c) 2020-2023 Sebastien Rombauts (sebastien.rombauts@gmail.com)
+ *
+ * Distributed under the MIT License (MIT) (See accompanying file LICENSE.txt or
+ * copy at http://opensource.org/licenses/MIT)
+ */
+
+#include <SQLiteCpp/Assertion.h>
+#include <SQLiteCpp/Database.h>
+#include <SQLiteCpp/Savepoint.h>
+#include <SQLiteCpp/Statement.h>
+
+namespace SQLite
+{
+
+// Begins the SQLite savepoint
+Savepoint::Savepoint(Database& aDatabase, const std::string& aName)
+    : mDatabase(aDatabase), msName(aName)
+{
+    // workaround because you cannot bind to SAVEPOINT
+    // escape name for use in query
+    Statement stmt(mDatabase, "SELECT quote(?)");
+    stmt.bind(1, msName);
+    stmt.executeStep();
+    msName = stmt.getColumn(0).getText();
+
+    mDatabase.exec(std::string("SAVEPOINT ") + msName);
+}
+
+// Safely rollback the savepoint if it has not been committed.
+Savepoint::~Savepoint()
+{
+    if (!mbReleased)
+    {
+        try
+        {
+            rollback();
+            release();
+        }
+        catch (SQLite::Exception&)
+        {
+            // Never throw an exception in a destructor: error if already released,
+            // but no harm is caused by this.
+        }
+    }
+}
+
+// Release the savepoint and commit
+void Savepoint::release()
+{
+    if (!mbReleased)
+    {
+        mDatabase.exec(std::string("RELEASE SAVEPOINT ") + msName);
+        mbReleased = true;
+    }
+    else
+    {
+        throw SQLite::Exception("Savepoint already released.");
+    }
+}
+
+// Rollback to the savepoint, but don't release it
+void Savepoint::rollbackTo()
+{
+    if (!mbReleased)
+    {
+        mDatabase.exec(std::string("ROLLBACK TO SAVEPOINT ") + msName);
+    }
+    else
+    {
+        throw SQLite::Exception("Savepoint already released.");
+    }
+}
+
+}  // namespace SQLite


### PR DESCRIPTION
Updates the bundled SQLite related libraries to latest releases. SQLite 3.44.2 is already available in current `opencpn-libs` so we bring the core to the same level