### PR TITLE
rest_server: Avoid wxWin data in worker thread (#3588)

### DIFF
--- a/model/src/rest_server.cpp
+++ b/model/src/rest_server.cpp
@@ -141,7 +141,6 @@ static void HandleRxObject(struct mg_connection* c, struct mg_http_message* hm,
     });
     if (!r) wxLogWarning("Timeout waiting for REST server condition");
     mg_http_reply(c, 200, "", "{\"result\": %d}\n", parent->GetReturnStatus());
-    parent->UpdateRouteMgr();
   }
 }
 
@@ -461,6 +460,7 @@ void RestServer::HandleRoute(pugi::xml_node object,
       UpdateReturnStatus(RestServerResult::RouteInsertError);
     m_dlg_ctx.top_level_refresh();
   }
+  UpdateRouteMgr();
 }
 
 void RestServer::HandleTrack(pugi::xml_node object,


### PR DESCRIPTION
rest_server.cpp invokes methods affecting wxWindows data structures from the server thread. Fix by moving to main thread.

This is a long standing issue which seems to be present also in 5.8.4 but for some reason does not trigger anything there.

Kudos to @hakansv which found the nasty #3588 bug while working with #3584. And of course also to @bdbcat who found the basic problem.

Closes: #3588