### PR TITLE
CI polish

### DIFF
--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -59,6 +59,14 @@ jobs:
           ls -l build/$CONFIGURATION/opencpn-cmd.exe || exit 1
           ls -l build/test/$CONFIGURATION/tests.exe || exit 1
 
+      - name: "Run tests"
+        shell: bash
+        run: |
+          set -x
+          cd build
+          cmake --install .
+          cmake --build . --config $CONFIGURATION --target run-tests
+
       - name: Upload
         shell: bash
         run: ci/generic-upload.sh

--- a/.github/workflows/zulip.yml
+++ b/.github/workflows/zulip.yml
@@ -19,10 +19,13 @@ env:
 jobs:
   on-anything:
     runs-on: ubuntu-latest
+    env:
+      zulip_api_key: ${{ secrets.ZULIP_API_KEY }}
     steps:
       - run: echo "GITHUB_ACTOR=$GITHUB_ACTOR" >> $GITHUB_ENV
       - run: echo "SHORT_SHA=${GITHUB_SHA:0:8}" >> $GITHUB_ENV
-      - name: Tell Zulip
+      - if: ${{ env.zulip_api_key != ''}} 
+        name: Tell Zulip
         uses: zulip/github-actions-zulip/send-message@v1
         with:
           email: github-actions-bot@opencpn.zulipchat.com

--- a/ci/appveyor.bat
+++ b/ci/appveyor.bat
@@ -52,6 +52,7 @@ cmake -A Win32 -G "Visual Studio 17 2022" ^
     -DOCPN_CI_BUILD=ON ^
     -DOCPN_BUNDLE_WXDLLS=ON ^
     -DOCPN_RELEASE=0 ^
+    -DCMAKE_INSTALL_PREFIX="%cd%/test/%CONFIGURATION%" ^
     -DOCPN_BUILD_TEST=ON ^
     ..
 

--- a/flatpak/org.opencpn.OpenCPN.yaml
+++ b/flatpak/org.opencpn.OpenCPN.yaml
@@ -169,6 +169,7 @@ modules:
           - -DCMAKE_FIND_ROOT_PATH_MODE_PROGRAM=BOTH
           - -DCMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY
           - -DCMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY
+          - -DCMAKE_BUILD_TYPE=Release
       build-options:
           build-args:
             - --share=network


### PR DESCRIPTION
  - fix long-standing issue where  the zulip GA workflow fails if  run on forks of master.
  - Make the Flatpak job make a Release build rather than Debug.
  -  Wndows: Run tests as part of build