### PR TITLE
Fix MBTILES cache bug

### DIFF
--- a/gui/src/mbtiles/mbtiles.cpp
+++ b/gui/src/mbtiles/mbtiles.cpp
@@ -667,7 +667,6 @@ bool ChartMBTiles::getTileTexture(mbTileDescriptor *tile) {
     return true;
   } else if (!tile->m_bAvailable) {
     // Tile is not in MbTiles file : no texture to render
-    m_tileCount--;
     return false;
   } else if (tile->m_teximage == 0) {
     if (tile->m_requested == false) {
@@ -1012,7 +1011,10 @@ bool ChartMBTiles::RenderRegionViewOnGL(const wxGLContext &glc,
 
   glChartCanvas::DisableClipRegion();
 
-  // Limit the cache size to 3 times the number of tiles to draw on a rendering
+  // Limit the cache size to 3 times the number of tiles to draw on the current
+  // viewport. This dynamic limit allows to automatically adapt to the actual
+  // resolution of the screen and to handle tricky configuration with multiple
+  // screens or hdpi displays
   m_tileCache->CleanCache(m_tileCount * 3);
 #endif
   return true;


### PR DESCRIPTION
**Description of the bug :** 

MBTiles Charts are flickering when moving the map at very high zoom levels.

**Explanation of the bug :**

MBTiles cache size is dynamically defined by counting the number of tiles which have to be rendered on the current display. The way tiles were being count was buggy, leading to very low values in some specific conditions. The cache was then almost flushed and this was leading to a flickery rendering of the chart (drawn a first time without any tile and then a second time with all tiles once the cache was filled again).

**Fix :**

One line fix to properly count the tiles to be rendered.