### PR TITLE
Implement improved support for multi monitor systems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -766,6 +766,7 @@ set(GUI_HDRS
     ${GUI_HDR_DIR}/connections_dialog.h
     ${GUI_HDR_DIR}/conn_params_panel.h
     ${GUI_HDR_DIR}/DetailSlider.h
+    ${GUI_HDR_DIR}/displays.h
     ${GUI_HDR_DIR}/download_mgr.h
     ${GUI_HDR_DIR}/dychart.h
     ${GUI_HDR_DIR}/emboss_data.h
@@ -882,6 +883,7 @@ set(GUI_SRC
     ${GUI_SRC_DIR}/connections_dialog.cpp
     ${GUI_SRC_DIR}/conn_params_panel.cpp
     ${GUI_SRC_DIR}/DetailSlider.cpp
+    ${GUI_SRC_DIR}/displays.cpp
     ${GUI_SRC_DIR}/download_mgr.cpp
     ${GUI_SRC_DIR}/FlexHash.cpp
     ${GUI_SRC_DIR}/FontDesc.cpp
@@ -1237,7 +1239,7 @@ if (UNIX)
     target_link_libraries(${PACKAGE_NAME} PRIVATE ${ZLIB_LIBRARY})
     find_package(X11)
     if (X11_FOUND AND NOT APPLE)
-      target_link_libraries(${PACKAGE_NAME} PRIVATE ${X11_LIBRARIES})
+      target_link_libraries(${PACKAGE_NAME} PRIVATE ${X11_LIBRARIES} ${X11_Xrandr_LIB})
       set(OCPN_HAVE_X11 ON) # => config.h
     endif ()
     if (NOT APPLE)
@@ -1550,6 +1552,7 @@ if (CMAKE_HOST_WIN32)
   # use gdi plus only on MSVC, it is not a free library
   if (MSVC)
     target_link_libraries(${PACKAGE_NAME} PRIVATE gdiplus.lib)
+    target_link_libraries(${PACKAGE_NAME} PRIVATE Shcore.lib)
   endif ()
 endif ()
 

--- a/android/androidUTIL.cpp
+++ b/android/androidUTIL.cpp
@@ -238,7 +238,7 @@ extern int g_nAutoHideToolbar;
 extern int g_GUIScaleFactor;
 extern int g_ChartScaleFactor;
 
-extern double g_config_display_size_mm;
+extern std::vector<size_t> g_config_display_size_mm;
 extern bool g_config_display_size_manual;
 
 extern Multiplexer *g_pMUX;
@@ -2449,9 +2449,9 @@ double getAndroidDPmm() {
   // qDebug() << "getAndroidDPmm" << g_androidDPmm;
 
   // User override?
-  if (g_config_display_size_manual && (g_config_display_size_mm > 0)) {
+  if (g_config_display_size_manual && (g_config_display_size_mm[0] > 0)) {
     double maxDim = wxMax(::wxGetDisplaySize().x, ::wxGetDisplaySize().y);
-    double size_mm = g_config_display_size_mm;
+    double size_mm = g_config_display_size_mm[0];
     size_mm = wxMax(size_mm, 50);
     size_mm = wxMin(size_mm, 400);
     double ret = maxDim / size_mm;

--- a/gui/include/gui/OCPNPlatform.h
+++ b/gui/include/gui/OCPNPlatform.h
@@ -111,7 +111,7 @@ public:
   double GetDisplayAreaCM2();
   virtual double GetDisplayDPmm();
 
-  void SetDisplaySizeMM(double size);
+  void SetDisplaySizeMM(size_t monitor, double size);
   unsigned int GetSelectRadiusPix();
   double GetToolbarScaleFactor(int GUIScaleFactor);
   double GetCompassScaleFactor(int GUIScaleFactor);

--- a/gui/include/gui/displays.h
+++ b/gui/include/gui/displays.h
@@ -1,0 +1,61 @@
+/***************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  OpenCPN Display utilities
+ * Author:   David Register
+ *
+ ***************************************************************************
+ *   Copyright (C) 2024 by David S. Register                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+#ifndef OCPN_DISPLAYS_H
+#define OCPN_DISPLAYS_H
+
+#include <string>
+#include <vector>
+
+/// @brief Structure to hold information about a monitor
+struct OCPN_MonitorInfo {
+  /// @brief Name of the monitor
+  std::string name;
+  /// @brief Width of the monitor in millimeters
+  size_t width_mm;
+  /// @brief Height of the monitor in millimeters
+  size_t height_mm;
+  /// @brief Width of the monitor in pixels
+  size_t width;
+  /// @brief Height of the monitor in pixels
+  size_t height;
+  /// @brief Width of the monitor in physical pixels, on eg. Apple Retina displays this value differs
+  size_t width_px;
+  /// @brief Height of the monitor in physical pixels, on eg. Apple Retina displays this value differs
+  size_t height_px;
+  /// @brief Scaling factor in percent
+  size_t scale;
+};
+
+/// @brief Number of monitors connected to the system
+extern size_t g_num_monitors;
+extern size_t g_current_monitor;
+/// @brief Information about the monitors connected to the system  
+extern std::vector<OCPN_MonitorInfo> g_monitor_info;
+
+/// @brief Enumerate the monitors connected to the system
+void EnumerateMonitors();
+
+#endif  // OCPN_DISPLAYS_H

--- a/gui/include/gui/ocpn_frame.h
+++ b/gui/include/gui/ocpn_frame.h
@@ -44,6 +44,7 @@
 #include "ocpn_print.h"
 #include "s52s57.h"
 #include "SencManager.h"
+#include "displays.h"
 
 wxColour GetGlobalColor(wxString colorName);
 wxColour GetDialogColor(DialogColor color);

--- a/gui/src/ConfigMgr.cpp
+++ b/gui/src/ConfigMgr.cpp
@@ -259,7 +259,7 @@ extern int g_NMEAAPBPrecision;
 
 extern bool g_bAdvanceRouteWaypointOnArrivalOnly;
 extern double g_display_size_mm;
-extern double g_config_display_size_mm;
+extern std::vector<size_t> g_config_display_size_mm;
 extern bool g_config_display_size_manual;
 
 extern bool g_benable_rotate;
@@ -913,7 +913,12 @@ bool ConfigMgr::SaveTemplate(wxString fileName) {
   conf->Write(_T ( "AutoHideToolbar" ), g_bAutoHideToolbar);
   conf->Write(_T ( "AutoHideToolbarSecs" ), g_nAutoHideToolbar);
 
-  conf->Write(_T ( "DisplaySizeMM" ), g_config_display_size_mm);
+  wxString st0;
+  for (const auto &mm : g_config_display_size_mm) {
+    st0.Append(wxString::Format(_T ( "%zu," ), mm));
+  }
+  st0.RemoveLast(); //Strip last comma
+  conf->Write(_T ( "DisplaySizeMM" ), st0);
   conf->Write(_T ( "DisplaySizeManual" ), g_config_display_size_manual);
 
   conf->Write(_T ( "PlanSpeed" ), wxString::Format(_T("%.2f"), g_PlanSpeed));

--- a/gui/src/OCPNPlatform.cpp
+++ b/gui/src/OCPNPlatform.cpp
@@ -50,6 +50,7 @@
 #include "gui_lib.h"
 #include "model/cutil.h"
 #include "model/config_vars.h"
+#include "displays.h"
 #include "model/logger.h"
 #include "snd_config.h"
 #include "styles.h"
@@ -150,7 +151,7 @@ extern bool g_boptionsactive;
 
 extern wxString *pInit_Chart_Dir;
 
-extern double g_config_display_size_mm;
+extern std::vector<size_t> g_config_display_size_mm;
 extern bool g_config_display_size_manual;
 
 extern bool g_bFullScreenQuilt;
@@ -236,10 +237,11 @@ static bool checkIfFlatpacked() {
 OCPNPlatform::OCPNPlatform() {
   m_pt_per_pixel = 0;  // cached value
   m_bdisableWindowsDisplayEnum = false;
-  m_displaySize = wxSize(0, 0);
-  m_displaySizeMM = wxSize(0, 0);
   m_monitorWidth = m_monitorHeight = 0;
-  m_displaySizeMMOverride = 0;
+  EnumerateMonitors();
+  for (size_t i = 0; i < g_monitor_info.size(); i++) {
+    m_displaySizeMMOverride.push_back(0);
+  }
   m_pluginDataPath = "";
 }
 
@@ -1643,60 +1645,23 @@ wxSize OCPNPlatform::getDisplaySize() {
 #ifdef __OCPN__ANDROID__
   return getAndroidDisplayDimensions();
 #else
-  if (m_displaySize.x < 10)
-    m_displaySize = ::wxGetDisplaySize();  // default, for most platforms
-  return m_displaySize;
+  return wxSize(g_monitor_info[g_current_monitor].width,
+                g_monitor_info[g_current_monitor].height);
 #endif
 }
 
 double OCPNPlatform::GetDisplaySizeMM() {
-  if (m_displaySizeMMOverride > 0) return m_displaySizeMMOverride;
-
-  if (m_displaySizeMM.x < 1) m_displaySizeMM = wxGetDisplaySizeMM();
-
-  double ret = m_displaySizeMM.GetWidth();
-
-#if 0
-#ifdef __WXGTK__
-    GdkScreen *screen = gdk_screen_get_default();
-    wxSize resolution = getDisplaySize();
-    double gdk_monitor_mm;
-    double ratio = (double)resolution.GetWidth() / (double)resolution.GetHeight();
-    if( std::abs(ratio - 32.0/10.0) < std::abs(ratio - 16.0/10.0) ) {
-        // We suspect that when the resolution aspect ratio is closer to 32:10 than 16:10, there are likely 2 monitors side by side. This works nicely when they are landscape, but what if both are rotated 90 degrees...
-        gdk_monitor_mm = gdk_screen_get_width_mm(screen);
-    } else {
-        gdk_monitor_mm = gdk_screen_get_monitor_width_mm(screen, 0);
+  if (g_current_monitor < m_displaySizeMMOverride.size()) {
+    if (m_displaySizeMMOverride[g_current_monitor] > 0) {
+      return m_displaySizeMMOverride[g_current_monitor];
     }
-    if(gdk_monitor_mm > 0) // if gdk detects a valid screen width (returns -1 on raspberry pi)
-        ret = gdk_monitor_mm;
-#endif
-#endif
-
-#ifdef __WXMSW__
-  int w, h;
-
-  if (!m_bdisableWindowsDisplayEnum) {
-    if (GetWindowsMonitorSize(&w, &h) && (w > 100)) {  // sanity check
-      m_displaySizeMM == wxSize(w, h);
-      ret = w;
-    } else
-      m_bdisableWindowsDisplayEnum = true;  // disable permanently
   }
 
-#endif
-
-#ifdef __WXOSX__
-  ret = GetMacMonitorSize();
-#endif
+  double ret = g_monitor_info[g_current_monitor].width_mm;
 
 #ifdef __OCPN__ANDROID__
   ret = GetAndroidDisplaySize();
 #endif
-
-  wxString msg;
-  msg.Printf(_T("Detected display size (horizontal): %d mm"), (int)ret);
-  //     wxLogMessage(msg);
 
   return ret;
 }
@@ -1715,8 +1680,10 @@ double OCPNPlatform::GetDisplayAreaCM2() {
   return area;
 }
 
-void OCPNPlatform::SetDisplaySizeMM(double sizeMM) {
-  m_displaySizeMMOverride = sizeMM;
+void OCPNPlatform::SetDisplaySizeMM(size_t monitor, double sizeMM) {
+  if (monitor < m_displaySizeMMOverride.size()) {
+    m_displaySizeMMOverride[monitor] = sizeMM;
+  }
 }
 
 double OCPNPlatform::GetDisplayDPmm() {
@@ -1865,7 +1832,7 @@ double OCPNPlatform::GetToolbarScaleFactor(int GUIScaleFactor) {
   //  This may be approximated in a device orientation-independent way as:
   //   45pixels * DENSITY
   double premult = 1.0;
-  if (g_config_display_size_manual && (g_config_display_size_mm > 0)) {
+  if (g_config_display_size_manual && g_config_display_size_mm[0] > 0) {
     double target_size = 9.0;  // mm
 
     double basic_tool_size_mm = tool_size / GetDisplayDPmm();

--- a/gui/src/TrackPropDlg.cpp
+++ b/gui/src/TrackPropDlg.cpp
@@ -37,6 +37,7 @@
 #include "TrackPropDlg.h"
 #include "model/track.h"
 #include "model/route.h"
+#include "displays.h"
 #include "chcanv.h"
 #include "gui_lib.h"
 #include "ocpn_frame.h"
@@ -618,7 +619,8 @@ void TrackPropDlg::CreateControlsCompact() {
   int char_size = GetCharWidth();
   // Set the maximum size of the entire  dialog
   int width, height;
-  ::wxDisplaySize(&width, &height);
+  width = g_monitor_info[g_current_monitor].width;
+  height = g_monitor_info[g_current_monitor].height;
   SetSizeHints(-1, -1, width - 100, height - 100);
 }
 

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -100,6 +100,7 @@
 #include "model/conn_params.h"
 #include "route_gui.h"
 #include "line_clip.h"
+#include "displays.h"
 
 #ifdef __ANDROID__
 #include "androidUTIL.h"
@@ -2366,7 +2367,10 @@ void ChartCanvas::SetDisplaySizeMM(double size) {
   m_pix_per_mm = (horizontal) / ((double)m_display_size_mm);
   m_canvas_scale_factor = (horizontal) / (m_display_size_mm / 1000.);
 
-  if (ps52plib) ps52plib->SetPPMM(m_pix_per_mm);
+  if (ps52plib) {
+    ps52plib->SetDisplayWidth(g_monitor_info[g_current_monitor].width);
+    ps52plib->SetPPMM(m_pix_per_mm);
+  }
 
   wxString msg;
   msg.Printf(
@@ -2376,8 +2380,9 @@ void ChartCanvas::SetDisplaySizeMM(double size) {
   wxLogMessage(msg);
 
   int ssx, ssy;
-  ::wxDisplaySize(&ssx, &ssy);
-  msg.Printf(_T("wxDisplaySize(): %d %d"), ssx, ssy);
+  ssx = g_monitor_info[g_current_monitor].width;
+  ssy = g_monitor_info[g_current_monitor].height;
+  msg.Printf(_T("monitor size: %d %d"), ssx, ssy);
   wxLogMessage(msg);
 
   m_focus_indicator_pix = /*std::round*/ wxRound(1 * GetPixPerMM());

--- a/gui/src/displays.cpp
+++ b/gui/src/displays.cpp
@@ -1,0 +1,247 @@
+/***************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  OpenCPN Display utilities
+ * Author:   David Register
+ *
+ ***************************************************************************
+ *   Copyright (C) 2010 by David S. Register                               *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+#include <iostream>
+#include "config.h"
+#include "displays.h"
+#include "model/logger.h"
+
+// Platform-specific includes
+#if __linux__
+#ifdef OCPN_HAVE_X11
+#include <X11/Xlib.h>
+#include <X11/extensions/Xrandr.h>
+#include <gdk/gdk.h>
+#endif
+#elif _WIN32
+#include <Windows.h>
+#include <ShellScalingApi.h>
+#include <locale>
+#include <codecvt>
+#elif __APPLE__
+#include <CoreGraphics/CoreGraphics.h>
+#endif
+
+size_t g_num_monitors = 0;
+size_t g_current_monitor = 0;
+std::vector<OCPN_MonitorInfo> g_monitor_info;
+
+#if _WIN32
+
+BOOL CALLBACK MonitorEnumProc(HMONITOR hMonitor, HDC hdcMonitor,
+                              LPRECT lprcMonitor, LPARAM dwData) {
+  MONITORINFOEX monitorInfo;
+  monitorInfo.cbSize = sizeof(MONITORINFOEX);
+  if (GetMonitorInfo(hMonitor, &monitorInfo)) {
+    UINT rawdpiX, rawdpiY;
+    UINT effectivedpiX, effectivedpiY;
+    /* In newer SDKs (Windows 8.1+) it is much simpler to get DPI for each
+     * monitor as GetDpiForMonitor actually is exposed */
+    HRESULT hr = GetDpiForMonitor(hMonitor, MDT_EFFECTIVE_DPI, &effectivedpiX, &effectivedpiY);
+    if (!SUCCEEDED(hr)) {
+      WARNING_LOG << "GetDpiForMonitor MDT_EFFECTIVE_DPI failed, falling back to 96 DPI";
+      effectivedpiX = 96;
+      effectivedpiY = 96;
+    }
+    hr = GetDpiForMonitor(hMonitor, MDT_RAW_DPI, &rawdpiX, &rawdpiY);
+    if (!SUCCEEDED(hr) || rawdpiX == 0 || rawdpiY == 0) {
+      WARNING_LOG << "GetDpiForMonitor MDT_RAW_DPI failed, falling back to " << effectivedpiX <<" DPI"; // This happens in virtualized environments
+      rawdpiX = effectivedpiX;
+      rawdpiY = effectivedpiY;
+    }
+    DEBUG_LOG << "Raw DPI " << rawdpiX << "x" << rawdpiY;
+    DEBUG_LOG << "Effective DPI " << effectivedpiX << "x" << effectivedpiY;
+    DEVICE_SCALE_FACTOR scaleFactor;
+    hr = GetScaleFactorForMonitor(hMonitor, &scaleFactor);
+    if (!SUCCEEDED(hr) || scaleFactor == DEVICE_SCALE_FACTOR_INVALID) {
+      WARNING_LOG << "GetScaleFactorForMonitor failed, falling back to 100";
+      scaleFactor = SCALE_100_PERCENT;
+    }
+
+    auto width = monitorInfo.rcMonitor.right - monitorInfo.rcMonitor.left;
+    auto height = monitorInfo.rcMonitor.bottom - monitorInfo.rcMonitor.top;
+    auto mmx = width * 25.4 / rawdpiX;
+    auto mmy = height * 25.4 / rawdpiY;
+    std::wstring ws(monitorInfo.szDevice);
+    DEBUG_LOG << "Display " << hMonitor << ":";
+    DEBUG_LOG << "  Monitor Name: " << std::string(ws.begin(), ws.end());
+    DEBUG_LOG << "  Resolution: " << width << "x" << height;
+    DEBUG_LOG << "  Physical Size: " << mmx << " mm x " << mmy << " mm";
+    DEBUG_LOG << "  Scale factor:" << scaleFactor;
+    g_monitor_info.push_back(
+        {std::string(ws.begin(), ws.end()), static_cast<size_t>(mmx),
+         static_cast<size_t>(mmy), static_cast<size_t>(width), static_cast<size_t>(height),
+         static_cast<size_t>(width), static_cast<size_t>(height),
+         static_cast<size_t>(scaleFactor)});
+  } else {
+    DEBUG_LOG << "GetMonitorInfo failed";
+  }
+  return TRUE;
+}
+#endif
+
+// Function to enumerate monitors and retrieve screen size
+void EnumerateMonitors() {
+  g_monitor_info.clear();
+#if __linux__
+#ifdef OCPN_HAVE_X11
+  Display* display = XOpenDisplay(nullptr);
+  if (!display) {
+    std::cerr << "Error opening X display." << std::endl;
+    return;
+  }
+
+  int screen = DefaultScreen(display);
+  Window root = RootWindow(display, screen);
+
+  XRRScreenResources* resources = XRRGetScreenResources(display, root);
+  if (!resources) {
+    ERROR_LOG << "Error getting screen resources.";
+    XCloseDisplay(display);
+    return;
+  }
+
+  GdkDisplay* gdk_display = gdk_display_get_default();
+  int gdk_num_monitors = gdk_display_get_n_monitors(gdk_display);
+  DEBUG_LOG << "GDK Monitors: " << gdk_num_monitors;
+  size_t scale;
+  for (int i = 0; i < resources->noutput; ++i) {
+    XRROutputInfo* outputInfo =
+        XRRGetOutputInfo(display, resources, resources->outputs[i]);
+    XRRCrtcInfo* crtcInfo =
+        XRRGetCrtcInfo(display, resources, resources->crtcs[i]);
+    scale = 100;
+    if (i < gdk_num_monitors) {
+      GdkMonitor* monitor = gdk_display_get_monitor(gdk_display, i);
+      scale = gdk_monitor_get_scale_factor(monitor) * 100;
+    }
+    if (outputInfo && crtcInfo) {
+      // Physical size can be unknown and reported as zero (For example over VNC, assume a "standard" DPI of 96 in that case to guess it)
+      size_t mm_width = outputInfo->mm_width > 0 ? outputInfo->mm_width : crtcInfo->width * 25.4 / 96.0;
+      size_t mm_height = outputInfo->mm_height > 0 ? outputInfo->mm_height : crtcInfo->height * 25.4 / 96.0;
+      DEBUG_LOG << "Monitor " << i + 1 << ":";
+      DEBUG_LOG << "  Name: " << outputInfo->name;
+      DEBUG_LOG << "  Physical Size (mm): " << mm_width << " x "
+                << mm_height;
+      DEBUG_LOG << "  Resolution: " << crtcInfo->width << " x "
+                << crtcInfo->height;
+      DEBUG_LOG << "  Scale: " << scale;
+      g_monitor_info.push_back({outputInfo->name, mm_width,
+                                mm_height, crtcInfo->width,
+                                crtcInfo->height, crtcInfo->width,
+                                crtcInfo->height, scale});
+    }
+    XRRFreeOutputInfo(outputInfo);
+    XRRFreeCrtcInfo(crtcInfo);
+  }
+
+  XRRFreeScreenResources(resources);
+  XCloseDisplay(display);
+#endif
+#elif _WIN32
+  EnumDisplayMonitors(NULL, NULL, MonitorEnumProc, 0);
+  // Get the names of the monitors
+  std::vector<DISPLAYCONFIG_PATH_INFO> paths;
+  std::vector<DISPLAYCONFIG_MODE_INFO> modes;
+  UINT32 flags = QDC_ONLY_ACTIVE_PATHS;
+  LONG isError = ERROR_INSUFFICIENT_BUFFER;
+
+  UINT32 pathCount, modeCount;
+  isError = GetDisplayConfigBufferSizes(flags, &pathCount, &modeCount);
+
+  if (!isError) {
+    // Allocate the path and mode arrays
+    paths.resize(pathCount);
+    modes.resize(modeCount);
+
+    // Get all active paths and their modes
+    isError = QueryDisplayConfig(flags, &pathCount, paths.data(), &modeCount,
+                                 modes.data(), nullptr);
+
+    // The function may have returned fewer paths/modes than estimated
+    paths.resize(pathCount);
+    modes.resize(modeCount);
+
+    if (!isError) {
+      // For each active path
+      for (int i = 0; i < paths.size(); i++) {
+        // Find the target (monitor) friendly name
+        DISPLAYCONFIG_TARGET_DEVICE_NAME targetName = {};
+        targetName.header.adapterId = paths[i].targetInfo.adapterId;
+        targetName.header.id = paths[i].targetInfo.id;
+        targetName.header.type = DISPLAYCONFIG_DEVICE_INFO_GET_TARGET_NAME;
+        targetName.header.size = sizeof(targetName);
+        isError = DisplayConfigGetDeviceInfo(&targetName.header);
+
+        if (!isError) {
+          if (targetName.flags.friendlyNameFromEdid) {
+            std::wstring ws(targetName.monitorFriendlyDeviceName);
+            std::wstring ws1(targetName.monitorDevicePath);
+            DEBUG_LOG << "Monitor found: " << std::string(ws.begin(), ws.end())
+                      << " - " << std::string(ws1.begin(), ws1.end());
+            if (i < g_monitor_info.size()) {
+              g_monitor_info[i].name = std::string(ws.begin(), ws.end());
+            }
+          }
+        }
+      }
+    }
+  }
+#elif __APPLE__
+  CGDirectDisplayID displayArray[32];
+  uint32_t displayCount;
+  CGGetOnlineDisplayList(32, displayArray, &displayCount);
+
+  for (uint32_t i = 0; i < displayCount; ++i) {
+    CGDirectDisplayID displayID = displayArray[i];
+    CGSize displayPhysicalSize = CGDisplayScreenSize(displayID);
+    int width = CGDisplayModeGetWidth(CGDisplayCopyDisplayMode(displayID));
+    int height = CGDisplayModeGetHeight(CGDisplayCopyDisplayMode(displayID));
+    int pixel_width = CGDisplayModeGetPixelWidth(CGDisplayCopyDisplayMode(displayID));
+    int pixel_height = CGDisplayModeGetPixelHeight(CGDisplayCopyDisplayMode(displayID));
+    DEBUG_LOG << "Display " << i + 1 << ":";
+    DEBUG_LOG << "  Physical Size: " << displayPhysicalSize.width << "x"
+              << displayPhysicalSize.height << " mm";
+    DEBUG_LOG << "  Resolution: " << width << "x" << height << " pixels";
+    DEBUG_LOG << "  Pixel resolution: " << pixel_width << "x" << pixel_height << " pixels";
+    g_monitor_info.push_back(
+        {std::to_string(i + 1), static_cast<size_t>(displayPhysicalSize.width),
+         static_cast<size_t>(displayPhysicalSize.height),
+         static_cast<size_t>(width), static_cast<size_t>(height), static_cast<size_t>(pixel_width), static_cast<size_t>(pixel_height), 100});
+  }
+#endif
+  if (g_monitor_info.size() == 0) {
+    // This should never happen, but just in case...
+    // If we didn't find any monitors at all, add some dummy default that makes at least some sense (15.6 inch full HD)
+    // We might also use wxDisplaySize and wxDisplaySizeMM here, but what the heck would they report?
+    g_monitor_info.push_back({"Dummy monitor", 340, 190, 1920, 1080, 1920, 1080, 100});
+  }
+  g_num_monitors = g_monitor_info.size();
+  DEBUG_LOG << "Number of monitors: " << g_num_monitors;
+  DEBUG_LOG << "Monitor info:";
+  for (const auto &monitor : g_monitor_info) {
+    DEBUG_LOG << "Monitor: " << monitor.name << " " << monitor.width_mm << "x" << monitor.height_mm << "mm " << monitor.width << "x" << monitor.height << "DIP " << monitor.width_px << "x" << monitor.height_px << "px " << monitor.scale << "%";
+  }
+}

--- a/gui/src/gui_lib.cpp
+++ b/gui/src/gui_lib.cpp
@@ -33,6 +33,7 @@
 #include "FontMgr.h"
 #include "OCPNPlatform.h"
 #include "ocpn_plugin.h"
+#include "displays.h"
 
 #ifdef __ANDROID__
 #include "androidUTIL.h"
@@ -338,7 +339,7 @@ void OCPN_TimedHTMLMessageDialog::RecalculateSize(void) {
   wxSize esize;
   esize.x = GetCharWidth() * 60;
   int sx, sy;
-  ::wxDisplaySize(&sx, &sy);
+  sx = g_monitor_info[g_current_monitor].width;
   esize.x = wxMin(esize.x, sx * 6 / 10);
   esize.y = -1;
   SetClientSize(esize);  // This will force a recalc of internal representation

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -390,7 +390,7 @@ int g_lastClientRecty;
 int g_lastClientRectw;
 int g_lastClientRecth;
 double g_display_size_mm;
-double g_config_display_size_mm;
+std::vector<size_t> g_config_display_size_mm;
 bool g_config_display_size_manual;
 
 int g_GUIScaleFactor;
@@ -1284,13 +1284,13 @@ bool MyApp::OnInit() {
   wxLogMessage(msg);
 
   // User override....
-  if ((g_config_display_size_mm > 0) && (g_config_display_size_manual)) {
-    g_display_size_mm = g_config_display_size_mm;
+  if (g_config_display_size_manual && g_config_display_size_mm.size() > g_current_monitor && g_config_display_size_mm[g_current_monitor] > 0) {
+    g_display_size_mm = g_config_display_size_mm[g_current_monitor];
     wxString msg;
     msg.Printf(_T("Display size (horizontal) config override: %d mm"),
                (int)g_display_size_mm);
     wxLogMessage(msg);
-    g_Platform->SetDisplaySizeMM(g_display_size_mm);
+    g_Platform->SetDisplaySizeMM(g_current_monitor, g_display_size_mm);
   }
 
   g_display_size_mm = wxMax(50, g_display_size_mm);

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -54,6 +54,7 @@
 
 #include <wx/stdpaths.h>
 #include <wx/tokenzr.h>
+#include <wx/display.h>
 
 #include "model/ais_decoder.h"
 #include "model/ais_state_vars.h"
@@ -70,6 +71,7 @@
 #include "model/gui.h"
 #include "model/idents.h"
 #include "model/local_api.h"
+#include "model/logger.h"
 #include "model/multiplexer.h"
 #include "model/nav_object_database.h"
 #include "model/navutil_base.h"
@@ -97,6 +99,7 @@
 #include "compass.h"
 #include "concanv.h"
 #include "ConfigMgr.h"
+#include "displays.h"
 #include "dychart.h"
 #include "FontMgr.h"
 #include "glChartCanvas.h"
@@ -259,7 +262,7 @@ extern wxString gWorldMapLocation, gDefaultWorldMapLocation;
 extern ChartGroupArray *g_pGroupArray;
 extern bool g_bEnableZoomToCursor;
 extern double g_display_size_mm;
-extern double g_config_display_size_mm;
+extern std::vector<size_t> g_config_display_size_mm;
 extern wxString ChartListFileName;
 extern bool g_bFullscreenToolbar;
 extern arrayofCanvasPtr g_canvasArray;
@@ -634,6 +637,7 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, const wxPoint &pos,
                  const wxSize &size, long style)
     : wxFrame(frame, -1, title, pos, size, style, kTopLevelWindowName)
       {
+  g_current_monitor = wxDisplay::GetFromWindow(this);
   m_last_track_rotation_ts = 0;
   m_ulLastNMEATicktime = 0;
 
@@ -1872,10 +1876,37 @@ void MyFrame::OnCloseWindow(wxCloseEvent &event) {
 }
 
 void MyFrame::OnMove(wxMoveEvent &event) {
+  auto idx = wxDisplay::GetFromWindow(this);
+  if (idx != wxNOT_FOUND && g_current_monitor != static_cast<size_t>(idx) && static_cast<size_t>(idx) < g_monitor_info.size()) {
+    g_current_monitor = idx;
+    DEBUG_LOG << "Moved to " << idx
+#if wxCHECK_VERSION(3, 1, 6)
+    << " PPI: " << wxDisplay(idx).GetPPI().GetX() << "x" << wxDisplay(idx).GetPPI().GetY() 
+    << " SF wxDisplay: " << wxDisplay(idx).GetScaleFactor()
+#endif
+    << " Size wxDisplay: " << wxDisplay(idx).GetGeometry().GetWidth() << "x" << wxDisplay(idx).GetGeometry().GetHeight()
+    << " MM wxDisplay: " << wxGetDisplaySizeMM().GetX() << "x" << wxGetDisplaySizeMM().GetY()
+    << " Name wxDisplay: " << wxDisplay(idx).GetName().c_str()
+    << " Real: " << g_monitor_info[idx].width_mm << "x" << g_monitor_info[idx].height_mm << "mm "
+    << g_monitor_info[idx].width_mm << "x" << g_monitor_info[idx].height_mm << "mm "
+    << g_monitor_info[idx].width << "x" << g_monitor_info[idx].height << "DIP "
+    << g_monitor_info[idx].width_px << "x" << g_monitor_info[idx].height_px << "px"
+    << g_monitor_info[idx].scale << "%";
+    if(g_config_display_size_manual) {
+      if(g_config_display_size_mm.size() > static_cast<size_t>(idx)) {
+        g_display_size_mm = g_config_display_size_mm[idx];
+      } // Do nothing if the user did not set any value for this monitor
+    } else {
+      g_display_size_mm = g_monitor_info[idx].width_mm;
+    }
+  }
   // ..For each canvas...
   for (unsigned int i = 0; i < g_canvasArray.GetCount(); i++) {
     ChartCanvas *cc = g_canvasArray.Item(i);
-    if (cc) cc->SetMUIBarPosition();
+    if (cc) {
+      cc->SetMUIBarPosition();
+      cc->SetDisplaySizeMM(g_display_size_mm);
+    }
   }
 
 #ifdef __WXOSX__
@@ -4285,8 +4316,8 @@ bool MyFrame::ProcessOptionsDialog(int rr, ArrayOfCDI *pNewDirArray) {
   }
 #endif
 
-  if ((g_config_display_size_mm > 0)  && g_config_display_size_manual){
-    g_display_size_mm = g_config_display_size_mm;
+  if (g_config_display_size_manual && g_config_display_size_mm.size() > g_current_monitor && g_config_display_size_mm[g_current_monitor] > 0) {
+    g_display_size_mm = g_config_display_size_mm[g_current_monitor];
   } else {
     g_display_size_mm = wxMax(50, g_Platform->GetDisplaySizeMM());
   }
@@ -8383,6 +8414,7 @@ void LoadS57() {
     ps52plib->SetPLIBColorScheme(global_color_scheme, ChartCtxFactory());
 
     if (gFrame){
+      ps52plib->SetDisplayWidth(g_monitor_info[g_current_monitor].width);
       ps52plib->SetPPMM(g_BasePlatform->GetDisplayDPmm());
       double dip_factor = g_BasePlatform->GetDisplayDIPMult(gFrame);
       ps52plib->SetDIPFactor(dip_factor);

--- a/libs/s52plib/src/s52plib.cpp
+++ b/libs/s52plib/src/s52plib.cpp
@@ -366,6 +366,7 @@ s52plib::s52plib(const wxString &PLib, bool b_forceLegacy) {
   SetGLLineSmoothing(false);
 
   m_displayScale = 1.0;
+  m_display_width = 0;
 
   // Clear the TexFont cache
   unsigned int i;
@@ -494,9 +495,7 @@ void s52plib::SetPPMM(float ppmm) {
   m_rv_scale_factor = 0.8;
 
   // Estimate the display size
-  int ww, hh;
-  ::wxDisplaySize(&ww, &hh);
-  m_display_size_mm = ww / GetPPMM();  // accurate enough for internal use
+  m_display_size_mm = m_display_width / GetPPMM();  // accurate enough for internal use
 
   m_display_size_mm /= m_displayScale;
 }

--- a/libs/s52plib/src/s52plib.h
+++ b/libs/s52plib/src/s52plib.h
@@ -185,7 +185,9 @@ public:
   s52plib(const wxString &PLib, bool b_forceLegacy = false);
   ~s52plib();
 
+  // TODO: SetPPM, SetDisplayWidth etc. should be combined to be set together by pointing them to info about current monitor
   void SetPPMM(float ppmm);
+  void SetDisplayWidth(size_t pixels) { m_display_width = pixels; }
   float GetPPMM() { return canvas_pix_per_mm; }
   void SetDIPFactor( double factor);
   void SetContentScaleFactor( double factor);
@@ -531,6 +533,7 @@ private:
       canvas_pix_per_mm;  // Set by parent, used to scale symbols/lines/patterns
   double m_rv_scale_factor;
   float m_display_size_mm;
+  size_t m_display_width;
 
   S52color m_unused_color;
   wxColor m_unused_wxColor;

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -292,6 +292,11 @@ if (UNIX AND NOT APPLE)
   endif ()
 endif ()
 
+if (LINUX)
+  target_link_libraries(_OCPN_MODEL INTERFACE ocpn::gtk)
+  target_link_libraries(_OCPN_MODEL INTERFACE ${X11_LIBRARIES} ${X11_Xrandr_LIB})
+endif ()
+
 if (NOT "${ENABLE_SANITIZER}" STREQUAL "none")
   target_link_libraries(_OCPN_MODEL INTERFACE -fsanitize=${ENABLE_SANITIZER})
 endif ()

--- a/model/include/model/base_platform.h
+++ b/model/include/model/base_platform.h
@@ -149,9 +149,7 @@ protected:
   wxLog* m_old_logger;
   wxString large_log_message;
 
-  wxSize m_displaySize;
-  wxSize m_displaySizeMM;
-  int m_displaySizeMMOverride;
+  std::vector<int> m_displaySizeMMOverride;
 
 
 #ifdef _MSC_VER

--- a/model/src/base_platform.cpp
+++ b/model/src/base_platform.cpp
@@ -751,36 +751,16 @@ wxSize BasePlatform::getDisplaySize() { return getAndroidDisplayDimensions(); }
 
 #else
 wxSize BasePlatform::getDisplaySize() {
-  if (m_displaySize.x < 10)
-    m_displaySize = ::wxGetDisplaySize();  // default, for most platforms
-  return m_displaySize;
+  return wxSize(0, 0);
 }
 #endif
 
 // GetDisplaySizeMM
 double BasePlatform::GetDisplaySizeMM() {
-
-  if (m_displaySizeMMOverride > 0) return m_displaySizeMMOverride;
-
-  if (m_displaySizeMM.x < 1) m_displaySizeMM = wxGetDisplaySizeMM();
-
-  double ret = m_displaySizeMM.GetWidth();
-
-#ifdef __WXMSW__
-  int w, h;
-
-  if (!m_bdisableWindowsDisplayEnum) {
-    if (GetWindowsMonitorSize(&w, &h) && (w > 100)) {  // sanity check
-      m_displaySizeMM == wxSize(w, h);
-      ret = w;
-    } else
-      m_bdisableWindowsDisplayEnum = true;  // disable permanently
+  if(m_displaySizeMMOverride.size() > 0 && m_displaySizeMMOverride[0] > 0) {
+    return m_displaySizeMMOverride[0];
   }
-#endif
-
-#ifdef __WXOSX__
-  ret = GetMacMonitorSize();
-#endif
+  double ret = 0;
 
 #ifdef __ANDROID__
   ret = GetAndroidDisplaySize();


### PR DESCRIPTION
- Implement platform specific logic to obtain geometry of all connected displays
- Replace all calls to wxDisplaySize in core applicationwith access to our multi-monitor implementation

This is ground work for real multi monitor awareness

Identifies physical size of my displays correctly on all platforms, but certainly needs testing on more hardware I don't have access to like the RPi touchscreen  monitors, real HiDPI screens etc.

Closes #3683