### PR TITLE
REST server update (#3648)

### DIFF
--- a/gui/include/gui/ocpn_app.h
+++ b/gui/include/gui/ocpn_app.h
@@ -92,7 +92,8 @@ private:
   int m_exitcode;  ///< by default -2. Otherwise, forces exit(exit_code)
 
   void InitRestListeners();
-  ObsListener rest_srv_listener;
+  ObsListener rest_activate_listener;
+  ObsListener rest_reverse_listener;
 
 };
 

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -767,7 +767,7 @@ void MyApp::InitRestListeners() {
   auto reverse_route = [&](wxCommandEvent ev) {
     auto guid = ev.GetString().ToStdString();
     ReverseRoute(guid); };
-  rest_reverse_listener.Init(m_rest_server.activate_route, reverse_route);
+  rest_reverse_listener.Init(m_rest_server.reverse_route, reverse_route);
 }
 
   bool MyApp::OpenFile(const std::string& path) {

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -745,6 +745,7 @@ static void ActivateRoute(const std::string &guid) {
     point = route->GetPoint(2);
   }
   g_pRouteMan->ActivateRoute(route, point);
+  if (g_pRouteMan) g_pRouteMan->on_routes_update.Notify();
   route->m_bRtIsSelected = false;
 }
 
@@ -755,7 +756,7 @@ static void ReverseRoute(const std::string &guid) {
     return;
   }
   route->Reverse();
-  // FIXNE (leamas) update routeman_gui
+  if (g_pRouteMan) g_pRouteMan->on_routes_update.Notify();
 }
 
 

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -748,11 +748,26 @@ static void ActivateRoute(const std::string &guid) {
   route->m_bRtIsSelected = false;
 }
 
+static void ReverseRoute(const std::string &guid) {
+  Route *route = g_pRouteMan->FindRouteByGUID(guid);
+  if (!route) {
+    wxLogMessage("Cannot activate guid: no such route");
+    return;
+  }
+  route->Reverse();
+  // FIXNE (leamas) update routeman_gui
+}
+
+
 void MyApp::InitRestListeners() {
   auto activate_route = [&](wxCommandEvent ev) {
     auto guid = ev.GetString().ToStdString();
     ActivateRoute(guid); };
-  rest_srv_listener.Init(m_rest_server.activate_route, activate_route);
+  rest_activate_listener.Init(m_rest_server.activate_route, activate_route);
+  auto reverse_route = [&](wxCommandEvent ev) {
+    auto guid = ev.GetString().ToStdString();
+    ReverseRoute(guid); };
+  rest_reverse_listener.Init(m_rest_server.activate_route, reverse_route);
 }
 
   bool MyApp::OpenFile(const std::string& path) {

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -1851,4 +1851,17 @@ extern DECL_EXP CommDriverResult RegisterTXPGNs(DriverHandle handle,
                                                 std::vector<int> &pgn_list);
 
 
+// API 1.19
+//
+
+/** Facade for NavAddrPluginMsg. */
+struct PluginMsgId {
+  const std::string id;
+  PluginMsgId(const std::string &s) : id(s){};
+};
+
+extern DECL_EXP std::shared_ptr<ObservableListener> GetListener(
+    PluginMsgId id, wxEventType ev, wxEvtHandler *handler);
+
+extern DECL_EXP std::string GetPluginMsgPayload(PluginMsgId id, ObservedEvt ev);
 #endif  //_PLUGIN_H_

--- a/model/include/model/rest_server.h
+++ b/model/include/model/rest_server.h
@@ -171,6 +171,45 @@ public:
  *    - Returns (example):
  *        {"version": "5.8.9" }
  *
+ *  GET /api/list-routes  <br>
+ *  Return list of available routes
+ *    - source=`<ip>` Mandatory, origin ip address or hostname.
+ *    - api_key=`<key>` Mandatory, as obtained when pairing, see below.
+ *    - Returns json data
+ *      {
+ *        "version": "5.8.0",
+ *        "routes":  [ ["guid-1": "name1" ], ["guid-2": "name2" ], ... ]
+ *      }
+ *
+ *
+ *  GET /api/activate-route  <br>
+ *  Activate an existing route.
+ *    - source=`<ip>` Mandatory, origin ip address or hostname.
+ *    - api_key=`<key>` Mandatory, as obtained when pairing, see below.
+ *    - guid=`<guid>` Route guid.
+ *    - Returns json data (activating already active route silently ignored)
+ *         {"result": `<code>`}
+ *
+ *  GET /api/reverse-route  <br>
+ *  Reverse an existing route
+ *    - source=`<ip>` Mandatory, origin ip address or hostname.
+ *    - api_key=`<key>` Mandatory, as obtained when pairing, see below.
+ *    - guid=`<guid>` Route guid.
+ *    - Returns json data
+ *         {"result": `<code>`}
+ *
+ *  POST /api/plugin-msg
+ *  Upload string message forwarded to all plugins
+ *     - Parameters:
+ *         - source=`<ip>` Mandatory, origin ip address or hostname.
+ *         - api_key=`<key>` Mandatory, as obtained when pairing, see below.
+ *         - id=`<id>` Mandatory, message id used by listeners.
+ *     - Body:
+ *         - Arbitrary text.
+ *     - Returns:
+ *         {"result": `<code>`}
+ *
+ *
  * Authentication uses a pairing mechanism. When an unpaired device
  * tries to connect, the API generates a random pincode which is
  * sent to the connecting party where it is displayed to user. User
@@ -232,7 +271,6 @@ public:
 
   /** IoThread interface: Guards return_status */
   std::condition_variable return_status_cv;
-
 
   /**
    * IoThread interface: Binary exit synchronization, released when

--- a/model/include/model/rest_server.h
+++ b/model/include/model/rest_server.h
@@ -232,6 +232,9 @@ public:
 
   /** Notified with a string GUID when user wants to activate a route. */
   EventVar activate_route;
+
+  /** Notified with a string GUID when user wants to reverse a route. */
+  EventVar reverse_route;
 };
 
 /** AbstractRestServer implementation and interface to underlying IO thread. */

--- a/model/include/model/rest_server.h
+++ b/model/include/model/rest_server.h
@@ -242,6 +242,7 @@ class RestServer : public AbstractRestServer, public wxEvtHandler {
   friend class RestServerObjectApp;  ///< Unit test hook
   friend class RestCheckWriteApp;    ///< Unit test hook
   friend class RestServerPingApp;    ///< Unit test hook
+  friend class RestPluginMsgApp;     ///< Unit test hook
 
 public:
   RestServer(RestServerDlgCtx ctx, RouteCtx route_ctx, bool& portable);

--- a/model/include/model/rest_server.h
+++ b/model/include/model/rest_server.h
@@ -266,6 +266,9 @@ public:
   /** Semi-static storage used by IoThread C code. */
   std::string m_key_file;
 
+  /** IoThread interface: body of return message, if any. */
+  std::string m_reply_body;
+
   /** IoThread interface: Guards return_status */
   std::mutex ret_mutex;
 

--- a/model/src/comm_navmsg.cpp
+++ b/model/src/comm_navmsg.cpp
@@ -1,11 +1,6 @@
-/***************************************************************************
- *
- * Project:  OpenCPN
- * Purpose:  Implements comm_navmsg -- raw, undecoded messages.
- * Author:   David Register, Alec Leamas
- *
- ***************************************************************************
- *   Copyright (C) 2022 by David Register, Alec Leamas                     *
+ /**************************************************************************
+ *   Copyright (C) 2022  David Register                                    *
+ *   Copyright (C) 2022 - 2024  Alec Leamas                                *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -22,6 +17,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
+
+/** \file comm_navmsg.cpp  Implement comm_navmsg.h */
 
 // For compilers that support precompilation, includes "wx.h".
 #include <wx/wxprec.h>
@@ -49,6 +46,9 @@ std::string NavAddr::BusToString(NavAddr::Bus b) {
       break;
     case NavAddr::Bus::Onenet:
       return "Onenet";
+      break;
+    case NavAddr::Bus::Plugin:
+      return "Plugin";
       break;
     case NavAddr::Bus::TestBus:
       return "TestBus";

--- a/model/src/comm_plugin_api.cpp
+++ b/model/src/comm_plugin_api.cpp
@@ -52,6 +52,12 @@ std::string GetN0183Payload(NMEA0183Id id, ObservedEvt ev) {
   return msg->payload;
 }
 
+std::string GetPluginMsgPayload(PluginMsgId id, ObservedEvt ev) {
+  auto msg = UnpackEvtPointer<PluginMsg>(ev);
+  return msg->message;
+}
+
+
 std::shared_ptr<void> GetSignalkPayload(ObservedEvt ev) {
   auto msg = UnpackEvtPointer<SignalkMsg>(ev);
   wxJSONReader reader;
@@ -97,6 +103,12 @@ shared_ptr<ObservableListener> GetListener(NavDataId id, wxEventType et,
                                            wxEvtHandler* eh) {
   return make_shared<ObservableListener>(BasicNavDataMsg(), eh, et);
 }
+
+std::shared_ptr<ObservableListener> GetListener(PluginMsgId id, wxEventType et,
+                                                wxEvtHandler* eh) {
+  return make_shared<ObservableListener>(PluginMsg(id.id, ""), eh, et);
+}
+
 
 PluginNavdata GetEventNavdata(ObservedEvt ev) {
   auto msg = UnpackEvtPointer<BasicNavDataMsg>(ev);

--- a/test/rest-tests.cpp
+++ b/test/rest-tests.cpp
@@ -25,6 +25,7 @@
 #include "model/certificates.h"
 #include "model/cli_platform.h"
 #include "model/config_vars.h"
+#include "model/comm_navmsg.h"
 #include "model/mDNS_query.h"
 #include "observable_confvar.h"
 #include "model/ocpn_types.h"
@@ -40,6 +41,7 @@ extern Select* pSelect;
 extern BasePlatform* g_BasePlatform;
 
 static std::string s_result;
+static std::string s_result2;
 static int int_result0;
 
 static void ConfigSetup() {
@@ -162,6 +164,52 @@ protected:
     }
   }
 };
+
+class RestPluginMsgApp : public RestServerApp {
+public:
+  RestPluginMsgApp(RestServerDlgCtx ctx, RouteCtx route_ctx, bool& portable)
+      : RestServerApp(ctx, route_ctx, portable) {}
+
+protected:
+  void Work() {
+    {
+      std::this_thread::sleep_for(50ms);
+      fs::path curl_prog(CURLPROG);
+      std::stringstream ss;
+      auto path = fs::path(CMAKE_BINARY_DIR) / "curl-result";
+      ss << curl_prog.make_preferred() << " --insecure -o " << path
+	  << " \"https://localhost:8443/api/ping?source=1.2.3.4&apikey=bad\"";
+      system(CmdString(ss.str()).c_str());
+      std::this_thread::sleep_for(50ms);
+      ProcessPendingEvents();
+      std::ifstream f(path.string());
+      std::string result;
+      std::getline(f, result);
+      const char* expected =
+          "{\"result\": 5, \"version\": \"" VERSION_FULL "\"}";
+      EXPECT_EQ(result, expected);  // Bad api key
+    }{
+      fs::path curl_prog(CURLPROG);
+      ObsListener listener;
+      listener.Init(PluginMsg("msg1", ""), [&](ObservedEvt ev) {
+        auto msg = UnpackEvtPointer<PluginMsg>(ev);
+        s_result = msg->name;
+        s_result2 = msg->message; });
+      std::stringstream ss;
+      auto key = m_rest_server.m_key_map["1.2.3.4"];
+      ss << curl_prog.make_preferred() << " --insecure -X post --data foobar "
+         << " \"https://localhost:8443/api/plugin-msg?source=1.2.3.4&apikey="
+         << key << "&id=msg1" << "\"";
+      auto foo = ss.str();
+      system(CmdString(ss.str()).c_str());
+      std::this_thread::sleep_for(50ms);
+      ProcessPendingEvents();
+      EXPECT_EQ(s_result, "msg1");
+      EXPECT_EQ(s_result2, "foobar");
+    }
+  }
+};
+
 
 class RestServer404App : public RestServerApp {
 public:
@@ -430,6 +478,16 @@ TEST(RestServer, CheckWrite) {
   RestServerDlgCtx dialog_ctx;
   RouteCtx route_ctx;
   RestCheckWriteApp app(dialog_ctx, route_ctx, g_portable);
+  app.Run();
+  delete g_BasePlatform;
+  g_BasePlatform = 0;
+}
+
+TEST(RestServer, PluginMessage) {
+  wxDisableAsserts();
+  RestServerDlgCtx dialog_ctx;
+  RouteCtx route_ctx;
+  RestPluginMsgApp app(dialog_ctx, route_ctx, g_portable);
   app.Run();
   delete g_BasePlatform;
   g_BasePlatform = 0;


### PR DESCRIPTION
Add the missing parts described in #3648

As for @nohal's request for a general JSON relay to plugins this is generalized to a sending an arbitrary string. The message has an id similar to communication messages, so plugins listens to a specific kind  of plugin message.

The plugin message service is yet not exported in the plugin interface. ~Will do before merge~ (done)

Closes: #3648

Besides using a remote client testing can also be done using curl. This requires a working api key. How to set up this is described in the [manual](https://opencpn-manuals.github.io/main/opencpn-dev/rest-interface.html#_headless_pairing). I just pushed a bugfix to this chapter, manual needs to be rebuilt before used.

With a correct `source` and `apikey` as of above testing could be done according to the specs in _model/include/model/rest_server.h_. Examples:

    curl --insecure "https://192.168.2.50:8443/api/list-routes?apikey=74327943f791&source=misan"
    curl --insecure "https://192.168.2.50:8443/api/activate-route?apikey=74327943f791&source=misan&guid=40987ba-63bf-41b6-9254-4931074d952a&id=msg1"
    curl -X post --data - --insecure  "https://192.168.2.50:8443/api/list-routes?apikey=74327943f791&source=misan&id=msg1" << EOF
    message line 1
    message line 2
    EOF