### PR TITLE
Enable import of plugin after failed attempt (#3114)

### DIFF
--- a/gui/include/gui/pluginmanager.h
+++ b/gui/include/gui/pluginmanager.h
@@ -287,6 +287,8 @@ public:
   ListOfPI_S57Obj* GetLightsObjRuleListVisibleAtLatLon(
       ChartPlugInWrapper* target, float zlat, float zlon, const ViewPort& vp);
 
+  void ResetPluginBlacklist() {m_blacklist->reset(); }
+
 private:
   bool CheckBlacklistedPlugin(wxString name, int major, int minor);
   bool CheckBlacklistedPlugin(opencpn_plugin* plugin);

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -3955,6 +3955,7 @@ void CatalogMgrPanel::OnTarballButton(wxCommandEvent& event) {
     handler->uninstall(metadata.name);
     return;
   }
+  g_pi_manager->ResetPluginBlacklist();   // See #3114
   UninstallPlugin(metadata.name);
   ok = handler->installPlugin(metadata, path.ToStdString());
   if (!ok) {

--- a/model/include/model/plugin_blacklist.h
+++ b/model/include/model/plugin_blacklist.h
@@ -92,6 +92,9 @@ public:
   virtual bool mark_unloadable(const std::string& name,
 		               int major, int minor) = 0;
 
+  /** Reset blacklist to contructor state. */
+  virtual void reset() = 0;
+
   /** Return true iff plugin (a path) is loadable. */
   virtual bool is_loadable(const std::string path) = 0;
 

--- a/model/src/plugin_blacklist.cpp
+++ b/model/src/plugin_blacklist.cpp
@@ -158,8 +158,12 @@ friend std::unique_ptr<AbstractBlacklist> blacklist_factory();
 typedef std::unordered_map<std::string, block> block_map;
 
 private:
-  PlugBlacklist() {
-    constexpr int list_len = sizeof(plugin_blacklist)/sizeof(config_block);
+  PlugBlacklist() { init(); }
+
+  void init() {
+    m_blocks.clear();
+    static constexpr int list_len =
+        sizeof(plugin_blacklist)/sizeof(config_block);
     for (int i = 0; i < list_len; i += 1) {
       m_blocks[plugin_blacklist[i].name] = block(plugin_blacklist[i]);
     }
@@ -233,6 +237,8 @@ public:
       filename = filename.substr(slashpos + 1);
     return update_block(filename, -1, -1);
   }
+
+  virtual void reset() { init(); }
 
   bool is_loadable(const std::string path) {
     auto filename(path);


### PR DESCRIPTION
Clear the plugin blacklist before importing plugin.

Side effect: unloadable plugins will be reported again when importing a possibly  unrelated plugin.

Closes: #3114