### PR TITLE
Peer transfers: client overhaul.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -799,7 +799,7 @@ set(GUI_HDRS
     ${GUI_HDR_DIR}/OCPNRegion.h
     ${GUI_HDR_DIR}/options.h
     ${GUI_HDR_DIR}/piano.h
-    ${GUI_HDR_DIR}/peer_client.h
+    ${GUI_HDR_DIR}/peer_client_dlg.h
     ${GUI_HDR_DIR}/pluginmanager.h
     ${GUI_HDR_DIR}/printtable.h
     ${GUI_HDR_DIR}/priority_gui.h
@@ -910,7 +910,7 @@ set(GUI_SRC
     ${GUI_SRC_DIR}/OCPNRegion.cpp
     ${GUI_SRC_DIR}/options.cpp
     ${GUI_SRC_DIR}/Osenc.cpp
-    ${GUI_SRC_DIR}/peer_client.cpp
+    ${GUI_SRC_DIR}/peer_client_dlg.cpp
     ${GUI_SRC_DIR}/piano.cpp
     ${GUI_SRC_DIR}/pluginmanager.cpp
     ${GUI_SRC_DIR}/printtable.cpp

--- a/gui/include/gui/SendToPeerDlg.h
+++ b/gui/include/gui/SendToPeerDlg.h
@@ -30,7 +30,16 @@
 #include <wx/wx.h>
 #endif  // precompiled headers
 
+#include <string>
+
 #include <wx/dialog.h>
+
+#include "model/route.h"
+#include "model/track.h"
+#include "model/route_point.h"
+
+#include "observable_evtvar.h"
+
 
 //    Constants for SendToPeer... Dialog
 #define ID_STPDIALOG 10006
@@ -43,10 +52,6 @@
 #define SYMBOL_STP_POSITION wxDefaultPosition
 
 enum { ID_STP_CANCEL = 10000, ID_STP_OK, ID_STP_CHOICE_PEER, ID_STP_SCAN };
-
-class Route;
-class RoutePoint;
-class Track;
 
 /**
  * Route "Send to Peer..." Dialog Definition
@@ -77,14 +82,13 @@ public:
   void SetScanTime(int t){ m_scanTime = t * 2;}
 
 private:
-  void CreateControls(const wxString& hint);
+  void CreateControls([[maybe_unused]] const wxString& hint);
 
   void OnCancelClick(wxCommandEvent& event);
-  void OnSendClick(wxCommandEvent& event);
+  void OnSendClick([[maybe_unused]] wxCommandEvent& event);
   void OnScanClick(wxCommandEvent& event);
   void OnTimerAutoscan(wxTimerEvent &event);
   void OnTimerScanTick(wxTimerEvent &event);
-  void OnTimerTransferTick(wxTimerEvent &event);
   void DoScan();
 
   std::vector<Route*> m_RouteList;
@@ -96,10 +100,11 @@ private:
   wxButton* m_SendButton;
   wxStaticText* premtext;
   wxButton *m_RescanButton;
+  EventVar progress;
+  ObsListener progress_listener;
 
   wxTimer m_autoScanTimer;
   wxTimer m_ScanTickTimer;
-  wxTimer m_TransferTimer;
   int m_tick;
   int m_scanTime;
   bool m_bScanOnCreate;

--- a/gui/include/gui/SendToPeerDlg.h
+++ b/gui/include/gui/SendToPeerDlg.h
@@ -25,18 +25,30 @@
 #ifndef __SENDTOPEERDLG_H__
 #define __SENDTOPEERDLG_H__
 
+#include <vector>
+
 #include <wx/wxprec.h>
 #ifndef WX_PRECOMP
 #include <wx/wx.h>
 #endif  // precompiled headers
 
-#include <string>
+#include <vector>
 
+#include <wx/button.h>
+#include <wx/checkbox.h>
+#include <wx/combobox.h>
 #include <wx/dialog.h>
+#include <wx/event.h>
+#include <wx/gauge.h>
+#include <wx/gdicmn.h>
+#include <wx/stattext.h>
+#include <wx/string.h>
+#include <wx/timer.h>
+#include <wx/window.h>
 
 #include "model/route.h"
-#include "model/track.h"
 #include "model/route_point.h"
+#include "model/track.h"
 
 #include "observable_evtvar.h"
 
@@ -95,7 +107,8 @@ private:
   wxButton* m_CancelButton;
   wxButton* m_SendButton;
   wxStaticText* premtext;
-  wxButton *m_RescanButton;
+  wxButton* m_RescanButton;
+  wxCheckBox* m_activate_chkbox;
   EventVar progress;
   ObsListener progress_listener;
 

--- a/gui/include/gui/SendToPeerDlg.h
+++ b/gui/include/gui/SendToPeerDlg.h
@@ -98,6 +98,7 @@ private:
   void OnTimerAutoscan(wxTimerEvent &event);
   void OnTimerScanTick(wxTimerEvent &event);
   void DoScan();
+  bool EnableActivateChkbox();
 
   std::vector<Route*> m_RouteList;
   std::vector<RoutePoint*> m_RoutePointList;

--- a/gui/include/gui/SendToPeerDlg.h
+++ b/gui/include/gui/SendToPeerDlg.h
@@ -62,9 +62,6 @@ class SendToPeerDlg : public wxDialog {
 
 public:
   SendToPeerDlg();
-  SendToPeerDlg(wxWindow* parent, wxWindowID id, const wxString& caption,
-               const wxString& hint, const wxPoint& pos, const wxSize& size,
-               long style);
   ~SendToPeerDlg();
 
   bool Create(wxWindow* parent, wxWindowID id = SYMBOL_STP_IDNAME,
@@ -76,7 +73,6 @@ public:
   void SetRoute(Route* pRoute) { m_RouteList.push_back(pRoute); }
   void SetWaypoint(RoutePoint* pRoutePoint) { m_RoutePointList.push_back(pRoutePoint); }
   void SetTrack(Track* pTrack) { m_TrackList.push_back(pTrack); }
-  wxGauge* GetProgressGauge() { return m_pgauge; }
   void SetMessage(wxString message);
   void SetScanOnCreate(bool s){ m_bScanOnCreate = s;}
   void SetScanTime(int t){ m_scanTime = t * 2;}

--- a/gui/include/gui/ocpn_app.h
+++ b/gui/include/gui/ocpn_app.h
@@ -75,7 +75,7 @@ public:
   InstanceCheck& m_checker;
   CommBridge m_comm_bridge;
 
-  RestServer m_RESTserver;
+  RestServer m_rest_server;
 
   DECLARE_EVENT_TABLE()
 private:
@@ -91,6 +91,9 @@ private:
 
   ParsedCmdline m_parsed_cmdline;
   int m_exitcode;  ///< by default -2. Otherwise, forces exit(exit_code)
+
+  void InitRestListeners();
+  ObsListener rest_srv_listener;
 
 };
 

--- a/gui/include/gui/ocpn_frame.h
+++ b/gui/include/gui/ocpn_frame.h
@@ -35,14 +35,15 @@
 #endif
 
 #include "model/ocpn_types.h"
-#include "ocpn_print.h"
-#include "color_handler.h"
-#include "gui_lib.h"
-#include "s52s57.h"
-#include "SencManager.h"
 #include "model/comm_appmsg_bus.h"
 #include "bbox.h"
+#include "color_handler.h"
+#include "gui_lib.h"
 #include "load_errors_dlg.h"
+#include "observable_evtvar.h"
+#include "ocpn_print.h"
+#include "s52s57.h"
+#include "SencManager.h"
 
 wxColour GetGlobalColor(wxString colorName);
 wxColour GetDialogColor(DialogColor color);
@@ -439,6 +440,7 @@ private:
   ObservableListener listener_gps_watchdog;
   ObsListener m_on_raise_listener;
   ObsListener m_on_quit_listener;
+  ObsListener m_routes_update_listener;
 
   DECLARE_EVENT_TABLE()
 };

--- a/gui/include/gui/peer_client.h
+++ b/gui/include/gui/peer_client.h
@@ -30,20 +30,21 @@
 #include "model/route.h"
 #include "model/track.h"
 
-int SendNavobjects(std::string dest_ip_address, std::string server_name, std::vector<Route*> route, std::vector<RoutePoint*> routepoint, std::vector<Track*> track, bool overwrite = false);
+int SendNavobjects(std::string dest_ip_address, std::string server_name,
+                   std::vector<Route*> route,
+                   std::vector<RoutePoint*> routepoint,
+                   std::vector<Track*> track, bool overwrite = false);
 
+#define ID_PCDDIALOG 10005
+#define SYMBOL_PCD_STYLE \
+  wxCAPTION | wxRESIZE_BORDER | wxSYSTEM_MENU | wxCLOSE_BOX
 
- #define ID_PCDDIALOG 10005
- #define SYMBOL_PCD_STYLE                                      \
-   wxCAPTION | wxRESIZE_BORDER | wxSYSTEM_MENU | wxCLOSE_BOX
-
- #define SYMBOL_PCD_TITLE _("Send to GPS")
- #define SYMBOL_PCD_IDNAME ID_PCDDIALOG
- #define SYMBOL_PCD_SIZE wxSize(500, 500)
- #define SYMBOL_PCD_POSITION wxDefaultPosition
+#define SYMBOL_PCD_TITLE _("Send to GPS")
+#define SYMBOL_PCD_IDNAME ID_PCDDIALOG
+#define SYMBOL_PCD_SIZE wxSize(500, 500)
+#define SYMBOL_PCD_POSITION wxDefaultPosition
 
 enum { ID_PCD_CANCEL = 10000, ID_PCD_OK, ID_PCD_CHECK1 };
-
 
 class PINConfirmDialog : public wxDialog {
   DECLARE_DYNAMIC_CLASS(PINConfirmDialog)
@@ -52,8 +53,8 @@ class PINConfirmDialog : public wxDialog {
 public:
   PINConfirmDialog();
   PINConfirmDialog(wxWindow* parent, wxWindowID id, const wxString& caption,
-               const wxString& hint, const wxPoint& pos, const wxSize& size,
-               long style);
+                   const wxString& hint, const wxPoint& pos, const wxSize& size,
+                   long style);
   ~PINConfirmDialog();
 
   bool Create(wxWindow* parent, wxWindowID id = SYMBOL_PCD_IDNAME,
@@ -62,10 +63,10 @@ public:
               const wxPoint& pos = SYMBOL_PCD_POSITION,
               const wxSize& size = SYMBOL_PCD_SIZE,
               long style = SYMBOL_PCD_STYLE);
-  void SetMessage(const wxString &message);
-  void SetText1Message(const wxString &message);
+  void SetMessage(const wxString& message);
+  void SetText1Message(const wxString& message);
 
-  wxString GetText1Value(){ return m_pText1->GetValue(); }
+  wxString GetText1Value() { return m_pText1->GetValue(); }
 
   void OnCancelClick(wxCommandEvent& event);
   void OnOKClick(wxCommandEvent& event);
@@ -73,11 +74,10 @@ public:
 private:
   void CreateControls(const wxString& hint);
 
-
   wxButton* m_CancelButton;
   wxButton* m_OKButton;
   wxStaticText* premtext;
-  wxTextCtrl *m_pText1;
+  wxTextCtrl* m_pText1;
   wxString m_checkbox1_msg;
 };
 

--- a/gui/include/gui/peer_client_dlg.h
+++ b/gui/include/gui/peer_client_dlg.h
@@ -27,13 +27,8 @@
 #define _PEER__CLIENT_DLG_H
 
 #include <string>
-#include "model/route.h"
-#include "model/track.h"
 
-int SendNavobjects(std::string dest_ip_address, std::string server_name,
-                   std::vector<Route*> route,
-                   std::vector<RoutePoint*> routepoint,
-                   std::vector<Track*> track, bool overwrite = false);
+#include "model/peer_client.h"
 
 #define ID_PCDDIALOG 10005
 #define SYMBOL_PCD_STYLE \
@@ -44,18 +39,16 @@ int SendNavobjects(std::string dest_ip_address, std::string server_name,
 #define SYMBOL_PCD_SIZE wxSize(500, 500)
 #define SYMBOL_PCD_POSITION wxDefaultPosition
 
-enum { ID_PCD_CANCEL = 10000, ID_PCD_OK, ID_PCD_CHECK1 };
+enum { ID_PCD_CANCEL = 10000, ID_PCD_OK = 10001, ID_PCD_CHECK1 };
 
-class PINConfirmDialog : public wxDialog {
-  DECLARE_DYNAMIC_CLASS(PINConfirmDialog)
-  DECLARE_EVENT_TABLE()
+class PINConfirmDlg : public wxDialog {
 
 public:
-  PINConfirmDialog();
-  PINConfirmDialog(wxWindow* parent, wxWindowID id, const wxString& caption,
+  PINConfirmDlg();
+  PINConfirmDlg(wxWindow* parent, wxWindowID id, const wxString& caption,
                    const wxString& hint, const wxPoint& pos, const wxSize& size,
                    long style);
-  ~PINConfirmDialog();
+  ~PINConfirmDlg();
 
   bool Create(wxWindow* parent, wxWindowID id = SYMBOL_PCD_IDNAME,
               const wxString& caption = SYMBOL_PCD_TITLE,

--- a/gui/include/gui/peer_client_dlg.h
+++ b/gui/include/gui/peer_client_dlg.h
@@ -43,8 +43,6 @@
 #define SYMBOL_PCD_SIZE wxSize(500, 500)
 #define SYMBOL_PCD_POSITION wxDefaultPosition
 
-enum { ID_PCD_CANCEL = 10000, ID_PCD_OK = 10001 };
-
 class PinConfirmDlg : public wxDialog {
 public:
   PinConfirmDlg();

--- a/gui/include/gui/peer_client_dlg.h
+++ b/gui/include/gui/peer_client_dlg.h
@@ -26,9 +26,13 @@
 #ifndef _PEER__CLIENT_DLG_H
 #define _PEER__CLIENT_DLG_H
 
-#include <string>
-
-#include "model/peer_client.h"
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/gdicmn.h>
+#include <wx/stattext.h>
+#include <wx/string.h>
+#include <wx/textctrl.h>
+#include <wx/window.h>
 
 #define ID_PCDDIALOG 10005
 #define SYMBOL_PCD_STYLE \
@@ -39,16 +43,15 @@
 #define SYMBOL_PCD_SIZE wxSize(500, 500)
 #define SYMBOL_PCD_POSITION wxDefaultPosition
 
-enum { ID_PCD_CANCEL = 10000, ID_PCD_OK = 10001, ID_PCD_CHECK1 };
+enum { ID_PCD_CANCEL = 10000, ID_PCD_OK = 10001 };
 
-class PINConfirmDlg : public wxDialog {
-
+class PinConfirmDlg : public wxDialog {
 public:
-  PINConfirmDlg();
-  PINConfirmDlg(wxWindow* parent, wxWindowID id, const wxString& caption,
-                   const wxString& hint, const wxPoint& pos, const wxSize& size,
-                   long style);
-  ~PINConfirmDlg();
+  PinConfirmDlg();
+  PinConfirmDlg(wxWindow* parent, wxWindowID id, const wxString& caption,
+                const wxString& hint, const wxPoint& pos, const wxSize& size,
+                long style);
+  ~PinConfirmDlg();
 
   bool Create(wxWindow* parent, wxWindowID id = SYMBOL_PCD_IDNAME,
               const wxString& caption = SYMBOL_PCD_TITLE,
@@ -57,20 +60,20 @@ public:
               const wxSize& size = SYMBOL_PCD_SIZE,
               long style = SYMBOL_PCD_STYLE);
   void SetMessage(const wxString& message);
-  void SetText1Message(const wxString& message);
+  void SetPincodeText(const wxString& message);
+  wxString GetPincodeText() { return m_pin_textctrl->GetValue(); }
 
-  wxString GetText1Value() { return m_pText1->GetValue(); }
-
+private:
   void OnCancelClick(wxCommandEvent& event);
   void OnOKClick(wxCommandEvent& event);
 
-private:
   void CreateControls(const wxString& hint);
+  void OnTextChange(wxCommandEvent& ev);
 
-  wxButton* m_CancelButton;
-  wxButton* m_OKButton;
+  wxButton* m_cancel_btn;
+  wxButton* m_ok_btn;
   wxStaticText* premtext;
-  wxTextCtrl* m_pText1;
+  wxTextCtrl* m_pin_textctrl;
   wxString m_checkbox1_msg;
 };
 

--- a/gui/include/gui/peer_client_dlg.h
+++ b/gui/include/gui/peer_client_dlg.h
@@ -23,8 +23,8 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 
-#ifndef _PEERCLIENT_H
-#define _PEERCLIENT_H
+#ifndef _PEER__CLIENT_DLG_H
+#define _PEER__CLIENT_DLG_H
 
 #include <string>
 #include "model/route.h"

--- a/gui/include/gui/route_ctx_factory.h
+++ b/gui/include/gui/route_ctx_factory.h
@@ -31,6 +31,7 @@
 #include "model/routeman.h"
 #include "model/track.h"
 
+extern WayPointman* pWayPointMan;
 extern Routeman *g_pRouteMan;
 extern std::vector<Track*> g_TrackList;
 
@@ -44,6 +45,10 @@ RouteCtx RouteCtxFactory() {
         [](wxString guid) {
             if (!g_pRouteMan) return static_cast<Track*>(0);
             return g_pRouteMan->FindTrackByGUID(guid); };
+    ctx.find_wpt_by_guid =
+        [](wxString guid) {
+            if (!pWayPointMan) return static_cast<RoutePoint*>(0);
+            return pWayPointMan->FindWaypointByGuid(guid.ToStdString()); };
     ctx.delete_route =
         [](Route* route) {
             if (!g_pRouteMan) return;
@@ -56,6 +61,10 @@ RouteCtx RouteCtxFactory() {
               }
               delete track;
         };
+    ctx.delete_waypoint =
+        [](RoutePoint* wpt) {
+            if (!pWayPointMan) return;
+            pWayPointMan->DestroyWaypoint(wpt); };
     return ctx;
 }
 #endif   //  _ROUTE_CTX_FACTORY_H__

--- a/gui/include/gui/routemanagerdialog.h
+++ b/gui/include/gui/routemanagerdialog.h
@@ -31,6 +31,8 @@
 #include <wx/textctrl.h>
 #include <wx/checkbox.h>
 
+#include "observable.h"
+
 #define NAME_COLUMN 2
 #define DISTANCE_COLUMN 3
 
@@ -223,6 +225,8 @@ private:
 
   int m_charWidth;
   int m_listIconSize;
+
+  ObsListener routes_update_listener;
 };
 
 #endif  // _RouteManagerDialog_h_

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -113,8 +113,7 @@ std::pair<PeerDlgResult, std::string> RunPincodeDlg() {
 
   dlg.SetMessage(msg);
   dlg.SetPincodeText("");
-  dlg.ShowModal();
-  if (dlg.GetReturnCode() == ID_PCD_OK) {
+  if (dlg.ShowModal() == ID_PCD_OK) {
     auto pin = dlg.GetPincodeText().Trim().Trim(false);
     return {PeerDlgResult::HasPincode, pin.ToStdString()};
   }

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -133,16 +133,6 @@ SendToPeerDlg::SendToPeerDlg() {
 #endif
 }
 
-SendToPeerDlg::SendToPeerDlg(wxWindow* parent, wxWindowID id,
-                             const wxString& caption, const wxString& hint,
-                             const wxPoint& pos, const wxSize& size,
-                             long style) {
-#ifdef __ANDROID__
-  androidDisableRotation();
-#endif
-  Create(parent, id, caption, hint, pos, size, style);
-}
-
 SendToPeerDlg::~SendToPeerDlg() {
   delete m_PeerListBox;
   delete m_pgauge;
@@ -157,7 +147,6 @@ bool SendToPeerDlg::Create(wxWindow* parent, wxWindowID id,
                            const wxString& caption, const wxString& hint,
                            const wxPoint& pos, const wxSize& size, long style) {
   SetExtraStyle(GetExtraStyle() | wxWS_EX_BLOCK_EVENTS);
-
   wxFont* pF = OCPNGetFont(_T("Dialog"), 0);
   SetFont(*pF);
 
@@ -172,11 +161,13 @@ bool SendToPeerDlg::Create(wxWindow* parent, wxWindowID id,
     m_autoScanTimer.SetOwner(this, TIMER_AUTOSCAN);
     m_autoScanTimer.Start(500, wxTIMER_ONE_SHOT);
   }
-
   m_ScanTickTimer.SetOwner(this, TIMER_SCANTICK);
 
   auto action = [&](ObservedEvt& evt) { m_pgauge->SetValue(evt.GetInt()); };
   progress_listener.Init(progress, action);
+#ifdef __ANDROID__
+  androidDisableRotation();
+#endif
   return true;
 }
 
@@ -280,7 +271,6 @@ void SendToPeerDlg::OnSendClick(wxCommandEvent&) {
   peer_data.run_pincode_dlg = RunPincodeDlg;
   peer_data.dest_ip_address = peer_ip.ToStdString();
   peer_data.server_name = server_name.ToStdString();
-
 
   GetApiVersion(peer_data);
   if (peer_data.api_version < SemanticVersion(5, 9)) {

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -274,6 +274,7 @@ void SendToPeerDlg::OnSendClick(wxCommandEvent&) {
   peer_data.routepoints = m_RoutePointList;
   peer_data.run_status_dlg = RunStatusDlg;
   peer_data.run_pincode_dlg = RunPincodeDlg;
+  peer_data.activate = m_activate_chkbox->GetValue();
 
   // And send it out
   m_pgauge->SetRange(100);

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -88,6 +88,15 @@ static PeerDlgResult RunStatusDlg(PeerDlg kind, int status) {
       dlg.ShowModal();
       return PeerDlgResult::Ok;
     }
+    case PeerDlg::ActivateUnsupported: {
+      std::string msg(_("Server does not support activation"));
+      OCPNMessageDialog dlg(NULL, msg, _("OpenCPN Info"),
+                            wxICON_ERROR | wxOK | wxCANCEL);
+
+      int r = dlg.ShowModal();
+      return r == wxID_OK ? PeerDlgResult::Ok : PeerDlgResult::Cancel;
+      return PeerDlgResult::Cancel;
+    }
     case PeerDlg::PinConfirm:
       assert(false && "Illegal PinConfirm result dialog");
   }

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -26,12 +26,17 @@
 #include "model/cmdline.h"
 #include "model/config_vars.h"
 #include "model/mDNS_query.h"
+#include "model/peer_client.h"
+#include "model/route.h"
+#include "model/route_point.h"
+
+#include "gui_lib.h"
 #include "OCPNPlatform.h"
+#include "ocpn_frame.h"
 #include "peer_client_dlg.h"
 #include "route_gui.h"
-#include "model/route.h"
 #include "route_point_gui.h"
-#include "model/route_point.h"
+
 #include "SendToPeerDlg.h"
 #include "ocpn_plugin.h"
 
@@ -39,24 +44,80 @@
 #include "androidUTIL.h"
 #endif
 
-#define TIMER_AUTOSCAN  94522
-#define TIMER_SCANTICK  94523
-#define TIMER_TRANSFER  94524
+#define TIMER_AUTOSCAN 94522
+#define TIMER_SCANTICK 94523
 
+extern MyFrame* gFrame;
 extern OCPNPlatform* g_Platform;
 extern std::vector<std::shared_ptr<ocpn_DNS_record_t>> g_DNS_cache;
 extern wxDateTime g_DNS_cache_time;
-extern int navobj_transfer_progress;
+
+static PeerDlgResult ConfirmWriteDlg() {
+  std::string msg(_("Objects exists on server. OK to overwrite?"));
+  long style = wxYES | wxNO | wxNO_DEFAULT | wxICON_QUESTION;
+  OCPNMessageDialog dlg(NULL, msg, _("OpenCPN Info"), style);
+  int reply = dlg.ShowModal();
+  return reply == wxID_YES ? PeerDlgResult::Ok : PeerDlgResult::Cancel;
+}
+
+static PeerDlgResult RunStatusDlg(PeerDlg kind, int status) {
+  switch (kind) {
+    case PeerDlg::InvalidHttpResponse: {
+      std::stringstream ss;
+      ss << _("Server HTTP response is :") << status;
+      OCPNMessageDialog dlg(NULL, ss.str(), _("OpenCPN Info"),
+                            wxICON_ERROR | wxOK | wxCANCEL);
+      int r = dlg.ShowModal();
+      return r == wxID_OK ? PeerDlgResult::Ok : PeerDlgResult::Cancel;
+    }
+    case PeerDlg::ErrorReturn: {
+      std::stringstream ss;
+      ss << _("Server internal error response:") << status;
+      OCPNMessageDialog dlg(NULL, ss.str(), _("OpenCPN Info"),
+                            wxICON_ERROR | wxOK | wxCANCEL);
+      int r = dlg.ShowModal();
+      return r == wxID_OK ? PeerDlgResult::Ok : PeerDlgResult::Cancel;
+    }
+    case PeerDlg::TransferOk: {
+      std::stringstream ss;
+      std::string msg(_("Transfer succesfully completed"));
+      OCPNMessageDialog dlg(NULL, msg, _("OpenCPN Info"),
+                            wxICON_INFORMATION | wxOK);
+      dlg.ShowModal();
+      return PeerDlgResult::Ok;
+    }
+    case PeerDlg::PinConfirm:
+      assert(false && "Illegal PinConfirm result dialog");
+  }
+  return PeerDlgResult::Cancel;  // For the compiler, not reached
+}
+
+std::pair<PeerDlgResult, std::string> RunPincodeDlg() {
+  PINConfirmDlg dlg(gFrame, wxID_ANY, _("OpenCPN Server Message"), "",
+                    wxDefaultPosition, wxDefaultSize, SYMBOL_PCD_STYLE);
+
+  static const char* const msg =
+      R""(_(A server pin is needed.
+  Please enter the PIN number from the server to pair with this device.))"";
+
+  dlg.SetMessage(msg);
+  dlg.SetText1Message("");
+  dlg.ShowModal();
+  if (dlg.GetReturnCode() == ID_PCD_OK) {
+    auto pin = dlg.GetText1Value().Trim().Trim(false);
+    return {PeerDlgResult::HasPincode, pin.ToStdString()};
+  }
+  return {PeerDlgResult::Cancel, ""};
+}
 
 IMPLEMENT_DYNAMIC_CLASS(SendToPeerDlg, wxDialog)
 
 BEGIN_EVENT_TABLE(SendToPeerDlg, wxDialog)
-  EVT_BUTTON(ID_STP_CANCEL, SendToPeerDlg::OnCancelClick)
-  EVT_BUTTON(ID_STP_OK, SendToPeerDlg::OnSendClick)
-  EVT_BUTTON(ID_STP_SCAN, SendToPeerDlg::OnScanClick)
-  EVT_TIMER(TIMER_AUTOSCAN, SendToPeerDlg::OnTimerAutoscan)
-  EVT_TIMER(TIMER_SCANTICK, SendToPeerDlg::OnTimerScanTick)
-  EVT_TIMER(TIMER_TRANSFER, SendToPeerDlg::OnTimerTransferTick)
+EVT_BUTTON(ID_STP_CANCEL, SendToPeerDlg::OnCancelClick)
+EVT_BUTTON(ID_STP_OK, SendToPeerDlg::OnSendClick)
+EVT_BUTTON(ID_STP_SCAN, SendToPeerDlg::OnScanClick)
+EVT_TIMER(TIMER_AUTOSCAN, SendToPeerDlg::OnTimerAutoscan)
+EVT_TIMER(TIMER_SCANTICK, SendToPeerDlg::OnTimerScanTick)
 END_EVENT_TABLE()
 
 SendToPeerDlg::SendToPeerDlg() {
@@ -65,17 +126,17 @@ SendToPeerDlg::SendToPeerDlg() {
   m_SendButton = NULL;
   m_CancelButton = NULL;
   premtext = NULL;
-  m_scanTime = 5;  //default, seconds
+  m_scanTime = 5;  // default, seconds
   m_bScanOnCreate = false;
 #ifdef __ANDROID__
   androidDisableRotation();
 #endif
-
 }
 
 SendToPeerDlg::SendToPeerDlg(wxWindow* parent, wxWindowID id,
-                           const wxString& caption, const wxString& hint,
-                           const wxPoint& pos, const wxSize& size, long style) {
+                             const wxString& caption, const wxString& hint,
+                             const wxPoint& pos, const wxSize& size,
+                             long style) {
 #ifdef __ANDROID__
   androidDisableRotation();
 #endif
@@ -93,11 +154,11 @@ SendToPeerDlg::~SendToPeerDlg() {
 }
 
 bool SendToPeerDlg::Create(wxWindow* parent, wxWindowID id,
-                          const wxString& caption, const wxString& hint,
-                          const wxPoint& pos, const wxSize& size, long style) {
+                           const wxString& caption, const wxString& hint,
+                           const wxPoint& pos, const wxSize& size, long style) {
   SetExtraStyle(GetExtraStyle() | wxWS_EX_BLOCK_EVENTS);
 
-  wxFont *pF = OCPNGetFont(_T("Dialog"), 0);
+  wxFont* pF = OCPNGetFont(_T("Dialog"), 0);
   SetFont(*pF);
 
   wxDialog::Create(parent, id, caption, pos, size, style);
@@ -107,18 +168,19 @@ bool SendToPeerDlg::Create(wxWindow* parent, wxWindowID id,
   GetSizer()->SetSizeHints(this);
   Centre();
 
-  if (m_bScanOnCreate){
+  if (m_bScanOnCreate) {
     m_autoScanTimer.SetOwner(this, TIMER_AUTOSCAN);
     m_autoScanTimer.Start(500, wxTIMER_ONE_SHOT);
   }
 
   m_ScanTickTimer.SetOwner(this, TIMER_SCANTICK);
-  m_TransferTimer.SetOwner(this, TIMER_TRANSFER);
 
-  return TRUE;
+  auto action = [&](ObservedEvt& evt) { m_pgauge->SetValue(evt.GetInt()); };
+  progress_listener.Init(progress, action);
+  return true;
 }
 
-void SendToPeerDlg::CreateControls(const wxString& hint) {
+void SendToPeerDlg::CreateControls(const wxString&) {
   SendToPeerDlg* itemDialog1 = this;
 
   wxBoxSizer* itemBoxSizer2 = new wxBoxSizer(wxVERTICAL);
@@ -135,10 +197,10 @@ void SendToPeerDlg::CreateControls(const wxString& hint) {
   m_PeerListBox = new wxComboBox(this, ID_STP_CHOICE_PEER);
 
   //    Fill in the wxComboBox with all detected peers
-  for (unsigned int i=0; i < g_DNS_cache.size(); i++){
+  for (unsigned int i = 0; i < g_DNS_cache.size(); i++) {
     wxString item(g_DNS_cache[i]->hostname.c_str());
 
-    //skip "self"
+    // skip "self"
     if (!g_hostname.IsSameAs(item.BeforeFirst('.'))) {
       item += " {";
       item += g_DNS_cache[i]->ip.c_str();
@@ -147,8 +209,7 @@ void SendToPeerDlg::CreateControls(const wxString& hint) {
     }
   }
 
-  if (m_PeerListBox->GetCount())
-    m_PeerListBox->SetSelection(0);
+  if (m_PeerListBox->GetCount()) m_PeerListBox->SetSelection(0);
 
   comm_box_sizer->Add(m_PeerListBox, 0, wxEXPAND | wxALL, 5);
 
@@ -159,8 +220,8 @@ void SendToPeerDlg::CreateControls(const wxString& hint) {
                                 wxDefaultPosition, wxDefaultSize, 0);
   itemBoxSizer3->Add(m_RescanButton, 0, wxALL, 5);
 
-  m_pgauge = new wxGauge(itemDialog1, -1, m_scanTime * 2,
-                          wxDefaultPosition, wxSize(-1, GetCharHeight()));
+  m_pgauge = new wxGauge(itemDialog1, -1, m_scanTime * 2, wxDefaultPosition,
+                         wxSize(-1, GetCharHeight()));
   itemBoxSizer3->Add(m_pgauge, 0, wxEXPAND | wxALL, 20);
 
   //    Add a reminder text box
@@ -187,7 +248,7 @@ void SendToPeerDlg::SetMessage(wxString msg) {
   }
 }
 
-void SendToPeerDlg::OnSendClick(wxCommandEvent& event) {
+void SendToPeerDlg::OnSendClick(wxCommandEvent&) {
   if (m_RouteList.empty() && m_TrackList.empty() && m_RoutePointList.empty())
     Close();
 
@@ -195,8 +256,7 @@ void SendToPeerDlg::OnSendClick(wxCommandEvent& event) {
   wxString peer_ip = m_PeerListBox->GetValue();
   wxString server_name = peer_ip.BeforeFirst('{').Trim();
   int tail = peer_ip.Find('{');
-  if (tail != wxNOT_FOUND)
-    peer_ip = peer_ip.Mid(tail+1);
+  if (tail != wxNOT_FOUND) peer_ip = peer_ip.Mid(tail + 1);
   peer_ip = peer_ip.BeforeFirst('}');
   peer_ip += ":";
 
@@ -207,78 +267,76 @@ void SendToPeerDlg::OnSendClick(wxCommandEvent& event) {
   else
     peer_ip += "8443";
 
-  std::string server_address("https://");
-  server_address += peer_ip.ToStdString();
-
-
-   //g_uploadConnection = src;  // save for persistence
-
-
   //    And send it out
   m_pgauge->SetRange(100);
   m_pgauge->SetValue(0);
-  m_TransferTimer.Start(50);
   m_pgauge->Show();
-  if (!m_RouteList.empty() || !m_RoutePointList.empty() || !m_TrackList.empty())
-  {
-    int return_code = SendNavobjects(server_address, server_name.ToStdString(), m_RouteList, m_RoutePointList, m_TrackList, true);
+
+  PeerData peer_data(progress);
+  peer_data.routes = m_RouteList;
+  peer_data.tracks = m_TrackList;
+  peer_data.routepoints = m_RoutePointList;
+  peer_data.run_status_dlg = RunStatusDlg;
+  peer_data.run_pincode_dlg = RunPincodeDlg;
+  peer_data.dest_ip_address = peer_ip.ToStdString();
+  peer_data.server_name = server_name.ToStdString();
+
+
+  GetApiVersion(peer_data);
+  if (peer_data.api_version < SemanticVersion(5, 9)) {
+    SendNavobjects(peer_data);
+  } else {
+    bool is_writable = CheckNavObjects(peer_data);
+    if (is_writable || ConfirmWriteDlg() == PeerDlgResult::Ok) {
+      peer_data.overwrite = true;
+      SendNavobjects(peer_data);
+    }
   }
-  m_TransferTimer.Stop();
+
   m_pgauge->Hide();
   Close();
 }
 
-void SendToPeerDlg::OnScanClick(wxCommandEvent& event) {
-  DoScan();
-}
+void SendToPeerDlg::OnScanClick(wxCommandEvent&) { DoScan(); }
 
-void SendToPeerDlg::OnTimerAutoscan(wxTimerEvent &event) {
-  DoScan();
-}
+void SendToPeerDlg::OnTimerAutoscan(wxTimerEvent&) { DoScan(); }
 
-void SendToPeerDlg::OnTimerScanTick(wxTimerEvent &event) {
+void SendToPeerDlg::OnTimerScanTick(wxTimerEvent&) {
   m_tick--;
-  if(m_pgauge) {
+  if (m_pgauge) {
     int v = m_pgauge->GetValue();
-    if( v + 1 <= m_pgauge->GetRange())
-      m_pgauge->SetValue(v+1);
+    if (v + 1 <= m_pgauge->GetRange()) m_pgauge->SetValue(v + 1);
   }
 
-  if (m_tick == 0){
+  if (m_tick == 0) {
     // Housekeeping
-   m_ScanTickTimer.Stop();
-   g_Platform->HideBusySpinner();
-   m_RescanButton->Enable();
-   m_SendButton->Enable();
-   m_SendButton->SetDefault();
-   m_pgauge->Hide();
-   m_bScanOnCreate = false;
+    m_ScanTickTimer.Stop();
+    g_Platform->HideBusySpinner();
+    m_RescanButton->Enable();
+    m_SendButton->Enable();
+    m_SendButton->SetDefault();
+    m_pgauge->Hide();
+    m_bScanOnCreate = false;
 
-      // Clear the combo box
-   m_PeerListBox->Clear();
+    // Clear the combo box
+    m_PeerListBox->Clear();
 
-   //    Fill in the wxComboBox with all detected peers
-   for (unsigned int i=0; i < g_DNS_cache.size(); i++){
-     wxString item(g_DNS_cache[i]->hostname.c_str());
+    //    Fill in the wxComboBox with all detected peers
+    for (unsigned int i = 0; i < g_DNS_cache.size(); i++) {
+      wxString item(g_DNS_cache[i]->hostname.c_str());
 
-    //skip "self"
-     if (!g_hostname.IsSameAs(item.BeforeFirst('.'))) {
-       item += " {";
-       item += g_DNS_cache[i]->ip.c_str();
-       item += "}";
-       m_PeerListBox->Append(item);
-     }
-   }
-   if (m_PeerListBox->GetCount())
-    m_PeerListBox->SetSelection(0);
+      // skip "self"
+      if (!g_hostname.IsSameAs(item.BeforeFirst('.'))) {
+        item += " {";
+        item += g_DNS_cache[i]->ip.c_str();
+        item += "}";
+        m_PeerListBox->Append(item);
+      }
+    }
+    if (m_PeerListBox->GetCount()) m_PeerListBox->SetSelection(0);
 
-   g_DNS_cache_time = wxDateTime::Now();
+    g_DNS_cache_time = wxDateTime::Now();
   }
-}
-
-void SendToPeerDlg::OnTimerTransferTick(wxTimerEvent &event) {
-  m_pgauge->SetValue(navobj_transfer_progress);
-  event.Skip();
 }
 
 void SendToPeerDlg::DoScan() {
@@ -295,7 +353,7 @@ void SendToPeerDlg::DoScan() {
   m_ScanTickTimer.Start(500, wxTIMER_CONTINUOUS);
 }
 
-void SendToPeerDlg::OnCancelClick(wxCommandEvent& event) {
+void SendToPeerDlg::OnCancelClick(wxCommandEvent&) {
   g_Platform->HideBusySpinner();
   Close();
 }

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -201,6 +201,11 @@ bool SendToPeerDlg::Create(wxWindow* parent, wxWindowID id,
   return true;
 }
 
+bool SendToPeerDlg::EnableActivateChkbox() {
+  return m_RouteList.size() == 1 && m_RoutePointList.empty() &&
+     m_TrackList.empty();
+}
+
 void SendToPeerDlg::CreateControls(const wxString&) {
   SendToPeerDlg* itemDialog1 = this;
 
@@ -253,6 +258,7 @@ void SendToPeerDlg::CreateControls(const wxString&) {
                                      wxALIGN_RIGHT);
   itemBoxSizer2->Add(m_activate_chkbox, 0,
                      wxALIGN_RIGHT | wxALL, 10);
+  if (!EnableActivateChkbox()) m_activate_chkbox->Disable();
 
 
   //    OK/Cancel/etc.

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -80,7 +80,7 @@ static PeerDlgResult RunStatusDlg(PeerDlg kind, int status) {
     }
     case PeerDlg::TransferOk: {
       std::stringstream ss;
-      std::string msg(_("Transfer succesfully completed"));
+      std::string msg(_("Transfer successfully completed"));
       OCPNMessageDialog dlg(NULL, msg, _("OpenCPN Info"),
                             wxICON_INFORMATION | wxOK);
       dlg.ShowModal();

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -25,6 +25,8 @@
 
 #include <wx/statline.h>
 
+#include <curl/curl.h>
+
 #include "model/cmdline.h"
 #include "model/config_vars.h"
 #include "model/mDNS_query.h"
@@ -66,7 +68,12 @@ static PeerDlgResult RunStatusDlg(PeerDlg kind, int status) {
   switch (kind) {
     case PeerDlg::InvalidHttpResponse: {
       std::stringstream ss;
-      ss << _("Server HTTP response is :") << status;
+      if (status >= 0) {
+        ss << _("Server HTTP response is :") << status;
+      } else {
+        ss << _("Curl transfer error: ")
+           << curl_easy_strerror(static_cast<CURLcode>(-status));
+      }
       OCPNMessageDialog dlg(NULL, ss.str(), _("OpenCPN Info"),
                             wxICON_ERROR | wxOK | wxCANCEL);
       int r = dlg.ShowModal();

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -113,7 +113,7 @@ std::pair<PeerDlgResult, std::string> RunPincodeDlg() {
 
   dlg.SetMessage(msg);
   dlg.SetPincodeText("");
-  if (dlg.ShowModal() == ID_PCD_OK) {
+  if (dlg.ShowModal() == wxID_OK) {
     auto pin = dlg.GetPincodeText().Trim().Trim(false);
     return {PeerDlgResult::HasPincode, pin.ToStdString()};
   }

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -95,6 +95,20 @@ static PeerDlgResult RunStatusDlg(PeerDlg kind, int status) {
       dlg.ShowModal();
       return PeerDlgResult::Ok;
     }
+    case PeerDlg::JsonParseError: {
+      std::string msg(_("Cannot parse server reply"));
+      OCPNMessageDialog dlg(NULL, msg, _("OpenCPN Info"),
+                            wxICON_ERROR | wxOK | wxCANCEL);
+      int r = dlg.ShowModal();
+      return r == wxID_OK ? PeerDlgResult::Ok : PeerDlgResult::Cancel;
+    }
+     case PeerDlg::BadPincode: {
+      std::string msg(_("Pincode not accepted"));
+      OCPNMessageDialog dlg(NULL, msg, _("OpenCPN Info"),
+                            wxICON_ERROR | wxOK | wxCANCEL);
+      int r = dlg.ShowModal();
+      return r == wxID_OK ? PeerDlgResult::Ok : PeerDlgResult::Cancel;
+    }
     case PeerDlg::ActivateUnsupported: {
       std::string msg(_("Server does not support activation"));
       OCPNMessageDialog dlg(NULL, msg, _("OpenCPN Info"),
@@ -102,7 +116,6 @@ static PeerDlgResult RunStatusDlg(PeerDlg kind, int status) {
 
       int r = dlg.ShowModal();
       return r == wxID_OK ? PeerDlgResult::Ok : PeerDlgResult::Cancel;
-      return PeerDlgResult::Cancel;
     }
     case PeerDlg::PinConfirm:
       assert(false && "Illegal PinConfirm result dialog");

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -23,6 +23,8 @@
  */
 #include <memory>
 
+#include <wx/statline.h>
+
 #include "model/cmdline.h"
 #include "model/config_vars.h"
 #include "model/mDNS_query.h"
@@ -228,8 +230,15 @@ void SendToPeerDlg::CreateControls(const wxString&) {
                          wxSize(-1, GetCharHeight()));
   itemBoxSizer3->Add(m_pgauge, 0, wxEXPAND | wxALL, 20);
 
-  //    Add a reminder text box
   itemBoxSizer2->AddSpacer(30);
+  itemBoxSizer2->Add(new wxStaticLine(this), wxSizerFlags(0).Expand());
+  m_activate_chkbox = new wxCheckBox(this,  wxID_ANY,
+                                     _("Activate after transfer"),
+                                     wxDefaultPosition, wxDefaultSize,
+                                     wxALIGN_RIGHT);
+  itemBoxSizer2->Add(m_activate_chkbox, 0,
+                     wxALIGN_RIGHT | wxALL, 10);
+
 
   //    OK/Cancel/etc.
   wxBoxSizer* itemBoxSizer16 = new wxBoxSizer(wxHORIZONTAL);

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -27,7 +27,7 @@
 #include "model/config_vars.h"
 #include "model/mDNS_query.h"
 #include "OCPNPlatform.h"
-#include "peer_client.h"
+#include "peer_client_dlg.h"
 #include "route_gui.h"
 #include "model/route.h"
 #include "route_point_gui.h"

--- a/gui/src/canvasMenu.cpp
+++ b/gui/src/canvasMenu.cpp
@@ -77,7 +77,7 @@
 #include "tide_time.h"
 #include "track_gui.h"
 #include "undo.h"
-#include "peer_client.h"
+#include "peer_client_dlg.h"
 #include "model/mDNS_query.h"
 #include "OCPNPlatform.h"
 

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -838,46 +838,6 @@ static bool LoadAllPlugIns(bool load_enabled) {
   return b;
 }
 
-
-#ifndef __ANDROID__
-// Connection class, for use by both communicating instances
-class stConnection : public wxConnection {
-public:
-  stConnection() {}
-  ~stConnection() {}
-  bool OnExec(const wxString &topic, const wxString &data);
-};
-
-// Opens a file passed from another instance
-bool stConnection::OnExec(const wxString &topic, const wxString &data) {
-  // not setup yet
-  if (!gFrame) return false;
-
-  wxString path(data);
-  if (path.IsEmpty()) {
-    gFrame->InvalidateAllGL();
-    gFrame->RefreshAllCanvas(false);
-    gFrame->Raise();
-  } else {
-    NavObjectCollection1 *pSet = new NavObjectCollection1;
-    pSet->load_file(path.fn_str());
-    int wpt_dups;
-    pSet->LoadAllGPXObjects(
-        !pSet->IsOpenCPN(), wpt_dups,
-        true);  // Import with full vizibility of names and objects
-    if (pRouteManagerDialog && pRouteManagerDialog->IsShown())
-      pRouteManagerDialog->UpdateLists();
-
-    LLBBox box = pSet->GetBBox();
-    if (box.GetValid()) {
-      gFrame->CenterView(gFrame->GetPrimaryCanvas(), box);
-    }
-    delete pSet;
-    return true;
-  }
-  return true;
-}
-#endif   // __ANDROID__
 //------------------------------------------------------------------------------
 //    PNG Icon resources
 //------------------------------------------------------------------------------
@@ -885,7 +845,6 @@ bool stConnection::OnExec(const wxString &topic, const wxString &data) {
 #if defined(__WXGTK__) || defined(__WXQT__)
 #include "bitmaps/opencpn.xpm"
 #endif
-
 
 
 wxString newPrivateFileName(wxString home_locn, const char *name,
@@ -1009,7 +968,6 @@ static void ParseLoglevel(wxCmdLineParser &parser) {
   wxLogLevel level = OcpnLog::str2level(strLevel);
   if (level == OcpnLog::LOG_BADLEVEL) {
     fprintf(stderr, "Bad loglevel %s, using \"info\"", strLevel);
-    strLevel = "info";
     level = wxLOG_Info;
   }
   wxLog::SetLogLevel(level);

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -918,7 +918,34 @@ BEGIN_EVENT_TABLE(MyApp, wxApp)
 EVT_ACTIVATE_APP(MyApp::OnActivateApp)
 END_EVENT_TABLE()
 
-bool MyApp::OpenFile(const std::string& path) {
+static void ActivateRoute(const std::string &guid) {
+  Route *route = g_pRouteMan->FindRouteByGUID(guid);
+  if (!route) {
+    wxLogMessage("Cannot activate guid: no such route");
+    return;
+  }
+  if (g_pRouteMan->GetpActiveRoute()) g_pRouteMan->DeactivateRoute();
+  //  If this is an auto-created MOB route, always select the second point
+  //  (the MOB)
+  // as the destination.
+  RoutePoint* point;
+  if (wxNOT_FOUND == route->m_RouteNameString.Find("MOB")) {
+    point = g_pRouteMan->FindBestActivatePoint(route, gLat, gLon, gCog, gSog);
+  } else {
+    point = route->GetPoint(2);
+  }
+  g_pRouteMan->ActivateRoute(route, point);
+  route->m_bRtIsSelected = false;
+}
+
+void MyApp::InitRestListeners() {
+  auto activate_route = [&](wxCommandEvent ev) {
+    auto guid = ev.GetString().ToStdString();
+    ActivateRoute(guid); };
+  rest_srv_listener.Init(m_rest_server.activate_route, activate_route);
+}
+
+  bool MyApp::OpenFile(const std::string& path) {
   NavObjectCollection1 nav_objects;
   auto result = nav_objects.load_file(path.c_str());
   if (!result)  {
@@ -1108,7 +1135,7 @@ int MyApp::OnRun() {
 
 MyApp::MyApp()
     : m_checker(InstanceCheck::GetInstance()),
-      m_RESTserver(PINCreateDialog::GetDlgCtx(),
+      m_rest_server(PINCreateDialog::GetDlgCtx(),
       RouteCtxFactory(),
       g_bportable),
       m_exitcode(-2) {
@@ -1572,6 +1599,8 @@ bool MyApp::OnInit() {
       pInit_Chart_Dir->Append(androidGetExtStorageDir());
 #endif
   }
+
+  InitRestListeners();
 
   //      Establish the GSHHS Dataset location
   gDefaultWorldMapLocation = "gshhs";
@@ -2058,8 +2087,7 @@ bool MyApp::OnInit() {
 
     make_certificate(ipAddr, data_dir.ToStdString());
 
-    m_RESTserver.StartServer(fs::path(data_dir.ToStdString()));
-
+    m_rest_server.StartServer(fs::path(data_dir.ToStdString()));
     StartMDNSService(g_hostname.ToStdString(),
                      "opencpn-object-control-service", 8000);
   }

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -5039,7 +5039,7 @@ void MyFrame::InitApiListeners() {
   m_on_raise_listener.Init(server.on_raise, [&](ObservedEvt){ Raise(); });
   m_on_quit_listener.Init(server.on_quit, [&](ObservedEvt){ FastClose(); });
   server.SetGetRestApiEndpointCb(
-    [&]{ return wxGetApp().m_RESTserver.GetEndpoint(); });
+    [&]{ return wxGetApp().m_rest_server.GetEndpoint(); });
   server.open_file_cb =
       [](const std::string& path) { return wxGetApp().OpenFile(path); };
 

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -806,6 +806,9 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, const wxPoint &pos,
   m_resizeTimer.SetOwner(this, RESIZE_TIMER);
   m_recaptureTimer.SetOwner(this, RECAPTURE_TIMER);
   m_tick_idx = 0;
+  assert(g_pRouteMan != 0 && "g_pRouteMan not available");
+  m_routes_update_listener.Init(g_pRouteMan->on_routes_update,
+                                [&](wxCommandEvent) { Refresh(); });
 
 
 #ifdef __WXOSX__

--- a/gui/src/peer_client.cpp
+++ b/gui/src/peer_client.cpp
@@ -140,7 +140,6 @@ long PostSendObjectMessage(std::string url, std::ostringstream& body,
   curl_easy_setopt(c, CURLOPT_XFERINFOFUNCTION, xfer_callback);
   if (timeout) curl_easy_setopt(c, CURLOPT_TIMEOUT, 5);
 
-
   CURLcode result = curl_easy_perform(c);
   navobj_transfer_progress = 0;
   if (result == CURLE_OK)
@@ -165,7 +164,6 @@ bool CheckApiKey(std::string url, MemoryStruct* response) {
   curl_easy_cleanup(c);
   return response_code == 200;
 }
-
 
 std::string GetClientKey(std::string& server_name) {
   if (TheBaseConfig()) {
@@ -229,7 +227,6 @@ void SaveClientKey(std::string& server_name, std::string key) {
   return;
 }
 
-
 SemanticVersion GetApiVersion(const std::string& dest_ip) {
   std::string url(dest_ip);
   url += "/api/get-version";
@@ -252,15 +249,13 @@ SemanticVersion GetApiVersion(const std::string& dest_ip) {
     wxString version = root["version"].AsString();
     return SemanticVersion::parse(version.ToStdString());
   } else {
-      return SemanticVersion(-1, -1);
+    return SemanticVersion(-1, -1);
   }
 }
 
-
 RestServerResult CheckApiKey(const std::string& source,
-	                     const std::string& api_key,
-			     const std::string& dest_ip)
-{
+                             const std::string& api_key,
+                             const std::string& dest_ip) {
   std::string url(dest_ip);
   url += "/api/ping";
   url += std::string("?source=") + g_hostname;
@@ -283,9 +278,9 @@ RestServerResult CheckApiKey(const std::string& source,
     int result = root["result"].AsInt();
 
     if (result > 0) {
-       return RestServerResult::NewPinRequested;
+      return RestServerResult::NewPinRequested;
     } else {
-       return RestServerResult::Void;
+      return RestServerResult::Void;
     }
   } else {
     return RestServerResult::Void;
@@ -342,22 +337,22 @@ int SendNavobjects(std::string dest_ip_address, std::string server_name,
           if (dlg.GetReturnCode() == ID_PCD_OK) {
             wxString PIN_tentative = dlg.GetText1Value().Trim().Trim(false);
             unsigned int dPIN = atoi(PIN_tentative.ToStdString().c_str());
-	    Pincode pincode(dPIN);
-	    std::string api_key = pincode.Hash();
+            Pincode pincode(dPIN);
+            std::string api_key = pincode.Hash();
             RestServerResult result;
             SemanticVersion v = GetApiVersion(dest_ip_address);
             if (v >= SemanticVersion(5, 9)) {
               result = CheckApiKey(g_hostname.ToStdString(), api_key,
-		                   dest_ip_address);
+                                   dest_ip_address);
             } else {
               api_key = pincode.CompatHash();
               result = CheckApiKey(g_hostname.ToStdString(), api_key,
-			           dest_ip_address);
+                                   dest_ip_address);
             }
             SaveClientKey(server_name, api_key);
           } else {
             b_cancel = true;
-	  }
+          }
         } else if (result == static_cast<int>(RestServerResult::GenericError))
           apikey_ok = true;
       } else

--- a/gui/src/peer_client_dlg.cpp
+++ b/gui/src/peer_client_dlg.cpp
@@ -1,0 +1,539 @@
+/***************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  Peer-peer data sharing.
+ * Author:   David Register
+ *
+ ***************************************************************************
+ *   Copyright (C) 2022 by David Register                                  *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+#include <iostream>
+#include <sstream>
+
+#include <curl/curl.h>
+
+#include "peer_client_dlg.h"
+
+#include <wx/fileconf.h>
+#include <wx/json_defs.h>
+#include <wx/jsonreader.h>
+#include <wx/tokenzr.h>
+
+#include "model/config_vars.h"
+#include "FontMgr.h"
+#include "gui_lib.h"
+#include "model/nav_object_database.h"
+#include "model/rest_server.h"
+#include "model/semantic_vers.h"
+#include "ocpn_frame.h"
+
+extern MyFrame* gFrame;
+
+wxString GetErrorText(RestServerResult result) {
+  switch (result) {
+    case RestServerResult::GenericError:
+      return _("Server Generic Error");
+    case RestServerResult::ObjectRejected:
+      return _("Peer rejected object");
+    case RestServerResult::DuplicateRejected:
+      return _("Peer rejected duplicate object");
+    case RestServerResult::RouteInsertError:
+      return _("Peer internal error (insert)");
+    default:
+      return _("Server Unknown Error");
+  }
+}
+
+size_t wxcurl_string_write_UTF8(void* ptr, size_t size, size_t nmemb,
+                                void* pcharbuf) {
+  size_t iRealSize = size * nmemb;
+  wxCharBuffer* pStr = (wxCharBuffer*)pcharbuf;
+
+  if (pStr) {
+#ifdef __WXMSW__
+    wxString str1a = wxString(*pStr);
+    wxString str2 = wxString((const char*)ptr, wxConvUTF8, iRealSize);
+    *pStr = (str1a + str2).mb_str();
+#else
+    wxString str = wxString(*pStr, wxConvUTF8) +
+                   wxString((const char*)ptr, wxConvUTF8, iRealSize);
+    *pStr = str.mb_str(wxConvUTF8);
+#endif
+  }
+
+  return iRealSize;
+}
+
+struct MemoryStruct {
+  char* memory;
+  size_t size;
+};
+
+static size_t WriteMemoryCallback(void* contents, size_t size, size_t nmemb,
+                                  void* userp) {
+  size_t realsize = size * nmemb;
+  struct MemoryStruct* mem = (struct MemoryStruct*)userp;
+
+  char* ptr = (char*)realloc(mem->memory, mem->size + realsize + 1);
+  if (!ptr) {
+    /* out of memory! */
+    printf("not enough memory (realloc returned NULL)\n");
+    return 0;
+  }
+
+  mem->memory = ptr;
+  memcpy(&(mem->memory[mem->size]), contents, realsize);
+  mem->size += realsize;
+  mem->memory[mem->size] = 0;
+
+  return realsize;
+}
+
+int navobj_transfer_progress;
+
+int xfer_callback(void* clientp, curl_off_t dltotal, curl_off_t dlnow,
+                  curl_off_t ultotal, curl_off_t ulnow) {
+  if (ultotal == 0) {
+    navobj_transfer_progress = 0;
+  } else {
+    navobj_transfer_progress = 100 * ulnow / ultotal;
+  }
+  wxYield();
+  return 0;
+}
+
+long PostSendObjectMessage(std::string url, std::ostringstream& body,
+                           MemoryStruct* response, bool timeout = false) {
+  long response_code = -1;
+  navobj_transfer_progress = 0;
+
+  CURL* c = curl_easy_init();
+  curl_easy_setopt(c, CURLOPT_ENCODING,
+                   "identity");  // No encoding, plain ASCII
+  curl_easy_setopt(c, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(c, CURLOPT_SSL_VERIFYPEER, 0L);
+  curl_easy_setopt(c, CURLOPT_SSL_VERIFYHOST, 0L);
+
+  int iSize = strlen(body.str().c_str());
+  curl_easy_setopt(c, CURLOPT_POSTFIELDSIZE, iSize);
+  curl_easy_setopt(c, CURLOPT_COPYPOSTFIELDS, body.str().c_str());
+
+  curl_easy_setopt(c, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
+  curl_easy_setopt(c, CURLOPT_WRITEDATA, (void*)response);
+  curl_easy_setopt(c, CURLOPT_NOPROGRESS, 0);
+  curl_easy_setopt(c, CURLOPT_XFERINFOFUNCTION, xfer_callback);
+  if (timeout) curl_easy_setopt(c, CURLOPT_TIMEOUT, 5);
+
+  CURLcode result = curl_easy_perform(c);
+  navobj_transfer_progress = 0;
+  if (result == CURLE_OK)
+    curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &response_code);
+
+  curl_easy_cleanup(c);
+
+  return response_code;
+}
+
+bool CheckApiKey(std::string url, MemoryStruct* response) {
+  long response_code = -1;
+
+  CURL* c = curl_easy_init();
+  curl_easy_setopt(c, CURLOPT_ENCODING, "identity");  // Encoding: plain ASCII
+  curl_easy_setopt(c, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(c, CURLOPT_SSL_VERIFYPEER, 0L);
+  curl_easy_setopt(c, CURLOPT_SSL_VERIFYHOST, 0L);
+  CURLcode result = curl_easy_perform(c);
+  if (result == CURLE_OK)
+    curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &response_code);
+  curl_easy_cleanup(c);
+  return response_code == 200;
+}
+
+std::string GetClientKey(std::string& server_name) {
+  if (TheBaseConfig()) {
+    TheBaseConfig()->SetPath("/Settings/RESTClient");
+
+    wxString key_string;
+
+    TheBaseConfig()->Read("ServerKeys", &key_string);
+    wxStringTokenizer st(key_string, _T(";"));
+    while (st.HasMoreTokens()) {
+      wxString s1 = st.GetNextToken();
+      wxString server_name_persisted = s1.BeforeFirst(':');
+      wxString server_key = s1.AfterFirst(':');
+
+      if (!server_name_persisted.ToStdString().compare(server_name))
+        return server_key.ToStdString();
+    }
+  }
+  return "1";
+}
+
+void SaveClientKey(std::string& server_name, std::string key) {
+  if (TheBaseConfig()) {
+    TheBaseConfig()->SetPath("/Settings/RESTClient");
+
+    wxArrayString array;
+    wxString key_string;
+    TheBaseConfig()->Read("ServerKeys", &key_string);
+    wxStringTokenizer st(key_string, _T(";"));
+    while (st.HasMoreTokens()) {
+      wxString s1 = st.GetNextToken();
+      array.Add(s1);
+    }
+
+    bool b_updated = false;
+    for (unsigned int i = 0; i < array.GetCount(); i++) {
+      wxString s1 = array[i];
+      wxString server_name_persisted = s1.BeforeFirst(':');
+      wxString server_key = s1.AfterFirst(':');
+      if (server_name_persisted.IsSameAs(server_name.c_str())) {
+        array[i] = server_name_persisted + ":" + key.c_str();
+        b_updated = true;
+        break;
+      }
+    }
+
+    if (!b_updated) {
+      wxString new_entry = server_name.c_str() + wxString(":") + key.c_str();
+      array.Add(new_entry);
+    }
+
+    wxString key_string_updated;
+    for (unsigned int i = 0; i < array.GetCount(); i++) {
+      wxString s1 = array[i];
+      key_string_updated += s1;
+      key_string_updated += ";";
+    }
+
+    TheBaseConfig()->Write("ServerKeys", key_string_updated);
+  }
+  return;
+}
+
+SemanticVersion GetApiVersion(const std::string& dest_ip) {
+  std::string url(dest_ip);
+  url += "/api/get-version";
+
+  struct MemoryStruct chunk;
+  chunk.memory = (char*)malloc(1);
+  chunk.size = 0;
+  std::string buf;
+  std::ostringstream ostream(buf);
+  long response_code = PostSendObjectMessage(url, ostream, &chunk, true);
+
+  if (response_code == 200) {
+    wxString body(chunk.memory);
+    wxJSONValue root;
+    wxJSONReader reader;
+
+    int numErrors = reader.Parse(body, &root);
+    if (numErrors != 0) return SemanticVersion(-1, -1);
+
+    wxString version = root["version"].AsString();
+    return SemanticVersion::parse(version.ToStdString());
+  } else {
+    return SemanticVersion(-1, -1);
+  }
+}
+
+RestServerResult CheckApiKey(const std::string& source,
+                             const std::string& api_key,
+                             const std::string& dest_ip) {
+  std::string url(dest_ip);
+  url += "/api/ping";
+  url += std::string("?source=") + g_hostname;
+  url += std::string("&apikey=") + api_key;
+
+  struct MemoryStruct chunk;
+  chunk.memory = (char*)malloc(1);
+  chunk.size = 0;
+  std::string buf;
+  std::ostringstream ostream(buf);
+  long response_code = PostSendObjectMessage(url, ostream, &chunk, true);
+
+  if (response_code == 200) {
+    wxString body(chunk.memory);
+    wxJSONValue root;
+    wxJSONReader reader;
+
+    int numErrors = reader.Parse(body, &root);
+    // Capture the result
+    int result = root["result"].AsInt();
+
+    if (result > 0) {
+      return RestServerResult::NewPinRequested;
+    } else {
+      return RestServerResult::Void;
+    }
+  } else {
+    return RestServerResult::Void;
+  }
+}
+
+int SendNavobjects(std::string dest_ip_address, std::string server_name,
+                   std::vector<Route*> route,
+                   std::vector<RoutePoint*> routepoint,
+                   std::vector<Track*> track, bool overwrite) {
+  if (route.empty() && routepoint.empty() && track.empty()) return -1;
+  bool apikey_ok = false;
+  bool b_cancel = false;
+  std::ostringstream stream;
+  std::string api_key;
+
+  while (!apikey_ok && b_cancel == false) {
+    api_key = GetClientKey(server_name);
+
+    std::string url(dest_ip_address);
+    url += "/api/ping";
+    url += std::string("?source=") + g_hostname;
+    url += std::string("&apikey=") + api_key;
+
+    struct MemoryStruct chunk;
+    chunk.memory = (char*)malloc(1);
+    chunk.size = 0;
+
+    long response_code = PostSendObjectMessage(url, stream, &chunk);
+
+    if (response_code == 200) {
+      wxString body(chunk.memory);
+      wxJSONValue root;
+      wxJSONReader reader;
+
+      int numErrors = reader.Parse(body, &root);
+      // Capture the result
+      int result = root["result"].AsInt();
+      if (result > 0) {
+        if (result == static_cast<int>(RestServerResult::NewPinRequested)) {
+          // Show the dialog asking for PIN
+          PINConfirmDialog dlg(
+              (wxWindow*)gFrame, wxID_ANY, _("OpenCPN Server Message"), "",
+              wxDefaultPosition, wxDefaultSize, SYMBOL_PCD_STYLE);
+
+          wxString hmsg(_("The server "));
+          hmsg += _("needs a PIN.\nPlease enter the PIN number from ");
+          hmsg += _("the server to pair with this device.\n");
+
+          dlg.SetMessage(hmsg);
+          dlg.SetText1Message("");
+
+          dlg.ShowModal();
+          if (dlg.GetReturnCode() == ID_PCD_OK) {
+            wxString PIN_tentative = dlg.GetText1Value().Trim().Trim(false);
+            unsigned int dPIN = atoi(PIN_tentative.ToStdString().c_str());
+            Pincode pincode(dPIN);
+            std::string api_key = pincode.Hash();
+            RestServerResult result;
+            SemanticVersion v = GetApiVersion(dest_ip_address);
+            if (v >= SemanticVersion(5, 9)) {
+              result = CheckApiKey(g_hostname.ToStdString(), api_key,
+                                   dest_ip_address);
+            } else {
+              api_key = pincode.CompatHash();
+              result = CheckApiKey(g_hostname.ToStdString(), api_key,
+                                   dest_ip_address);
+            }
+            SaveClientKey(server_name, api_key);
+          } else {
+            b_cancel = true;
+          }
+        } else if (result == static_cast<int>(RestServerResult::GenericError))
+          apikey_ok = true;
+      } else
+        apikey_ok = true;
+    } else {
+      wxString err_msg;
+      err_msg.Printf("Server HTTP response is: %ld", response_code);
+      OCPNMessageDialog mdlg(NULL, err_msg, wxString(_("OpenCPN Info")),
+                             wxICON_ERROR | wxOK);
+      mdlg.ShowModal();
+
+      b_cancel = true;
+    }
+  }
+  if (!apikey_ok || b_cancel) {
+    return false;
+  }
+  // Get XML representation of object.
+  NavObjectCollection1* pgpx = new NavObjectCollection1;
+  navobj_transfer_progress = 0;
+  int total = route.size() + track.size() + routepoint.size();
+  int gpxgen = 0;
+  for (auto r : route) {
+    gpxgen++;
+    pgpx->AddGPXRoute(r);
+    navobj_transfer_progress = 100 * gpxgen / total;
+    wxYield();
+  }
+  for (auto r : routepoint) {
+    gpxgen++;
+    pgpx->AddGPXWaypoint(r);
+    navobj_transfer_progress = 100 * gpxgen / total;
+    wxYield();
+  }
+  for (auto r : track) {
+    gpxgen++;
+    pgpx->AddGPXTrack(r);
+    navobj_transfer_progress = 100 * gpxgen / total;
+    wxYield();
+  }
+  pgpx->save(stream, PUGIXML_TEXT(" "));
+
+  while (b_cancel == false) {
+    std::string api_key = GetClientKey(server_name);
+
+    std::string url(dest_ip_address);
+    url += "/api/rx_object";
+    url += std::string("?source=") + g_hostname;
+    url += std::string("&apikey=") + api_key;
+
+    struct MemoryStruct chunk;
+    chunk.memory = (char*)malloc(1);
+    chunk.size = 0;
+    long response_code = PostSendObjectMessage(url, stream, &chunk);
+
+    if (response_code == 200) {
+      wxString body(chunk.memory);
+      wxJSONValue root;
+      wxJSONReader reader;
+
+      int numErrors = reader.Parse(body, &root);
+      // Capture the result
+      int result = root["result"].AsInt();
+      if (result > 0) {
+        wxString error_text =
+            GetErrorText(static_cast<RestServerResult>(result));
+        OCPNMessageDialog mdlg(NULL, error_text, wxString(_("OpenCPN Info")),
+                               wxICON_ERROR | wxOK);
+        mdlg.ShowModal();
+        b_cancel = true;
+      } else {
+        OCPNMessageDialog mdlg(
+            NULL, _("Objects successfully sent to peer OpenCPN instance."),
+            wxString(_("OpenCPN Info")), wxICON_INFORMATION | wxOK);
+        mdlg.ShowModal();
+        b_cancel = true;
+      }
+    } else {
+      wxString err_msg;
+      err_msg.Printf("Server HTTP response is: %ld", response_code);
+      OCPNMessageDialog mdlg(NULL, err_msg, wxString(_("OpenCPN Info")),
+                             wxICON_ERROR | wxOK);
+      mdlg.ShowModal();
+
+      b_cancel = true;
+    }
+  }
+  return true;
+}
+
+IMPLEMENT_DYNAMIC_CLASS(PINConfirmDialog, wxDialog)
+
+BEGIN_EVENT_TABLE(PINConfirmDialog, wxDialog)
+EVT_BUTTON(ID_PCD_CANCEL, PINConfirmDialog::OnCancelClick)
+EVT_BUTTON(ID_PCD_OK, PINConfirmDialog::OnOKClick)
+END_EVENT_TABLE()
+
+PINConfirmDialog::PINConfirmDialog() {
+  m_OKButton = NULL;
+  m_CancelButton = NULL;
+  premtext = NULL;
+}
+
+PINConfirmDialog::PINConfirmDialog(wxWindow* parent, wxWindowID id,
+                                   const wxString& caption,
+                                   const wxString& hint, const wxPoint& pos,
+                                   const wxSize& size, long style) {
+  wxFont* pif = FontMgr::Get().GetFont(_T("Dialog"));
+  SetFont(*pif);
+  Create(parent, id, caption, hint, pos, size, style);
+}
+
+PINConfirmDialog::~PINConfirmDialog() {
+  delete m_OKButton;
+  delete m_CancelButton;
+}
+
+bool PINConfirmDialog::Create(wxWindow* parent, wxWindowID id,
+                              const wxString& caption, const wxString& hint,
+                              const wxPoint& pos, const wxSize& size,
+                              long style) {
+  SetExtraStyle(GetExtraStyle() | wxWS_EX_BLOCK_EVENTS);
+  wxDialog::Create(parent, id, caption, pos, size, style);
+
+  CreateControls(hint);
+  GetSizer()->Fit(this);
+  GetSizer()->SetSizeHints(this);
+  Centre();
+
+  return TRUE;
+}
+
+void PINConfirmDialog::CreateControls(const wxString& hint) {
+  PINConfirmDialog* itemDialog1 = this;
+
+  wxBoxSizer* itemBoxSizer2 = new wxBoxSizer(wxVERTICAL);
+  SetSizer(itemBoxSizer2);
+
+  //    Add a reminder text box
+  itemBoxSizer2->AddSpacer(20);
+
+  premtext = new wxStaticText(
+      this, -1, "A loooooooooooooooooooooooooooooooooooooooooooooong line\n");
+  itemBoxSizer2->Add(premtext, 0, wxEXPAND | wxALL, 10);
+
+  m_pText1 = new wxTextCtrl(this, wxID_ANY, "        ", wxDefaultPosition,
+                            wxDefaultSize, wxTE_CENTRE);
+  itemBoxSizer2->Add(m_pText1, 0, wxALIGN_CENTER_HORIZONTAL | wxALL, 10);
+
+  //    OK/Cancel/etc.
+  wxBoxSizer* itemBoxSizer16 = new wxBoxSizer(wxHORIZONTAL);
+  itemBoxSizer2->Add(itemBoxSizer16, 0, wxALIGN_RIGHT | wxALL, 5);
+
+  m_CancelButton = new wxButton(itemDialog1, ID_PCD_CANCEL, _("Cancel"),
+                                wxDefaultPosition, wxDefaultSize, 0);
+  itemBoxSizer16->Add(m_CancelButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+
+  m_OKButton = new wxButton(itemDialog1, ID_PCD_OK, "OK", wxDefaultPosition,
+                            wxDefaultSize, 0);
+  itemBoxSizer16->Add(m_OKButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
+  m_OKButton->SetDefault();
+}
+
+void PINConfirmDialog::SetMessage(const wxString& msg) {
+  if (premtext) {
+    premtext->SetLabel(msg);
+    premtext->Refresh(true);
+  }
+}
+
+void PINConfirmDialog::SetText1Message(const wxString& msg) {
+  m_pText1->ChangeValue(msg);
+  m_pText1->Show();
+  GetSizer()->Fit(this);
+}
+
+void PINConfirmDialog::OnOKClick(wxCommandEvent& event) {
+  SetReturnCode(ID_PCD_OK);
+  EndModal(ID_PCD_OK);
+}
+
+void PINConfirmDialog::OnCancelClick(wxCommandEvent& event) {
+  EndModal(ID_PCD_CANCEL);
+}

--- a/gui/src/peer_client_dlg.cpp
+++ b/gui/src/peer_client_dlg.cpp
@@ -23,27 +23,35 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 
+#include <cassert>
 #include <iostream>
 #include <sstream>
-
-#include <curl/curl.h>
-
-#include "peer_client_dlg.h"
 
 #include <wx/fileconf.h>
 #include <wx/json_defs.h>
 #include <wx/jsonreader.h>
 #include <wx/tokenzr.h>
 
-#include "model/config_vars.h"
-#include "FontMgr.h"
-#include "gui_lib.h"
+#include <curl/curl.h>
+
 #include "model/nav_object_database.h"
+#include "model/peer_client.h"
 #include "model/rest_server.h"
 #include "model/semantic_vers.h"
+#include "model/config_vars.h"
+
+#include "peer_client_dlg.h"
 #include "ocpn_frame.h"
+#include "FontMgr.h"
+#include "gui_lib.h"
 
 extern MyFrame* gFrame;
+
+struct MemoryStruct {
+  char* memory;
+  size_t size;
+};
+
 
 wxString GetErrorText(RestServerResult result) {
   switch (result) {
@@ -60,417 +68,27 @@ wxString GetErrorText(RestServerResult result) {
   }
 }
 
-size_t wxcurl_string_write_UTF8(void* ptr, size_t size, size_t nmemb,
-                                void* pcharbuf) {
-  size_t iRealSize = size * nmemb;
-  wxCharBuffer* pStr = (wxCharBuffer*)pcharbuf;
-
-  if (pStr) {
-#ifdef __WXMSW__
-    wxString str1a = wxString(*pStr);
-    wxString str2 = wxString((const char*)ptr, wxConvUTF8, iRealSize);
-    *pStr = (str1a + str2).mb_str();
-#else
-    wxString str = wxString(*pStr, wxConvUTF8) +
-                   wxString((const char*)ptr, wxConvUTF8, iRealSize);
-    *pStr = str.mb_str(wxConvUTF8);
-#endif
-  }
-
-  return iRealSize;
-}
-
-struct MemoryStruct {
-  char* memory;
-  size_t size;
-};
-
-static size_t WriteMemoryCallback(void* contents, size_t size, size_t nmemb,
-                                  void* userp) {
-  size_t realsize = size * nmemb;
-  struct MemoryStruct* mem = (struct MemoryStruct*)userp;
-
-  char* ptr = (char*)realloc(mem->memory, mem->size + realsize + 1);
-  if (!ptr) {
-    /* out of memory! */
-    printf("not enough memory (realloc returned NULL)\n");
-    return 0;
-  }
-
-  mem->memory = ptr;
-  memcpy(&(mem->memory[mem->size]), contents, realsize);
-  mem->size += realsize;
-  mem->memory[mem->size] = 0;
-
-  return realsize;
-}
-
-int navobj_transfer_progress;
-
-int xfer_callback(void* clientp, curl_off_t dltotal, curl_off_t dlnow,
-                  curl_off_t ultotal, curl_off_t ulnow) {
-  if (ultotal == 0) {
-    navobj_transfer_progress = 0;
-  } else {
-    navobj_transfer_progress = 100 * ulnow / ultotal;
-  }
-  wxYield();
-  return 0;
-}
-
-long PostSendObjectMessage(std::string url, std::ostringstream& body,
-                           MemoryStruct* response, bool timeout = false) {
-  long response_code = -1;
-  navobj_transfer_progress = 0;
-
-  CURL* c = curl_easy_init();
-  curl_easy_setopt(c, CURLOPT_ENCODING,
-                   "identity");  // No encoding, plain ASCII
-  curl_easy_setopt(c, CURLOPT_URL, url.c_str());
-  curl_easy_setopt(c, CURLOPT_SSL_VERIFYPEER, 0L);
-  curl_easy_setopt(c, CURLOPT_SSL_VERIFYHOST, 0L);
-
-  int iSize = strlen(body.str().c_str());
-  curl_easy_setopt(c, CURLOPT_POSTFIELDSIZE, iSize);
-  curl_easy_setopt(c, CURLOPT_COPYPOSTFIELDS, body.str().c_str());
-
-  curl_easy_setopt(c, CURLOPT_WRITEFUNCTION, WriteMemoryCallback);
-  curl_easy_setopt(c, CURLOPT_WRITEDATA, (void*)response);
-  curl_easy_setopt(c, CURLOPT_NOPROGRESS, 0);
-  curl_easy_setopt(c, CURLOPT_XFERINFOFUNCTION, xfer_callback);
-  if (timeout) curl_easy_setopt(c, CURLOPT_TIMEOUT, 5);
-
-  CURLcode result = curl_easy_perform(c);
-  navobj_transfer_progress = 0;
-  if (result == CURLE_OK)
-    curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &response_code);
-
-  curl_easy_cleanup(c);
-
-  return response_code;
-}
-
-bool CheckApiKey(std::string url, MemoryStruct* response) {
-  long response_code = -1;
-
-  CURL* c = curl_easy_init();
-  curl_easy_setopt(c, CURLOPT_ENCODING, "identity");  // Encoding: plain ASCII
-  curl_easy_setopt(c, CURLOPT_URL, url.c_str());
-  curl_easy_setopt(c, CURLOPT_SSL_VERIFYPEER, 0L);
-  curl_easy_setopt(c, CURLOPT_SSL_VERIFYHOST, 0L);
-  CURLcode result = curl_easy_perform(c);
-  if (result == CURLE_OK)
-    curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &response_code);
-  curl_easy_cleanup(c);
-  return response_code == 200;
-}
-
-std::string GetClientKey(std::string& server_name) {
-  if (TheBaseConfig()) {
-    TheBaseConfig()->SetPath("/Settings/RESTClient");
-
-    wxString key_string;
-
-    TheBaseConfig()->Read("ServerKeys", &key_string);
-    wxStringTokenizer st(key_string, _T(";"));
-    while (st.HasMoreTokens()) {
-      wxString s1 = st.GetNextToken();
-      wxString server_name_persisted = s1.BeforeFirst(':');
-      wxString server_key = s1.AfterFirst(':');
-
-      if (!server_name_persisted.ToStdString().compare(server_name))
-        return server_key.ToStdString();
-    }
-  }
-  return "1";
-}
-
-void SaveClientKey(std::string& server_name, std::string key) {
-  if (TheBaseConfig()) {
-    TheBaseConfig()->SetPath("/Settings/RESTClient");
-
-    wxArrayString array;
-    wxString key_string;
-    TheBaseConfig()->Read("ServerKeys", &key_string);
-    wxStringTokenizer st(key_string, _T(";"));
-    while (st.HasMoreTokens()) {
-      wxString s1 = st.GetNextToken();
-      array.Add(s1);
-    }
-
-    bool b_updated = false;
-    for (unsigned int i = 0; i < array.GetCount(); i++) {
-      wxString s1 = array[i];
-      wxString server_name_persisted = s1.BeforeFirst(':');
-      wxString server_key = s1.AfterFirst(':');
-      if (server_name_persisted.IsSameAs(server_name.c_str())) {
-        array[i] = server_name_persisted + ":" + key.c_str();
-        b_updated = true;
-        break;
-      }
-    }
-
-    if (!b_updated) {
-      wxString new_entry = server_name.c_str() + wxString(":") + key.c_str();
-      array.Add(new_entry);
-    }
-
-    wxString key_string_updated;
-    for (unsigned int i = 0; i < array.GetCount(); i++) {
-      wxString s1 = array[i];
-      key_string_updated += s1;
-      key_string_updated += ";";
-    }
-
-    TheBaseConfig()->Write("ServerKeys", key_string_updated);
-  }
-  return;
-}
-
-SemanticVersion GetApiVersion(const std::string& dest_ip) {
-  std::string url(dest_ip);
-  url += "/api/get-version";
-
-  struct MemoryStruct chunk;
-  chunk.memory = (char*)malloc(1);
-  chunk.size = 0;
-  std::string buf;
-  std::ostringstream ostream(buf);
-  long response_code = PostSendObjectMessage(url, ostream, &chunk, true);
-
-  if (response_code == 200) {
-    wxString body(chunk.memory);
-    wxJSONValue root;
-    wxJSONReader reader;
-
-    int numErrors = reader.Parse(body, &root);
-    if (numErrors != 0) return SemanticVersion(-1, -1);
-
-    wxString version = root["version"].AsString();
-    return SemanticVersion::parse(version.ToStdString());
-  } else {
-    return SemanticVersion(-1, -1);
-  }
-}
-
-RestServerResult CheckApiKey(const std::string& source,
-                             const std::string& api_key,
-                             const std::string& dest_ip) {
-  std::string url(dest_ip);
-  url += "/api/ping";
-  url += std::string("?source=") + g_hostname;
-  url += std::string("&apikey=") + api_key;
-
-  struct MemoryStruct chunk;
-  chunk.memory = (char*)malloc(1);
-  chunk.size = 0;
-  std::string buf;
-  std::ostringstream ostream(buf);
-  long response_code = PostSendObjectMessage(url, ostream, &chunk, true);
-
-  if (response_code == 200) {
-    wxString body(chunk.memory);
-    wxJSONValue root;
-    wxJSONReader reader;
-
-    int numErrors = reader.Parse(body, &root);
-    // Capture the result
-    int result = root["result"].AsInt();
-
-    if (result > 0) {
-      return RestServerResult::NewPinRequested;
-    } else {
-      return RestServerResult::Void;
-    }
-  } else {
-    return RestServerResult::Void;
-  }
-}
-
-int SendNavobjects(std::string dest_ip_address, std::string server_name,
-                   std::vector<Route*> route,
-                   std::vector<RoutePoint*> routepoint,
-                   std::vector<Track*> track, bool overwrite) {
-  if (route.empty() && routepoint.empty() && track.empty()) return -1;
-  bool apikey_ok = false;
-  bool b_cancel = false;
-  std::ostringstream stream;
-  std::string api_key;
-
-  while (!apikey_ok && b_cancel == false) {
-    api_key = GetClientKey(server_name);
-
-    std::string url(dest_ip_address);
-    url += "/api/ping";
-    url += std::string("?source=") + g_hostname;
-    url += std::string("&apikey=") + api_key;
-
-    struct MemoryStruct chunk;
-    chunk.memory = (char*)malloc(1);
-    chunk.size = 0;
-
-    long response_code = PostSendObjectMessage(url, stream, &chunk);
-
-    if (response_code == 200) {
-      wxString body(chunk.memory);
-      wxJSONValue root;
-      wxJSONReader reader;
-
-      int numErrors = reader.Parse(body, &root);
-      // Capture the result
-      int result = root["result"].AsInt();
-      if (result > 0) {
-        if (result == static_cast<int>(RestServerResult::NewPinRequested)) {
-          // Show the dialog asking for PIN
-          PINConfirmDialog dlg(
-              (wxWindow*)gFrame, wxID_ANY, _("OpenCPN Server Message"), "",
-              wxDefaultPosition, wxDefaultSize, SYMBOL_PCD_STYLE);
-
-          wxString hmsg(_("The server "));
-          hmsg += _("needs a PIN.\nPlease enter the PIN number from ");
-          hmsg += _("the server to pair with this device.\n");
-
-          dlg.SetMessage(hmsg);
-          dlg.SetText1Message("");
-
-          dlg.ShowModal();
-          if (dlg.GetReturnCode() == ID_PCD_OK) {
-            wxString PIN_tentative = dlg.GetText1Value().Trim().Trim(false);
-            unsigned int dPIN = atoi(PIN_tentative.ToStdString().c_str());
-            Pincode pincode(dPIN);
-            std::string api_key = pincode.Hash();
-            RestServerResult result;
-            SemanticVersion v = GetApiVersion(dest_ip_address);
-            if (v >= SemanticVersion(5, 9)) {
-              result = CheckApiKey(g_hostname.ToStdString(), api_key,
-                                   dest_ip_address);
-            } else {
-              api_key = pincode.CompatHash();
-              result = CheckApiKey(g_hostname.ToStdString(), api_key,
-                                   dest_ip_address);
-            }
-            SaveClientKey(server_name, api_key);
-          } else {
-            b_cancel = true;
-          }
-        } else if (result == static_cast<int>(RestServerResult::GenericError))
-          apikey_ok = true;
-      } else
-        apikey_ok = true;
-    } else {
-      wxString err_msg;
-      err_msg.Printf("Server HTTP response is: %ld", response_code);
-      OCPNMessageDialog mdlg(NULL, err_msg, wxString(_("OpenCPN Info")),
-                             wxICON_ERROR | wxOK);
-      mdlg.ShowModal();
-
-      b_cancel = true;
-    }
-  }
-  if (!apikey_ok || b_cancel) {
-    return false;
-  }
-  // Get XML representation of object.
-  NavObjectCollection1* pgpx = new NavObjectCollection1;
-  navobj_transfer_progress = 0;
-  int total = route.size() + track.size() + routepoint.size();
-  int gpxgen = 0;
-  for (auto r : route) {
-    gpxgen++;
-    pgpx->AddGPXRoute(r);
-    navobj_transfer_progress = 100 * gpxgen / total;
-    wxYield();
-  }
-  for (auto r : routepoint) {
-    gpxgen++;
-    pgpx->AddGPXWaypoint(r);
-    navobj_transfer_progress = 100 * gpxgen / total;
-    wxYield();
-  }
-  for (auto r : track) {
-    gpxgen++;
-    pgpx->AddGPXTrack(r);
-    navobj_transfer_progress = 100 * gpxgen / total;
-    wxYield();
-  }
-  pgpx->save(stream, PUGIXML_TEXT(" "));
-
-  while (b_cancel == false) {
-    std::string api_key = GetClientKey(server_name);
-
-    std::string url(dest_ip_address);
-    url += "/api/rx_object";
-    url += std::string("?source=") + g_hostname;
-    url += std::string("&apikey=") + api_key;
-
-    struct MemoryStruct chunk;
-    chunk.memory = (char*)malloc(1);
-    chunk.size = 0;
-    long response_code = PostSendObjectMessage(url, stream, &chunk);
-
-    if (response_code == 200) {
-      wxString body(chunk.memory);
-      wxJSONValue root;
-      wxJSONReader reader;
-
-      int numErrors = reader.Parse(body, &root);
-      // Capture the result
-      int result = root["result"].AsInt();
-      if (result > 0) {
-        wxString error_text =
-            GetErrorText(static_cast<RestServerResult>(result));
-        OCPNMessageDialog mdlg(NULL, error_text, wxString(_("OpenCPN Info")),
-                               wxICON_ERROR | wxOK);
-        mdlg.ShowModal();
-        b_cancel = true;
-      } else {
-        OCPNMessageDialog mdlg(
-            NULL, _("Objects successfully sent to peer OpenCPN instance."),
-            wxString(_("OpenCPN Info")), wxICON_INFORMATION | wxOK);
-        mdlg.ShowModal();
-        b_cancel = true;
-      }
-    } else {
-      wxString err_msg;
-      err_msg.Printf("Server HTTP response is: %ld", response_code);
-      OCPNMessageDialog mdlg(NULL, err_msg, wxString(_("OpenCPN Info")),
-                             wxICON_ERROR | wxOK);
-      mdlg.ShowModal();
-
-      b_cancel = true;
-    }
-  }
-  return true;
-}
-
-IMPLEMENT_DYNAMIC_CLASS(PINConfirmDialog, wxDialog)
-
-BEGIN_EVENT_TABLE(PINConfirmDialog, wxDialog)
-EVT_BUTTON(ID_PCD_CANCEL, PINConfirmDialog::OnCancelClick)
-EVT_BUTTON(ID_PCD_OK, PINConfirmDialog::OnOKClick)
-END_EVENT_TABLE()
-
-PINConfirmDialog::PINConfirmDialog() {
+PINConfirmDlg::PINConfirmDlg() {
   m_OKButton = NULL;
   m_CancelButton = NULL;
   premtext = NULL;
 }
 
-PINConfirmDialog::PINConfirmDialog(wxWindow* parent, wxWindowID id,
-                                   const wxString& caption,
-                                   const wxString& hint, const wxPoint& pos,
-                                   const wxSize& size, long style) {
+PINConfirmDlg::PINConfirmDlg(wxWindow* parent, wxWindowID id,
+                             const wxString& caption,
+                             const wxString& hint, const wxPoint& pos,
+                             const wxSize& size, long style) {
   wxFont* pif = FontMgr::Get().GetFont(_T("Dialog"));
   SetFont(*pif);
   Create(parent, id, caption, hint, pos, size, style);
 }
 
-PINConfirmDialog::~PINConfirmDialog() {
+PINConfirmDlg::~PINConfirmDlg() {
   delete m_OKButton;
   delete m_CancelButton;
 }
 
-bool PINConfirmDialog::Create(wxWindow* parent, wxWindowID id,
+bool PINConfirmDlg::Create(wxWindow* parent, wxWindowID id,
                               const wxString& caption, const wxString& hint,
                               const wxPoint& pos, const wxSize& size,
                               long style) {
@@ -481,12 +99,11 @@ bool PINConfirmDialog::Create(wxWindow* parent, wxWindowID id,
   GetSizer()->Fit(this);
   GetSizer()->SetSizeHints(this);
   Centre();
-
   return TRUE;
 }
 
-void PINConfirmDialog::CreateControls(const wxString& hint) {
-  PINConfirmDialog* itemDialog1 = this;
+void PINConfirmDlg::CreateControls(const wxString&) {
+  PINConfirmDlg* itemDialog1 = this;
 
   wxBoxSizer* itemBoxSizer2 = new wxBoxSizer(wxVERTICAL);
   SetSizer(itemBoxSizer2);
@@ -508,32 +125,36 @@ void PINConfirmDialog::CreateControls(const wxString& hint) {
 
   m_CancelButton = new wxButton(itemDialog1, ID_PCD_CANCEL, _("Cancel"),
                                 wxDefaultPosition, wxDefaultSize, 0);
+   m_CancelButton->Bind(wxEVT_COMMAND_BUTTON_CLICKED,
+                        [&](wxCommandEvent e)  {OnCancelClick(e); });
   itemBoxSizer16->Add(m_CancelButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
   m_OKButton = new wxButton(itemDialog1, ID_PCD_OK, "OK", wxDefaultPosition,
                             wxDefaultSize, 0);
   itemBoxSizer16->Add(m_OKButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
   m_OKButton->SetDefault();
+  m_OKButton->Bind(wxEVT_COMMAND_BUTTON_CLICKED,
+                   [&](wxCommandEvent e)  {OnOKClick(e); });
 }
 
-void PINConfirmDialog::SetMessage(const wxString& msg) {
+void PINConfirmDlg::SetMessage(const wxString& msg) {
   if (premtext) {
     premtext->SetLabel(msg);
     premtext->Refresh(true);
   }
 }
 
-void PINConfirmDialog::SetText1Message(const wxString& msg) {
+void PINConfirmDlg::SetText1Message(const wxString& msg) {
   m_pText1->ChangeValue(msg);
   m_pText1->Show();
   GetSizer()->Fit(this);
 }
 
-void PINConfirmDialog::OnOKClick(wxCommandEvent& event) {
+void PINConfirmDlg::OnOKClick(wxCommandEvent&) {
   SetReturnCode(ID_PCD_OK);
   EndModal(ID_PCD_OK);
 }
 
-void PINConfirmDialog::OnCancelClick(wxCommandEvent& event) {
+void PINConfirmDlg::OnCancelClick(wxCommandEvent&) {
   EndModal(ID_PCD_CANCEL);
 }

--- a/gui/src/peer_client_dlg.cpp
+++ b/gui/src/peer_client_dlg.cpp
@@ -117,13 +117,13 @@ void PinConfirmDlg::CreateControls(const wxString&) {
   wxBoxSizer* itemBoxSizer16 = new wxBoxSizer(wxHORIZONTAL);
   itemBoxSizer2->Add(itemBoxSizer16, 0, wxALIGN_RIGHT | wxALL, 5);
 
-  m_cancel_btn = new wxButton(this, ID_PCD_CANCEL, _("Cancel"));
+  m_cancel_btn = new wxButton(this, wxID_CANCEL);
 
   m_cancel_btn->Bind(wxEVT_COMMAND_BUTTON_CLICKED,
                      [&](wxCommandEvent e) { OnCancelClick(e); });
   itemBoxSizer16->Add(m_cancel_btn, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-  m_ok_btn = new wxButton(this, ID_PCD_OK, "OK");
+  m_ok_btn = new wxButton(this, wxID_OK);
   itemBoxSizer16->Add(m_ok_btn, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
   m_ok_btn->SetDefault();
   m_ok_btn->Bind(wxEVT_COMMAND_BUTTON_CLICKED,
@@ -147,8 +147,7 @@ void PinConfirmDlg::SetPincodeText(const wxString& message) {
 }
 
 void PinConfirmDlg::OnOKClick(wxCommandEvent&) {
-  SetReturnCode(ID_PCD_OK);
-  EndModal(ID_PCD_OK);
+  EndModal(wxID_OK);
 }
 
-void PinConfirmDlg::OnCancelClick(wxCommandEvent&) { EndModal(ID_PCD_CANCEL); }
+void PinConfirmDlg::OnCancelClick(wxCommandEvent&) { EndModal(wxID_CANCEL); }

--- a/gui/src/routemanagerdialog.cpp
+++ b/gui/src/routemanagerdialog.cpp
@@ -65,7 +65,7 @@
 #include "model/mDNS_query.h"
 #include "SendToPeerDlg.h"
 
-#ifdef __OCPN__ANDROID__
+#ifdef __ANDROID__
 #include "androidUTIL.h"
 #endif
 
@@ -317,6 +317,8 @@ RouteManagerDialog::RouteManagerDialog(wxWindow *parent) {
   btnExportViz = NULL;
 
   Create();
+  routes_update_listener.Init(g_pRouteMan->on_routes_update,
+                              [&](wxCommandEvent) { UpdateRouteListCtrl(); });
 }
 
 void RouteManagerDialog::Create() {

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -87,6 +87,7 @@ set(
   ${MODEL_HDR_DIR}/ocpn_types.h
   ${MODEL_HDR_DIR}/ocpn_utils.h
   ${MODEL_HDR_DIR}/own_ship.h
+  ${MODEL_HDR_DIR}/peer_client.h
   ${MODEL_HDR_DIR}/pincode.h
   ${MODEL_HDR_DIR}/plugin_blacklist.h
   ${MODEL_HDR_DIR}/plugin_cache.h
@@ -163,6 +164,7 @@ set(SRC
   ${MODEL_SRC_DIR}/ocpn_plugin.cpp
   ${MODEL_SRC_DIR}/ocpn_utils.cpp
   ${MODEL_SRC_DIR}/own_ship.cpp
+  ${MODEL_SRC_DIR}/peer_client.cpp
   ${MODEL_SRC_DIR}/pincode.cpp
   ${MODEL_SRC_DIR}/plugin_blacklist.cpp
   ${MODEL_SRC_DIR}/plugin_cache.cpp

--- a/model/include/model/peer_client.h
+++ b/model/include/model/peer_client.h
@@ -39,7 +39,13 @@
 
 enum class PeerDlgResult { Ok, Cancel, HasPincode };
 
-enum class PeerDlg { PinConfirm, InvalidHttpResponse, ErrorReturn, TransferOk };
+enum class PeerDlg {
+  PinConfirm,
+  InvalidHttpResponse,
+  ErrorReturn,
+  TransferOk,
+  ActivateUnsupported
+};
 
 struct PeerData {
   std::string dest_ip_address;
@@ -48,8 +54,8 @@ struct PeerData {
   std::vector<Route*> routes;
   std::vector<RoutePoint*> routepoints;
   std::vector<Track*> tracks;
-  bool overwrite;     ///< API parameter, force overwrite w/o server dialogs.
-  bool activate;      ///< API parameter, activate route after transfer
+  bool overwrite;  ///< API parameter, force overwrite w/o server dialogs.
+  bool activate;   ///< API parameter, activate route after transfer
 
   /** Notified with transfer percent progress (0-100). */
   EventVar& progress;
@@ -76,6 +82,5 @@ bool SendNavobjects(PeerData& peer_data);
  * i. e., that the object(s) does not exist or can be overwritten.
  */
 bool CheckNavObjects(PeerData& peer_data);
-
 
 #endif  // guard

--- a/model/include/model/peer_client.h
+++ b/model/include/model/peer_client.h
@@ -31,9 +31,12 @@
 #include <string>
 
 #include "model/route.h"
-#include "model/route_point.h"
 #include "model/track.h"
 #include "model/semantic_vers.h"
+
+#include "observable_evtvar.h"
+
+enum class PeerDlgResult { Ok, Cancel, HasPincode };
 
 enum class PeerDlg { PinConfirm, InvalidHttpResponse, ErrorReturn, TransferOk };
 
@@ -46,27 +49,31 @@ struct PeerData {
   std::vector<Track*> tracks;
   bool overwrite;
 
-  /** Dialog with possible HTTP or RestServer error code. */
-  std::function<int(PeerDlg, int)> run_status_dlg;
+  /** Notified with transfer percent progress (0-100). */
+  EventVar& progress;
+
+  /** Dialog returning status */
+  std::function<PeerDlgResult(PeerDlg, int)> run_status_dlg;
 
   /**
    * Pin confirm dialog, returns new {0, user_pin} or
    * {error_code, error msg)
    */
-  std::function<std::pair<int, std::string>()> run_pincode_dlg;
+  std::function<std::pair<PeerDlgResult, std::string>()> run_pincode_dlg;
 
-  PeerData();
+  PeerData(EventVar& p);
 };
 
+void GetApiVersion(PeerData& peer_data);
 
 /** Send data to server peer.*/
-int SendNavobjects(const PeerData& peer_data);
+int SendNavobjects(PeerData& peer_data);
 
 /**
  * Check if server peer deems that writing these objects can be accepted
  * i. e., that the object(s) does not exist or can be overwritten.
  */
-bool CheckNavObjects(const PeerData& peer_data);
+bool CheckNavObjects(PeerData& peer_data);
 
 
 #endif  // guard

--- a/model/include/model/peer_client.h
+++ b/model/include/model/peer_client.h
@@ -29,6 +29,7 @@
 
 #include <functional>
 #include <string>
+#include <vector>
 
 #include "model/route.h"
 #include "model/track.h"

--- a/model/include/model/peer_client.h
+++ b/model/include/model/peer_client.h
@@ -42,9 +42,11 @@ enum class PeerDlgResult { Ok, Cancel, HasPincode };
 enum class PeerDlg {
   PinConfirm,
   InvalidHttpResponse,
-  ErrorReturn,
+  ErrorReturn,        // Unexpected result code in json server reply.
   TransferOk,
-  ActivateUnsupported
+  ActivateUnsupported,
+  JsonParseError,
+  BadPincode          // User pincode not accepted by server
 };
 
 struct PeerData {

--- a/model/include/model/peer_client.h
+++ b/model/include/model/peer_client.h
@@ -67,7 +67,7 @@ struct PeerData {
 void GetApiVersion(PeerData& peer_data);
 
 /** Send data to server peer.*/
-int SendNavobjects(PeerData& peer_data);
+bool SendNavobjects(PeerData& peer_data);
 
 /**
  * Check if server peer deems that writing these objects can be accepted

--- a/model/include/model/peer_client.h
+++ b/model/include/model/peer_client.h
@@ -44,16 +44,17 @@ enum class PeerDlg { PinConfirm, InvalidHttpResponse, ErrorReturn, TransferOk };
 struct PeerData {
   std::string dest_ip_address;
   std::string server_name;
-  SemanticVersion api_version;  /**< API version for server. */
+  SemanticVersion api_version;  ///< server API version
   std::vector<Route*> routes;
   std::vector<RoutePoint*> routepoints;
   std::vector<Track*> tracks;
-  bool overwrite;
+  bool overwrite;     ///< API parameter, force overwrite w/o server dialogs.
+  bool activate;      ///< API parameter, activate route after transfer
 
   /** Notified with transfer percent progress (0-100). */
   EventVar& progress;
 
-  /** Dialog returning status */
+  /** Dialog displaying status (good, bad, ...) */
   std::function<PeerDlgResult(PeerDlg, int)> run_status_dlg;
 
   /**

--- a/model/include/model/peer_client.h
+++ b/model/include/model/peer_client.h
@@ -1,0 +1,72 @@
+/***************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:
+ * Author:   David Register
+ *
+ ***************************************************************************
+ *   Copyright (C) 2022 David Register                                     *
+ *   Copyright (C) 2023 Alec Leamas                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+#ifndef _PEERCLIENT_H
+#define _PEERCLIENT_H
+
+#include <functional>
+#include <string>
+
+#include "model/route.h"
+#include "model/route_point.h"
+#include "model/track.h"
+#include "model/semantic_vers.h"
+
+enum class PeerDlg { PinConfirm, InvalidHttpResponse, ErrorReturn, TransferOk };
+
+struct PeerData {
+  std::string dest_ip_address;
+  std::string server_name;
+  SemanticVersion api_version;  /**< API version for server. */
+  std::vector<Route*> routes;
+  std::vector<RoutePoint*> routepoints;
+  std::vector<Track*> tracks;
+  bool overwrite;
+
+  /** Dialog with possible HTTP or RestServer error code. */
+  std::function<int(PeerDlg, int)> run_status_dlg;
+
+  /**
+   * Pin confirm dialog, returns new {0, user_pin} or
+   * {error_code, error msg)
+   */
+  std::function<std::pair<int, std::string>()> run_pincode_dlg;
+
+  PeerData();
+};
+
+
+/** Send data to server peer.*/
+int SendNavobjects(const PeerData& peer_data);
+
+/**
+ * Check if server peer deems that writing these objects can be accepted
+ * i. e., that the object(s) does not exist or can be overwritten.
+ */
+bool CheckNavObjects(const PeerData& peer_data);
+
+
+#endif  // guard

--- a/model/include/model/rest_server.h
+++ b/model/include/model/rest_server.h
@@ -59,7 +59,7 @@ namespace fs = std::filesystem;
 #include "track.h"
 
 /**
- *  Return codes from HandleServerMessage and eventually in the http response
+ *  Return codes from HandleServerMessage and eventually in the http response.
  *  Since they are transported as integers on the wire they cannot really be
  *  changed without breaking compatibility with older servers. Adding new types
  *  should be fine.

--- a/model/include/model/rest_server.h
+++ b/model/include/model/rest_server.h
@@ -30,6 +30,8 @@
 #include <thread>
 #include <unordered_map>
 
+#include "observable_evtvar.h"
+
 
 // MacOS 1.13:
 #if defined(__clang_major__) && (__clang_major__ < 15)
@@ -150,6 +152,8 @@ public:
  *         - api_key=`<key>` Mandatory, as obtained when pairing, see below.
  *         - force=`<1>` if present, the host object is unconditionally
  *           updated. If not, host may run a "OK to overwrite" dialog.
+ *         - activate=`<1>` Optional, activate route or waypoint after
+ *           transfer
  *
  *     - Body:
  *         xml-encoded GPX data for one or more route(s), track(s) and/or
@@ -191,6 +195,9 @@ public:
 
   /** Return HTTPS url to local rest server. */
   virtual std::string GetEndpoint() = 0;
+
+  /** Notified with a string GUID when user wants to activate a route. */
+  EventVar ActivateRequest;
 };
 
 /** AbstractRestServer implementation and interface to underlying IO thread. */

--- a/model/include/model/rest_server.h
+++ b/model/include/model/rest_server.h
@@ -116,8 +116,10 @@ class RouteCtx {
 public:
   std::function<Route*(wxString)> find_route_by_guid;
   std::function<Track*(wxString)> find_track_by_guid;
+  std::function<RoutePoint*(wxString)> find_wpt_by_guid;
   std::function<void(Route*)> delete_route;
   std::function<void(Track*)> delete_track;
+  std::function<void(RoutePoint*)> delete_waypoint;
 
   /** Dummy stubs constructor. */
   RouteCtx();

--- a/model/include/model/rest_server.h
+++ b/model/include/model/rest_server.h
@@ -137,7 +137,8 @@ public:
  *        - source=`<ip>` Mandatory, origin ip address or hostname.
  *        - api_key=`<key>` Mandatory, as obtained when pairing, see below.
  *    - Returns:
- *        {"result": `<code>`}
+ *        {"result": `<code>`, "version": `<version>`}
+ *        `<version>` is a printable version like 5.9.0
  *
  *  POST /api/rx_object?api_key=`<pincode>`&source=`<ip address>`&force=1 <br>
  *  Upload GPX route(s), track(s) or waypoint(s).

--- a/model/include/model/rest_server.h
+++ b/model/include/model/rest_server.h
@@ -76,6 +76,9 @@ enum class RestServerResult {
 /** Dialog return codes. */
 enum { ID_STG_CANCEL = 10000, ID_STG_OK, ID_STG_CHECK1, ID_STG_CHOICE_COMM };
 
+/** RestServerResult string representation */
+std::string RestResultText(RestServerResult result);
+
 /** Data from IO thread to main */
 struct RestIoEvtData;
 

--- a/model/include/model/rest_server.h
+++ b/model/include/model/rest_server.h
@@ -197,7 +197,7 @@ public:
   virtual std::string GetEndpoint() = 0;
 
   /** Notified with a string GUID when user wants to activate a route. */
-  EventVar ActivateRequest;
+  EventVar activate_route;
 };
 
 /** AbstractRestServer implementation and interface to underlying IO thread. */

--- a/model/include/model/routeman.h
+++ b/model/include/model/routeman.h
@@ -175,6 +175,9 @@ public:
   /** Notified when a message available as GetString() is sent to garmin. */
   EventVar  on_message_sent;
 
+  /** Notified when list of routes is updated (no data in event) */
+  EventVar on_routes_update;
+
 private:
   Route *pActiveRoute;
   RoutePoint *pActivePoint;

--- a/model/include/model/routeman.h
+++ b/model/include/model/routeman.h
@@ -236,6 +236,7 @@ public:
   int GetFIconImageListIndex(const wxBitmap *pbm);
   int GetNumIcons(void) { return m_pIconArray->Count(); }
   wxString CreateGUID(RoutePoint *pRP);
+  RoutePoint* FindWaypointByGuid(const std::string& guid);
   RoutePoint *GetNearbyWaypoint(double lat, double lon, double radius_meters);
   RoutePoint *GetOtherNearbyWaypoint(double lat, double lon,
                                      double radius_meters,

--- a/model/src/peer_client.cpp
+++ b/model/src/peer_client.cpp
@@ -252,7 +252,13 @@ RestServerResult CheckApiKey(const std::string& api_key,
                                    num_errors);
     // Capture the result
     int result = root["result"].AsInt();
-
+    if (root.HasMember("version")) {
+      wxString version = root["version"].AsString();
+      peer_data.api_version = SemanticVersion::parse(version.ToStdString());
+    } else {
+      // Assume "old" version without /api/writable support:
+      peer_data.api_version = SemanticVersion(5, 8);
+    }
     if (result > 0) {
       return RestServerResult::NewPinRequested;  // FIXME (leamas) WTF
     } else {

--- a/model/src/peer_client.cpp
+++ b/model/src/peer_client.cpp
@@ -59,6 +59,7 @@ using PeerDlgPair = std::pair<PeerDlgResult, std::string>;
 
 PeerData::PeerData(EventVar& p)
     : overwrite(false),
+      activate(false),
       progress(p),
       run_status_dlg([](PeerDlg, int) { return PeerDlgResult::Cancel; }),
       run_pincode_dlg([] { return PeerDlgPair(PeerDlgResult::Cancel, ""); }) {}
@@ -320,6 +321,7 @@ static void SendObjects(std::string& body, const std::string& api_key,
     url << "https://" << peer_data.dest_ip_address << "/api/rx_object"
         << "?source=" << g_hostname << "&apikey=" << api_key;
     if (peer_data.overwrite) url << "&force=1";
+    if (peer_data.activate) url << "&activate=1";
 
     struct MemoryStruct chunk;
     long response_code =

--- a/model/src/peer_client.cpp
+++ b/model/src/peer_client.cpp
@@ -28,7 +28,6 @@
 
 #include <curl/curl.h>
 
-#include "peer_client.h"
 
 #include <wx/fileconf.h>
 #include <wx/json_defs.h>
@@ -36,15 +35,12 @@
 #include <wx/tokenzr.h>
 
 #include "model/config_vars.h"
-#include "FontMgr.h"
-#include "gui_lib.h"
 #include "model/nav_object_database.h"
+#include "model/peer_client.h"
 #include "model/rest_server.h"
 #include "model/semantic_vers.h"
-#include "ocpn_frame.h"
 
-extern MyFrame* gFrame;
-
+#if 0
 wxString GetErrorText(RestServerResult result) {
   switch (result) {
     case RestServerResult::GenericError:
@@ -537,3 +533,5 @@ void PINConfirmDialog::OnOKClick(wxCommandEvent& event) {
 void PINConfirmDialog::OnCancelClick(wxCommandEvent& event) {
   EndModal(ID_PCD_CANCEL);
 }
+
+#endif    // 0

--- a/model/src/peer_client.cpp
+++ b/model/src/peer_client.cpp
@@ -92,7 +92,13 @@ static int xfer_callback(void* clientp, [[maybe_unused]] curl_off_t dltotal,
   } else {
     peer_data->progress.Notify(100 * ulnow / ultotal, "");
   }
+// FIXME (leamas) dirty fix for outdated, bundled curl
+// returning 0 is undocumented, but worked for  5.8
+#ifdef CURL_PROGRESSFUNC_CONTINUE
   return CURL_PROGRESSFUNC_CONTINUE;
+#else
+  return 0;
+#endif
 }
 
 /** Perform a POST operation on server, store possible reply in response. */

--- a/model/src/peer_client.cpp
+++ b/model/src/peer_client.cpp
@@ -102,7 +102,10 @@ static int xfer_callback(void* clientp, [[maybe_unused]] curl_off_t dltotal,
 #endif
 }
 
-/** Perform a POST operation on server, store possible reply in response. */
+/**
+ *  Perform a POST operation on server, store possible reply in response.
+ *  @return positive http status or negated CURLcode error
+ */
 static long PostSendObjectMessage(std::string url, std::string& body,
                                   PeerData& peer_data, MemoryStruct* response) {
   long response_code = -1;
@@ -133,10 +136,13 @@ static long PostSendObjectMessage(std::string url, std::string& body,
     curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &response_code);
 
   curl_easy_cleanup(c);
-  return response_code;
+  return response_code == -1 ? -static_cast<long>(result) : response_code;
 }
 
-/** Perform a GET operation on server, store possible reply in chunk. */
+/**
+ * Perform a GET operation on server, store possible reply in chunk.
+ * @return positive http status or negated CURLcode error
+ */
 static int ApiGetUrl(std::string url, const MemoryStruct* chunk,
                      int timeout = 0) {
   int response_code = -1;
@@ -154,7 +160,7 @@ static int ApiGetUrl(std::string url, const MemoryStruct* chunk,
   if (result == CURLE_OK)
     curl_easy_getinfo(c, CURLINFO_RESPONSE_CODE, &response_code);
   curl_easy_cleanup(c);
-  return response_code;
+  return response_code == -1 ? -static_cast<long>(result) : response_code;
 }
 
 static std::string GetClientKey(std::string& server_name) {

--- a/model/src/peer_client.cpp
+++ b/model/src/peer_client.cpp
@@ -261,6 +261,8 @@ static bool GetApiKey(PeerData& peer_data, std::string& key) {
 
   while (true) {
     api_key = GetClientKey(peer_data.server_name);
+    // long enough to be identified as 5.9+ by server
+    if (api_key.size() < 9) api_key = "0123456789abc";
     std::stringstream url;
     url << "https://" << peer_data.dest_ip_address << "/api/ping"
         << "?source=" << g_hostname << "&apikey=" << api_key;

--- a/model/src/peer_client.cpp
+++ b/model/src/peer_client.cpp
@@ -409,8 +409,8 @@ static int CheckChunk(struct MemoryStruct& chunk, const std::string& guid) {
 static bool CheckObjects(const std::string& api_key,
                          PeerData& peer_data) {
   std::stringstream url;
-  url << "https://" << peer_data.dest_ip_address
-      << "?source=" << peer_data.server_name << "&apikey=" << api_key
+  url << "https://" << peer_data.dest_ip_address << "/api/writable"
+      << "?source=" << g_hostname << "&apikey=" << api_key
       << "&guid=";
   for (const auto& r : peer_data.routes) {
     std::string guid = r->GetGUID().ToStdString();

--- a/model/src/peer_client.cpp
+++ b/model/src/peer_client.cpp
@@ -414,6 +414,10 @@ bool SendNavobjects(PeerData& peer_data) {
   std::string api_key;
   bool apikey_ok = GetApiKey(peer_data, api_key);
   if (!apikey_ok) return false;
+  if (peer_data.api_version < SemanticVersion(5, 9) && peer_data.activate) {
+    peer_data.run_status_dlg(PeerDlg::ActivateUnsupported, 0);
+    return false;
+  }
   std::string body = PeerDataToXml(peer_data);
   SendObjects(body, api_key, peer_data);
   return true;

--- a/model/src/peer_client.cpp
+++ b/model/src/peer_client.cpp
@@ -257,6 +257,8 @@ static bool GetApiKey(PeerData& peer_data, std::string& key) {
             api_key = pincode.CompatHash();
           }
           SaveClientKey(peer_data.server_name, api_key);
+        } else if (pin_result.first == PeerDlgResult::Cancel) {
+          return false;
         } else {
           auto r = peer_data.run_status_dlg(PeerDlg::ErrorReturn, int_result);
           if (r == PeerDlgResult::Ok) continue;

--- a/model/src/plugin_loader.cpp
+++ b/model/src/plugin_loader.cpp
@@ -849,9 +849,8 @@ PluginMetadata PluginLoader::MetadataByName(const std::string& name) {
   if (matches.size() == 1) return matches[0];  // only one found with given name
 
   auto version = VersionFromManifest(name);
-  auto predicate = [version](const PluginMetadata& md) {
-    return version == md.version;
-  };
+  auto predicate =
+          [version](const PluginMetadata& md) { return version == md.version; };
   auto found = find_if(matches.begin(), matches.end(), predicate);
   return found != matches.end() ? *found : matches[0];
 }

--- a/model/src/rest_server.cpp
+++ b/model/src/rest_server.cpp
@@ -378,6 +378,7 @@ bool RestServer::CheckApiKey(const RestIoEvtData& evt_data) {
   ss << evt_data.source << " " << _("wants to send you new data.") << "\n"
      << _("Please enter the following PIN number on ") << evt_data.source << " "
      << _("to pair with this device") << "\n";
+  if (m_pin_dialog) m_pin_dialog->Destroy();
   m_pin_dialog = m_dlg_ctx.run_pincode_dlg(ss.str(), m_pincode.ToString());
 
   return false;

--- a/model/src/rest_server.cpp
+++ b/model/src/rest_server.cpp
@@ -405,7 +405,7 @@ void RestServer::HandleServerMessage(ObservedEvt& event) {
       return;
     case ORS_CHUNK_LAST:
       // Cancel existing dialog and close temp file
-      wxQueueEvent(m_pin_dialog, new wxCloseEvent);
+      if (m_pin_dialog) wxQueueEvent(m_pin_dialog, new wxCloseEvent);
       if (!m_upload_path.empty() && m_ul_stream.is_open()) m_ul_stream.close();
       break;
   }
@@ -487,7 +487,7 @@ void RestServer::HandleRoute(pugi::xml_node object,
       UpdateReturnStatus(RestServerResult::NoError);
       if (evt_data.activate)
         activate_route.Notify(route->GetGUID().ToStdString());
-      g_pRouteMan->on_routes_update.Notify();
+      if (g_pRouteMan) g_pRouteMan->on_routes_update.Notify();
     } else {
       UpdateReturnStatus(RestServerResult::RouteInsertError);
     }

--- a/model/src/rest_server.cpp
+++ b/model/src/rest_server.cpp
@@ -483,7 +483,7 @@ void RestServer::HandleRoute(pugi::xml_node object,
     if (InsertRouteA(route, &pSet))  {
       UpdateReturnStatus(RestServerResult::NoError);
       if (evt_data.activate)
-        ActivateRequest.Notify(route->GetGUID().ToStdString());
+        activate_route.Notify(route->GetGUID().ToStdString());
    } else {
       UpdateReturnStatus(RestServerResult::RouteInsertError);
     }

--- a/model/src/rest_server.cpp
+++ b/model/src/rest_server.cpp
@@ -161,7 +161,7 @@ static void HandlePing(struct mg_connection* c, struct mg_http_message* hm,
     });
     if (!r) wxLogWarning("Timeout waiting for REST server condition");
   }
-  mg_http_reply(c, 200, "", "{\"result\": %d, \"version\": %s}\n",
+  mg_http_reply(c, 200, "", "{\"result\": %d, \"version\": \"%s\"}\n",
                 parent->GetReturnStatus(), VERSION_FULL);
 }
 

--- a/model/src/rest_server.cpp
+++ b/model/src/rest_server.cpp
@@ -23,6 +23,7 @@
 
 #include <memory>
 #include <mutex>
+#include <string>
 #include <utility>
 #include <vector>
 
@@ -34,11 +35,11 @@
 #include "config.h"
 #include "model/config_vars.h"
 #include "model/logger.h"
-#include "mongoose.h"
 #include "model/nav_object_database.h"
 #include "model/ocpn_utils.h"
-#include "observable_evt.h"
 #include "model/rest_server.h"
+#include "mongoose.h"
+#include "observable_evt.h"
 
 /** Event from IO thread to main */
 wxDEFINE_EVENT(REST_IO_EVT, ObservedEvt);
@@ -160,7 +161,8 @@ static void HandlePing(struct mg_connection* c, struct mg_http_message* hm,
     });
     if (!r) wxLogWarning("Timeout waiting for REST server condition");
   }
-  mg_http_reply(c, 200, "", "{\"result\": %d}\n", parent->GetReturnStatus());
+  mg_http_reply(c, 200, "", "{\"result\": %d, \"version\": %s}\n",
+                parent->GetReturnStatus(), VERSION_FULL);
 }
 
 static void HandleWritable(struct mg_connection* c, struct mg_http_message* hm,

--- a/model/src/rest_server.cpp
+++ b/model/src/rest_server.cpp
@@ -217,6 +217,30 @@ static void fn(struct mg_connection* c, int ev, void* ev_data, void* fn_data) {
   }
 }
 
+std::string RestResultText(RestServerResult result) {
+  wxString s;
+  switch (result) {
+    case RestServerResult::NoError:
+      s =  _("No error");
+    case RestServerResult::GenericError:
+      s =  _("Server Generic Error");
+    case RestServerResult::ObjectRejected:
+      s =  _("Peer rejected object");
+    case RestServerResult::DuplicateRejected:
+      s =  _("Peer rejected duplicate object");
+    case RestServerResult::RouteInsertError:
+      s =  _("Peer internal error (insert)");
+    case RestServerResult::NewPinRequested:
+      s =  _("Peer requests new pincode");
+    case RestServerResult::ObjectParseError:
+      s =  _("XML parse error");
+    case RestServerResult::Void:
+      s =  _("Unspecified error");
+  }
+  return s.ToStdString();
+}
+
+
 //========================================================================
 /*    RestServer implementation */
 

--- a/model/src/rest_server.cpp
+++ b/model/src/rest_server.cpp
@@ -38,11 +38,14 @@
 #include "model/nav_object_database.h"
 #include "model/ocpn_utils.h"
 #include "model/rest_server.h"
+#include "model/routeman.h"
 #include "mongoose.h"
 #include "observable_evt.h"
 
 /** Event from IO thread to main */
 wxDEFINE_EVENT(REST_IO_EVT, ObservedEvt);
+
+extern Routeman* g_pRouteMan;
 
 using namespace std::chrono_literals;
 
@@ -484,10 +487,10 @@ void RestServer::HandleRoute(pugi::xml_node object,
       UpdateReturnStatus(RestServerResult::NoError);
       if (evt_data.activate)
         activate_route.Notify(route->GetGUID().ToStdString());
-   } else {
+      g_pRouteMan->on_routes_update.Notify();
+    } else {
       UpdateReturnStatus(RestServerResult::RouteInsertError);
     }
-    m_dlg_ctx.top_level_refresh();
   }
   UpdateRouteMgr();
 }

--- a/model/src/routeman.cpp
+++ b/model/src/routeman.cpp
@@ -1469,6 +1469,15 @@ void WayPointman::DeleteAllWaypoints(bool b_delete_used) {
   return;
 }
 
+RoutePoint* WayPointman::FindWaypointByGuid(const std::string& guid) {
+  wxRoutePointListNode *node = m_pWayPointList->GetFirst();
+  while (node) {
+    RoutePoint* rp  = node->GetData();
+    if (guid == rp->m_GUID) return rp;
+    node = node->GetNext();
+  }
+  return 0;
+}
 void WayPointman::DestroyWaypoint(RoutePoint *pRp, bool b_update_changeset) {
   if (!b_update_changeset)
     NavObjectChanges::getInstance()->m_bSkipChangeSetUpdate = true;

--- a/test/rest-tests.cpp
+++ b/test/rest-tests.cpp
@@ -140,7 +140,8 @@ protected:
       std::ifstream f(path.string());
       std::string result;
       std::getline(f, result);
-      const char* expected =  "{\"result\": 5, \"version\": \"" VERSION_FULL "\"}";
+      const char* expected =
+          "{\"result\": 5, \"version\": \"" VERSION_FULL "\"}";
       EXPECT_EQ(result, expected);  // Bad api key
     }{
       fs::path curl_prog(CURLPROG);

--- a/test/rest-tests.cpp
+++ b/test/rest-tests.cpp
@@ -88,7 +88,7 @@ public:
     for (int i = 0; addresses.size() == 0 && i < 10; i++) {
        std::this_thread::sleep_for(500ms);
        addresses = GetLocalAddresses();
-    } 
+    }
     if (!addresses.size()) {
         std::cerr << "Cannot get local IP address(!)\n";
         return;
@@ -140,7 +140,8 @@ protected:
       std::ifstream f(path.string());
       std::string result;
       std::getline(f, result);
-      EXPECT_EQ(result, "{\"result\": 5}");  // Bad api key
+      const char* expected =  "{\"result\": 5, \"version\": " VERSION_FULL "}";
+      EXPECT_EQ(result, expected);  // Bad api key
     }{
       fs::path curl_prog(CURLPROG);
       std::stringstream ss;
@@ -154,7 +155,8 @@ protected:
       std::ifstream f(path.string());
       std::string result;
       std::getline(f, result);
-      EXPECT_EQ(result, "{\"result\": 0}");  // ok
+      const char* expected =  "{\"result\": 0, \"version\": " VERSION_FULL "}";
+      EXPECT_EQ(result, expected);  // ok
     }
   }
 };

--- a/test/rest-tests.cpp
+++ b/test/rest-tests.cpp
@@ -140,7 +140,7 @@ protected:
       std::ifstream f(path.string());
       std::string result;
       std::getline(f, result);
-      const char* expected =  "{\"result\": 5, \"version\": " VERSION_FULL "}";
+      const char* expected =  "{\"result\": 5, \"version\": \"" VERSION_FULL "\"}";
       EXPECT_EQ(result, expected);  // Bad api key
     }{
       fs::path curl_prog(CURLPROG);
@@ -155,7 +155,8 @@ protected:
       std::ifstream f(path.string());
       std::string result;
       std::getline(f, result);
-      const char* expected =  "{\"result\": 0, \"version\": " VERSION_FULL "}";
+      const char* expected =
+          "{\"result\": 0, \"version\": \"" VERSION_FULL "\"}";
       EXPECT_EQ(result, expected);  // ok
     }
   }


### PR DESCRIPTION
Client side of the peer transfer code.
  - Refactor peer_client into somewhat proper model + gui parts.
  - Fix the "Ok to overwrite dialog" so it occurs on the originating peer rather than the server. This requires that both client and server is updated.
  - Fix bug leading to duplicated waypoints on the receiving side. This is a server only fix not requiring an updated client.

All sorts of code clean up and GUI polish. Some memory leaks was detected and plugged.

Closes: #3121
Closes: #3522 

EDIT: Added new commits handling activation of a transferred route (#3406). This is only the initial part of issue which is left open.
: 