### PR TITLE
Restore the Signal K server mDNS discovery

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1496,6 +1496,9 @@ target_link_libraries(${PACKAGE_NAME} PRIVATE ocpn::tess2)
 add_subdirectory(libs/tinyxml)
 target_link_libraries(${PACKAGE_NAME} PRIVATE ocpn::tinyxml)
 
+message(STATUS "    Adding local wxserverdisc")
+add_subdirectory(libs/wxservdisc)
+
 if (MSVC)
   install(FILES "cache/buildwin/libssl-3.dll" DESTINATION ".")
   install(FILES "cache/buildwin/libcrypto-3.dll" DESTINATION ".")

--- a/gui/src/connection_edit.cpp
+++ b/gui/src/connection_edit.cpp
@@ -52,6 +52,7 @@
 #endif
 
 #include "model/comm_drv_factory.h"
+#include "model/comm_drv_signalk_net.h"
 #include "model/config_vars.h"
 #include "model/ser_ports.h"
 #include "model/sys_events.h"
@@ -691,9 +692,10 @@ void ConnectionEditDialog::Init() {
   m_cbCheckSKDiscover->SetToolTip(
       _("If checked, signal K server will be discovered automatically"));
   fgSizer5->Add(m_cbCheckSKDiscover, 0, wxALL, 2);
+  m_cbCheckSKDiscover->Hide(); // Hide it as the functionality is disabled and likely to be completely removed
 
   // signal K "Discover now" button
-  m_ButtonSKDiscover = new wxButton(m_scrolledwin, wxID_ANY, _("Discover now..."),
+  m_ButtonSKDiscover = new wxButton(m_scrolledwin, wxID_ANY, _("Discover local server..."),
                                     wxDefaultPosition, wxDefaultSize, 0);
   m_ButtonSKDiscover->Hide();
   fgSizer5->Add(m_ButtonSKDiscover, 0, wxALL, 2);
@@ -1158,7 +1160,7 @@ void ConnectionEditDialog::SetDSFormOptionVizStates(void) {
   ShowInFilter();
   ShowOutFilter();
 
-  m_cbCheckSKDiscover->Show();
+  m_cbCheckSKDiscover->Hide(); // The functionality is disabled and probably to be completely removed in the future
   m_stAuthToken->Show();
   m_tAuthToken->Show();
   m_ButtonSKDiscover->Show();
@@ -1622,7 +1624,6 @@ void ConnectionEditDialog::OnSelectDatasource(wxListEvent& event) {
 }
 
 void ConnectionEditDialog::OnDiscoverButton(wxCommandEvent& event) {
-#if 0  // FIXME (dave)
   wxString ip;
   int port;
   std::string serviceIdent =
@@ -1630,8 +1631,8 @@ void ConnectionEditDialog::OnDiscoverButton(wxCommandEvent& event) {
 
   g_Platform->ShowBusySpinner();
 
-  if (SignalKDataStream::DiscoverSKServer(serviceIdent, ip, port,
-                                          1))  // 1 second scan
+  if (CommDriverSignalKNet::DiscoverSKServer(serviceIdent, ip, port,
+                                             3))  // 3 second scan
   {
     m_tNetAddress->SetValue(ip);
     m_tNetPort->SetValue(wxString::Format(wxT("%i"), port));
@@ -1640,8 +1641,6 @@ void ConnectionEditDialog::OnDiscoverButton(wxCommandEvent& event) {
     UpdateDiscoverStatus(_("Signal K server not found."));
   }
   g_Platform->HideBusySpinner();
-#endif
-  event.Skip();
 }
 
 void ConnectionEditDialog::UpdateDiscoverStatus(wxString stat) {
@@ -2145,6 +2144,10 @@ void ConnectionEditDialog::ConnectControls(){
       wxEVT_COMMAND_BUTTON_CLICKED,
       wxCommandEventHandler(ConnectionEditDialog::OnBtnOStcs), NULL, this);
 
+//Signal K server discovery
+  m_ButtonSKDiscover->Connect(
+      wxEVT_COMMAND_BUTTON_CLICKED,
+      wxCommandEventHandler(ConnectionEditDialog::OnDiscoverButton), NULL, this);
 
 #if 0
     m_tNetAddress->Connect(
@@ -2186,9 +2189,6 @@ void ConnectionEditDialog::ConnectControls(){
   m_cbCheckSKDiscover->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
       wxCommandEventHandler(ConnectionEditDialog::OnConnValChange), NULL, this);
-  m_ButtonSKDiscover->Connect(
-      wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(ConnectionEditDialog::OnDiscoverButton), NULL, this);
 
     m_rbOAccept->Connect(wxEVT_COMMAND_RADIOBUTTON_SELECTED,
                        wxCommandEventHandler(ConnectionEditDialog::OnRbOutput),

--- a/libs/wxservdisc/mdnsd.c
+++ b/libs/wxservdisc/mdnsd.c
@@ -43,7 +43,7 @@ __int32    tv_sec;         /* seconds */
 __int32    tv_usec;        /* microseconds */
 };
 
-int gettimeofday(struct timeval *tv/*in*/, struct timezone2 *tz/*in*/)
+int mdnsd_gettimeofday(struct timeval *tv/*in*/, struct timezone2 *tz/*in*/)
 {
   FILETIME ft;
   __int64 tmpres = 0;
@@ -76,6 +76,8 @@ int gettimeofday(struct timeval *tv/*in*/, struct timezone2 *tz/*in*/)
 
   return 0;
 }
+#else
+#define mdnsd_gettimeofday gettimeofday
 #endif
 
 
@@ -438,7 +440,7 @@ mdnsd mdnsd_new(int class, int frame)
     mdnsd d;
     d = (mdnsd)malloc(sizeof(struct mdnsd_struct));
     bzero(d,sizeof(struct mdnsd_struct));
-    gettimeofday(&d->now,0);
+    mdnsd_gettimeofday(&d->now,0);
     d->expireall = d->now.tv_sec + GC;
     d->class = class;
     d->frame = frame;
@@ -485,7 +487,7 @@ void mdnsd_in(mdnsd d, struct message *m, unsigned long int ip, unsigned short i
 
     if(d->shutdown) return;
 
-    gettimeofday(&d->now,0);
+    mdnsd_gettimeofday(&d->now,0);
 
     if(m->header.qr == 0)
     {
@@ -530,7 +532,7 @@ int mdnsd_out(mdnsd d, struct message *m, unsigned long int *ip, unsigned short 
     mdnsdr r;
     int ret = 0;
 
-    gettimeofday(&d->now,0);
+    mdnsd_gettimeofday(&d->now,0);
     bzero(m,sizeof(struct message));
 
     // defaults, multicast
@@ -690,7 +692,7 @@ struct timeval *mdnsd_sleep(mdnsd d)
     // first check for any immediate items to handle
     if(d->uanswers || d->a_now) return &d->sleep;
 
-    gettimeofday(&d->now,0);
+    mdnsd_gettimeofday(&d->now,0);
 
     if(d->a_pause)
     { // then check for paused answers

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -319,6 +319,7 @@ target_link_libraries(
     ocpn::sound
     ocpn::wxjson
     ocpn::filesystem
+    ocpn::wxservdisc
     pico_sha2
 )
 


### PR DESCRIPTION
Restores the mDNS discovery of local Signal K server.
Tested on macOS and Linux
I have not restored and actually completely disabled even in the UI the option to discover the server dynamically at startup as it never was reliable enough anyway and made the startup take way too long in case the server was actually not available. I do not think there is much use case for it where the SK server has dynamic address that changes, but if someone sees any, am open to hear it.

Fixes #3757 