### PR TITLE
Refactor OpenGL capability test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2716,6 +2716,10 @@ if (NOT QT_ANDROID)
   add_subdirectory(cli)
 endif ()
 
+if (NOT QT_ANDROID)
+  add_subdirectory(glutil)
+endif ()
+
 if (OCPN_BUILD_TEST)
   add_subdirectory(libs/gtest)
   add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2716,7 +2716,7 @@ if (NOT QT_ANDROID)
   add_subdirectory(cli)
 endif ()
 
-if (NOT QT_ANDROID)
+if (NOT QT_ANDROID AND OCPN_USE_GL)
   add_subdirectory(glutil)
 endif ()
 

--- a/NSIS.template.in.in
+++ b/NSIS.template.in.in
@@ -823,6 +823,7 @@ SectionEnd
 ;# Install Section /hidden
 Section "-Install Section" SecInstall
         File "@CPACK_BINDIR@\_CPack_Packages\win32\NSIS\opencpn_@CPACK_PACKAGE_VERSION@_setup\bin\opencpn-cmd.exe"
+		File "@CPACK_BINDIR@\_CPack_Packages\win32\NSIS\opencpn_@CPACK_PACKAGE_VERSION@_setup\bin\opencpn-glutil.exe"
 	@CPACK_NSIS_FULL_INSTALL@
 
 	@CPACK_NSIS_EXTRA_INSTALL_COMMANDS@
@@ -927,6 +928,7 @@ Section "-un.Uninstall" UnSecUninstall
 		${StrFilter} "$0" "" "" "$\"" $0
 		Delete $0
 		Delete $INSTDIR\opencpn-cmd.exe
+		Delete $INSTDIR\opencpn-glutil.exe
 		;# Remove the installation log file
 		Delete "$INSTDIR\install.log"
 		@CPACK_NSIS_DELETE_FILES@

--- a/glutil/CMakeLists.txt
+++ b/glutil/CMakeLists.txt
@@ -1,0 +1,63 @@
+# ************************************************************************
+#  Copyright (C) 2023 Alec Leamas                                        *
+#  Copyright (C) 2010 David S Register                                   *
+#                                                                        *
+#  This program is free software; you can redistribute it and/or modify  *
+#  it under the terms of the GNU General Public License as published by  *
+#  the Free Software Foundation; either version 2 of the License, or     *
+#  (at your option) any later version.                                   *
+#                                                                        .
+#  This program is distributed in the hope that it will be useful,       *
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+#  GNU General Public License for more details.                          *
+#                                                                        *
+#  You should have received a copy of the GNU General Public License     *
+#  along with this program; if not, write to the                         *
+#  Free Software Foundation, Inc.,                                       *
+#  51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+# ************************************************************************
+
+
+set(SRC_CONSOLE console.cpp)
+
+if(WIN32)
+  add_executable(opencpn-glutil WIN32 ${SRC_CONSOLE})
+else()
+  add_executable(opencpn-glutil ${SRC_CONSOLE})
+endif()
+
+if (NOT "${ENABLE_SANITIZER}" MATCHES "none")
+  target_link_libraries(opencpn-glutil PRIVATE -fsanitize=${ENABLE_SANITIZER})
+endif ()
+
+target_include_directories(
+  opencpn-glutil
+    PRIVATE
+      ${PROJECT_SOURCE_DIR}/include
+)
+
+target_link_libraries(opencpn-glutil PRIVATE ${wxWidgets_LIBRARIES} ${OPENGL_LIBRARIES} ocpn::wxjson)
+
+if (CMAKE_HOST_WIN32)
+  target_link_libraries(
+    opencpn-glutil PRIVATE setupapi.lib "GLU_static" psapi.lib
+      iphlpapi.lib # glu32.lib
+  ) 
+  # use gdi plus only on MSVC, it is not a free library
+  if (MSVC)
+    target_link_libraries(opencpn-glutil PRIVATE gdiplus.lib)
+  endif ()
+endif ()
+
+
+install(TARGETS opencpn-glutil RUNTIME DESTINATION ${PREFIX_BIN})
+
+if (APPLE)
+  install(
+    FILES ${CMAKE_CURRENT_BINARY_DIR}/opencpn-glutil
+    DESTINATION "bin/OpenCPN.app/Contents/MacOS"
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ
+      WORLD_EXECUTE GROUP_EXECUTE OWNER_EXECUTE
+  )
+endif ()

--- a/glutil/console.cpp
+++ b/glutil/console.cpp
@@ -88,11 +88,10 @@ public:
 
   ~TestGLCanvas() final;
 
-private:
-  void InitGL();
-
   wxGLContext* m_glRC;
 
+private:
+  void InitGL();
 };
 
 TestGLCanvas::TestGLCanvas(wxWindow* parent, wxWindowID id, const wxPoint& pos,
@@ -101,7 +100,6 @@ TestGLCanvas::TestGLCanvas(wxWindow* parent, wxWindowID id, const wxPoint& pos,
                  style | wxFULL_REPAINT_ON_RESIZE, name) {
   // Explicitly create a new rendering context instance for this canvas.
   m_glRC = new wxGLContext(this);
-  SetCurrent(*m_glRC);
 }
 
 TestGLCanvas::~TestGLCanvas() { delete m_glRC; }
@@ -186,6 +184,8 @@ public:
     wxLogDebug("Creating canvas");
     TestGLCanvas canvas(&frame, wxID_ANY, wxPoint(0, 0),
                                    frame.GetClientSize());
+    wxYield();
+    canvas.SetCurrent(*canvas.m_glRC);
     wxLogDebug("Collecting information");
 #ifndef __WXOSX__
     auto ret = glewInit();

--- a/glutil/console.cpp
+++ b/glutil/console.cpp
@@ -1,0 +1,279 @@
+/******************************************************************************
+ *
+ * Project:  OpenCPN
+ *
+ * Purpose:  Simple CLI application to check OpenGL capabilities.
+ *
+ ***************************************************************************
+ *   Copyright (C) 2022 Alec Leamas                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ */
+
+#include "wx/wxprec.h"
+
+#ifndef WX_PRECOMP
+#include "wx/wx.h"
+#endif
+
+#include "config.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+#include <iostream>
+#include <fstream>
+
+#if defined(__MSVC__)
+#include "glew.h"
+#elif defined(__WXOSX__)
+#include <OpenGL/gl.h>
+#include <OpenGL/glu.h>
+typedef void (*_GLUfuncptr)();
+#define GL_COMPRESSED_RGB_FXT1_3DFX 0x86B0
+#elif defined(__WXQT__) || defined(__WXGTK__)
+#include <GL/glew.h>
+#include <GL/glu.h>
+// #include <GL/glut.h>
+#endif
+
+#include <wx/cmdline.h>
+#include <wx/json_defs.h>
+#include <wx/jsonwriter.h>
+#include <wx/glcanvas.h>
+#include <wx/tokenzr.h>
+
+static const char* USAGE = R"""(
+Usage: opencpn-cli [options] <command> [arguments]
+
+Options:
+
+  -h, --help
+      Show the help information.
+  -d, --debug
+      Print debug messages.
+  -v, --verbose
+      Verbose output.
+
+Commands:
+  opengl-info:
+      Try to collect information about OpenGL subsystem and output it in JSON format.
+)""";
+
+using namespace std;
+
+class TestGLCanvas : public wxGLCanvas {
+public:
+  TestGLCanvas(wxWindow* parent, wxWindowID id = wxID_ANY,
+               const wxPoint& pos = wxPoint(0, 0),
+               const wxSize& size = wxSize(0, 0), long style = 0,
+               const wxString& name = "OpenCPNGLUtilAppTestCanvas");
+  TestGLCanvas(const TestGLCanvas&) = delete;
+  TestGLCanvas& operator=(const TestGLCanvas&) = delete;
+
+  ~TestGLCanvas() final;
+
+private:
+  void InitGL();
+
+  wxGLContext* m_glRC;
+
+};
+
+TestGLCanvas::TestGLCanvas(wxWindow* parent, wxWindowID id, const wxPoint& pos,
+                           const wxSize& size, long style, const wxString& name)
+    : wxGLCanvas(parent, id, nullptr, pos, size,
+                 style | wxFULL_REPAINT_ON_RESIZE, name) {
+  // Explicitly create a new rendering context instance for this canvas.
+  m_glRC = new wxGLContext(this);
+  SetCurrent(*m_glRC);
+}
+
+TestGLCanvas::~TestGLCanvas() { delete m_glRC; }
+
+class GLUtilApp : public wxApp {
+public:
+  GLUtilApp() : wxApp() {
+#ifdef __linux__
+    // Handle e. g., wayland default display -- see #1166.
+    if (wxGetEnv("WAYLAND_DISPLAY", nullptr)) setenv("GDK_BACKEND", "x11", 1);
+#endif  // __linux__
+    CheckBuildOptions(WX_BUILD_OPTIONS_SIGNATURE, "program");
+    SetAppName("opencpn-glutil");
+  }
+
+  void OnInitCmdLine(wxCmdLineParser& parser) override {
+    parser.AddSwitch("h", "help", "Print help");
+    parser.AddSwitch("v", "verbose", "Verbose output"); // Actually not used, but prevents wxWidgets from asserting 
+    parser.AddSwitch("d", "debug", "Debug output");
+    parser.AddParam("<command>", wxCMD_LINE_VAL_STRING,
+                    wxCMD_LINE_PARAM_OPTIONAL);
+    parser.AddParam("[arg]", wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL);
+    parser.AddParam("[arg]", wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL);
+
+    delete wxLog::SetActiveTarget(new wxLogStderr(nullptr));
+    wxLog::SetTimestamp("");
+    wxLog::SetLogLevel(wxLOG_Warning);
+  }
+
+  bool OnInit() final {
+    if (!wxApp::OnInit()) {
+      return false;
+    }
+    return true;
+  }
+
+  int OnExit() final {
+    delete wxLog::SetActiveTarget(nullptr);
+    return wxApp::OnExit();
+  }
+
+  GLboolean QueryExtension(const char* extName) const {
+    size_t extNameLen;
+
+    extNameLen = strlen(extName);
+
+    auto p = reinterpret_cast<const char*>(glGetString(GL_EXTENSIONS));
+    if (nullptr == p) {
+      return GL_FALSE;
+    }
+
+    const char* end = p + strlen(p);
+
+    while (p < end) {
+      size_t n = strcspn(p, " ");
+      if ((extNameLen == n) && (strncmp(extName, p, n) == 0)) {
+        return GL_TRUE;
+      }
+      p += (n + 1);
+    }
+    return GL_FALSE;
+  }
+
+  void opengl_info(std::ostream & output) const {
+    using namespace std;
+    wxJSONWriter w;
+    wxString out;
+    wxJSONValue v;
+
+    // Avoids wxGLCanvas, but not portable - eg. no glut easily available on
+    // Windows
+    // int argc = 0;
+    // char **argv = 0;
+    // glutInit(&argc, argv);
+    // auto winid = glutCreateWindow("GLUT");
+    wxLogDebug("Creating frame");
+    wxFrame frame(nullptr, wxID_ANY, "GLCanvas Test", wxPoint(0, 0),
+                   wxSize(0, 0));
+    wxLogDebug("Showing frame");
+    frame.Show(true);
+    wxYield();
+    wxLogDebug("Creating canvas");
+    TestGLCanvas canvas(&frame, wxID_ANY, wxPoint(0, 0),
+                                   frame.GetClientSize());
+    wxLogDebug("Collecting information");
+#ifndef __WXOSX__
+    auto ret = glewInit();
+    v["GL_ERROR_STRING"] = wxString(glewGetErrorString(ret));
+    v["GL_ERROR"] = glGetError();
+    if (ret != GLEW_OK) {
+      v["GL_USABLE"] = false;
+      w.Write(v, out);
+      cout << out << endl;
+      exit(1);
+    }
+#endif
+    v["GL_USABLE"] = true;
+    v["GL_VERSION"] = wxString(glGetString(GL_VERSION));
+    v["GL_RENDERER"] = wxString(glGetString(GL_RENDERER));
+    v["GL_VENDOR"] = wxString(glGetString(GL_VENDOR));
+    v["GL_SHADING_LANGUAGE_VERSION"] =
+        wxString(glGetString(GL_SHADING_LANGUAGE_VERSION));
+    v["GL_ARB_texture_non_power_of_two"] =
+        QueryExtension("GL_ARB_texture_non_power_of_two");
+    v["GL_OES_texture_npot"] = QueryExtension("GL_OES_texture_npot");
+    v["GL_ARB_texture_rectangle"] = QueryExtension("GL_ARB_texture_rectangle");
+    v["GL_EXT_framebuffer_object"] =
+        QueryExtension("GL_EXT_framebuffer_object");
+    wxStringTokenizer tkz(wxString(glGetString(GL_EXTENSIONS)), " ");
+    while (tkz.HasMoreTokens())
+    {
+      v["GL_EXTENSIONS"].Append(tkz.GetNextToken());
+    }
+#ifdef __WXOSX__
+    v["GL_ERROR"] = glGetError();
+    v["GL_ERROR_STRING"] = wxString("No error");
+#endif
+    w.Write(v, out);
+    output << out << endl;
+    frame.Close();
+    // glutDestroyWindow(winid);
+  }
+
+  void check_param_count(const wxCmdLineParser& parser, size_t count) const {
+    if (parser.GetParamCount() < count) {
+      std::cerr << USAGE << std::endl;
+      exit(1);
+    }
+  }
+
+  bool OnCmdLineParsed(wxCmdLineParser& parser) override {
+    if (auto initializer = wxInitializer{}; !initializer) {
+      std::cerr << "Failed to initialize the wxWidgets library, aborting.";
+      exit(1);
+    }
+    wxAppConsole::OnCmdLineParsed(parser);
+    if (argc == 1) {
+      std::cout << "OpenCPN OpenGL Utility application. Use -h for help" << std::endl;
+      exit(0);
+    }
+    wxString option_val;
+    if (parser.Found("debug")) {
+      wxLog::SetLogLevel(wxLOG_Debug);
+    }
+    if (parser.Found("help")) {
+      std::cout << USAGE << std::endl;
+      exit(0);
+    }
+    if (parser.GetParamCount() < 1) {
+      std::cerr << USAGE << std::endl;
+      exit(1);
+    }
+    if (const std::string command = parser.GetParam(0).ToStdString(); command == "opengl-info") {
+      if (parser.GetParamCount() > 1) {
+        std::ofstream myfile;
+        myfile.open(parser.GetParam(1).ToStdString(), std::ios::out | std::ios::trunc);
+        if (myfile.is_open()) {
+          opengl_info(myfile);
+          myfile.close();
+        } else {
+          std::cerr << "ERROR: Can't open " << parser.GetParam(1).ToStdString() << std::endl;
+          exit(2);
+        }
+      } else {
+        opengl_info(std::cout);
+      }
+    } else {
+      std::cerr << USAGE << std::endl;
+      exit(2);
+    }
+    exit(0);
+  }
+};
+
+wxIMPLEMENT_APP(GLUtilApp);

--- a/gui/src/OCPNPlatform.cpp
+++ b/gui/src/OCPNPlatform.cpp
@@ -892,14 +892,6 @@ bool OCPNPlatform::IsGLCapable() {
   if(g_bdisable_opengl)
     return false;
 
-  // Protect against fault in OpenGL caps test
-  // If this method crashes due to bad GL drivers,
-  // next startup will disable OpenGL
-  g_bdisable_opengl = true;
-
-  // Update and flush the config file
-  pConfig->UpdateSettings();
-
   wxLogMessage("Starting OpenGL test...");
   wxLog::FlushActive();
 

--- a/gui/src/OCPNPlatform.cpp
+++ b/gui/src/OCPNPlatform.cpp
@@ -608,7 +608,7 @@ void OCPNPlatform::Initialize_3(void) {
   if(!bcapable)
     g_bopengl = false;
   else {
-    g_bopengl = true;
+    //g_bopengl = true;
     g_bdisable_opengl = false;
     pConfig->UpdateSettings();
   }
@@ -923,7 +923,7 @@ bool OCPNPlatform::IsGLCapable() {
   wxLog::FlushActive();
 
   g_bdisable_opengl = false;
-  g_bopengl = true;
+  //g_bopengl = true;
 
   // Update and flush the config file
   pConfig->UpdateSettings();

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -512,30 +512,7 @@ ChartCanvas::ChartCanvas(wxFrame *frame, int canvasIndex)
 #endif /* HAVE_WX_GESTURE_EVENTS */
 
   SetupGlCanvas();
-  /*
-  #ifdef ocpnUSE_GL
-      if ( !g_bdisable_opengl )
-      {
-          if(g_bopengl){
-              wxLogMessage( _T("Creating glChartCanvas") );
-              m_glcc = new glChartCanvas(this);
-
-          // We use one context for all GL windows, so that textures etc will be
-  automatically shared if(IsPrimaryCanvas()){ wxGLContext *pctx = new
-  wxGLContext(m_glcc); m_glcc->SetContext(pctx); g_pGLcontext = pctx; // Save a
-  copy of the common context
-              }
-              else{
-  #ifdef __WXOSX__
-                  m_glcc->SetContext(new wxGLContext(m_glcc, g_pGLcontext));
-  #else
-                  m_glcc->SetContext(g_pGLcontext);   // If not primary canvas,
-  use the saved common context #endif
-              }
-          }
-      }
-  #endif
-  */
+  
   singleClickEventIsValid = false;
 
   //    Build the cursors

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -2394,7 +2394,9 @@ void MyConfig::UpdateSettings() {
   Write(_T ( "ShowCM93DetailSlider" ), g_bShowDetailSlider);
 
   Write(_T ( "SkewToNorthUp" ), g_bskew_comp);
-  Write(_T ( "OpenGL" ), g_bopengl);
+  if (!g_bdisable_opengl) { // Only modify the saved value if OpenGL is not force-disabled from the command line
+    Write(_T ( "OpenGL" ), g_bopengl);
+  }
   Write(_T ( "SoftwareGL" ), g_bSoftwareGL);
   Write(_T ( "ShowFPS" ), g_bShowFPS);
 

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -736,7 +736,6 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   if (wxIsEmpty(g_CmdSoundString))
     g_CmdSoundString = wxString(OCPN_SOUND_CMD);
   Read(_T ( "NavMessageShown" ), &n_NavMessageShown);
-  Read(_T ( "DisableOpenGL" ), &g_bdisable_opengl);
 
   Read(_T ( "AndroidVersionCode" ), &g_AndroidVersionCode);
 
@@ -2396,7 +2395,6 @@ void MyConfig::UpdateSettings() {
 
   Write(_T ( "SkewToNorthUp" ), g_bskew_comp);
   Write(_T ( "OpenGL" ), g_bopengl);
-  Write(_T ( "DisableOpenGL" ), g_bdisable_opengl);
   Write(_T ( "SoftwareGL" ), g_bSoftwareGL);
   Write(_T ( "ShowFPS" ), g_bShowFPS);
 


### PR DESCRIPTION
- Add command line utility `opencpn-glutil` for testing OpenGL capabilities, producing JSON output
- Replace the in-process GL capability test with call to the utility to prevent main application crash in case of fatal problems
- Make the logic handle the `-G` command line switch correctly (really disable OpenGL for the session, but do not modify the user's saved configuration)

The `opencpn-glutil` executable has to be in the same directory as the running `opencpn` on Unix platforms and in `<opencpn.exe location>\bin` (next to `opencpn-cmd.exe`) on Windows. This works out of the box for installed application, but for local ad hoc builds not being installed the developer needs to place or symlink the binary to correct location for the test to be able to work.

Closes #3649