### PR TITLE
Add a new -c --configdir command line switch

### DIFF
--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -193,6 +193,8 @@ R"""(Usage:
   opencpn --remote [-R] | -q] | -e] |-o <str>]
 
 Options for starting opencpn
+
+  -c, --configdir=<dirpath>     Use alternative configuration directory.
   -p, --portable               	Run in portable mode.
   -f, --fullscreen             	Switch to full screen mode on start.
   -G, --no_opengl              	Disable OpenGL video acceleration. This setting will
@@ -801,6 +803,7 @@ void MyApp::OnInitCmdLine(wxCmdLineParser &parser) {
   // is hardcoded in kUsage;
   parser.AddSwitch("h", "help", "", wxCMD_LINE_OPTION_HELP);
   parser.AddSwitch("p", "portable");
+  parser.AddSwitch("c", "configdir", "", wxCMD_LINE_VAL_STRING);
   parser.AddSwitch("f", "fullscreen");
   parser.AddSwitch("G", "no_opengl");
   parser.AddSwitch("g", "rebuild_gl_raster_cache");

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -61,6 +61,18 @@
 #include <X11/Xlib.h>
 #endif
 
+#if (defined(__clang_major__) && (__clang_major__ < 15))
+// MacOS 1.13
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+#else
+#include <filesystem>
+#include <utility>
+namespace fs = std::filesystem;
+#endif
+
+using namespace std::literals::chrono_literals;
+
 #include <wx/apptrait.h>
 #include <wx/arrimpl.cpp>
 #include <wx/artprov.h>
@@ -182,9 +194,7 @@ void RedirectIOToConsole();
 #include "serial/serial.h"
 #endif
 
-using namespace std::literals::chrono_literals;
 
-extern int ShowNavWarning();
 
 const char* const kUsage =
 R"""(Usage:
@@ -650,6 +660,7 @@ ChartCanvas *g_focusCanvas;
 ChartCanvas *g_overlayCanvas;
 
 bool b_inCloseWindow;
+extern int ShowNavWarning();
 
 #ifdef LINUX_CRASHRPT
 wxCrashPrint g_crashprint;
@@ -803,7 +814,8 @@ void MyApp::OnInitCmdLine(wxCmdLineParser &parser) {
   // is hardcoded in kUsage;
   parser.AddSwitch("h", "help", "", wxCMD_LINE_OPTION_HELP);
   parser.AddSwitch("p", "portable");
-  parser.AddSwitch("c", "configdir", "", wxCMD_LINE_VAL_STRING);
+  parser.AddOption("c", "configdir",  "", wxCMD_LINE_VAL_STRING,
+                   wxCMD_LINE_PARAM_OPTIONAL);
   parser.AddSwitch("f", "fullscreen");
   parser.AddSwitch("G", "no_opengl");
   parser.AddSwitch("g", "rebuild_gl_raster_cache");
@@ -872,6 +884,15 @@ bool MyApp::OnCmdLineParsed(wxCmdLineParser &parser) {
   }
   safe_mode::set_mode(parser.Found("safe_mode"));
   ParseLoglevel(parser);
+  wxString wxstr;
+  if (parser.Found("configdir", &wxstr)) {
+    g_configdir = wxstr.ToStdString();
+    fs::path path(g_configdir);
+    if (!fs::exists(path) || !fs::is_directory(path)) {
+      std::cerr << g_configdir << " is not an existing directory.\n";
+      return false;
+    }
+  }
 
   bool has_start_options = false;
   static const std::vector<std::string> kStartOptions = {

--- a/model/include/model/base_platform.h
+++ b/model/include/model/base_platform.h
@@ -75,9 +75,17 @@ public:
   AbstractPlatform() = default;
   virtual ~AbstractPlatform()  = default;
 
+  /** Return dir path for opencpn.log, etc., respecting -c cli option. */
   wxString& GetPrivateDataDir();
+
+  /** Return dir path for opencpn.log, etc., does not respect -c option. */
+  wxString& DefaultPrivateDataDir();
+
+
   wxString* GetPluginDirPtr();
   wxString* GetSharedDataDirPtr();
+
+  /** Legacy compatibility syntactic sugar for GetPrivateDataDir(). */
   wxString* GetPrivateDataDirPtr();
 
   /** The original in-tree plugin directory, sometimes not user-writable.*/
@@ -133,6 +141,7 @@ public:
 protected:
   bool DetectOSDetail(OCPN_OSDetail* detail);
 
+  wxString m_default_private_datadir;
   wxString m_PrivateDataDir;
   wxString m_PluginsDir;
   bool m_isFlatpacked;

--- a/model/include/model/cmdline.h
+++ b/model/include/model/cmdline.h
@@ -35,6 +35,7 @@ extern bool g_rebuild_gl_cache;
 extern bool g_parse_all_enc;
 extern bool g_bportable;
 extern bool g_bdisable_opengl;
+extern std::string g_configdir;
 extern std::vector<std::string> g_params;
 
 #endif  // _CMDLINE_H__

--- a/model/src/base_platform.cpp
+++ b/model/src/base_platform.cpp
@@ -318,11 +318,10 @@ wxString& AbstractPlatform::GetPrivateDataDir() {
     m_PrivateDataDir = std_path.GetUserDataDir();    // should be ~/.opencpn
 #endif
 
-    if (g_bportable) {
-      m_PrivateDataDir = GetHomeDir();
-      if (m_PrivateDataDir.Last() == wxFileName::GetPathSeparator())
-        m_PrivateDataDir.RemoveLast();
-    }
+    if (g_bportable) m_PrivateDataDir = GetHomeDir();
+    if (!g_configdir.empty()) m_PrivateDataDir = g_configdir;
+    if (m_PrivateDataDir.Last() == wxFileName::GetPathSeparator())
+      m_PrivateDataDir.RemoveLast();
 
 #ifdef __ANDROID__
     m_PrivateDataDir = androidGetPrivateDir();

--- a/model/src/base_platform.cpp
+++ b/model/src/base_platform.cpp
@@ -292,6 +292,19 @@ wxString GetPluginDataDir(const char* plugin_name) {
 }
 
 wxString& AbstractPlatform::GetPrivateDataDir() {
+  if (!m_PrivateDataDir.IsEmpty() && g_configdir.empty())
+    return m_PrivateDataDir;
+  if (!g_configdir.empty()) {
+    wxString path  = g_configdir;
+    if (path.Last() == wxFileName::GetPathSeparator()) path.RemoveLast();
+    m_default_private_datadir = path;
+    return m_default_private_datadir;  // FIXME (leamas) normalize and trust
+                                       // g_configdir
+  }
+  return DefaultPrivateDataDir();
+}
+
+wxString& AbstractPlatform::DefaultPrivateDataDir() {
   if (m_PrivateDataDir.IsEmpty()) {
     //      Establish the prefix of the location of user specific data files
     wxStandardPaths& std_path = GetStdPaths();
@@ -319,7 +332,6 @@ wxString& AbstractPlatform::GetPrivateDataDir() {
 #endif
 
     if (g_bportable) m_PrivateDataDir = GetHomeDir();
-    if (!g_configdir.empty()) m_PrivateDataDir = g_configdir;
     if (m_PrivateDataDir.Last() == wxFileName::GetPathSeparator())
       m_PrivateDataDir.RemoveLast();
 
@@ -602,6 +614,10 @@ wxString& AbstractPlatform::GetConfigFileName() {
     appendOSDirSlash(&m_config_file_name);
     m_config_file_name += "opencpn.conf";
 #endif
+    if (!g_configdir.empty()) {
+      m_config_file_name = g_configdir;
+      m_config_file_name.Append("/opencpn.conf");
+    }
   }
   return m_config_file_name;
 }

--- a/model/src/cmdline.cpp
+++ b/model/src/cmdline.cpp
@@ -19,6 +19,7 @@
 
 #include "model/cmdline.h"
 
+
 int g_unit_test_1 = 0;
 int g_unit_test_2 = 0;
 bool g_start_fullscreen = false;
@@ -26,4 +27,5 @@ bool g_rebuild_gl_cache = false;
 bool g_parse_all_enc = false;
 bool g_bportable = false;
 bool g_bdisable_opengl = false;
+std::string g_configdir;
 std::vector<std::string> g_params;

--- a/model/src/plugin_handler.cpp
+++ b/model/src/plugin_handler.cpp
@@ -157,7 +157,7 @@ static ssize_t PlugInIxByName(const std::string& name,
 }
 
 static std::string pluginsConfigDir() {
-  std::string pluginDataDir = g_BasePlatform->GetPrivateDataDir().ToStdString();
+  auto pluginDataDir = g_BasePlatform->DefaultPrivateDataDir().ToStdString();
   pluginDataDir += SEP + "plugins";
   if (!ocpn::exists(pluginDataDir)) {
     mkdir(pluginDataDir);
@@ -166,6 +166,7 @@ static std::string pluginsConfigDir() {
   if (!ocpn::exists(pluginDataDir)) {
     mkdir(pluginDataDir);
   }
+std::cout << "pluginsConfigDir: " << pluginDataDir << "\n";
   return pluginDataDir;
 }
 

--- a/opencpn.1
+++ b/opencpn.1
@@ -29,6 +29,9 @@ Set amount of logged information. Level is any of \fItrace\fR,
 defaulting to \fIinfo\fR if not set in environment; see ENVIRONMENT.
 
 .TP
+.B  \-c, \-\-configdir=<directory>
+Use alternative configuration directory instead  of \fI~/.openpcn\fR on
+Linux or MacOS.
 .B  \-f, \-\-fullscreen
 Switch to full screen mode on start.
 .TP
@@ -68,7 +71,7 @@ arguments and there already is a running instance.
 
 .TP
 .B \-e, \-\-get_rest_endpoint
-Print the url for connecting to the local opencpn REST server e. g. 
+Print the url for connecting to the local opencpn REST server e. g.
 http://localhost:8000. Requires \-\-remote.
 
 .TP
@@ -81,7 +84,7 @@ Plugin loading depends on that the opencpn main program can locate the
 plugin object file and that the plugin can locate it's own data.
 .P
 On Linux,  the main program searches for plugin .so-files  in two locatiosn.
-The first is \fI~/.local/lib/opencpn\fR. 
+The first is \fI~/.local/lib/opencpn\fR.
 
 The second is \fI@install-dir@/../lib/opencpn\fR where \fI@install-dir@\fR
 is the location where opencpn is installed.
@@ -90,7 +93,7 @@ from \fI/usr/lib/opencpn\fR.
 .P
 On other platforms plugins are also loaded from two different locations,
 one of which used primarely for system plugins and requiring administrative
-privileges. 
+privileges.
 The other is a user-writable locations used by the plugin manager.
 .P
 A plugin's data directory is a path ending with

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -46,6 +46,7 @@ target_link_libraries(tests PRIVATE ocpn::model ocpn::model-src)
 if (UNIX AND NOT DEFINED ENV{FLATPAK_ID})
   set(IPC_SRV_TESTS_SRC
     ipc-srv-tests.cpp
+    ${MODEL_SRC_DIR}/cmdline.cpp
     ${MODEL_SRC_DIR}/config_vars.cpp
     ${MODEL_SRC_DIR}/local_api.cpp
     ${MODEL_SRC_DIR}/ipc_api.cpp
@@ -58,12 +59,11 @@ if (UNIX AND NOT DEFINED ENV{FLATPAK_ID})
   endif ()
   add_executable(ipc-srv-tests ${IPC_SRV_TESTS_SRC})
 
-
   # See note in ipc-srv-tests.cpp
   target_compile_options(ipc-srv-tests PRIVATE -O0)
-  target_link_libraries(ipc-srv-tests PRIVATE observable::observable)
-  target_link_libraries(ipc-srv-tests PRIVATE ${wxWidgets_LIBRARIES})
   target_link_libraries(ipc-srv-tests PRIVATE ocpn::gtest)
+  target_link_libraries(ipc-srv-tests PRIVATE ${wxWidgets_LIBRARIES})
+  target_link_libraries(ipc-srv-tests PRIVATE observable::observable)
   target_include_directories(ipc-srv-tests PRIVATE .
     ${CMAKE_SOURCE_DIR}/model/include
     ${CMAKE_SOURCE_DIR}/include
@@ -137,6 +137,7 @@ if (LINUX)
     dbus_tests.cpp
     ${MODEL_SRC_DIR}/dbus_client.cpp
     ${MODEL_SRC_DIR}/dbus_server.cpp
+    ${MODEL_SRC_DIR}/cmdline.cpp
     ${MODEL_SRC_DIR}/config_vars.cpp
     ${MODEL_SRC_DIR}/ipc_api.cpp
     ${MODEL_SRC_DIR}/local_api.cpp
@@ -147,6 +148,7 @@ if (LINUX)
   target_link_libraries(dbus_tests PRIVATE observable::observable)
   target_link_libraries(dbus_tests PRIVATE ${wxWidgets_LIBRARIES})
   target_link_libraries(dbus_tests PRIVATE ocpn::gtest)
+  target_link_libraries(dbus_tests PRIVATE ocpn::model)
   target_link_libraries(dbus_tests PRIVATE glib::glib)
   target_include_directories(dbus_tests PRIVATE
     ${CMAKE_SOURCE_DIR}/model/include
@@ -231,6 +233,7 @@ endif ()
 set (WX_INSTANCE_SRC
   wx_instance.cpp
   ${MODEL_SRC_DIR}/base_platform.cpp
+  ${MODEL_SRC_DIR}/cmdline.cpp
   ${MODEL_SRC_DIR}/config_vars.cpp
   ${MODEL_SRC_DIR}/ocpn_utils.cpp
   ${MODEL_SRC_DIR}/logger.cpp
@@ -240,7 +243,7 @@ if (APPLE)
 endif ()
 add_executable(wx-instance ${WX_INSTANCE_SRC})
 target_link_libraries(wx-instance PRIVATE ${wxWidgets_LIBRARIES})
-target_link_libraries(wx-instance PRIVATE ocpn::opencpn)
+target_link_libraries(wx-instance PRIVATE ocpn::opencpn ocpn::model)
 target_include_directories(wx-instance PRIVATE
   ${CMAKE_SOURCE_DIR}/model/include
   ${CMAKE_SOURCE_DIR}/include
@@ -258,6 +261,7 @@ if (UNIX)
     std_instance.cpp
     ${MODEL_SRC_DIR}/std_instance_chk.cpp
     ${MODEL_SRC_DIR}/base_platform.cpp
+    ${MODEL_SRC_DIR}/cmdline.cpp
     ${MODEL_SRC_DIR}/config_vars.cpp
     ${MODEL_SRC_DIR}/ocpn_utils.cpp
     ${MODEL_SRC_DIR}/logger.cpp
@@ -267,6 +271,7 @@ if (UNIX)
   endif ()
   add_executable(std-instance ${STD_INSTANCE_SRC})
   target_link_libraries(std-instance PRIVATE ${wxWidgets_LIBRARIES})
+  target_link_libraries(std-instance PRIVATE ocpn::model)
   target_include_directories(std-instance PRIVATE
     ${CMAKE_SOURCE_DIR}/model/include
     ${CMAKE_SOURCE_DIR}/include

--- a/test/dbus_tests.cpp
+++ b/test/dbus_tests.cpp
@@ -18,8 +18,6 @@
 
 using namespace std::literals::chrono_literals;
 
-bool g_bportable;
-
 static bool bool_result0;
 static std::string s_result;
 

--- a/test/ipc-srv-tests.cpp
+++ b/test/ipc-srv-tests.cpp
@@ -56,8 +56,6 @@
 
 using namespace std::literals::chrono_literals;
 
-bool g_bportable;
-
 /** Define an action to be performed when a KeyProvider is notified. */
 class IpcServerTest : public wxAppConsole {
 public:

--- a/test/std_instance.cpp
+++ b/test/std_instance.cpp
@@ -8,8 +8,6 @@
 #include "model/std_instance_chk.h"
 #include "model/base_platform.h"
 
-bool g_bportable;
-
 class StdInstanceApp : public wxAppConsole {
 public:
 

--- a/test/wx_instance.cpp
+++ b/test/wx_instance.cpp
@@ -8,8 +8,6 @@
 
 #include "model/base_platform.h"
 
-bool g_bportable;
-
 class WxInstanceApp : public wxAppConsole {
 public:
 


### PR DESCRIPTION
Add a new command line option which uses an alternative configuration directory instead of the linux default ~/.opencn

Closes: #1022
