### PR TITLE
Fix chart bubbles on scaled displays (#3612)

### DIFF
--- a/gui/src/RolloverWin.cpp
+++ b/gui/src/RolloverWin.cpp
@@ -184,10 +184,6 @@ void RolloverWin::SetBitmap(int rollover) {
     } else
       glBindTexture(g_texture_rectangle_format, m_texture);
 
-    wxString msg;
-    msg.Printf(_T("Render texture  %d"), m_texture);
-    wxLogMessage(msg);
-
     // make texture data
     wxImage image = m_pbm->ConvertToImage();
 

--- a/gui/src/glChartCanvas.cpp
+++ b/gui/src/glChartCanvas.cpp
@@ -1073,7 +1073,7 @@ void glChartCanvas::SetupOpenGL() {
   }
   else
   {
-  printf("GLEW init success!n");
+  wxLogMessage("GLEW init success!n");
   }
 #endif
 #endif

--- a/gui/src/piano.cpp
+++ b/gui/src/piano.cpp
@@ -784,10 +784,7 @@ wxString &Piano::GetStoredHash() { return m_hash; }
 void Piano::FormatKeys(void) {
   ocpnStyle::Style *style = g_StyleManager->GetCurrentStyle();
   int width = m_parentCanvas->GetClientSize().x;
-#ifdef __WXOSX__
-  if(g_bopengl)
-    width *= m_parentCanvas->GetContentScaleFactor();
-#endif
+  width *= m_parentCanvas->GetContentScaleFactor();
   int height = GetHeight();
   width *= g_btouch ? 0.98f : 0.6f;
 
@@ -826,13 +823,7 @@ wxPoint Piano::GetKeyOrigin(int key_index) {
 bool Piano::MouseEvent(wxMouseEvent &event) {
   int x, y;
   event.GetPosition(&x, &y);
-#ifdef __WXOSX__
-  if (g_bopengl){
-    x *= OCPN_GetDisplayContentScaleFactor();
-    y *= OCPN_GetDisplayContentScaleFactor();
-  }
-#endif
-
+  y *= OCPN_GetDisplayContentScaleFactor();
   int ytop = m_parentCanvas->GetCanvasHeight() - GetHeight();
 #ifdef __WXOSX__
   if (!g_bopengl)
@@ -842,11 +833,11 @@ bool Piano::MouseEvent(wxMouseEvent &event) {
   if (event.Leaving() || y < ytop) {
     if (m_bleaving) return false;
     m_bleaving = true;
-  } else
+  } else {
     m_bleaving = false;
+  }
 
   //    Check the regions
-
   int sel_index = -1;
   int sel_dbindex = -1;
 


### PR DESCRIPTION
This attempts to fix #3612 by applying the scaled windows logic in more cases.

While on it, remove some left over debug messages.

