### PR TITLE
c: windows: clean up

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -52,6 +52,13 @@ jobs:
         shell: cmd
         run: ci\appveyor.bat
 
+      - name: "Check build results"
+        shell: bash
+        run: |
+          ls -l build/$CONFIGURATION/opencpn.exe || exit 1
+          ls -l build/$CONFIGURATION/opencpn-cmd.exe || exit 1
+          ls -l build/test/$CONFIGURATION/tests.exe || exit 1
+
       - name: Upload
         shell: bash
         run: ci/generic-upload.sh

--- a/buildwin/win_deps.bat
+++ b/buildwin/win_deps.bat
@@ -51,6 +51,7 @@ if not exist C:\ProgramData\chocolatey\lib\nsis (
 
 :: Make sure the pre-compiled libraries are in place
 set "GH_DL_BASE=https://github.com/OpenCPN/OCPNWindowsCoreBuildSupport"
+set "opencpn_support_base=https://dl.cloudsmith.io/public/alec-leamas"
 if not exist %CACHE_DIR%\buildwin\libcurl.dll (
   wget -nv -O !CACHE_DIR!\OCPNWindowsCoreBuildSupport.zip ^
       %GH_DL_BASE%/archive/refs/tags/v0.3.zip
@@ -63,4 +64,6 @@ if not exist %CACHE_DIR%\buildwin\libcurl.dll (
   if exist !CACHE_DIR!\buildwin\wxWidgets (
     rmdir !CACHE_DIR!\buildwin\wxWidgets /s /q
   )
+  wget !opencpn_support_base!/opencpn-support/raw/files/iphlpapi.lib ^
+   -O %CACHE_DIR%\buildwin\iphlpapi.lib
 )

--- a/ci/appveyor.bat
+++ b/ci/appveyor.bat
@@ -52,7 +52,7 @@ cmake -A Win32 -G "Visual Studio 17 2022" ^
     -DOCPN_CI_BUILD=ON ^
     -DOCPN_BUNDLE_WXDLLS=ON ^
     -DOCPN_RELEASE=0 ^
-    -DOCPN_BUILD_TEST=OFF ^
+    -DOCPN_BUILD_TEST=ON ^
     ..
 
 cmake --build . --target package --config %CONFIGURATION%

--- a/test/n2k_tests.cpp
+++ b/test/n2k_tests.cpp
@@ -132,7 +132,7 @@ extern float g_selection_radius_touch_mm;
 extern int g_nCOMPortCheck;
 extern bool g_benableUDPNullHeader;
 
-extern AbstractPlatform* g_BasePlatform;
+extern BasePlatform* g_BasePlatform;
 extern void* g_pi_manager;
 extern wxString g_compatOS;
 extern wxString g_compatOsVersion;
@@ -187,7 +187,7 @@ protected:
   wxAppConsole* app;
 
   virtual void SetUp()  override {
-    g_BasePlatform = new CliPlatform();
+    g_BasePlatform = new BasePlatform();
     pSelectAIS = new Select();
     pSelect = new Select();
     g_pAIS = new AisDecoder(AisDecoderCallbacks());
@@ -273,7 +273,7 @@ public:
     wxAppConsole::OnInit();
 
     //Observable::Clear();
-    g_BasePlatform = new CliPlatform();
+    g_BasePlatform = new BasePlatform();
     delete pSelectAIS;
     pSelectAIS = new Select();
     delete pSelect;

--- a/test/rest-tests.cpp
+++ b/test/rest-tests.cpp
@@ -37,7 +37,7 @@ using namespace std::chrono_literals;
 extern WayPointman* pWayPointMan;
 extern RouteList* pRouteList;
 extern Select* pSelect;
-extern AbstractPlatform* g_BasePlatform;
+extern BasePlatform* g_BasePlatform;
 
 static std::string s_result;
 static int int_result0;
@@ -215,7 +215,8 @@ protected:
   }
 };
 
-class RestServerObjectApp : public RestServerApp {
+class
+RestServerObjectApp : public RestServerApp {
 public:
   RestServerObjectApp(RestServerDlgCtx ctx, RouteCtx route_ctx, bool& portable)
       : RestServerApp(ctx, route_ctx, portable) {}
@@ -225,7 +226,7 @@ protected:
     auto colour_func = [] (wxString c) { return *wxBLACK; };
     pWayPointMan = new WayPointman(colour_func);
     pRouteList = new RouteList;
-    g_BasePlatform = new CliPlatform();
+    g_BasePlatform = new BasePlatform();
     pSelect =  new Select();
 
     auto outpath = fs::path(CMAKE_BINARY_DIR) / "curl-result";
@@ -317,7 +318,7 @@ protected:
     auto colour_func = [] (wxString c) { return *wxBLACK; };
     pWayPointMan = new WayPointman(colour_func);
     pRouteList = new RouteList;
-    g_BasePlatform = new CliPlatform();
+    g_BasePlatform = new BasePlatform();
     pSelect = new Select();
 
     fs::path curl_prog(CURLPROG);

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -75,7 +75,7 @@ float g_selection_radius_touch_mm;
 int g_nCOMPortCheck = 32;
 bool g_benableUDPNullHeader;
 
-AbstractPlatform* g_BasePlatform = 0;
+BasePlatform* g_BasePlatform = 0;
 void* g_pi_manager = reinterpret_cast<void*>(1L);
 wxString g_compatOS = PKG_TARGET;
 wxString g_compatOsVersion = PKG_TARGET_VERSION;
@@ -410,7 +410,7 @@ public:
   AisApp(const char* type, const char* msg) : wxAppConsole() {
     ConfigSetup();
     SetAppName("opencpn_unittests");
-    g_BasePlatform = new CliPlatform();
+    g_BasePlatform = new BasePlatform();
     pSelectAIS = new Select();
     pSelect = new Select();
     g_pAIS = new AisDecoder(AisDecoderCallbacks());


### PR DESCRIPTION
- Make sure that failing builds are actually vissible as such
- Add tests to the default build target
- Fix errors in tests and a missing library in the build