### PR TITLE
comm_drv_n0183_net: Avoid creating wxTimerEvent (#3643)

### DIFF
--- a/model/include/model/comm_drv_n0183_net.h
+++ b/model/include/model/comm_drv_n0183_net.h
@@ -77,7 +77,8 @@ public:
   bool SetOutputSocketOptions(wxSocketBase* tsock);
   bool SendSentenceNetwork(const wxString& payload);
   void OnServerSocketEvent(wxSocketEvent& event);  // The listener
-  void OnTimerSocket(wxTimerEvent& event);
+  void OnTimerSocket(wxTimerEvent& event) { OnTimerSocket(); }
+  void OnTimerSocket();
   void OnSocketEvent(wxSocketEvent& event);
   void OpenNetworkGPSD();
   void OpenNetworkTCP(unsigned int addr);

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -173,11 +173,8 @@ CommDriverN0183Net::CommDriverN0183Net(const ConnectionParams* params,
 
   m_mrq_container = new MrqContainer;
 
-  auto resume_action = [&](ObservedEvt&) {
-    wxTimerEvent evt;
-    OnTimerSocket(evt); };
-  resume_listener.Init(SystemEvents::GetInstance().evt_resume, resume_action);
-
+  resume_listener.Init(SystemEvents::GetInstance().evt_resume,
+                       [&](ObservedEvt&) { OnTimerSocket(); });
   Open();
 }
 
@@ -363,7 +360,7 @@ void CommDriverN0183Net::OnSocketReadWatchdogTimer(wxTimerEvent& event) {
   }
 }
 
-void CommDriverN0183Net::OnTimerSocket(wxTimerEvent&) {
+void CommDriverN0183Net::OnTimerSocket() {
   //  Attempt a connection
   wxSocketClient* tcp_socket = dynamic_cast<wxSocketClient*>(GetSock());
   if (tcp_socket) {


### PR DESCRIPTION
Refactor OnTimerSocket to avoid the silly need to create a wxTimerEvent.

Closes: #3643