### PR TITLE
macos: ci: Handle std::filesystem missing on 10.13

### DIFF
--- a/ci/generic-build-macos.sh
+++ b/ci/generic-build-macos.sh
@@ -18,6 +18,7 @@ brew list --versions python3 || {
 }
 
 # Install the build dependencies for OpenCPN
+brew install boost   # Pre-10.15 compatibility
 brew install cmake
 brew install gettext
 brew install lame

--- a/include/rest_server.h
+++ b/include/rest_server.h
@@ -33,6 +33,11 @@
 #if defined(__GNUC__) && (__GNUC__ < 8)
 #include <experimental/filesystem>
 namespace fs = std::experimental::filesystem;
+
+#elif defined(__clang_major__) && (__clang_major__ < 15)
+#include <boost/filesystem.hpp>
+namespace fs = boost::filesystem;
+
 #else
 #include <filesystem>
 #include <utility>


### PR DESCRIPTION
Handle MacOS ci build errors, not detected since the ci jobs seemd to be OK although they are not