### PR TITLE
Fix minor color issues

### DIFF
--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -12540,9 +12540,11 @@ void ChartCanvas::DrawAllCurrentsInBBox(ocpnDC &dc, LLBBox &BBox) {
   wxBrush *pblack_brush = wxTheBrushList->FindOrCreateBrush(
       GetGlobalColor(_T ( "UINFD" )), wxBRUSHSTYLE_SOLID);
 
+
   double skew_angle = GetVPRotation();
 
   wxFont *dFont = FontMgr::Get().GetFont(_("CurrentValue"));
+  dc.SetTextForeground(FontMgr::Get().GetFontColor(_("CurrentValue")));
   int font_size = wxMax(10, dFont->GetPointSize());
   font_size /= g_Platform->GetDisplayDIPMult(this);
   pTCFont =

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -8492,7 +8492,7 @@ void ChartGroupsUI::PopulateTrees(void) {
     if (!dirname.IsEmpty()) dir_array.Add(dirname);
   }
 
-  PopulateTreeCtrl(allAvailableCtl->GetTreeCtrl(), dir_array, wxColour(0, 0, 0),
+  PopulateTreeCtrl(allAvailableCtl->GetTreeCtrl(), dir_array, wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT),
                    dialogFont);
   m_pActiveChartsTree = allAvailableCtl->GetTreeCtrl();
 
@@ -8505,7 +8505,7 @@ void ChartGroupsUI::PopulateTrees(void) {
     if (!dirname.IsEmpty()) dir_array0.Add(dirname);
   }
   PopulateTreeCtrl(defaultAllCtl->GetTreeCtrl(), dir_array0,
-                   wxColour(128, 128, 128), iFont);
+                   wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT), iFont);
 }
 
 void ChartGroupsUI::CompleteInitialSettings(void) {


### PR DESCRIPTION
This pull request fixes two minor color problems :

- The current value drawn below the current arrow is using Tide font color instead of current font color -> Fixed
- Colors of chart directories in chart group panel of option window are not changed in case of dark color theme -> fixed 