### PR TITLE
Fix mbtiles quilting issue: mbtiles not displayed at big scales

### DIFF
--- a/gui/src/Quilt.cpp
+++ b/gui/src/Quilt.cpp
@@ -1325,7 +1325,12 @@ bool Quilt::BuildExtendedChartStackAndCandidateArray(int ref_db_index,
     double chart_native_ppm =
         m_canvas_scale_factor / (double)candidate_chart_scale;
     double zoom_factor = vp_local.view_scale_ppm / chart_native_ppm;
-    if (zoom_factor < zoom_test_val) {
+    if ((zoom_factor < zoom_test_val) &&
+      // MBTILES charts report the scale of their smallest layer (i.e. most
+      // detailed) as native chart scale, even if they are embedding many more
+      // layers. Since we don't know their maximum scale at this stage, we don't
+      // skip the chart if this native scale is apparently too small.
+        (cte.GetChartType() != CHART_TYPE_MBTILES)) {
       m_extended_stack_array.pop_back();
       continue;
     }

--- a/gui/src/mbtiles/mbtiles.cpp
+++ b/gui/src/mbtiles/mbtiles.cpp
@@ -1012,7 +1012,7 @@ bool ChartMBTiles::RenderRegionViewOnGL(const wxGLContext &glc,
   glChartCanvas::DisableClipRegion();
 
   // Limit the cache size to 3 times the number of tiles to draw on a rendering
-  m_tileCache->CleanCache(m_tileCount * 5);
+  m_tileCache->CleanCache(m_tileCount * 3);
 #endif
   return true;
 }


### PR DESCRIPTION
Quilt.cpp collects all charts candidates to display before starting drawing. It decides which chart will be displayed and with chart won't. One of the criteria consist in checking that the native scale of the chart is not too small compared to the target scale of display. However, mbtiles charts returns their smallest scale as native scale, even if they have many more layers embedded for bigger scales. This cause an mbtiles charts with a small scale layer to be discarded by Quilt.cpp when display is set to big scales. Practically it means the chart disappears from the screen at big scales.

The fix disables this scale check when the chart is of mbtiles type. The risk of having a small scale layer of the mbtiles being displayed does not exists since the mbtiles renderer (mbtiles.cpp) itself won't display a chart with too many tiles.