### PR TITLE
Rewrite safe mode plugin handling (#3685)

### DIFF
--- a/gui/include/gui/pluginmanager.h
+++ b/gui/include/gui/pluginmanager.h
@@ -431,6 +431,7 @@ public:
 
 private:
   void AddPlugin(const PlugInData& pd);
+  void AddPlugin(const std::string& name);
   int ComputePluginSpace(ArrayOfPluginPanel plugins, wxBoxSizer* sizer);
   // void Clear();
 
@@ -464,6 +465,9 @@ public:
   /** Construct an entry reflecting a plugin available in the catalog. */
   PluginPanel(wxPanel* parent, wxWindowID id, const wxPoint& pos,
               const wxSize& size, PluginMetadata plugin);
+
+  /** Construct an entry reflecting a safe-loaded "uninstall-only" item */
+  PluginPanel(wxPanel* parent, const std::string&  name);
 
   ~PluginPanel();
 
@@ -503,6 +507,7 @@ private:
   WebsiteButton* m_info_btn;
   ActionVerb m_action;
   int m_penWidthUnselected, m_penWidthSelected;
+  bool m_is_safe_panel;
 };
 
 //  API 1.11 adds access to S52 Presentation library

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -4340,11 +4340,12 @@ PluginPanel::PluginPanel(wxPanel* parent, const std::string& name)
                       wxALIGN_CENTER_VERTICAL | wxALL, 2);
   auto uninstall = [&](wxCommandEvent ev) {
     auto n = m_pName->GetLabel().ToStdString();
+    int result = OCPNMessageBox(gFrame,
+                                std::string(_("Uninstall plugin ")) + n + "?",
+                                _("Un-Installation"),
+                                wxICON_QUESTION | wxOK | wxCANCEL);
+    if (result != wxID_OK) return;
     PluginHandler::getInstance()->ClearInstallData(n);
-    auto msg(std::string("Uninstalling plugin ") + n);
-    OCPNMessageBox(gFrame, msg,
-                   _("Un-Installation complete"),
-                   wxICON_INFORMATION | wxOK);
     m_PluginListPanel->ReloadPluginPanels();
   };
   m_pButtonUninstall->Bind(wxEVT_COMMAND_BUTTON_CLICKED, uninstall);

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -4070,13 +4070,20 @@ std::vector<const PlugInData*> GetInstalled() {
   return result;
 }
 
-/* Is plugin with given name present in loaded? */
+/* Is plugin with given name present in loaded or safe list if installed? */
 static bool IsPluginLoaded(const std::string& name) {
-  auto loaded = PluginLoader::getInstance()->GetPlugInArray();
-  for (size_t i = 0; i < loaded->GetCount(); i++) {
-    if (loaded->Item(i)->m_common_name.ToStdString() == name) return true;
+  if (safe_mode::get_mode()) {
+    auto installed = PluginHandler::getInstance()->GetInstalldataPlugins();
+    auto found =
+        std::find(installed.begin(), installed.end(), ocpn::tolower(name));
+    return found != installed.end();
+  } else {
+    auto loaded = PluginLoader::getInstance()->GetPlugInArray();
+    for (size_t i = 0; i < loaded->GetCount(); i++) {
+      if (loaded->Item(i)->m_common_name.ToStdString() == name) return true;
+    }
+    return false;
   }
-  return false;
 }
 
 void PluginListPanel::ReloadPluginPanels() {
@@ -4101,28 +4108,34 @@ void PluginListPanel::ReloadPluginPanels() {
   Hide();
   m_PluginSelected = 0;
 
-  /* The catalog entries. */
-  auto available = getCompatiblePlugins();
+  if (safe_mode::get_mode()) {
+    /** Add panels for installed, unloaded plugins. */
+    auto installed = PluginHandler::getInstance()->GetInstalldataPlugins();
+    for (const auto& name : installed) AddPlugin(name)  ;
+  } else {
+    /* The catalog entries. */
+    auto available = getCompatiblePlugins();
 
-  /* Remove those which are loaded. */
-  auto predicate = [](const PluginMetadata& md) {
-    return IsPluginLoaded(md.name);
-  };
-  auto end = std::remove_if(available.begin(), available.end(), predicate);
-  available.erase(end, available.end());
+    /* Remove those which are loaded or in safe list. */
+    auto predicate = [](const PluginMetadata& md) {
+      return IsPluginLoaded(md.name);
+    };
+    auto end = std::remove_if(available.begin(), available.end(), predicate);
+    available.erase(end, available.end());
 
-  /* Remove duplicates. */
-  struct Comp {
-    bool operator()(const PluginMetadata& lhs, const PluginMetadata rhs) const {
-      return lhs.name.compare(rhs.name) < 0;
-    }
-  } comp;
-  std::set<PluginMetadata, Comp> unique_entries(comp);
-  for (const auto& p : available) unique_entries.insert(p);
+    /* Remove duplicates. */
+    struct Comp {
+      bool operator()(const PluginMetadata& lhs, const PluginMetadata rhs) const {
+        return lhs.name.compare(rhs.name) < 0;
+      }
+    } comp;
+    std::set<PluginMetadata, Comp> unique_entries(comp);
+    for (const auto& p : available) unique_entries.insert(p);
 
-  /* Add panels for first loaded plugins and then catalog entries. */
-  for (const auto& p : GetInstalled()) AddPlugin(*p);
-  for (const auto& p : unique_entries) AddPlugin(PlugInData(p));
+    /* Add panels for first loaded plugins, then catalog entries. */
+    for (const auto& p : GetInstalled()) AddPlugin(*p);
+    for (const auto& p : unique_entries) AddPlugin(PlugInData(p));
+  }
 
   Show();
   Layout();
@@ -4130,6 +4143,15 @@ void PluginListPanel::ReloadPluginPanels() {
   Scroll(0, 0);
 
   m_is_loading.clear();
+}
+
+void PluginListPanel::AddPlugin(const std::string& name) {
+  auto panel = new PluginPanel(this, name);
+  panel->SetSelected(false);
+  GetSizer()->Add(panel, 0, wxEXPAND);
+  m_PluginItems.Add(panel);
+  m_pluginSpacer = g_Platform->GetDisplayDPmm() * 1.0;
+  GetSizer()->AddSpacer(m_pluginSpacer);
 }
 
 void PluginListPanel::AddPlugin(const PlugInData& pic) {
@@ -4282,13 +4304,61 @@ static bool canUninstall(std::string name) {
   return false;
 }
 
+PluginPanel::PluginPanel(wxPanel* parent, const std::string& name)
+    : wxPanel(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize,
+              wxBORDER_NONE),
+      m_is_safe_panel(true) {
+
+  m_PluginListPanel = dynamic_cast<PluginListPanel*>(parent);
+  wxASSERT(m_PluginListPanel != 0);
+  wxBoxSizer* top_sizer = new wxBoxSizer(wxVERTICAL);
+  SetSizer(top_sizer);
+  wxBoxSizer* top_horizontal = new wxBoxSizer(wxHORIZONTAL);
+  top_sizer->Add(top_horizontal, 0, wxEXPAND);
+
+  double iconSize = GetCharWidth() * 4;
+  double dpi_mult = g_Platform->GetDisplayDIPMult(this);
+  int icon_scale = iconSize * dpi_mult;
+  ocpnStyle::Style* style = g_StyleManager->GetCurrentStyle();
+  wxBitmap bitmap(style->GetIcon("default_pi", icon_scale, icon_scale));
+  m_itemStaticBitmap = new wxStaticBitmap(this, wxID_ANY, bitmap);
+  top_horizontal->Add(m_itemStaticBitmap, 0, wxEXPAND | wxALL, 10);
+
+  m_pName = new wxStaticText(this, wxID_ANY, name);
+  top_horizontal->Add(m_pName, wxID_ANY, wxALIGN_CENTER_VERTICAL);
+  m_pVersion = new wxStaticText(this, wxID_ANY, "");
+  top_horizontal->Add(m_pVersion);
+  m_pVersion->Hide();
+
+  m_pButtons = new wxBoxSizer(wxHORIZONTAL);
+  top_horizontal->Add(m_pButtons);
+  m_info_btn = new WebsiteButton(this, "https:\\opencpn.org");
+  top_horizontal->Add(m_info_btn);
+  m_pButtonUninstall = new wxButton(this, wxID_ANY, _("Uninstall"),
+                                    wxDefaultPosition, wxDefaultSize, 0);
+  top_horizontal->Add(m_pButtonUninstall, 0,
+                      wxALIGN_CENTER_VERTICAL | wxALL, 2);
+  auto uninstall = [&](wxCommandEvent ev) {
+    auto n = m_pName->GetLabel().ToStdString();
+    PluginHandler::getInstance()->ClearInstallData(n);
+    auto msg(std::string("Uninstalling plugin ") + n);
+    OCPNMessageBox(gFrame, msg,
+                   _("Un-Installation complete"),
+                   wxICON_INFORMATION | wxOK);
+    m_PluginListPanel->ReloadPluginPanels();
+  };
+  m_pButtonUninstall->Bind(wxEVT_COMMAND_BUTTON_CLICKED, uninstall);
+}
+
 BEGIN_EVENT_TABLE(PluginPanel, wxPanel)
 EVT_PAINT(PluginPanel::OnPaint)
 END_EVENT_TABLE()
 
 PluginPanel::PluginPanel(wxPanel* parent, wxWindowID id, const wxPoint& pos,
                          const wxSize& size, const PlugInData plugin)
-    : wxPanel(parent, id, pos, size, wxBORDER_NONE), m_plugin(plugin) {
+    : wxPanel(parent, id, pos, size, wxBORDER_NONE),
+      m_plugin(plugin),
+      m_is_safe_panel(false) {
   m_PluginListPanel = (PluginListPanel*)parent;  //->GetParent();
   m_PluginListPanel = dynamic_cast<PluginListPanel*>(parent /*->GetParent()*/);
   wxASSERT(m_PluginListPanel != 0);
@@ -4531,6 +4601,7 @@ PluginPanel::PluginPanel(wxPanel* parent, wxWindowID id, const wxPoint& pos,
 
 PluginPanel::~PluginPanel() {
   Unbind(wxEVT_LEFT_DOWN, &PluginPanel::OnPluginSelected, this);
+  if (m_is_safe_panel) return;
   m_itemStaticBitmap->Unbind(wxEVT_LEFT_DOWN, &PluginPanel::OnPluginSelected,
                              this);
   m_pName->Unbind(wxEVT_LEFT_DOWN, &PluginPanel::OnPluginSelected, this);
@@ -4813,6 +4884,7 @@ void PluginPanel::OnPluginAction(wxCommandEvent& event) {
 }
 
 void PluginPanel::SetEnabled(bool enabled) {
+  if (m_is_safe_panel) return;
   PluginLoader::getInstance()->SetEnabled(m_plugin.m_common_name, enabled);
   PluginLoader::getInstance()->UpdatePlugIns();
   NotifySetupOptionsPlugin(&m_plugin);

--- a/model/include/model/plugin_handler.h
+++ b/model/include/model/plugin_handler.h
@@ -121,8 +121,14 @@ public:
   /** Check if given plugin can be installed/updated. */
   bool isPluginWritable(std::string name);
 
-  /** Return list of all installed plugins. */
+  /** Return list of all installed  and loaded plugins. */
   const std::vector<PluginMetadata> getInstalled();
+
+  /**
+   *  Return list of installed plugins lower case names, not necessarily
+   *  loaded
+   */
+  std::vector<std::string> GetInstalldataPlugins();
 
   /** Set metadata for an installed plugin */
   void SetInstalledMetadata(const PluginMetadata& pm);
@@ -160,8 +166,11 @@ public:
   /* Install a new, downloaded but not installed plugin tarball. */
   bool installPlugin(const std::string& path);
 
-  /** Uninstall an installed plugin. */
+  /** Uninstall an installed  and loaded plugin. */
   bool uninstall(const std::string plugin);
+
+  /** Remove installation data for loaded plugin. */
+  bool ClearInstallData(const std::string plugin_name);
 
   /** Install plugin tarball from local cache. */
   bool installPluginFromCache(PluginMetadata plugin);

--- a/model/include/model/plugin_handler.h
+++ b/model/include/model/plugin_handler.h
@@ -169,7 +169,7 @@ public:
   /** Uninstall an installed  and loaded plugin. */
   bool uninstall(const std::string plugin);
 
-  /** Remove installation data for loaded plugin. */
+  /** Remove installation data for not loaded plugin. */
   bool ClearInstallData(const std::string plugin_name);
 
   /** Install plugin tarball from local cache. */

--- a/model/include/model/plugin_handler.h
+++ b/model/include/model/plugin_handler.h
@@ -200,6 +200,7 @@ private:
                       bool only_metadata = false);
   bool archive_check(int r, const char* msg, struct archive* a);
   std::unordered_map<std::string, std::vector<std::string>> files_by_plugin;
+  bool DoClearInstallData(const std::string plugin_name);
 };
 
 #endif  // PLUGIN_HANDLER_H__

--- a/model/src/plugin_handler.cpp
+++ b/model/src/plugin_handler.cpp
@@ -1200,16 +1200,20 @@ bool PluginHandler::ExtractMetadata(const std::string& path,
 }
 
 bool PluginHandler::ClearInstallData(const std::string plugin_name) {
-  std::string path = PluginHandler::fileListPath(plugin_name);
-  if (!ocpn::exists(path)) {
-    wxLogWarning("Cannot find installation data for %s (%s)",
-                 plugin_name.c_str(), path);
-    return false;
-  }
   auto ix = PlugInIxByName(plugin_name,
                            PluginLoader::getInstance()->GetPlugInArray());
   if (ix != -1) {
     wxLogWarning("Attempt to remove installation data for loaded plugin");
+    return false;
+  }
+  return DoClearInstallData(plugin_name);
+}
+
+bool PluginHandler::DoClearInstallData(const std::string plugin_name) {
+  std::string path = PluginHandler::fileListPath(plugin_name);
+  if (!ocpn::exists(path)) {
+    wxLogWarning("Cannot find installation data for %s (%s)",
+                 plugin_name.c_str(), path);
     return false;
   }
   std::vector<std::string> plug_paths = LoadLinesFromFile(path);
@@ -1249,7 +1253,7 @@ bool PluginHandler::uninstall(const std::string plugin_name) {
   string libfile = pic->m_plugin_file.ToStdString();
   loader->UnLoadPlugIn(ix);
 
-  bool ok = ClearInstallData(plugin_name);
+  bool ok = DoClearInstallData(plugin_name);
 
   //  If this is an orphan plugin, there may be no installation record
   //  So make sure that the library file (.so/.dylib/.dll) is removed

--- a/model/src/plugin_handler.cpp
+++ b/model/src/plugin_handler.cpp
@@ -145,10 +145,10 @@ static std::vector<std::string> glob_dir(const std::string& dir_path,
  * Return index in ArrayOfPlugins for plugin with given name,
  * or -1 if not found
  */
-static ssize_t PlugInIxByName(const std::string name,
+static ssize_t PlugInIxByName(const std::string& name,
                               const ArrayOfPlugIns* plugins) {
+  const auto lc_name = ocpn::tolower(name);
   for (unsigned i = 0; i < plugins->GetCount(); i += 1) {
-    auto lc_name = ocpn::tolower(name);
     if (lc_name == plugins->Item(i)->m_common_name.Lower().ToStdString()) {
       return i;
     }
@@ -1213,7 +1213,7 @@ bool PluginHandler::DoClearInstallData(const std::string plugin_name) {
   std::string path = PluginHandler::fileListPath(plugin_name);
   if (!ocpn::exists(path)) {
     wxLogWarning("Cannot find installation data for %s (%s)",
-                 plugin_name.c_str(), path);
+                 plugin_name.c_str(), path.c_str());
     return false;
   }
   std::vector<std::string> plug_paths = LoadLinesFromFile(path);


### PR DESCRIPTION
Rewrite the safe mode plugin handling so it only offers a single operation "uninstall". This is based on installation data which should cover all "normal" installations including imports. 

This does **not** handle the case when a user manually drops a library file in a plugin directory, such files are not listed in the GUI and must still be removed manually.
![safe-plugins](https://github.com/OpenCPN/OpenCPN/assets/405541/05fede68-417c-4f54-a64e-ecf87305b326)

There is an unrelated build error on Android, currently being fixed.

There is another unrelated build error on the Gtihub windows build.  However, manual smoke tests on Linux and and Windows builds and looks OK.

Closes: #3685
