### PR TITLE
Input buffering (#3391)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,7 @@
         "condition_variable": "cpp",
         "iosfwd": "cpp",
         "ostream": "cpp",
+        "ratio": "cpp",
         "iostream": "cpp",
         "sstream": "cpp",
         "*.xpm": "cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -756,6 +756,7 @@ set(GUI_HDRS
     ${GUI_HDR_DIR}/chcanv.h
     ${GUI_HDR_DIR}/ChInfoWin.h
     ${GUI_HDR_DIR}/color_handler.h
+    ${GUI_HDR_DIR}/comm_overflow_dlg.h
     ${GUI_HDR_DIR}/compass.h
     ${GUI_HDR_DIR}/concanv.h
     ${GUI_HDR_DIR}/ConfigMgr.h
@@ -877,6 +878,7 @@ set(GUI_SRC
     ${GUI_SRC_DIR}/ChInfoWin.cpp
     ${GUI_SRC_DIR}/cm93.cpp
     ${GUI_SRC_DIR}/color_handler.cpp
+    ${GUI_SRC_DIR}/comm_overflow_dlg.cpp
     ${GUI_SRC_DIR}/compass.cpp
     ${GUI_SRC_DIR}/concanv.cpp
     ${GUI_SRC_DIR}/ConfigMgr.cpp

--- a/gui/include/gui/comm_overflow_dlg.h
+++ b/gui/include/gui/comm_overflow_dlg.h
@@ -1,0 +1,38 @@
+/***************************************************************************
+ *   Copyright (C) 2024 Alec Leamas                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+/** \file  comm_oveflow_dlg.h Popup dialog on communication overflows. */
+
+#ifndef COMM_OVERFLOW_DLG_H__
+#define COMM_OVERFLOW_DLG_H__
+
+#include "observable.h"
+
+class CommOverflowDlg {
+public:
+  CommOverflowDlg(wxWindow* parent);
+
+private:
+  void ShowDialog(const std::string& msg);
+
+  ObsListener m_listener;
+  wxWindow* m_parent;
+};
+
+#endif  // COMM_OVERFLOW_DLG_H__

--- a/gui/include/gui/conn_params_panel.h
+++ b/gui/include/gui/conn_params_panel.h
@@ -35,6 +35,7 @@
 #endif  // precompiled headers
 
 #include "model/conn_params.h"
+#include "connections_dialog.h"
 
 class options;
 

--- a/gui/include/gui/connection_edit.h
+++ b/gui/include/gui/connection_edit.h
@@ -144,6 +144,7 @@ public:
       *m_cbCheckSKDiscover;
   wxCheckBox *m_cbFurunoGP3X, *m_cbNMEADebug, *m_cbFilterSogCog, *m_cbInput;
   wxCheckBox *m_cbOutput, *m_cbAPBMagnetic;
+  wxCheckBox* m_drop_overruns_cb;
   wxComboBox *m_comboPort;
   wxStdDialogButtonSizer *m_sdbSizerDlgButtons;
   wxButton  *m_ButtonSKDiscover, *m_ButtonPriorityDialog;

--- a/gui/include/gui/connection_edit.h
+++ b/gui/include/gui/connection_edit.h
@@ -37,6 +37,7 @@
 #include "model/conn_params.h"
 #include "model/comm_util.h"
 
+#include "connections_dialog.h"
 #include "observable.h"
 
 class options;

--- a/gui/include/gui/ocpn_frame.h
+++ b/gui/include/gui/ocpn_frame.h
@@ -406,6 +406,8 @@ private:
   ObsListener m_on_quit_listener;
   ObsListener m_routes_update_listener;
 
+  ObsListener m_dump_stats_lstnr;
+
   DECLARE_EVENT_TABLE()
 };
 

--- a/gui/include/gui/ocpn_frame.h
+++ b/gui/include/gui/ocpn_frame.h
@@ -37,6 +37,7 @@
 #include "model/ocpn_types.h"
 #include "model/comm_appmsg_bus.h"
 #include "bbox.h"
+#include "comm_overflow_dlg.h"
 #include "color_handler.h"
 #include "gui_lib.h"
 #include "load_errors_dlg.h"
@@ -407,6 +408,7 @@ private:
   ObsListener m_routes_update_listener;
 
   ObsListener m_dump_stats_lstnr;
+  CommOverflowDlg comm_overflow_dlg;
 
   DECLARE_EVENT_TABLE()
 };

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -8833,7 +8833,8 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
       if (b_start_rollover)
         m_RolloverPopupTimer.Start(m_rollover_popup_timer_msec,
                                    wxTIMER_ONE_SHOT);
-      Route *tail = 0, *current;
+      Route *tail = 0;
+      Route *current = 0;
       bool appending = false;
       bool inserting = false;
       int connect = 0;

--- a/gui/src/comm_overflow_dlg.cpp
+++ b/gui/src/comm_overflow_dlg.cpp
@@ -1,0 +1,54 @@
+/***************************************************************************
+ *   Copyright (C) 2024 Alec Leamas                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+/** \file  comm_oveflow_dlg.cpp Implement comm_oveflow_dlg.cpp.h. */
+
+#include <cassert>
+
+#include <wx/window.h>
+
+#include "comm_overflow_dlg.h"
+#include "gui_lib.h"
+
+#include "model/comm_drv_registry.h"
+
+static const char* const kMessage =
+    _(R"---(Communication overflow detected, the system is not able to process
+all input. This is not fatal, system will continue to work but
+will have to discard some input data.
+
+It is possible to control the data discarded using filtering,
+see the manual.
+
+Please review the logfile for more info on discarded messages.
+)---");
+
+static const char* const kCaption = _("Communication overflow");
+
+CommOverflowDlg::CommOverflowDlg(wxWindow* parent) : m_parent(parent) {
+  assert(parent && "Null parent window");
+  auto action = [&](ObservedEvt& evt) {
+    ShowDialog(evt.GetString().ToStdString());
+  };
+  m_listener.Init(CommDriverRegistry::GetInstance().evt_comm_overrun, action);
+}
+
+void CommOverflowDlg::ShowDialog(const std::string& msg) {
+  OCPNMessageBox(m_parent, kMessage, kCaption, wxICON_INFORMATION);
+}

--- a/gui/src/connection_edit.cpp
+++ b/gui/src/connection_edit.cpp
@@ -1934,6 +1934,8 @@ void ConnectionEditDialog::ApplySettings() {
     // Connection has been disabled
     if (!cp->bEnabled) continue;
 
+    cp->drop_overruns = g_drop_overruns;  // FIXME (alec) centralize
+
     // Make any new or re-enabled drivers
     MakeCommDriver(cp);
     cp->b_IsSetup = TRUE;

--- a/gui/src/connection_edit.cpp
+++ b/gui/src/connection_edit.cpp
@@ -34,6 +34,8 @@
 
 #include "config.h"
 
+#include <cassert>
+
 #include <wx/tokenzr.h>
 #include <wx/regex.h>
 
@@ -74,6 +76,12 @@ extern int g_COGFilterSec;
 extern int g_SOGFilterSec;
 
 extern OCPNPlatform* g_Platform;
+
+static ConnectionParamsPanel* GetOptionsPanel(const ConnectionParams* params) {
+  auto panel = dynamic_cast<ConnectionParamsPanel*>(params->m_optionsPanel);
+  assert(panel && "m_optionsPanel: wrong type");
+  return panel;
+}
 
 static wxString StringArrayToString(wxArrayString arr) {
   wxString ret = wxEmptyString;
@@ -854,7 +862,7 @@ void ConnectionEditDialog::SetSelectedConnectionPanel(
   //  Clear any selections
 
   if (mSelectedConnection && mSelectedConnection->m_optionsPanel)
-    mSelectedConnection->m_optionsPanel->SetSelected(false);
+     GetOptionsPanel(mSelectedConnection)->SetSelected(false);
 
   if (panel) {
     mSelectedConnection = panel->m_pConnectionParams;
@@ -1609,8 +1617,7 @@ bool ConnectionEditDialog::SortSourceList(void) {
     m_scrollWinConnections->SetSizer(boxSizerConnections);
 
     for (size_t i = 0; i < ivec.size(); i++) {
-      ConnectionParamsPanel* pPanel =
-          TheConnectionParams()->Item(ivec[i])->m_optionsPanel;
+      auto pPanel = GetOptionsPanel(TheConnectionParams()->Item(ivec[i]));
       boxSizerConnections->Add(pPanel, 0, wxEXPAND | wxALL, 0);
     }
   }
@@ -1629,7 +1636,7 @@ void ConnectionEditDialog::LayoutDialog() {
 void ConnectionEditDialog::UpdateSourceList(bool bResort) {
   for (size_t i = 0; i < TheConnectionParams()->Count(); i++) {
     ConnectionParams* cp = TheConnectionParams()->Item(i);
-    ConnectionParamsPanel* panel = cp->m_optionsPanel;
+    ConnectionParamsPanel* panel = GetOptionsPanel(cp);
     if (panel) panel->Update(TheConnectionParams()->Item(i));
   }
 
@@ -2477,4 +2484,3 @@ void SentenceListDlg::OnCheckAllClick(wxCommandEvent& event) {
   for (size_t i = 0; i < m_clbSentences->GetCount(); i++)
     m_clbSentences->Check(i, TRUE);
 }
-

--- a/gui/src/connection_edit.cpp
+++ b/gui/src/connection_edit.cpp
@@ -153,6 +153,17 @@ static void LoadSerialPorts(wxComboBox* box) {
   delete ports;
 }
 
+class DropOverrunsCheckBox: public wxCheckBox {
+public:
+  DropOverrunsCheckBox(wxWindow* parent)
+      : wxCheckBox(parent, wxID_ANY, "EXPERIMENTAL: Drop input overruns")
+  {
+    SetValue(g_drop_comm_overruns);
+    Bind(wxEVT_CHECKBOX,
+         [&](wxCommandEvent&){ g_drop_comm_overruns = GetValue(); });
+  }
+};
+
 //------------------------------------------------------------------------------
 //          ConnectionEditDialog Implementation
 //------------------------------------------------------------------------------
@@ -684,6 +695,9 @@ void ConnectionEditDialog::Init() {
                                       _("as autopilot or NMEA repeater")),
                      wxDefaultPosition, wxDefaultSize, 0);
   fgSizer5->Add(m_cbOutput, 0, wxALL, 2);
+  fgSizer5->AddSpacer(1);
+  m_drop_overruns_cb = new DropOverrunsCheckBox(m_scrolledwin);
+  fgSizer5->Add(m_drop_overruns_cb, 0, wxALL, 2);
   fgSizer5->AddSpacer(1);
 
   m_stTalkerIdText = new wxStaticText(

--- a/gui/src/connections_dialog.cpp
+++ b/gui/src/connections_dialog.cpp
@@ -541,6 +541,8 @@ void ConnectionsDialog::UpdateDatastreams() {
     // Connection has been disabled
     if (!cp->bEnabled) continue;
 
+    cp->drop_overruns = g_drop_comm_overruns;  // FIXME (alec) centralize
+
     // Make any new or re-enabled drivers
     MakeCommDriver(cp);
     cp->b_IsSetup = TRUE;

--- a/gui/src/connections_dialog.cpp
+++ b/gui/src/connections_dialog.cpp
@@ -50,6 +50,12 @@ extern bool g_bfilter_cogsog;
 extern int g_COGFilterSec;
 extern int g_SOGFilterSec;
 
+static ConnectionParamsPanel* GetOptionsPanel(const ConnectionParams* params) {
+  auto panel = dynamic_cast<ConnectionParamsPanel*>(params->m_optionsPanel);
+  assert(panel && "m_optionsPanel: wrong type");
+  return panel;
+}
+
 
 //------------------------------------------------------------------------------
 //          ConnectionsDialog Implementation
@@ -275,7 +281,7 @@ void ConnectionsDialog::SetSelectedConnectionPanel(
   //  Clear any selections
 
   if (mSelectedConnection && mSelectedConnection->m_optionsPanel)
-    mSelectedConnection->m_optionsPanel->SetSelected(false);
+    GetOptionsPanel(mSelectedConnection)->SetSelected(false);
 
   if (panel) {
     mSelectedConnection = panel->m_pConnectionParams;
@@ -340,7 +346,7 @@ bool ConnectionsDialog::SortSourceList(void) {
 
     for (size_t i = 0; i < ivec.size(); i++) {
       ConnectionParamsPanel* pPanel =
-          TheConnectionParams()->Item(ivec[i])->m_optionsPanel;
+          GetOptionsPanel(TheConnectionParams()->Item(ivec[i]));
       boxSizerConnections->Add(pPanel, 0, wxEXPAND | wxRIGHT, 10);
     }
   }
@@ -362,7 +368,7 @@ void ConnectionsDialog::FillSourceList(void) {
       boxSizerConnections->Add(pPanel, 0, wxEXPAND | wxRIGHT, 10);
       cp->m_optionsPanel = pPanel;
     } else {
-      cp->m_optionsPanel->Update(cp);
+      GetOptionsPanel(cp)->Update(cp);
     }
   }
   SortSourceList();
@@ -376,7 +382,8 @@ void ConnectionsDialog::FillSourceList(void) {
 void ConnectionsDialog::UpdateSourceList(bool bResort) {
   for (size_t i = 0; i < TheConnectionParams()->Count(); i++) {
     ConnectionParams* cp = TheConnectionParams()->Item(i);
-    ConnectionParamsPanel* panel = cp->m_optionsPanel;
+    ConnectionParamsPanel* panel = 0;
+    if (cp->m_optionsPanel) panel = GetOptionsPanel(cp);
     if (panel) panel->Update(TheConnectionParams()->Item(i));
   }
 
@@ -390,7 +397,7 @@ void ConnectionsDialog::UpdateSourceList(bool bResort) {
 void ConnectionsDialog::OnAddDatasourceClick(wxCommandEvent& event) {
   //  Unselect all panels
   for (size_t i = 0; i < TheConnectionParams()->Count(); i++)
-    TheConnectionParams()->Item(i)->m_optionsPanel->SetSelected(false);
+    GetOptionsPanel(TheConnectionParams()->Item(i))->SetSelected(false);
 
   ConnectionEditDialog dialog(m_parent, this);
   dialog.SetSize(m_parent->GetSize());  // fill the entire "settings" dialog space
@@ -555,5 +562,3 @@ void ConnectionsDialog::OnPriorityDialog(wxCommandEvent& event) {
   pdlg->ShowModal();
   delete pdlg;
 }
-
-

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -944,6 +944,7 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   Read(_T ( "FullscreenToolbar" ), &g_bFullscreenToolbar);
   Read(_T ( "PermanentMOBIcon" ), &g_bPermanentMOBIcon);
   Read(_T ( "ShowLayers" ), &g_bShowLayers);
+  Read("DropCommOverruns", &g_drop_comm_overruns);
   Read(_T ( "ShowDepthUnits" ), &g_bShowDepthUnits);
   Read(_T ( "AutoAnchorDrop" ), &g_bAutoAnchorMark);
   Read(_T ( "ShowChartOutlines" ), &g_bShowOutlines);
@@ -2355,6 +2356,7 @@ void MyConfig::UpdateSettings() {
   Write(_T ( "TransparentToolbar" ), g_bTransparentToolbar);
   Write(_T ( "PermanentMOBIcon" ), g_bPermanentMOBIcon);
   Write(_T ( "ShowLayers" ), g_bShowLayers);
+  Write("DropCommOverruns", g_drop_comm_overruns);
   Write(_T ( "AutoAnchorDrop" ), g_bAutoAnchorMark);
   Write(_T ( "ShowChartOutlines" ), g_bShowOutlines);
   Write(_T ( "ShowActiveRouteTotal" ), g_bShowRouteTotal);

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -913,7 +913,7 @@ bool MyApp::OnCmdLineParsed(wxCmdLineParser &parser) {
 
   bool has_remote_options = false;
   static const std::vector<std::string> kRemoteOptions = {
-    "raise", "quit", "open", "get_rest_endpoint"};
+    "raise", "quit", "open", "get_rest_endpoint", "dump_stats"};
   for (const auto& opt : kRemoteOptions) {
     if (parser.Found(opt)) has_remote_options = true;
   }

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -225,6 +225,7 @@ Options manipulating already started opencpn
   -q, --quit                   	Terminate already running opencpn
   -e, --get_rest_endpoint      	Print rest server endpoint and exit.
   -o, --open=<GPX file>         Open file in running opencpn
+  -d, --dump_stats              Dump debugging statistics
 
 Arguments:
   GPX  file                     GPX-formatted file with waypoints or routes.
@@ -832,6 +833,7 @@ void MyApp::OnInitCmdLine(wxCmdLineParser &parser) {
   parser.AddSwitch("r", "remote");
   parser.AddSwitch("R", "raise");
   parser.AddSwitch("q", "quit");
+  parser.AddSwitch("d", "dump_stats");
   parser.AddSwitch("e", "get_rest_endpoint");
   parser.AddOption("o", "open", "", wxCMD_LINE_VAL_STRING,
                    wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE);
@@ -932,6 +934,8 @@ bool MyApp::OnCmdLineParsed(wxCmdLineParser &parser) {
     m_parsed_cmdline = ParsedCmdline(CmdlineAction::Quit);
   else if (parser.Found("get_rest_endpoint"))
     m_parsed_cmdline = ParsedCmdline(CmdlineAction::GetRestEndpoint);
+  else if (parser.Found("dump_stats"))
+    m_parsed_cmdline = ParsedCmdline(CmdlineAction::DumpStats);
   else if (parser.Found("open", &optarg))
     m_parsed_cmdline = ParsedCmdline(CmdlineAction::Open,
                                      optarg.ToStdString());

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -5025,6 +5025,8 @@ void MyFrame::InitApiListeners() {
   auto& server = LocalServerApi::GetInstance();
   m_on_raise_listener.Init(server.on_raise, [&](ObservedEvt){ Raise(); });
   m_on_quit_listener.Init(server.on_quit, [&](ObservedEvt){ FastClose(); });
+  m_dump_stats_lstnr.Init(server.on_dump_stats,
+                             [&](ObservedEvt){ std::cout << "DUMP stats\n"; });
   server.SetGetRestApiEndpointCb(
     [&]{ return wxGetApp().m_rest_server.GetEndpoint(); });
   server.open_file_cb =

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -630,8 +630,9 @@ static void onBellsFinishedCB(void *ptr) {
 // My frame constructor
 MyFrame::MyFrame(wxFrame *frame, const wxString &title, const wxPoint &pos,
                  const wxSize &size, long style)
-    : wxFrame(frame, -1, title, pos, size, style, kTopLevelWindowName)
-      {
+    : wxFrame(frame, -1, title, pos, size, style, kTopLevelWindowName),
+      comm_overflow_dlg(this) {
+
   g_current_monitor = wxDisplay::GetFromWindow(this);
 #ifdef __WXOSX__
   // On retina displays there is a difference between the physical size of the OpenGL canvas and the DIP

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -632,7 +632,6 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, const wxPoint &pos,
                  const wxSize &size, long style)
     : wxFrame(frame, -1, title, pos, size, style, kTopLevelWindowName),
       comm_overflow_dlg(this) {
-
   g_current_monitor = wxDisplay::GetFromWindow(this);
 #ifdef __WXOSX__
   // On retina displays there is a difference between the physical size of the OpenGL canvas and the DIP

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -5025,8 +5025,9 @@ void MyFrame::InitApiListeners() {
   auto& server = LocalServerApi::GetInstance();
   m_on_raise_listener.Init(server.on_raise, [&](ObservedEvt){ Raise(); });
   m_on_quit_listener.Init(server.on_quit, [&](ObservedEvt){ FastClose(); });
-  m_dump_stats_lstnr.Init(server.on_dump_stats,
-                             [&](ObservedEvt){ std::cout << "DUMP stats\n"; });
+  auto& registry = CommDriverRegistry::GetInstance();
+  auto dump_notify = [&](ObservedEvt){ registry.evt_dump_stats.Notify(); };
+  m_dump_stats_lstnr.Init( server.on_dump_stats, dump_notify);
   server.SetGetRestApiEndpointCb(
     [&]{ return wxGetApp().m_rest_server.GetEndpoint(); });
   server.open_file_cb =

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -59,6 +59,7 @@ set(
   ${MODEL_HDR_DIR}/comm_n0183_output.h
   ${MODEL_HDR_DIR}/comm_navmsg_bus.h
   ${MODEL_HDR_DIR}/comm_navmsg.h
+  ${MODEL_HDR_DIR}/comm_out_queue.h
   ${MODEL_HDR_DIR}/comm_util.h
   ${MODEL_HDR_DIR}/comm_vars.h
   ${MODEL_HDR_DIR}/config_vars.h
@@ -149,6 +150,8 @@ set(SRC
   ${MODEL_SRC_DIR}/comm_navmsg_bus.cpp
   ${MODEL_SRC_DIR}/comm_navmsg.cpp
   ${MODEL_SRC_DIR}/comm_navmsg.cpp
+  ${MODEL_SRC_DIR}/comm_out_queue.cpp
+  # ${MODEL_SRC_DIR}/comm_plugin_api.cpp
   ${MODEL_SRC_DIR}/comm_util.cpp
   ${MODEL_SRC_DIR}/comm_vars.cpp
   ${MODEL_SRC_DIR}/config_vars.cpp

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -135,6 +135,7 @@ set(SRC
   ${MODEL_SRC_DIR}/comm_bridge.cpp
   ${MODEL_SRC_DIR}/comm_can_util.cpp
   ${MODEL_SRC_DIR}/comm_decoder.cpp
+  ${MODEL_SRC_DIR}/comm_driver.cpp
   ${MODEL_SRC_DIR}/comm_drv_factory.cpp
   ${MODEL_SRC_DIR}/comm_drv_file.cpp
   ${MODEL_SRC_DIR}/comm_drv_n0183.cpp

--- a/model/include/model/comm_driver.h
+++ b/model/include/model/comm_driver.h
@@ -59,6 +59,9 @@ class AbstractCommDriver
 public:
   AbstractCommDriver() : bus(NavAddr::Bus::Undef), iface("nil"){};
 
+  /** Return path to dump file inn private data directory. */
+  static std::string DumpFilePath();
+
   virtual bool SendMessage(std::shared_ptr<const NavMsg> msg,
                            std::shared_ptr<const NavAddr> addr) = 0;
 
@@ -83,7 +86,11 @@ public:
     return std::pair<CommStatus, std::string>(CommStatus::NotImplemented, "");
   }
 
+  /** Return unique string identifying driver instance. */
   std::string Key() const { return NavAddr::BusToString(bus) + "!@!" + iface; }
+
+  /** Possibly dump driver specific debug statistics. */
+  virtual void DumpStats() const {};
 
   const NavAddr::Bus bus;
   const std::string iface; /**< Physical device for 0183, else a

--- a/model/include/model/comm_drv_n0183_net.h
+++ b/model/include/model/comm_drv_n0183_net.h
@@ -57,6 +57,7 @@
 #endif
 
 #include "model/comm_drv_n0183.h"
+#include "model/comm_out_queue.h"
 #include "model/conn_params.h"
 #include "observable.h"
 
@@ -149,6 +150,7 @@ private:
   bool m_bok;
 
   ObsListener resume_listener;
+  const std::unique_ptr<CommOutQueue> m_out_queue;
 
   DECLARE_EVENT_TABLE()
 };

--- a/model/include/model/comm_drv_n0183_net.h
+++ b/model/include/model/comm_drv_n0183_net.h
@@ -59,6 +59,7 @@
 #include "model/comm_drv_n0183.h"
 #include "model/comm_out_queue.h"
 #include "model/conn_params.h"
+
 #include "observable.h"
 
 class CommDriverN0183NetEvent;  // Internal
@@ -153,6 +154,7 @@ private:
   bool m_bok;
 
   ObsListener resume_listener;
+  ObsListener dump_stats_lstnr;
   const std::unique_ptr<CommOutQueue> m_out_queue;
 
   DECLARE_EVENT_TABLE()

--- a/model/include/model/comm_drv_n0183_net.h
+++ b/model/include/model/comm_drv_n0183_net.h
@@ -73,6 +73,9 @@ public:
 
   void Open();
   void Close();
+
+  void DumpStats() const override;
+
   ConnectionParams GetParams() const { return m_params; }
 
   bool SetOutputSocketOptions(wxSocketBase* tsock);

--- a/model/include/model/comm_drv_n0183_serial.h
+++ b/model/include/model/comm_drv_n0183_serial.h
@@ -32,6 +32,7 @@
 #include <wx/event.h>
 
 #include "model/comm_drv_n0183.h"
+#include "model/comm_out_queue.h"
 #include "model/conn_params.h"
 #include "model/garmin_protocol_mgr.h"
 
@@ -105,6 +106,7 @@ private:
 
   ConnectionParams m_params;
   DriverListener& m_listener;
+  const std::unique_ptr<CommOutQueue> m_out_queue;
   void handle_N0183_MSG(CommDriverN0183SerialEvent& event);
 };
 

--- a/model/include/model/comm_drv_n0183_serial.h
+++ b/model/include/model/comm_drv_n0183_serial.h
@@ -31,6 +31,7 @@
 
 #include <wx/event.h>
 
+#include "observable.h"
 #include "model/comm_drv_n0183.h"
 #include "model/comm_out_queue.h"
 #include "model/conn_params.h"
@@ -110,6 +111,7 @@ private:
   DriverListener& m_listener;
   const std::unique_ptr<CommOutQueue> m_out_queue;
   void handle_N0183_MSG(CommDriverN0183SerialEvent& event);
+  ObsListener m_dump_stats_lstnr;
 };
 
 #endif  // guard

--- a/model/include/model/comm_drv_n0183_serial.h
+++ b/model/include/model/comm_drv_n0183_serial.h
@@ -65,6 +65,8 @@ public:
   /** Register driver and possibly do other post-ctor steps. */
   void Activate() override;
 
+  void DumpStats() const override;
+
   bool Open();
   void Close();
 

--- a/model/include/model/comm_drv_registry.h
+++ b/model/include/model/comm_drv_registry.h
@@ -56,6 +56,9 @@ public:
   /** Notified by all driverlist updates. */
   EventVar evt_driverlist_change;
 
+  /** Notified when receiving --remote --dump_stat on local API. */
+  EventVar evt_dump_stats;
+
   /**
    *  Notified for messages from drivers. The generated event contains:
    *  - A wxLogLevel stored as an int.

--- a/model/include/model/comm_drv_registry.h
+++ b/model/include/model/comm_drv_registry.h
@@ -59,6 +59,9 @@ public:
   /** Notified when receiving --remote --dump_stat on local API. */
   EventVar evt_dump_stats;
 
+  /** Notified with a printable message on first detected overrun. */
+  EventVar evt_comm_overrun;
+
   /**
    *  Notified for messages from drivers. The generated event contains:
    *  - A wxLogLevel stored as an int.

--- a/model/include/model/comm_out_queue.h
+++ b/model/include/model/comm_out_queue.h
@@ -116,6 +116,7 @@ protected:
   std::vector<BufferItem> m_buffer;
   mutable std::mutex m_mutex;
   int m_size;
+  bool m_overrun_reported;
 };
 
 /** A  CommOutQueue limited to one message of each kind. */

--- a/model/include/model/comm_out_queue.h
+++ b/model/include/model/comm_out_queue.h
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -37,7 +38,7 @@ public:
 
 protected:
   struct BufferItem {
-    long type;
+    uint64_t type;
     std::string line;
     BufferItem(const std::string& line);
     BufferItem(const BufferItem& other);

--- a/model/include/model/comm_out_queue.h
+++ b/model/include/model/comm_out_queue.h
@@ -1,6 +1,6 @@
-#include  <mutex>
-#include  <string>
-#include  <vector>
+#include <mutex>
+#include <string>
+#include <vector>
 
 /**
  *  Queue of NMEA0183 messages which only holds a limited amount
@@ -8,11 +8,16 @@
  */
 class CommOutQueue {
 public:
+  /**
+   * Insert valid line of NMEA0183 data in buffer.
+   * @return false on errors including invalid input, else true.
+   */
+  virtual bool push_back(const std::string& line);
 
-  /** Insert line of NMEA0183 data in buffer. */
-  virtual void push_back(const std::string& line);
-
-  /** Return copy of next line to send, throws exception if empty. */
+  /**
+   * Return  next line to send and remove it from buffer,
+   * throws exception if empty.
+   */
   std::string pop();
 
   /** Return number of lines in queue. */
@@ -29,7 +34,6 @@ public:
   // Disable copying and assignment
   CommOutQueue(const CommOutQueue& other) = delete;
   CommOutQueue& operator=(const CommOutQueue&) = delete;
-
 
 protected:
   struct BufferItem {
@@ -50,5 +54,15 @@ public:
   CommOutQueueSingle() : CommOutQueue(1) {}
 
   /** Insert line of NMEA0183 data in buffer. */
-  void push_back(const std::string& line);
+  bool push_back(const std::string& line);
+};
+
+/** Add unit test measurements to CommOutQueue. */
+class MeasuredCommOutQueue : public CommOutQueue {
+public:
+  MeasuredCommOutQueue(int size) : CommOutQueue(size), push_time(0) {}
+
+  bool push_back(const std::string& line);
+
+  double push_time;
 };

--- a/model/include/model/comm_out_queue.h
+++ b/model/include/model/comm_out_queue.h
@@ -88,7 +88,7 @@ public:
   virtual std::string pop();
 
   /** Return number of lines in queue. */
-  int size() const;
+  virtual int size() const;
 
   /**
    * Create a buffer which stores at most message_count items of each
@@ -101,6 +101,8 @@ public:
   // Disable copying and assignment
   CommOutQueue(const CommOutQueue& other) = delete;
   CommOutQueue& operator=(const CommOutQueue&) = delete;
+
+  virtual ~CommOutQueue() = default;
 
 protected:
   struct BufferItem {
@@ -134,9 +136,11 @@ public:
       : CommOutQueue(size), push_time(0), pop_time(0) {}
 
   bool push_back(const std::string& line) override;
+
   std::string pop() override;
 
   std::unordered_map<unsigned long, PerfCounter> msg_perf;
+
   PerfCounter perf;
   double push_time;
   double pop_time;
@@ -147,13 +151,13 @@ class DummyCommOutQueue :  public CommOutQueue {
 public:
   DummyCommOutQueue() {};
 
-  bool push_back(const std::string& line) {
+  bool push_back(const std::string& line) override {
     std::lock_guard<std::mutex> lock(m_mutex);
     buff.insert(buff.begin(), line);
     return true;
   }
 
-  std::string pop() {
+  std::string pop() override {
     std::lock_guard<std::mutex> lock(m_mutex);
     if (buff.size() <= 0)
       throw std::underflow_error("Attempt to pop() from empty buffer");
@@ -162,7 +166,7 @@ public:
     return line;
   }
 
-  int size() const {
+  int size() const override {
     std::lock_guard<std::mutex> lock(m_mutex);
     return buff.size();
   }

--- a/model/include/model/comm_out_queue.h
+++ b/model/include/model/comm_out_queue.h
@@ -1,3 +1,6 @@
+#ifndef COMM__OUT_QUEUE_H__
+#define COMM__OUT_QUEUE_H__
+
 #include <cstdint>
 #include <mutex>
 #include <string>
@@ -63,22 +66,7 @@ public:
   std::chrono::time_point<std::chrono::steady_clock> last_out;
 };
 
-std::ostream& operator<<(std::ostream& os, const PerfCounter& pc) {
-  os << "{";
-  os << "msgs_in: " << pc.msgs_in << ", ";
-  os << "msgs_out: " << pc.msgs_out << ", ";
-  os << "bytes_in: " << pc.bytes_in << ", ";
-  os << "bytes_out: " << pc.bytes_out << ", ";
-  os << "bps_in: " << pc.bps_in << ", ";
-  os << "mps_in: " << pc.mps_in << ", ";
-  os << "bps_out: " << pc.bps_out << ", ";
-  os << "mps_out: " << pc.mps_out << ", ";
-  os << "in_out_delay_us: " << pc.in_out_delay_us << ", ";
-  os << "overflow_msgs: " << pc.overflow_msgs << ", ";
-  os << "in_queue: " << pc.in_queue;
-  os << "}";
-  return os;
-};
+std::ostream& operator<<(std::ostream& os, const PerfCounter& pc);
 
 /**
  *  Queue of NMEA0183 messages which only holds a limited amount
@@ -152,16 +140,7 @@ public:
   double push_time;
   double pop_time;
 };
-std::ostream& operator<<(std::ostream& os, const MeasuredCommOutQueue& q) {
-  os << "{";
-  os << "push_time: " << q.push_time << ", ";
-  os << "pop_time: " << q.pop_time << ", ";
-  os << "perf: " << q.perf << ", ";
-  os << "msg_perf: [";
-  for (const auto& kv : q.msg_perf) {
-    os << kv.first << ": " << kv.second << ", ";
-  }
-  os << "]";
-  os << "}";
-  return os;
-};
+
+std::ostream& operator<<(std::ostream& os, const MeasuredCommOutQueue& q);
+
+#endif  //  COMM__OUT_QUEUE_H__

--- a/model/include/model/comm_out_queue.h
+++ b/model/include/model/comm_out_queue.h
@@ -6,54 +6,64 @@
 #include <unordered_map>
 #include <iostream>
 
-
 class PerfCounter {
-  public:
-    PerfCounter() : msgs_in(0), msgs_out(0), bytes_in(0), bytes_out(0), bps_in(0), mps_in(0), bps_out(0), mps_out(0), in_out_delay_us(0), overflow_msgs(0), in_queue(0) {}
-    void in(const size_t bytes, bool ok) {
-      auto t1 = std::chrono::steady_clock::now();
-      std::chrono::duration<double, std::micro> us_time = t1 - last_in;
-      bps_in = 0.95 * bps_in + 0.05 * bytes * 1000000 / us_time.count();
-      mps_in = 0.95 * bps_in + 0.05 * 1000000 / us_time.count();
-      msgs_in++;
-      bytes_in += bytes;
-      last_in = t1;
-      if(!ok) {
-        overflow_msgs++;
-      }
-      in_queue++;
+public:
+  PerfCounter()
+      : msgs_in(0),
+        msgs_out(0),
+        bytes_in(0),
+        bytes_out(0),
+        bps_in(0),
+        mps_in(0),
+        bps_out(0),
+        mps_out(0),
+        in_out_delay_us(0),
+        overflow_msgs(0),
+        in_queue(0) {}
+  void in(const size_t bytes, bool ok) {
+    auto t1 = std::chrono::steady_clock::now();
+    std::chrono::duration<double, std::micro> us_time = t1 - last_in;
+    bps_in = 0.95 * bps_in + 0.05 * bytes * 1000000 / us_time.count();
+    mps_in = 0.95 * bps_in + 0.05 * 1000000 / us_time.count();
+    msgs_in++;
+    bytes_in += bytes;
+    last_in = t1;
+    if (!ok) {
+      overflow_msgs++;
     }
+    in_queue++;
+  }
 
-    void out(const size_t bytes, std::chrono::time_point<std::chrono::steady_clock> in_ts) {
-      auto t1 = std::chrono::steady_clock::now();
-      std::chrono::duration<double, std::micro> us_time = t1 - last_in;
-      bps_out = 0.95 * bps_out + 0.05 * bytes * 1000000 / us_time.count();
-      mps_out = 0.95 * bps_out + 0.05 * 1000000 / us_time.count();
-      us_time = t1 - in_ts;
-      in_out_delay_us = 0.95 * in_out_delay_us + 0.05 * us_time.count();
-      msgs_out++;
-      bytes_out += bytes;
-      last_out = t1;
-      in_queue--;
-    }
+  void out(const size_t bytes,
+           std::chrono::time_point<std::chrono::steady_clock> in_ts) {
+    auto t1 = std::chrono::steady_clock::now();
+    std::chrono::duration<double, std::micro> us_time = t1 - last_in;
+    bps_out = 0.95 * bps_out + 0.05 * bytes * 1000000 / us_time.count();
+    mps_out = 0.95 * bps_out + 0.05 * 1000000 / us_time.count();
+    us_time = t1 - in_ts;
+    in_out_delay_us = 0.95 * in_out_delay_us + 0.05 * us_time.count();
+    msgs_out++;
+    bytes_out += bytes;
+    last_out = t1;
+    in_queue--;
+  }
 
-    size_t msgs_in;
-    size_t msgs_out;
-    size_t bytes_in;
-    size_t bytes_out;
-    uint32_t bps_in;
-    double mps_in;
-    uint32_t bps_out;
-    double mps_out;
-    size_t in_out_delay_us;
-    size_t overflow_msgs;
-    size_t in_queue;
-    std::chrono::time_point<std::chrono::steady_clock> last_in;
-    std::chrono::time_point<std::chrono::steady_clock> last_out;
+  size_t msgs_in;
+  size_t msgs_out;
+  size_t bytes_in;
+  size_t bytes_out;
+  uint32_t bps_in;
+  double mps_in;
+  uint32_t bps_out;
+  double mps_out;
+  size_t in_out_delay_us;
+  size_t overflow_msgs;
+  size_t in_queue;
+  std::chrono::time_point<std::chrono::steady_clock> last_in;
+  std::chrono::time_point<std::chrono::steady_clock> last_out;
 };
 
-std::ostream& operator <<(std::ostream& os, const PerfCounter& pc) 
-{
+std::ostream& operator<<(std::ostream& os, const PerfCounter& pc) {
   os << "{";
   os << "msgs_in: " << pc.msgs_in << ", ";
   os << "msgs_out: " << pc.msgs_out << ", ";
@@ -131,7 +141,8 @@ public:
 
 class MeasuredCommOutQueue : public CommOutQueue {
 public:
-  MeasuredCommOutQueue(int size) : CommOutQueue(size), push_time(0), pop_time(0) {}
+  MeasuredCommOutQueue(int size)
+      : CommOutQueue(size), push_time(0), pop_time(0) {}
 
   bool push_back(const std::string& line) override;
   std::string pop() override;
@@ -141,14 +152,13 @@ public:
   double push_time;
   double pop_time;
 };
-std::ostream& operator <<(std::ostream& os, const MeasuredCommOutQueue& q) 
-{
+std::ostream& operator<<(std::ostream& os, const MeasuredCommOutQueue& q) {
   os << "{";
   os << "push_time: " << q.push_time << ", ";
   os << "pop_time: " << q.pop_time << ", ";
   os << "perf: " << q.perf << ", ";
   os << "msg_perf: [";
-  for(const auto& kv : q.msg_perf) {
+  for (const auto& kv : q.msg_perf) {
     os << kv.first << ": " << kv.second << ", ";
   }
   os << "]";

--- a/model/include/model/comm_out_queue.h
+++ b/model/include/model/comm_out_queue.h
@@ -2,6 +2,51 @@
 #include <mutex>
 #include <string>
 #include <vector>
+#include <chrono>
+#include <unordered_map>
+
+
+class PerfCounter {
+  public:
+    PerfCounter() : msgs_in(0), msgs_out(0), bytes_in(0), bytes_out(0), bps_in(0), mps_in(0), bps_out(0), mps_out(0), in_out_delay_us(0), overflow_msgs(0) {}
+    void in(const size_t bytes, bool ok) {
+      auto t1 = std::chrono::steady_clock::now();
+      std::chrono::duration<double, std::micro> us_time = t1 - last_in;
+      bps_in = 0.95 * bps_in + 0.05 * bytes * 1000000 / us_time.count();
+      mps_in = 0.95 * bps_in + 0.05 * 1000000 / us_time.count();
+      msgs_in++;
+      bytes_in += bytes;
+      last_in = t1;
+      if(!ok) {
+        overflow_msgs++;
+      }
+    }
+
+    void out(const size_t bytes, std::chrono::time_point<std::chrono::steady_clock> in_ts) {
+      auto t1 = std::chrono::steady_clock::now();
+      std::chrono::duration<double, std::micro> us_time = t1 - last_in;
+      bps_out = 0.95 * bps_out + 0.05 * bytes * 1000000 / us_time.count();
+      mps_out = 0.95 * bps_out + 0.05 * 1000000 / us_time.count();
+      us_time = t1 - in_ts;
+      in_out_delay_us = 0.95 * in_out_delay_us + 0.05 * us_time.count();
+      msgs_out++;
+      bytes_out += bytes;
+      last_out = t1;
+    }
+
+    size_t msgs_in;
+    size_t msgs_out;
+    size_t bytes_in;
+    size_t bytes_out;
+    uint32_t bps_in;
+    double mps_in;
+    uint32_t bps_out;
+    double mps_out;
+    size_t in_out_delay_us;
+    size_t overflow_msgs;
+    std::chrono::time_point<std::chrono::steady_clock> last_in;
+    std::chrono::time_point<std::chrono::steady_clock> last_out;
+};
 
 /**
  *  Queue of NMEA0183 messages which only holds a limited amount
@@ -19,7 +64,7 @@ public:
    * Return  next line to send and remove it from buffer,
    * throws exception if empty.
    */
-  std::string pop();
+  virtual std::string pop();
 
   /** Return number of lines in queue. */
   int size() const;
@@ -42,6 +87,7 @@ protected:
     std::string line;
     BufferItem(const std::string& line);
     BufferItem(const BufferItem& other);
+    std::chrono::time_point<std::chrono::steady_clock> ts;
   };
 
   std::vector<BufferItem> m_buffer;
@@ -55,15 +101,21 @@ public:
   CommOutQueueSingle() : CommOutQueue(1) {}
 
   /** Insert line of NMEA0183 data in buffer. */
-  bool push_back(const std::string& line);
+  bool push_back(const std::string& line) override;
 };
 
 /** Add unit test measurements to CommOutQueue. */
+#include <unordered_map>
+
 class MeasuredCommOutQueue : public CommOutQueue {
 public:
-  MeasuredCommOutQueue(int size) : CommOutQueue(size), push_time(0) {}
+  MeasuredCommOutQueue(int size) : CommOutQueue(size), push_time(0), pop_time(0) {}
 
-  bool push_back(const std::string& line);
+  bool push_back(const std::string& line) override;
+  std::string pop() override;
 
+  std::unordered_map<unsigned long, PerfCounter> msg_perf;
+  PerfCounter perf;
   double push_time;
+  double pop_time;
 };

--- a/model/include/model/comm_out_queue.h
+++ b/model/include/model/comm_out_queue.h
@@ -1,0 +1,54 @@
+#include  <mutex>
+#include  <string>
+#include  <vector>
+
+/**
+ *  Queue of NMEA0183 messages which only holds a limited amount
+ *  of each message type.
+ */
+class CommOutQueue {
+public:
+
+  /** Insert line of NMEA0183 data in buffer. */
+  virtual void push_back(const std::string& line);
+
+  /** Return copy of next line to send, throws exception if empty. */
+  std::string pop();
+
+  /** Return number of lines in queue. */
+  int size() const;
+
+  /**
+   * Create a buffer which stores at most message_count items of each
+   * message.
+   */
+  CommOutQueue(int message_count);
+
+  CommOutQueue() : CommOutQueue(1) {}
+
+  // Disable copying and assignment
+  CommOutQueue(const CommOutQueue& other) = delete;
+  CommOutQueue& operator=(const CommOutQueue&) = delete;
+
+
+protected:
+  struct BufferItem {
+    long type;
+    std::string line;
+    BufferItem(const std::string& line);
+    BufferItem(const BufferItem& other);
+  };
+
+  std::vector<BufferItem> m_buffer;
+  mutable std::mutex m_mutex;
+  int m_size;
+};
+
+/** A  CommOutQueue limited to one message of each kind. */
+class CommOutQueueSingle : public CommOutQueue {
+public:
+  CommOutQueueSingle() : CommOutQueue(1) {}
+
+  /** Insert line of NMEA0183 data in buffer. */
+  void push_back(const std::string& line);
+};

--- a/model/include/model/config_vars.h
+++ b/model/include/model/config_vars.h
@@ -46,6 +46,7 @@ extern bool g_bShowWptName;
 extern bool g_bUserIconsFirst;
 extern bool g_btouch;
 extern bool g_bUseWptScaMin;
+extern bool g_drop_comm_overruns;
 extern bool g_persist_active_route;
 
 extern double g_n_arrival_circle_radius;

--- a/model/include/model/conn_params.h
+++ b/model/include/model/conn_params.h
@@ -124,11 +124,12 @@ public:
   std::string GetStrippedDSPort();
   NavAddr::Bus GetCommProtocol();
 
-  bool SentencePassesFilter(const wxString& sentence, FilterDirection direction);
-
+  bool SentencePassesFilter(const wxString& sentence,
+                            FilterDirection direction);
   bool Valid;
-  bool b_IsSetup;
   bool drop_overruns;
+  bool b_IsSetup;
+  std::string m_dump_stats_path;  // Used by DumpStats() in driver
   wxWindow* m_optionsPanel;   // A ConnectionParamsPanel.
 
 private:

--- a/model/include/model/conn_params.h
+++ b/model/include/model/conn_params.h
@@ -40,7 +40,6 @@
 #include "model/comm_navmsg.h"
 
 class ConnectionParams;
-class ConnectionsDialog;
 
 typedef enum {
   SERIAL = 0,
@@ -71,8 +70,6 @@ typedef enum {
 
 #define CONN_ENABLE_ID 47621
 
-
-class ConnectionParamsPanel;
 
 class ConnectionParams {
 public:
@@ -132,7 +129,7 @@ public:
   bool Valid;
   bool b_IsSetup;
   bool drop_overruns;
-  ConnectionParamsPanel *m_optionsPanel;
+  wxWindow* m_optionsPanel;   // A ConnectionParamsPanel.
 
 private:
   wxString FilterTypeToStr(ListType type, FilterDirection dir) const;

--- a/model/include/model/conn_params.h
+++ b/model/include/model/conn_params.h
@@ -131,6 +131,7 @@ public:
 
   bool Valid;
   bool b_IsSetup;
+  bool drop_overruns;
   ConnectionParamsPanel *m_optionsPanel;
 
 private:

--- a/model/include/model/dbus_client.h
+++ b/model/include/model/dbus_client.h
@@ -42,6 +42,8 @@ public:
   LocalApiResult SendQuit();
 
   LocalApiResult GetRestEndpoint();
+
+  LocalApiResult SendDumpStats();
 };
 
 #endif  // DBUS_LOCAL_API_H__

--- a/model/include/model/dbus_server.h
+++ b/model/include/model/dbus_server.h
@@ -60,6 +60,10 @@ static const gchar introspection_xml[] = R"""(
       <annotation name='org.gtk.GDBus.Annotation' value='OnMethod'/>
       <!-- In the GUI case, raise application to top. -->
     </method>
+    <method name='DumpStats'>
+      <annotation name='org.gtk.GDBus.Annotation' value='OnMethod'/>
+      <!-- Dump debugging stats  -->
+    </method>
     <method name='Open'>
       <annotation name='org.gtk.GDBus.Annotation' value='OnMethod'/>
       <arg type='s' name='level' direction='in'/>

--- a/model/include/model/ipc_api.h
+++ b/model/include/model/ipc_api.h
@@ -58,6 +58,7 @@ public:
   LocalApiResult SendOpen(const char* path);
   LocalApiResult SendQuit();
   LocalApiResult GetRestEndpoint();
+  LocalApiResult SendDumpStats();
   wxConnectionBase* OnMakeConnection() { return new IpcClientConnection; }
 
 private:
@@ -164,6 +165,10 @@ public:
 
   LocalApiResult GetRestEndpoint() {
     return LocalApiResult(false, "get_rest_endpoint command not implemented");
+  }
+
+  LocalApiResult SendDumpStats() {
+    return LocalApiResult(false, "dump_stats command not implemented");
   }
 
   wxConnectionBase* OnMakeConnection() {

--- a/model/include/model/local_api.h
+++ b/model/include/model/local_api.h
@@ -30,6 +30,7 @@
  *   - Quit: Exit server application.
  *   - GetRestEndpoint: Returns an address/port tuple string like
  *     128.0.0.1/1503 giving the adress/port used by the REST server.
+ *   - DumpStats: Dump debugging info
  *
  * Besides GetRestAddress all commands returns a std::pair with a boolean and
  * a string. The boolean indicates successful completion, the string is either
@@ -45,7 +46,8 @@
 
 using LocalApiResult = std::pair<bool, std::string>;
 
-enum class CmdlineAction { Raise, Quit, Open, GetRestEndpoint, Fail, Skip };
+enum class CmdlineAction {
+    Raise, Quit, Open, GetRestEndpoint, DumpStats, Fail, Skip };
 
 
 class LocalApiException :  public std::exception {
@@ -73,6 +75,9 @@ public:
 
   /** Notified on the Quit command. */
   EventVar on_quit;
+
+  /** Notified on the DumpStats command. */
+  EventVar on_dump_stats;
 
   /** Callback invoked on open command with a file path argument. */
   std::function<bool(const std::string&)> open_file_cb;
@@ -105,6 +110,7 @@ public:
   virtual LocalApiResult SendRaise() = 0;
   virtual LocalApiResult SendOpen(const char* path) = 0;
   virtual LocalApiResult SendQuit() = 0;
+  virtual LocalApiResult SendDumpStats() = 0;
   virtual LocalApiResult GetRestEndpoint() = 0;
 
 protected:

--- a/model/src/base_platform.cpp
+++ b/model/src/base_platform.cpp
@@ -772,6 +772,10 @@ wxSize BasePlatform::getDisplaySize() {
 
 // GetDisplaySizeMM
 double BasePlatform::GetDisplaySizeMM() {
+  if (!dynamic_cast<wxApp*>(wxAppConsole::GetInstance())) {
+      // This is a console app
+      return 250;
+  }
   if(m_displaySizeMMOverride.size() > 0 && m_displaySizeMMOverride[0] > 0) {
     return m_displaySizeMMOverride[0];
   }

--- a/model/src/comm_driver.cpp
+++ b/model/src/comm_driver.cpp
@@ -1,0 +1,56 @@
+/***************************************************************************
+ *
+ * Project:  OpenCPN
+ *
+ ***************************************************************************
+ *   Copyright (C) 2024 Alec Leamas                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+/** \file comm_driver.cpp Common driver code */
+
+// For compilers that support precompilation, includes "wx.h".
+#include <wx/wxprec.h>
+
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif  // precompiled headers
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+#if (defined(__clang_major__) && (__clang_major__ < 15))   // MacOS 10.13
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+#else
+#include <filesystem>
+#include <utility>
+namespace fs = std::filesystem;
+#endif
+
+#include <wx/log.h>
+
+#include "model/comm_driver.h"
+#include "model/base_platform.h"
+
+
+std::string AbstractCommDriver::DumpFilePath() {
+  fs::path path(g_BasePlatform->GetPrivateDataDir().ToStdString());
+  path /= "dump_stats.txt";
+  return path.string();
+}

--- a/model/src/comm_drv_factory.cpp
+++ b/model/src/comm_drv_factory.cpp
@@ -53,8 +53,7 @@
 
 std::shared_ptr<AbstractCommDriver> MakeCommDriver(
     const ConnectionParams* params) {
-  wxLogMessage(
-      wxString::Format(_T("MakeCommDriver: %s"), params->GetDSPort().c_str()));
+  wxLogMessage("MakeCommDriver: %s", params->GetDSPort().c_str());
 
   auto& msgbus = NavMsgBus::GetInstance();
   auto& registry = CommDriverRegistry::GetInstance();

--- a/model/src/comm_drv_factory.cpp
+++ b/model/src/comm_drv_factory.cpp
@@ -45,6 +45,7 @@
 #include "model/comm_drv_n0183_android_bt.h"
 #include "model/comm_navmsg_bus.h"
 #include "model/comm_drv_registry.h"
+#include "model/config_vars.h"
 
 #if defined(__linux__) && !defined(__ANDROID__) && !defined(__WXOSX__)
 #include "model/comm_drv_n2k_socketcan.h"

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -163,7 +163,7 @@ CommDriverN0183Net::CommDriverN0183Net(const ConnectionParams* params,
         // Initiate the const pointer using a lambda call..
         // FIXME (leamas) To be cleaned up once we settled on type of queue
         if (params->drop_overruns)
-          return static_cast<CommOutQueue*>(new MeasuredCommOutQueue(100));
+          return static_cast<CommOutQueue*>(new MeasuredCommOutQueue(12));
         else
           return static_cast<CommOutQueue*>(new DummyCommOutQueue());
       }()))

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -194,6 +194,17 @@ CommDriverN0183Net::~CommDriverN0183Net() {
   Close();
 }
 
+void CommDriverN0183Net::DumpStats() const {
+  auto path = AbstractCommDriver::DumpFilePath();
+  auto queue = dynamic_cast<MeasuredCommOutQueue*>(m_out_queue.get());
+  std::ofstream f(path, std::ios_base::app);
+  if (queue) {
+    f << *queue << "\n";
+  } else {
+    f << "No stats available\n";
+  }
+}
+
 void CommDriverN0183Net::handle_N0183_MSG(CommDriverN0183NetEvent& event) {
   auto p = event.GetPayload();
   std::vector<unsigned char>* payload = p.get();

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -203,7 +203,7 @@ void CommDriverN0183Net::DumpStats() const {
   auto queue = dynamic_cast<MeasuredCommOutQueue*>(m_out_queue.get());
   std::ofstream f(path, std::ios_base::app);
   if (queue) {
-    f << *queue << "\n";
+    f << iface << ": " << *queue << "\n";
   } else {
     f << "No stats available\n";
   }

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -29,6 +29,9 @@
 #include <windows.h>
 #endif
 
+#include <fstream>
+#include <vector>
+
 #ifdef __MSVC__
 #include "winsock2.h"
 #include <wx/msw/winundef.h>
@@ -53,7 +56,6 @@
 #include <netinet/tcp.h>
 #endif
 
-#include <vector>
 #include <wx/socket.h>
 #include <wx/log.h>
 #include <wx/memory.h>

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -64,6 +64,7 @@
 #include <wx/sckaddr.h>
 
 #include "model/comm_drv_n0183_net.h"
+#include "model/comm_drv_registry.h"
 #include "model/comm_navmsg_bus.h"
 #include "model/garmin_protocol_mgr.h"
 #include "model/idents.h"
@@ -186,6 +187,9 @@ CommDriverN0183Net::CommDriverN0183Net(const ConnectionParams* params,
   // Establish the power events response
   resume_listener.Init(SystemEvents::GetInstance().evt_resume,
                        [&](ObservedEvt&) { HandleResume(); });
+  dump_stats_lstnr.Init(CommDriverRegistry::GetInstance().evt_dump_stats,
+                        [&](ObservedEvt&) { DumpStats(); });
+
   Open();
 }
 

--- a/model/src/comm_drv_n0183_serial.cpp
+++ b/model/src/comm_drv_n0183_serial.cpp
@@ -242,6 +242,17 @@ CommDriverN0183Serial::CommDriverN0183Serial(const ConnectionParams* params,
 
 CommDriverN0183Serial::~CommDriverN0183Serial() { Close(); }
 
+void CommDriverN0183Serial::DumpStats() const {
+  auto path = AbstractCommDriver::DumpFilePath();
+  auto queue = dynamic_cast<MeasuredCommOutQueue*>(m_out_queue.get());
+  std::ofstream f(path, std::ios_base::app);
+  if (queue) {
+    f << *queue << "\n";
+  } else {
+    f << "No stats available\n";
+  }
+}
+
 bool CommDriverN0183Serial::Open() {
   wxString comx;
   comx = m_params.GetDSPort().AfterFirst(':');  // strip "Serial:"

--- a/model/src/comm_drv_n0183_serial.cpp
+++ b/model/src/comm_drv_n0183_serial.cpp
@@ -47,6 +47,7 @@
 #include "model/comm_drv_registry.h"
 #include "model/sys_events.h"
 #include "model/wait_continue.h"
+
 #include "observable.h"
 
 #ifndef __ANDROID__
@@ -236,6 +237,8 @@ CommDriverN0183Serial::CommDriverN0183Serial(const ConnectionParams* params,
   // Prepare the wxEventHandler to accept events from the actual hardware thread
   Bind(wxEVT_COMMDRIVER_N0183_SERIAL, &CommDriverN0183Serial::handle_N0183_MSG,
        this);
+  m_dump_stats_lstnr.Init(CommDriverRegistry::GetInstance().evt_dump_stats,
+                          [&](ObservedEvt&) { DumpStats(); });
 
   Open();
 }

--- a/model/src/comm_drv_n0183_serial.cpp
+++ b/model/src/comm_drv_n0183_serial.cpp
@@ -250,7 +250,7 @@ void CommDriverN0183Serial::DumpStats() const {
   auto queue = dynamic_cast<MeasuredCommOutQueue*>(m_out_queue.get());
   std::ofstream f(path, std::ios_base::app);
   if (queue) {
-    f << *queue << "\n";
+    f << iface << ": " << *queue << "\n";
   } else {
     f << "No stats available\n";
   }

--- a/model/src/comm_drv_n0183_serial.cpp
+++ b/model/src/comm_drv_n0183_serial.cpp
@@ -226,7 +226,7 @@ CommDriverN0183Serial::CommDriverN0183Serial(const ConnectionParams* params,
         // Initiate the const pointer using a lambda call..
         // FIXME (leamas) To be cleaned up once we settled on type of queue
         if (params->drop_overruns)
-          return static_cast<CommOutQueue*>(new MeasuredCommOutQueue(100));
+          return static_cast<CommOutQueue*>(new MeasuredCommOutQueue(12));
         else
           return static_cast<CommOutQueue*>(new DummyCommOutQueue());
       }())) {

--- a/model/src/comm_n0183_output.cpp
+++ b/model/src/comm_n0183_output.cpp
@@ -190,6 +190,7 @@ std::shared_ptr<AbstractCommDriver> CreateOutputConnection(
     cp.Baudrate = baud;
     //cp.Garmin = bGarmin;
     cp.IOSelect = DS_TYPE_OUTPUT;
+    cp.drop_overruns = g_drop_comm_overruns;
 
     driver = MakeCommDriver(&cp);
     btempStream = true;
@@ -252,6 +253,7 @@ std::shared_ptr<AbstractCommDriver> CreateOutputConnection(
       ConnectionParams.NetProtocol = PROTO_UNDEFINED;
       ConnectionParams.Baudrate = 0;
 
+      ConnectionParams.drop_overruns = g_drop_comm_overruns;
       driver = MakeCommDriver(&ConnectionParams);
 
       btempStream = true;
@@ -276,6 +278,7 @@ std::shared_ptr<AbstractCommDriver> CreateOutputConnection(
       cp.NetworkAddress = address;
       cp.NetworkPort = port;
       cp.IOSelect = DS_TYPE_INPUT_OUTPUT;
+      cp.drop_overruns = g_drop_comm_overruns;
 
       driver = MakeCommDriver(&cp);
       btempStream = true;

--- a/model/src/comm_out_queue.cpp
+++ b/model/src/comm_out_queue.cpp
@@ -13,19 +13,38 @@ static const uint64_t kFirstFiveBytes = 0x000000ffffffffff;
 static const uint64_t kFirstFiveBytes = 0xffffffffff000000;
 #endif
 
+#define PUBX 190459303248 //"PUBX,"
+#define STALK 323401897043 //"STALK"
 
-/** Return bytes 1..5 in line as an uint64_t. */
+/** Return bytes 1..5 in line as an uint64_t with esceptions for u-blox GNSS and converted Seatalk.
+ * Note: Some vendor extension messages also do not have 5 character talker ID + message ID, but 6 (PMGNST, PRWIZCH, PSMDST).
+ * This is probably not critical as the last character seems to not be making any difference in producing a uinique ID for the messages commonly seen.
+*/
 static inline uint64_t GetNmeaType(const std::string& line) {
-  uint64_t result = *reinterpret_cast<const uint64_t*>(&line[1]);
-  result &= kFirstFiveBytes;
-  return result;
+  size_t skipchars = 1;
+  if (line[0] == 0x5c) { //Starts with the tag block '\', we need to skip it and then also the start delimiter
+    skipchars = line.find(',', 1);
+    if(skipchars == std::string::npos) {
+      skipchars = 1; // This should never happen, there is no end of the tag block, but just in case...
+    }
+  }
+  uint64_t result = *reinterpret_cast<const uint64_t*>(&line[skipchars]);
+  uint64_t result5 = result & kFirstFiveBytes;
+  if(result5 == PUBX || result5 == STALK) {
+    /* PUBX from possibly high-speed u-blox GNSS receivers that are sure to overload slow connections has a 2 digit zero-padded numerical message ID in the first field
+       Similar with STALK, the two digit Seatalk message ID is in the first field
+       Both fit nicely into 8 bytes though... */
+    return result;
+  } else {
+    return result5;
+  }
 }
 
 CommOutQueue::BufferItem::BufferItem(const std::string& _line)
-    : type(GetNmeaType(_line)), line(_line) {}
+    : type(GetNmeaType(_line)), line(_line), ts(std::chrono::steady_clock::now()) {}
 
 CommOutQueue::BufferItem::BufferItem(const BufferItem& other)
-    : type(other.type), line(other.line) {}
+    : type(other.type), line(other.line), ts(std::chrono::steady_clock::now()) {}
 
 CommOutQueue::CommOutQueue(int size) : m_size(size - 1) {
   assert(size >= 1 && "Illegal buffer size");
@@ -83,13 +102,36 @@ bool CommOutQueueSingle::push_back(const std::string& line) {
 
 bool MeasuredCommOutQueue::push_back(const std::string& line) {
   using std::chrono::duration;
-  using std::chrono::high_resolution_clock;
+  using std::chrono::steady_clock;
 
-  auto t1 = high_resolution_clock::now();
+  auto t1 = steady_clock::now();
   bool ok = CommOutQueue::push_back(line);
-  auto t2 = high_resolution_clock::now();
+  msg_perf[GetNmeaType(line)].in(line.size(), ok);
+  perf.in(line.size(), ok);
+  auto t2 = steady_clock::now();
   duration<double, std::micro> us_time = t2 - t1;
 
   push_time = 0.95 * push_time + 0.05 * us_time.count();  // LP filter.
   return ok;
+}
+
+std::string  MeasuredCommOutQueue::pop() {
+  using std::chrono::duration;
+  using std::chrono::steady_clock;
+
+  auto t1 = steady_clock::now();
+  //auto msg = CommOutQueue::pop(); // We need to update the perf counters, can't just pop() here
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (m_buffer.size() <= 0)
+    throw std::underflow_error("Attempt to pop() from empty buffer");
+  auto item = m_buffer.back();
+  m_buffer.pop_back();
+  perf.out(item.line.size(), item.ts);
+  msg_perf[item.type].out(item.line.size(), item.ts);
+  auto t2 = steady_clock::now();
+  duration<double, std::micro>us_time = t2 - t1;
+  us_time = t2 - t1;
+
+  pop_time = 0.95 * pop_time + 0.05 * us_time.count();  // LP filter.
+  return item.line;
 }

--- a/model/src/comm_out_queue.cpp
+++ b/model/src/comm_out_queue.cpp
@@ -145,3 +145,35 @@ std::string MeasuredCommOutQueue::pop() {
   pop_time = 0.95 * pop_time + 0.05 * us_time.count();  // LP filter.
   return item.line;
 }
+
+std::ostream& operator<<(std::ostream& os, const MeasuredCommOutQueue& q) {
+  os << "{";
+  os << "push_time: " << q.push_time << ", ";
+  os << "pop_time: " << q.pop_time << ", ";
+  os << "perf: " << q.perf << ", ";
+  os << "msg_perf: [";
+  for (const auto& kv : q.msg_perf) {
+    os << kv.first << ": " << kv.second << ", ";
+  }
+  os << "]";
+  os << "}";
+  return os;
+};
+
+std::ostream& operator<<(std::ostream& os, const PerfCounter& pc) {
+  os << "{";
+  os << "msgs_in: " << pc.msgs_in << ", ";
+  os << "msgs_out: " << pc.msgs_out << ", ";
+  os << "bytes_in: " << pc.bytes_in << ", ";
+  os << "bytes_out: " << pc.bytes_out << ", ";
+  os << "bps_in: " << pc.bps_in << ", ";
+  os << "mps_in: " << pc.mps_in << ", ";
+  os << "bps_out: " << pc.bps_out << ", ";
+  os << "mps_out: " << pc.mps_out << ", ";
+  os << "in_out_delay_us: " << pc.in_out_delay_us << ", ";
+  os << "overflow_msgs: " << pc.overflow_msgs << ", ";
+  os << "in_queue: " << pc.in_queue;
+  os << "}";
+  return os;
+};
+

--- a/model/src/comm_out_queue.cpp
+++ b/model/src/comm_out_queue.cpp
@@ -1,0 +1,65 @@
+#include  <algorithm>
+#include  <cassert>
+#include  <vector>
+
+#include "model/comm_out_queue.h"
+
+static long GetNmeaType(const std::string& line) {
+  auto id = line.substr(1, 6);
+  for (int i = 0; i < 6; i += 1) id[i] &= 127;
+  return id[0] * id[1] * id[2] * id[3] * id[4] * id[5];
+}
+
+CommOutQueue::CommOutQueue(int size) : m_size(size - 1) {
+  assert(size >=1 && "Illegal buffer size");
+}
+
+void CommOutQueue::push_back(const std::string& line) {
+  BufferItem item(line);
+  auto match = [item] (const BufferItem& it) { return it.type == item.type; };
+  std::lock_guard<std::mutex> lock(m_mutex);
+  int found = std::count_if(m_buffer.begin(), m_buffer.end(), match);
+  if (found > m_size) {
+    // overflow: too many of these kind of messages
+    // are still not processed. Drop so we keep m_size of them.
+    int matches = 0;
+    auto match_cnt = [&] (const BufferItem& it) {
+        return it.type == item.type && matches++ >= m_size; };
+    m_buffer.erase(std::remove_if(m_buffer.begin(), m_buffer.end(), match_cnt),
+                   m_buffer.end());
+  }
+  m_buffer.push_back(item);
+  return;
+}
+
+CommOutQueue::BufferItem::BufferItem(const std::string& _line)
+    : type(GetNmeaType(_line)), line(_line) {}
+
+CommOutQueue::BufferItem::BufferItem(const BufferItem& other)
+    : type(other.type), line(other.line) {}
+
+std::string CommOutQueue::pop() {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  auto item = m_buffer[0];
+  m_buffer.erase(m_buffer.begin());
+  return item.line;
+}
+
+int CommOutQueue::size() const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_buffer.size();
+}
+
+void CommOutQueueSingle::push_back(const std::string& line) {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  BufferItem item(line);
+  auto match = [&item](const BufferItem& it) { return it.type == item.type; };
+  auto found = std::find_if(m_buffer.begin(), m_buffer.end(), match);
+  if (found != m_buffer.end()) {
+    // overflow: this kind of message is still not processed. Drop it
+    m_buffer.erase(std::remove_if(found, m_buffer.end(), match),
+                   m_buffer.end());
+  }
+  m_buffer.push_back(item);
+  return;
+}

--- a/model/src/comm_out_queue.cpp
+++ b/model/src/comm_out_queue.cpp
@@ -1,35 +1,18 @@
-#include  <algorithm>
-#include  <cassert>
-#include  <vector>
+#include <algorithm>
+#include <cassert>
+#include <stdexcept>
 
 #include "model/comm_out_queue.h"
 
-static long GetNmeaType(const std::string& line) {
-  auto id = line.substr(1, 6);
-  for (int i = 0; i < 6; i += 1) id[i] &= 127;
-  return id[0] * id[1] * id[2] * id[3] * id[4] * id[5];
+static inline unsigned long ShiftChar(unsigned char ch, int shift) {
+  return static_cast<unsigned long>(ch) << shift;
 }
 
-CommOutQueue::CommOutQueue(int size) : m_size(size - 1) {
-  assert(size >=1 && "Illegal buffer size");
-}
-
-void CommOutQueue::push_back(const std::string& line) {
-  BufferItem item(line);
-  auto match = [item] (const BufferItem& it) { return it.type == item.type; };
-  std::lock_guard<std::mutex> lock(m_mutex);
-  int found = std::count_if(m_buffer.begin(), m_buffer.end(), match);
-  if (found > m_size) {
-    // overflow: too many of these kind of messages
-    // are still not processed. Drop so we keep m_size of them.
-    int matches = 0;
-    auto match_cnt = [&] (const BufferItem& it) {
-        return it.type == item.type && matches++ >= m_size; };
-    m_buffer.erase(std::remove_if(m_buffer.begin(), m_buffer.end(), match_cnt),
-                   m_buffer.end());
-  }
-  m_buffer.push_back(item);
-  return;
+static unsigned long GetNmeaType(const std::string& line) {
+  auto id = line.substr(1, 5);
+  unsigned long result = 0;
+  for (int i = 5; i >= 0; i--) result += ShiftChar(id[i], i * 8);
+  return result;
 }
 
 CommOutQueue::BufferItem::BufferItem(const std::string& _line)
@@ -38,10 +21,36 @@ CommOutQueue::BufferItem::BufferItem(const std::string& _line)
 CommOutQueue::BufferItem::BufferItem(const BufferItem& other)
     : type(other.type), line(other.line) {}
 
+CommOutQueue::CommOutQueue(int size) : m_size(size - 1) {
+  assert(size >= 1 && "Illegal buffer size");
+}
+
+bool CommOutQueue::push_back(const std::string& line) {
+  if (line.size() < 7 ) return false;
+  BufferItem item(line);
+  auto match = [item](const BufferItem& it) { return it.type == item.type; };
+  std::lock_guard<std::mutex> lock(m_mutex);
+  int found = std::count_if(m_buffer.begin(), m_buffer.end(), match);
+  if (found > m_size) {
+    // overflow: too many of these kind of messages
+    // are still not processed. Drop so we keep m_size of them.
+    int matches = 0;
+    auto match_cnt = [&](const BufferItem& it) {
+      return it.type == item.type && matches++ >= m_size;
+    };
+    m_buffer.erase(std::remove_if(m_buffer.begin(), m_buffer.end(), match_cnt),
+                   m_buffer.end());
+  }
+  m_buffer.insert(m_buffer.begin(), item);
+  return true;
+}
+
 std::string CommOutQueue::pop() {
   std::lock_guard<std::mutex> lock(m_mutex);
-  auto item = m_buffer[0];
-  m_buffer.erase(m_buffer.begin());
+  if (m_buffer.size() <= 0)
+    throw std::underflow_error("Attempt to pop() from empty buffer");
+  auto item = m_buffer.back();
+  m_buffer.pop_back();
   return item.line;
 }
 
@@ -50,10 +59,12 @@ int CommOutQueue::size() const {
   return m_buffer.size();
 }
 
-void CommOutQueueSingle::push_back(const std::string& line) {
-  std::lock_guard<std::mutex> lock(m_mutex);
+bool CommOutQueueSingle::push_back(const std::string& line) {
+  if (line.size() < 7 ) return false;
   BufferItem item(line);
   auto match = [&item](const BufferItem& it) { return it.type == item.type; };
+
+  std::lock_guard<std::mutex> lock(m_mutex);
   auto found = std::find_if(m_buffer.begin(), m_buffer.end(), match);
   if (found != m_buffer.end()) {
     // overflow: this kind of message is still not processed. Drop it
@@ -61,5 +72,18 @@ void CommOutQueueSingle::push_back(const std::string& line) {
                    m_buffer.end());
   }
   m_buffer.push_back(item);
-  return;
+  return true;
+}
+
+bool MeasuredCommOutQueue::push_back(const std::string& line) {
+  using std::chrono::duration;
+  using std::chrono::high_resolution_clock;
+
+  auto t1 = high_resolution_clock::now();
+  bool ok = CommOutQueue::push_back(line);
+  auto t2 = high_resolution_clock::now();
+  duration<double, std::micro> us_time = t2 - t1;
+
+  push_time = 0.95 * push_time + 0.05 * us_time.count();  // LP filter.
+  return ok;
 }

--- a/model/src/config_vars.cpp
+++ b/model/src/config_vars.cpp
@@ -41,6 +41,7 @@ bool g_bShowTrue = false;
 bool g_bTrackDaily = false;
 bool g_bUseWptScaMin = false;
 bool g_bWplUsePosition = false;
+bool g_drop_comm_overruns = false;
 bool g_persist_active_route = false;
 
 double g_n_arrival_circle_radius = 0.0;

--- a/model/src/conn_params.cpp
+++ b/model/src/conn_params.cpp
@@ -110,7 +110,10 @@ void ConnectionParams::Deserialize(const wxString &configStr) {
     DisableEcho = wxAtoi(prms[22]);
   }
   if (prms.Count() >= 24) {
-    AuthToken = prms[22];
+    AuthToken = prms[23];
+  }
+  if (prms.Count() >= 25) {
+    drop_overruns = wxAtoi(prms[24]);
   }
 }
 
@@ -126,13 +129,12 @@ wxString ConnectionParams::Serialize() const {
     ostcs.Append(OutputSentenceList[i]);
   }
   wxString ret = wxString::Format(
-      _T("%d;%d;%s;%d;%d;%s;%d;%d;%d;%d;%s;%d;%s;%d;%d;%d;%d;%d;%s;%d;%s;%d;%d;%s"), Type,
+      "%d;%d;%s;%d;%d;%s;%d;%d;%d;%d;%s;%d;%s;%d;%d;%d;%d;%d;%s;%d;%s;%d;%d;%s;%d", Type,
       NetProtocol, NetworkAddress.c_str(), NetworkPort, Protocol, Port.c_str(),
       Baudrate, ChecksumCheck, IOSelect, InputSentenceListType, istcs.c_str(),
       OutputSentenceListType, ostcs.c_str(), Priority, Garmin, GarminUpload,
       FurunoGP3X, bEnabled, UserComment.c_str(), AutoSKDiscover, socketCAN_port.c_str(),
-      NoDataReconnect, DisableEcho, AuthToken.c_str());
-
+      NoDataReconnect, DisableEcho, AuthToken.c_str(), drop_overruns);
   return ret;
 }
 
@@ -159,6 +161,7 @@ ConnectionParams::ConnectionParams() {
   NoDataReconnect = false;
   DisableEcho = false;
   AuthToken = wxEmptyString;
+  drop_overruns = false;
 }
 
 ConnectionParams::~ConnectionParams() {

--- a/model/src/dbus_client.cpp
+++ b/model/src/dbus_client.cpp
@@ -60,6 +60,27 @@ LocalApiResult DbusLocalClient::SendRaise() {
   return LocalApiResult(ok, message);
 }
 
+LocalApiResult DbusLocalClient::SendDumpStats() {
+  auto proxy = GetProxy();
+  if (!proxy) return LocalApiResult(false, "Cannot create proxy");
+  GError* error = 0;
+  GVariant* result = g_dbus_proxy_call_sync (proxy,
+                                             "DumpStats",
+                                             0 /* parameters */,
+                                             G_DBUS_CALL_FLAGS_NONE,
+                                             -1 /* timeout msec */,
+                                             0 /* cancellable */,
+                                             &error);
+  const std::string message(error ? error->message : "");
+  bool ok(error == 0 && g_variant_is_container(result)
+          && g_variant_n_children(result) == 0);
+  if (error) g_clear_error(&error);
+  g_variant_unref(result);
+  g_object_unref(proxy);
+  return LocalApiResult(ok, message);
+}
+
+
 LocalApiResult DbusLocalClient::SendQuit() {
   auto proxy = GetProxy();
   if (!proxy) return LocalApiResult(false, "Cannot create proxy");

--- a/model/src/dbus_server.cpp
+++ b/model/src/dbus_server.cpp
@@ -91,6 +91,9 @@ static void HandleMethodCall(GDBusConnection*, const gchar* /* sender */,
   } else if (0 == g_strcmp0(method_name, "Raise")) {
     if (ctx) ctx->handler->on_raise.Notify();
     g_dbus_method_invocation_return_value(invocation, 0);
+  } else if (0 == g_strcmp0(method_name, "DumpStats")) {
+    if (ctx) ctx->handler->on_dump_stats.Notify();
+    g_dbus_method_invocation_return_value(invocation, 0);
   } else if (0 == g_strcmp0(method_name, "Quit")) {
     if (ctx) ctx->handler->on_quit.Notify();
     g_dbus_method_invocation_return_value(invocation, 0);

--- a/model/src/ipc_api.cpp
+++ b/model/src/ipc_api.cpp
@@ -51,6 +51,13 @@ LocalApiResult IpcClient::SendQuit() {
   }
 }
 
+LocalApiResult IpcClient::SendDumpStats() {
+  if (connection->Execute(wxString("dump_stats"))) {
+    return LocalApiResult(true, "");
+  } else {
+    return LocalApiResult(false, "Server error running dump_stats command");
+  }
+}
 
 LocalApiResult IpcClient::SendRaise() {
   if (connection->Execute(wxString("raise"))) {
@@ -94,6 +101,9 @@ bool IpcConnection::OnExec(const wxString&, const wxString& data) {
     return true;
   } else if (data == "raise") {
     server.on_raise.Notify();
+    return true;
+  } else if (data == "dump_stats") {
+    server.on_dump_stats.Notify();
     return true;
   } else {
     return false;

--- a/model/src/local_api.cpp
+++ b/model/src/local_api.cpp
@@ -86,6 +86,15 @@ LocalApiResult LocalClientApi::HandleCmdline(CmdlineAction action,
           return result;
         }
         break;
+    case CmdlineAction::DumpStats: {
+          auto result = SendDumpStats();
+          if (!result.first) {
+            MESSAGE_LOG << "Error running remote dump_stats cmd: "
+                        << result.second;
+          }
+          return result;
+        }
+        break;
     case CmdlineAction::Open: {
           auto result = SendOpen(arg.c_str());
           if (!result.first) {

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -136,6 +136,8 @@ set(BUF_TEST_SRC
   buffer_tests.cpp
   ${MODEL_SRC_DIR}/cmdline.cpp
   ${MODEL_SRC_DIR}/config_vars.cpp
+  ${MODEL_SRC_DIR}/comm_drv_registry.cpp
+  ${MODEL_SRC_DIR}/comm_navmsg.cpp
   ${MODEL_SRC_DIR}/comm_out_queue.cpp
   ${MODEL_SRC_DIR}/ocpn_utils.cpp
   ${MODEL_SRC_DIR}/base_platform.cpp

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -149,6 +149,9 @@ target_include_directories(buffer_tests PRIVATE
   ${CMAKE_SOURCE_DIR}/include
   ${CMAKE_SOURCE_DIR}/resources
 )
+target_compile_definitions(
+  buffer_tests PUBLIC TESTDATA="${CMAKE_CURRENT_LIST_DIR}/testdata"
+)
 
 if (LINUX)
   add_executable(dbus_tests

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -132,6 +132,24 @@ if (HAVE_LIBUDEV)
   target_link_libraries(tests PRIVATE ocpn::libudev)
 endif ()
 
+add_executable(buffer_tests
+  buffer_tests.cpp
+  ${MODEL_SRC_DIR}/cmdline.cpp
+  ${MODEL_SRC_DIR}/config_vars.cpp
+  ${MODEL_SRC_DIR}/comm_out_queue.cpp
+  ${MODEL_SRC_DIR}/ocpn_utils.cpp
+  ${MODEL_SRC_DIR}/base_platform.cpp
+  ${MODEL_SRC_DIR}/logger.cpp
+)
+target_link_libraries(buffer_tests PRIVATE observable::observable)
+target_link_libraries(buffer_tests PRIVATE ${wxWidgets_LIBRARIES})
+target_link_libraries(buffer_tests PRIVATE ocpn::gtest)
+target_include_directories(buffer_tests PRIVATE
+  ${CMAKE_SOURCE_DIR}/model/include
+  ${CMAKE_SOURCE_DIR}/include
+  ${CMAKE_SOURCE_DIR}/resources
+)
+
 if (LINUX)
   add_executable(dbus_tests
     dbus_tests.cpp
@@ -198,6 +216,7 @@ endif ()
 target_link_libraries(tests PRIVATE ocpn::gtest)
 include(GoogleTest)
 gtest_add_tests(TARGET tests)
+gtest_add_tests(TARGET buffer_tests)
 if (LINUX AND NOT DEFINED ENV{FLATPAK_ID})
   gtest_add_tests(TARGET ipc-srv-tests)
   # We don't have a session bus available when testing flatpak

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -132,7 +132,7 @@ if (HAVE_LIBUDEV)
   target_link_libraries(tests PRIVATE ocpn::libudev)
 endif ()
 
-add_executable(buffer_tests
+set(BUF_TEST_SRC
   buffer_tests.cpp
   ${MODEL_SRC_DIR}/cmdline.cpp
   ${MODEL_SRC_DIR}/config_vars.cpp
@@ -140,10 +140,27 @@ add_executable(buffer_tests
   ${MODEL_SRC_DIR}/ocpn_utils.cpp
   ${MODEL_SRC_DIR}/base_platform.cpp
   ${MODEL_SRC_DIR}/logger.cpp
+  ${MODEL_SRC_DIR}/ocpn_plugin.cpp
+  ${CMAKE_SOURCE_DIR}/cli/api_shim.cpp
 )
+
+if (APPLE)
+  list(APPEND BUF_TEST_SRC ${MODEL_SRC_DIR}/macutils.c)
+endif ()
+
+add_executable(buffer_tests ${BUF_TEST_SRC})
+
 target_link_libraries(buffer_tests PRIVATE observable::observable)
 target_link_libraries(buffer_tests PRIVATE ${wxWidgets_LIBRARIES})
 target_link_libraries(buffer_tests PRIVATE ocpn::gtest)
+if (MSVC)
+  target_link_libraries(buffer_tests PRIVATE setupapi.lib)
+endif ()
+if (APPLE)
+target_link_libraries(buffer_tests PRIVATE ocpn::filesystem)
+endif ()
+
+
 target_include_directories(buffer_tests PRIVATE
   ${CMAKE_SOURCE_DIR}/model/include
   ${CMAKE_SOURCE_DIR}/include

--- a/test/buffer_tests.cpp
+++ b/test/buffer_tests.cpp
@@ -1,0 +1,41 @@
+#include "config.h"
+
+#include <chrono>
+
+#include <gtest/gtest.h>
+
+#include "model/base_platform.h"
+#include "model/comm_out_queue.h"
+#include "model/logger.h"
+#include "model/ocpn_utils.h"
+
+using namespace std::literals::chrono_literals;
+
+static bool bool_result0;
+static std::string s_result;
+
+static const char* const GPGGA = "$GPGGA 00";
+static const char* const GPGGL = "$GPGGL 00";
+
+TEST(Buffer, Single) {
+  CommOutQueueSingle queue;
+  for (int i = 0; i < 10; i++) queue.push_back(GPGGA);
+  EXPECT_EQ(queue.size(), 1);
+  EXPECT_EQ(queue.pop(), GPGGA);
+  EXPECT_EQ(queue.size(), 0);
+}
+
+TEST(Buffer, Size_3 ) {
+  CommOutQueue queue(3);
+  for (int i = 0; i < 100; i++) queue.push_back(GPGGA);
+  EXPECT_EQ(queue.size(), 3);
+  for (int i = 0; i < 3; i++) queue.push_back(GPGGL);
+  EXPECT_EQ(queue.size(), 6);
+  EXPECT_EQ(queue.pop(), GPGGA);
+  EXPECT_EQ(queue.pop(), GPGGA);
+  EXPECT_EQ(queue.pop(), GPGGA);
+  EXPECT_EQ(queue.pop(), GPGGL);
+  EXPECT_EQ(queue.pop(), GPGGL);
+  EXPECT_EQ(queue.pop(), GPGGL);
+  EXPECT_EQ(queue.size(), 0);
+}

--- a/test/buffer_tests.cpp
+++ b/test/buffer_tests.cpp
@@ -1,6 +1,17 @@
 #include "config.h"
 
 #include <chrono>
+#include <fstream>
+#include <string>
+
+#if (defined(__clang_major__) && (__clang_major__ < 15))   // MacOS 1.13
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+#else
+#include <filesystem>
+#include <utility>
+namespace fs = std::filesystem;
+#endif
 
 #include <gtest/gtest.h>
 
@@ -23,19 +34,50 @@ TEST(Buffer, Single) {
   EXPECT_EQ(queue.size(), 1);
   EXPECT_EQ(queue.pop(), GPGGA);
   EXPECT_EQ(queue.size(), 0);
+  EXPECT_THROW({ queue.pop(); }, std::underflow_error);
+  EXPECT_FALSE(queue.push_back("foo"));
 }
 
 TEST(Buffer, Size_3 ) {
   CommOutQueue queue(3);
-  for (int i = 0; i < 100; i++) queue.push_back(GPGGA);
+
+  for (int i = 0; i < 20; i++) queue.push_back(GPGGL);
   EXPECT_EQ(queue.size(), 3);
-  for (int i = 0; i < 3; i++) queue.push_back(GPGGL);
+
+  std::string line(GPGGA);
+  for (int i = 0; i < 100; i++) {
+    std::string line(GPGGA);
+    ocpn::replace(line, "00", std::to_string(i));
+    queue.push_back(line);
+  }
   EXPECT_EQ(queue.size(), 6);
-  EXPECT_EQ(queue.pop(), GPGGA);
-  EXPECT_EQ(queue.pop(), GPGGA);
-  EXPECT_EQ(queue.pop(), GPGGA);
+
   EXPECT_EQ(queue.pop(), GPGGL);
   EXPECT_EQ(queue.pop(), GPGGL);
   EXPECT_EQ(queue.pop(), GPGGL);
+  EXPECT_EQ(queue.pop(), "$GPGGA 97");
+  EXPECT_EQ(queue.pop(), "$GPGGA 98");
+  EXPECT_EQ(queue.pop(), "$GPGGA 99");
   EXPECT_EQ(queue.size(), 0);
+  EXPECT_THROW({ queue.pop(); }, std::underflow_error);
+}
+
+TEST(Buffer, Hakefjord) {
+  const auto path = fs::path(TESTDATA) / "Hakefjord.log";
+  std::ifstream stream(path.string());
+  MeasuredCommOutQueue queue(3);
+  for (std::string line; std::getline(stream, line); ) {
+    queue.push_back(line);
+  }
+  RecordProperty("buffer size", std::to_string(queue.size()));
+  for (int i = 0; i < 3; i++) queue.push_back(GPGGA);
+  std::string line;
+  do { line = queue.pop(); } while (!ocpn::startswith(line, "$GPGGA"));
+  EXPECT_EQ(line, GPGGA);
+  do { line = queue.pop(); } while (!ocpn::startswith(line, "$GPGGA"));
+  EXPECT_EQ(line, GPGGA);
+  do { line = queue.pop(); } while (!ocpn::startswith(line, "$GPGGA"));
+  EXPECT_EQ(line, GPGGA) ;
+  RecordProperty("push_time", std::to_string(queue.push_time));
+  // writes to test_detail.xml if invoked with --gtest_output.xml
 }

--- a/test/buffer_tests.cpp
+++ b/test/buffer_tests.cpp
@@ -118,6 +118,9 @@ TEST(Buffer, RateLimit1) {
   EXPECT_EQ(queue.size(), 20);
 }
 
+#ifndef __APPLE__
+// The MacOS builders seems to have a lot of "too" long sleeps.
+// Disable for now.
 TEST(Buffer, RateLimit2) {
   CommOutQueue queue(20, 5ms);
   for (int i = 0; i < 20; i++) {
@@ -127,6 +130,7 @@ TEST(Buffer, RateLimit2) {
   EXPECT_EQ(queue.size(), 1);
   // might fail due to OS gitter i. e., sleep takes "too" long
 }
+#endif
 
 TEST(Buffer, RateAndSizeLimit) {
   CommOutQueue queue(10, 1ms);

--- a/test/buffer_tests.cpp
+++ b/test/buffer_tests.cpp
@@ -122,7 +122,7 @@ TEST(Buffer, RateLimit2) {
   CommOutQueue queue(20, 5ms);
   for (int i = 0; i < 20; i++) {
     queue.push_back(GPGGL);
-    std::this_thread::sleep_for(4ms);
+    std::this_thread::sleep_for(2ms);
   }
   EXPECT_EQ(queue.size(), 1);
   // might fail due to OS gitter i. e., sleep takes "too" long


### PR DESCRIPTION
Add some input buffering to handle overruns if data cannot be consumed fast enough for whatever reason. This is basically as discussed in #3391: if there are multiple messages of the same kind in the buffer, use the latest.

EDIT: This adds a single "EXPERIMENTAL: Drop input overruns" checkbox which enables/disables the buffering logic. This is thought as a testing aid, to be removed if/when we decide on the buffer strategy. It is certainly not a nice thing to throw in the face of unwary new users.

