### PR TITLE
Increase serial output sentence buffer size

### DIFF
--- a/model/src/comm_drv_n0183_serial.cpp
+++ b/model/src/comm_drv_n0183_serial.cpp
@@ -95,7 +95,7 @@ private:
   mutable std::mutex m_mutex;
 };
 
-#define OUT_QUEUE_LENGTH                20
+#define OUT_QUEUE_LENGTH                50
 #define MAX_OUT_QUEUE_MESSAGE_LENGTH    100
 
 wxDEFINE_EVENT(wxEVT_COMMDRIVER_N0183_SERIAL, CommDriverN0183SerialEvent);


### PR DESCRIPTION
The current implementation of the NMEA0183 serial driver uses a queue to exchange NMEA sentences between the main thread and the serial thread. The default maximum size of this queue is fixed to 20 NMEA sentences. If a new NMEA sentence arrive in the queue while it is full, the sentence is dropped and lost.
This loss of data arrives quite often when the serial port is connected to a slow device using 4800 or 38400 baud and when the source is sending bursts of sentences (SK signaling, AIS by internet, etc.), even if the average bitrate is far below 4800 or 38400 baud.
I propose to increase the size from 20 to 50 messages. The value of 50 seems ok with the various configurations I tested. Note that very few memory is used here since only one pointer is stored in the queue.