### PR TITLE
ci: Add official cmake Android definitions

### DIFF
--- a/ci/circleci-build-android-corelib-armhf.sh
+++ b/ci/circleci-build-android-corelib-armhf.sh
@@ -28,6 +28,9 @@ cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DOCPN_TARGET_TUPLE:STRING="Android-armhf;16;armhf" \
   -Dtool_base="$HOME/android-sdk/ndk/26.1.10909125/toolchains/llvm/prebuilt/linux-x86_64"\
+  -DCMAKE_SYSTEM_NAME=Android \
+  -DCMAKE_SYSTEM_VERSION=26 \
+  -DCMAKE_ANDROID_ARCH_ABI=armeabi-v7a \
   ..
 
 make VERBOSE=1


### PR DESCRIPTION
Adding the official definitions for a cmake Android NDK cross build. Overall, this should simplify things over time. Notably, it makes the cmake ANDROID variable defined. This is the "official" way to determine an Android build and makes it possible to detect an Android build without resorting to the OpenCPN specific QT_ANDROID

Definitions copied from shipdriver where they have been used for long.

Merging this PR will need updating the complete Android build chain with similar definitions.