### PR TITLE
IPC - Release the wxDDEserver object before exit

### DIFF
--- a/gui/include/gui/ocpn_frame.h
+++ b/gui/include/gui/ocpn_frame.h
@@ -347,6 +347,7 @@ public:
 
   void InitAppMsgBusListener();
   void InitApiListeners();
+  void ReleaseApiListeners();
   void UpdateStatusBar(void);
 
 private:

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -1815,6 +1815,8 @@ void MyFrame::OnCloseWindow(wxCloseEvent &event) {
 
   NMEALogWindow::Shutdown();
 
+  ReleaseApiListeners();
+
   g_MainToolbar = NULL;
   g_bTempShowMenuBar = false;
 
@@ -4976,6 +4978,7 @@ void MyFrame::InitAppMsgBusListener() {
 /** Setup handling of events from the local ipc/dbus API. */
 #ifdef __ANDROID__
 void MyFrame::InitApiListeners() {}
+void MyFrame::ReleaseApiListeners() {}
 
 #else
 void MyFrame::InitApiListeners() {
@@ -4988,6 +4991,8 @@ void MyFrame::InitApiListeners() {
       [](const std::string& path) { return wxGetApp().OpenFile(path); };
 
 }
+
+void MyFrame::ReleaseApiListeners() { LocalServerApi::ReleaseInstance(); }
 #endif
 
 void MyFrame::HandleGPSWatchdogMsg(std::shared_ptr<const GPSWatchdogMsg> msg) {

--- a/model/include/model/ipc_api.h
+++ b/model/include/model/ipc_api.h
@@ -99,6 +99,7 @@ protected:
 
 private:
   std::string buffer;
+  static IpcServer* s_instance;
 };
 
 /**

--- a/model/include/model/ipc_api.h
+++ b/model/include/model/ipc_api.h
@@ -75,6 +75,7 @@ friend  class IpcServer;
 
 public:
   static LocalServerApi& GetInstance();
+  static void ReleaseInstance();
 
   IpcConnection(IpcConnection&) = delete;
   void operator= (const IpcConnection&) = delete;

--- a/model/include/model/local_api.h
+++ b/model/include/model/local_api.h
@@ -65,6 +65,8 @@ public:
   /** @return Reference to a LocalServerApi implementation. */
   static LocalServerApi& GetInstance();
 
+  /** Release Instance */
+  static void ReleaseInstance();
 
   /** Notified on the Raise command. */
   EventVar on_raise;

--- a/model/src/ipc_api.cpp
+++ b/model/src/ipc_api.cpp
@@ -26,6 +26,8 @@
 #include "model/logger.h"
 #include "model/ocpn_utils.h"
 
+IpcServer* IpcConnection::s_instance = nullptr;
+
 // FIXME (leamas) Bad name
 std::string GetSocketPath() {
   auto const static sep = static_cast<char>(wxFileName::GetPathSeparator());
@@ -74,17 +76,15 @@ LocalApiResult IpcClient::GetRestEndpoint() {
   return LocalApiResult(false, "Server error running get_rest_endpoint");
 }
 
-static IpcServer* factory = nullptr;
-
 LocalServerApi& IpcConnection::GetInstance() {
-  if (!factory) factory = new IpcServer(GetSocketPath());
-  return *factory;
+  if (!s_instance) s_instance = new IpcServer(GetSocketPath());
+  return *s_instance;
 }
 
 void IpcConnection::ReleaseInstance() {
-  if (factory) {
-    delete factory;
-    factory = nullptr;
+  if (s_instance) {
+    delete s_instance;
+    s_instance = nullptr;
   }
 }
 

--- a/model/src/ipc_api.cpp
+++ b/model/src/ipc_api.cpp
@@ -74,12 +74,19 @@ LocalApiResult IpcClient::GetRestEndpoint() {
   return LocalApiResult(false, "Server error running get_rest_endpoint");
 }
 
+static IpcServer* factory = nullptr;
+
 LocalServerApi& IpcConnection::GetInstance() {
-  static IpcServer* factory = nullptr;
   if (!factory) factory = new IpcServer(GetSocketPath());
   return *factory;
 }
 
+void IpcConnection::ReleaseInstance() {
+  if (factory) {
+    delete factory;
+    factory = nullptr;
+  }
+}
 
 bool IpcConnection::OnExec(const wxString&, const wxString& data) {
   if (data == "quit") {

--- a/model/src/ipc_factories.cpp
+++ b/model/src/ipc_factories.cpp
@@ -48,6 +48,8 @@ LocalServerApi& LocalServerApi:: GetInstance() {
   return DummyIpcServer::GetInstance();
 }
 
+void LocalServerApi::ReleaseInstance() {}
+
 InstanceCheck& InstanceCheck::GetInstance() {
   return DummyInstanceChk::GetInstance();
 }
@@ -70,6 +72,8 @@ LocalServerApi& LocalServerApi:: GetInstance() {
   return UseDbus() ? DbusServer::GetInstance() : IpcConnection::GetInstance();
 }
 
+void LocalServerApi::ReleaseInstance() {}
+
 InstanceCheck& InstanceCheck::GetInstance() {
   if (UseDbus())
     return DbusServer::GetInstance();
@@ -85,6 +89,8 @@ std::unique_ptr<LocalClientApi> LocalClientApi::GetClient() {
 LocalServerApi& LocalServerApi:: GetInstance() {
   return IpcConnection::GetInstance();
 }
+
+void LocalServerApi::ReleaseInstance() { IpcConnection::ReleaseInstance(); }
 
 InstanceCheck& InstanceCheck::GetInstance() {
   return GetWxInstanceChk();


### PR DESCRIPTION
 - Add `ReleaseInstance()` method in various classes
 - Add 'ReleaseApiListner()' method in various classes
 - Add `ReleaseApiListeners()` method in the 'MyFrame` class
 - Move static pointer 'factory' into local file scope

  These methods are designed to do nothing when running on non-wxMSW
  systems. On wxMSW systems, 'MyFrame' will use existing and the new
  methods to create one 'wxDDEserver' object at startup and release
  it before closing the main window thus eliminating a wxDebug assert.

 See discussion: [IPC](https://opencpn.zulipchat.com/#narrow/stream/332168-Master---5.2E8.2E0--.28was.3A-comms.29/topic/IPC.20feature)