### PR TITLE
Macos ci; Fixes for std::filesystem

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1755,6 +1755,13 @@ if (APPLE AND OCPN_USE_SYSTEM_LIBARCHIVE)
   set(LIBARCHIVE_COMMENT_END "-->")
 endif ()
 
+if (APPLE)
+  # Required for 10.13 compat.
+  find_library(BOOST_SYSTEM NAMES boost_system REQUIRED)
+  find_library(BOOST_FILESYSTEM NAMES boost_filesystem REQUIRED)
+  target_link_libraries(${PACKAGE_NAME} PUBLIC BOOST_SYSTEM BOOST_FILESYSTEM)
+endif ()
+
 message(STATUS "    Adding local LIBTESS2")
 add_subdirectory(libs/libtess2)
 target_link_libraries(${PACKAGE_NAME} PRIVATE ocpn::tess2)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1281,6 +1281,7 @@ add_library(_opencpn INTERFACE) # plugin link target.
 target_link_libraries(_opencpn INTERFACE ${PACKAGE_NAME})
 target_include_directories(
   _opencpn
+  BEFORE
   INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 add_library(ocpn::opencpn ALIAS _opencpn)
@@ -1296,6 +1297,7 @@ set_target_properties(
 
 target_include_directories(
   ${PACKAGE_NAME}
+  BEFORE
   PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 

--- a/ci/universal-build-macos.sh
+++ b/ci/universal-build-macos.sh
@@ -40,6 +40,7 @@ brew list --versions python3 || {
 
 
 # Install the build dependencies for OpenCPN
+brew install boost    # pre-10.15 compatibility
 brew install cmake
 brew install gettext
 

--- a/include/rest_server.h
+++ b/include/rest_server.h
@@ -30,13 +30,13 @@
 #include <thread>
 #include <unordered_map>
 
-#if defined(__GNUC__) && (__GNUC__ < 8)
-#include <experimental/filesystem>
-namespace fs = std::experimental::filesystem;
-
-#elif defined(__clang_major__) && (__clang_major__ < 15)
+#if defined(__clang_major__) && (__clang_major__ < 15)
 #include <boost/filesystem.hpp>
 namespace fs = boost::filesystem;
+
+#elif !defined(llvm) && defined(__GNUC__) && (__GNUC__ < 8)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
 
 #else
 #include <filesystem>


### PR DESCRIPTION
Fixes for std:.filesystem MacOS CI build errors. 

Builds still fails on unrelated include paths problems leading to the use of /usr/local/include/geodesic.h instead of ./geodesic.h