### PR TITLE
Serial driver: Fix high load problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -756,6 +756,7 @@ set(GUI_HDRS
     ${GUI_HDR_DIR}/chcanv.h
     ${GUI_HDR_DIR}/ChInfoWin.h
     ${GUI_HDR_DIR}/color_handler.h
+    ${GUI_HDR_DIR}/comm_overflow_dlg.h
     ${GUI_HDR_DIR}/compass.h
     ${GUI_HDR_DIR}/concanv.h
     ${GUI_HDR_DIR}/ConfigMgr.h
@@ -877,6 +878,7 @@ set(GUI_SRC
     ${GUI_SRC_DIR}/ChInfoWin.cpp
     ${GUI_SRC_DIR}/cm93.cpp
     ${GUI_SRC_DIR}/color_handler.cpp
+    ${GUI_SRC_DIR}/comm_overflow_dlg.cpp
     ${GUI_SRC_DIR}/compass.cpp
     ${GUI_SRC_DIR}/concanv.cpp
     ${GUI_SRC_DIR}/ConfigMgr.cpp

--- a/cmake/in-files/config.h.in
+++ b/cmake/in-files/config.h.in
@@ -45,6 +45,7 @@
 #cmakedefine HAVE_SYS_TYPES_H
 #cmakedefine HAVE_SYS_FCNTL_H
 #cmakedefine HAVE_SYS_IOCTL_H
+#cmakedefine OCPN_DISTRO_BUILD
 
 // The os compatible plugins are are built for
 #define PKG_TARGET "${PKG_TARGET}"

--- a/gui/include/gui/comm_overflow_dlg.h
+++ b/gui/include/gui/comm_overflow_dlg.h
@@ -1,0 +1,38 @@
+/***************************************************************************
+ *   Copyright (C) 2024 Alec Leamas                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+/** \file  comm_oveflow_dlg.h Popup dialog on communication overflows. */
+
+#ifndef COMM_OVERFLOW_DLG_H__
+#define COMM_OVERFLOW_DLG_H__
+
+#include "observable.h"
+
+class CommOverflowDlg {
+public:
+  CommOverflowDlg(wxWindow* parent);
+
+private:
+  void ShowDialog(const std::string& msg);
+
+  ObsListener m_listener;
+  wxWindow* m_parent;
+};
+
+#endif  // COMM_OVERFLOW_DLG_H__

--- a/gui/include/gui/ocpn_frame.h
+++ b/gui/include/gui/ocpn_frame.h
@@ -37,6 +37,7 @@
 #include "model/ocpn_types.h"
 #include "model/comm_appmsg_bus.h"
 #include "bbox.h"
+#include "comm_overflow_dlg.h"
 #include "color_handler.h"
 #include "gui_lib.h"
 #include "load_errors_dlg.h"
@@ -405,6 +406,8 @@ private:
   ObsListener m_on_raise_listener;
   ObsListener m_on_quit_listener;
   ObsListener m_routes_update_listener;
+
+  CommOverflowDlg comm_overflow_dlg;
 
   DECLARE_EVENT_TABLE()
 };

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -8833,7 +8833,8 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
       if (b_start_rollover)
         m_RolloverPopupTimer.Start(m_rollover_popup_timer_msec,
                                    wxTIMER_ONE_SHOT);
-      Route *tail = 0, *current;
+      Route *tail = 0;
+      Route *current = 0;
       bool appending = false;
       bool inserting = false;
       int connect = 0;

--- a/gui/src/comm_overflow_dlg.cpp
+++ b/gui/src/comm_overflow_dlg.cpp
@@ -1,0 +1,54 @@
+/***************************************************************************
+ *   Copyright (C) 2024 Alec Leamas                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+/** \file  comm_oveflow_dlg.cpp Implement comm_oveflow_dlg.cpp.h. */
+
+#include <cassert>
+
+#include <wx/window.h>
+
+#include "comm_overflow_dlg.h"
+#include "gui_lib.h"
+
+#include "model/comm_drv_registry.h"
+
+static const char* const kMessage =
+    _(R"---(Communication overflow detected, the system is not able to process
+all input. This is not fatal, system will continue to work but
+will have to discard some input data.
+
+It is possible to control the data discarded using filtering,
+see the manual.
+
+Please review the logfile for more info on discarded messages.
+)---");
+
+static const char* const kCaption = _("Communication overflow");
+
+CommOverflowDlg::CommOverflowDlg(wxWindow* parent) : m_parent(parent) {
+  assert(parent && "Null parent window");
+  auto action = [&](ObservedEvt& evt) {
+    ShowDialog(evt.GetString().ToStdString());
+  };
+  m_listener.Init(CommDriverRegistry::GetInstance().evt_comm_overrun, action);
+}
+
+void CommOverflowDlg::ShowDialog(const std::string& msg) {
+  OCPNMessageBox(m_parent, kMessage, kCaption, wxICON_INFORMATION);
+}

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -630,8 +630,9 @@ static void onBellsFinishedCB(void *ptr) {
 // My frame constructor
 MyFrame::MyFrame(wxFrame *frame, const wxString &title, const wxPoint &pos,
                  const wxSize &size, long style)
-    : wxFrame(frame, -1, title, pos, size, style, kTopLevelWindowName)
-      {
+    : wxFrame(frame, -1, title, pos, size, style, kTopLevelWindowName),
+      comm_overflow_dlg(this) {
+
   g_current_monitor = wxDisplay::GetFromWindow(this);
 #ifdef __WXOSX__
   // On retina displays there is a difference between the physical size of the OpenGL canvas and the DIP

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -3405,7 +3405,7 @@ void options::CreatePanel_VectorCharts(size_t parent, int border_size,
     optionsColumn->Add(new wxStaticText(ps57Ctl, wxID_ANY, ""),
                        labelFlags);
     pCheck_SuperSCAMIN = new wxCheckBox(ps57Ctl, ID_SUPERSCAMINCHECKBOX,
-                                   _("Additonal detail reduction at Small Scale"));
+                                   _("Additional detail reduction at Small Scale"));
     pCheck_SuperSCAMIN->SetValue(FALSE);
     optionsColumn->Add(pCheck_SuperSCAMIN, inputFlags);
 
@@ -3593,7 +3593,7 @@ void options::CreatePanel_VectorCharts(size_t parent, int border_size,
     optionsColumn->Add(new wxStaticText(ps57Ctl, wxID_ANY, ""),
                        labelFlags);
     pCheck_SuperSCAMIN = new wxCheckBox(ps57Ctl, ID_SUPERSCAMINCHECKBOX,
-                                   _("Additonal detail reduction at Small Scale"));
+                                   _("Additional detail reduction at Small Scale"));
     pCheck_SuperSCAMIN->SetValue(FALSE);
     optionsColumn->Add(pCheck_SuperSCAMIN, inputFlags);
 

--- a/gui/src/udev_rule_mgr.cpp
+++ b/gui/src/udev_rule_mgr.cpp
@@ -313,7 +313,7 @@ public:
   DongleRuleDialog(wxWindow* parent)
       : wxDialog(parent, wxID_ANY, _("Manage dongle udev rule")) {
     auto sizer = new wxBoxSizer(wxVERTICAL);
-    auto flags = wxSizerFlags().Expand();
+    auto flags = wxSizerFlags().Expand().Border();
     std::string intro(DONGLE_INTRO);
     if (getenv("FLATPAK_ID")) {
       intro += FLATPAK_INTRO_TRAILER;

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -59,6 +59,7 @@ set(
   ${MODEL_HDR_DIR}/comm_n0183_output.h
   ${MODEL_HDR_DIR}/comm_navmsg_bus.h
   ${MODEL_HDR_DIR}/comm_navmsg.h
+  ${MODEL_HDR_DIR}/comm_out_queue.h
   ${MODEL_HDR_DIR}/comm_util.h
   ${MODEL_HDR_DIR}/comm_vars.h
   ${MODEL_HDR_DIR}/config_vars.h
@@ -134,6 +135,7 @@ set(SRC
   ${MODEL_SRC_DIR}/comm_bridge.cpp
   ${MODEL_SRC_DIR}/comm_can_util.cpp
   ${MODEL_SRC_DIR}/comm_decoder.cpp
+  #${MODEL_SRC_DIR}/comm_driver.cpp
   ${MODEL_SRC_DIR}/comm_drv_factory.cpp
   ${MODEL_SRC_DIR}/comm_drv_file.cpp
   ${MODEL_SRC_DIR}/comm_drv_n0183.cpp
@@ -149,6 +151,7 @@ set(SRC
   ${MODEL_SRC_DIR}/comm_navmsg_bus.cpp
   ${MODEL_SRC_DIR}/comm_navmsg.cpp
   ${MODEL_SRC_DIR}/comm_navmsg.cpp
+  ${MODEL_SRC_DIR}/comm_out_queue.cpp
   ${MODEL_SRC_DIR}/comm_util.cpp
   ${MODEL_SRC_DIR}/comm_vars.cpp
   ${MODEL_SRC_DIR}/config_vars.cpp

--- a/model/include/model/comm_drv_n0183_serial.h
+++ b/model/include/model/comm_drv_n0183_serial.h
@@ -1,10 +1,4 @@
-/***************************************************************************
- *
- * Project:  OpenCPN
- * Purpose:
- * Author:   David Register, Alec Leamas
- *
- ***************************************************************************
+ /**************************************************************************
  *   Copyright (C) 2022 by David Register, Alec Leamas                     *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -22,6 +16,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
+
+/** \file comm_drv_n0183_serial.h  NMEA0183 serial driver */
 
 #ifndef _COMMDRIVERN0183SERIAL_H
 #define _COMMDRIVERN0183SERIAL_H

--- a/model/include/model/comm_drv_n0183_serial.h
+++ b/model/include/model/comm_drv_n0183_serial.h
@@ -28,6 +28,7 @@
 #include <wx/event.h>
 
 #include "model/comm_drv_n0183.h"
+#include "model/comm_out_queue.h"
 #include "model/conn_params.h"
 #include "model/garmin_protocol_mgr.h"
 
@@ -101,6 +102,9 @@ private:
 
   ConnectionParams m_params;
   DriverListener& m_listener;
+
+  std::unique_ptr<CommOutQueue> m_out_queue;
+
   void handle_N0183_MSG(CommDriverN0183SerialEvent& event);
 };
 

--- a/model/include/model/comm_drv_n0183_serial.h
+++ b/model/include/model/comm_drv_n0183_serial.h
@@ -67,18 +67,18 @@ public:
   //    Secondary thread life toggle
   //    Used to inform launching object (this) to determine if the thread can
   //    be safely called or polled, e.g. wxThread->Destroy();
-  void SetSecThreadActive(void) { m_bsec_thread_active = true; }
-  void SetSecThreadInActive(void) { m_bsec_thread_active = false; }
-  bool IsSecThreadActive() const { return m_bsec_thread_active; }
+  void SetSecThreadActive(void) { m_sec_thread_active = true; }
+  void SetSecThreadInActive(void) { m_sec_thread_active = false; }
+  bool IsSecThreadActive() const { return m_sec_thread_active; }
 
   bool IsGarminThreadActive();
   void StopGarminUSBIOThread(bool bPause);
 
   void SetSecondaryThread(CommDriverN0183SerialThread* secondary_Thread) {
-    m_pSecondary_Thread = secondary_Thread;
+    m_secondary_thread = secondary_Thread;
   }
   CommDriverN0183SerialThread* GetSecondaryThread() {
-    return m_pSecondary_Thread;
+    return m_secondary_thread;
   }
   void SetThreadRunFlag(int run) { m_Thread_run_flag = run; }
 
@@ -90,15 +90,15 @@ public:
                    std::shared_ptr<const NavAddr> addr) override;
 
 private:
-  bool m_bok;
+  bool m_ok;
   std::string m_portstring;
-  std::string m_BaudRate;
+  std::string m_baudrate;
   int m_handshake;
 
-  CommDriverN0183SerialThread* m_pSecondary_Thread;
-  bool m_bsec_thread_active;
+  CommDriverN0183SerialThread* m_secondary_thread;
+  bool m_sec_thread_active;
 
-  GarminProtocolHandler *m_GarminHandler;
+  GarminProtocolHandler * m_garmin_handler;
 
   ConnectionParams m_params;
   DriverListener& m_listener;

--- a/model/include/model/comm_drv_registry.h
+++ b/model/include/model/comm_drv_registry.h
@@ -56,6 +56,12 @@ public:
   /** Notified by all driverlist updates. */
   EventVar evt_driverlist_change;
 
+  /** Notified when receiving --remote --dump_stat on local API. */
+  EventVar evt_dump_stats;
+
+  /** Notified with a printable message on first detected overrun. */
+  EventVar evt_comm_overrun;
+
   /**
    *  Notified for messages from drivers. The generated event contains:
    *  - A wxLogLevel stored as an int.

--- a/model/include/model/comm_out_queue.h
+++ b/model/include/model/comm_out_queue.h
@@ -1,0 +1,206 @@
+#ifndef COMM__OUT_QUEUE_H__
+#define COMM__OUT_QUEUE_H__
+
+#include <chrono>
+#include <cstdint>
+#include <mutex>
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+using namespace std::literals::chrono_literals;
+
+class PerfCounter {
+public:
+  PerfCounter()
+      : msgs_in(0),
+        msgs_out(0),
+        bytes_in(0),
+        bytes_out(0),
+        bps_in(0),
+        mps_in(0),
+        bps_out(0),
+        mps_out(0),
+        in_out_delay_us(0),
+        overflow_msgs(0),
+        in_queue(0) {}
+
+  void in(const size_t bytes, bool ok) {
+    auto t1 = std::chrono::steady_clock::now();
+    std::chrono::duration<double, std::micro> us_time = t1 - last_in;
+    bps_in = 0.95 * bps_in + 0.05 * bytes * 1000000 / us_time.count();
+    mps_in = 0.95 * bps_in + 0.05 * 1000000 / us_time.count();
+    msgs_in++;
+    bytes_in += bytes;
+    last_in = t1;
+    if (!ok) {
+      overflow_msgs++;
+    }
+    in_queue++;
+  }
+
+  void out(const size_t bytes,
+           std::chrono::time_point<std::chrono::steady_clock> in_ts) {
+    auto t1 = std::chrono::steady_clock::now();
+    std::chrono::duration<double, std::micro> us_time = t1 - last_in;
+    bps_out = 0.95 * bps_out + 0.05 * bytes * 1000000 / us_time.count();
+    mps_out = 0.95 * bps_out + 0.05 * 1000000 / us_time.count();
+    us_time = t1 - in_ts;
+    in_out_delay_us = 0.95 * in_out_delay_us + 0.05 * us_time.count();
+    msgs_out++;
+    bytes_out += bytes;
+    last_out = t1;
+    in_queue--;
+  }
+
+  size_t msgs_in;
+  size_t msgs_out;
+  size_t bytes_in;
+  size_t bytes_out;
+  uint32_t bps_in;
+  double mps_in;
+  uint32_t bps_out;
+  double mps_out;
+  size_t in_out_delay_us;
+  size_t overflow_msgs;
+  size_t in_queue;
+  std::chrono::time_point<std::chrono::steady_clock> last_in;
+  std::chrono::time_point<std::chrono::steady_clock> last_out;
+};
+
+std::ostream& operator<<(std::ostream& os, const PerfCounter& pc);
+
+/**
+ *  Queue of NMEA0183 messages which only holds a limited amount
+ *  of each message type.
+ */
+class CommOutQueue {
+public:
+
+  /**
+   * Insert valid line of NMEA0183 data in buffer.
+   * @return false on errors including invalid input, else true.
+   */
+  virtual bool push_back(const std::string& line);
+
+  /**
+   * Return  next line to send and remove it from buffer,
+   * throws exception if empty.
+   */
+  virtual std::string pop();
+
+  /** Return number of lines in queue. */
+  virtual int size() const;
+
+  /**
+   * Create a buffer which stores at most max_buffered items of each
+   * message, applying rate limits if messages are entered "too" fast
+   *
+   * @param max_buffered Max number of messages of a type kept in buffer
+   *                     without discarding data as overrun.
+   * @param min_msg_gap  minimum time between two messages of the same
+   *                     type without applying rate limits.
+   */
+  CommOutQueue(unsigned max_buffered,
+               std::chrono::duration<unsigned, std::milli> min_msg_gap);
+  /**
+   * Create a buffer which stores at most max_buffered items of each
+   * message
+   */
+  CommOutQueue(unsigned max_buffered) : CommOutQueue(max_buffered, 0ms) {}
+
+  /**
+   * Default buffer, allows 10 buffered messages of each type, applies
+   * rate limits when repeated with less than 600 ms intervals
+   */
+  CommOutQueue() : CommOutQueue(12) {}
+
+  // Disable copying and assignment
+  CommOutQueue(const CommOutQueue& other) = delete;
+  CommOutQueue& operator=(const CommOutQueue&) = delete;
+
+  virtual ~CommOutQueue() = default;
+
+protected:
+  struct BufferItem {
+    uint64_t type;
+    std::string line;
+    BufferItem(const std::string& line);
+    BufferItem(const BufferItem& other);
+    std::chrono::time_point<std::chrono::steady_clock> stamp;
+  };
+
+  std::vector<BufferItem> m_buffer;
+  mutable std::mutex m_mutex;
+  int m_size;
+  using duration_ms = std::chrono::duration<unsigned, std::milli>;
+  duration_ms m_min_msg_gap;
+  bool m_overrun_reported;
+  std::set<uint64_t> m_rate_limits_logged;;
+};
+
+/** A  CommOutQueue limited to one message of each kind. */
+class CommOutQueueSingle : public CommOutQueue {
+public:
+  CommOutQueueSingle() : CommOutQueue(1, 0ms) {}
+
+  /** Insert line of NMEA0183 data in buffer. */
+  bool push_back(const std::string& line) override;
+};
+
+/** Add unit test measurements to CommOutQueue. */
+
+class MeasuredCommOutQueue : public CommOutQueue {
+public:
+  MeasuredCommOutQueue(unsigned max_buffered,
+                       std::chrono::duration<unsigned, std::milli> min_msg_gap)
+      : CommOutQueue(max_buffered, min_msg_gap), push_time(0), pop_time(0) {}
+
+  MeasuredCommOutQueue(unsigned max_buffered)
+      : MeasuredCommOutQueue(max_buffered, 0ms) {}
+
+  bool push_back(const std::string& line) override;
+
+  std::string pop() override;
+
+  std::unordered_map<unsigned long, PerfCounter> msg_perf;
+
+  PerfCounter perf;
+  double push_time;
+  double pop_time;
+};
+
+/** Simple FIFO queue without added logic. */
+class DummyCommOutQueue :  public CommOutQueue {
+public:
+  DummyCommOutQueue() {};
+
+  bool push_back(const std::string& line) override {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    buff.insert(buff.begin(), line);
+    return true;
+  }
+
+  std::string pop() override {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (buff.size() <= 0)
+      throw std::underflow_error("Attempt to pop() from empty buffer");
+    auto line = buff.back();
+    buff.pop_back();
+    return line;
+  }
+
+  int size() const override {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return buff.size();
+  }
+
+private:
+  mutable std::mutex m_mutex;
+  std::vector<std::string> buff;
+};
+
+std::ostream& operator<<(std::ostream& os, const MeasuredCommOutQueue& q);
+
+#endif  //  COMM__OUT_QUEUE_H__

--- a/model/src/comm_drv_n0183_serial.cpp
+++ b/model/src/comm_drv_n0183_serial.cpp
@@ -1,10 +1,4 @@
-/***************************************************************************
- *
- * Project:  OpenCPN
- * Purpose:  Implement comm_drv_n0183_serial.h -- serial Nmea 0183 driver.
- * Author:   David Register, Alec Leamas
- *
- ***************************************************************************
+ /**************************************************************************
  *   Copyright (C) 2022 by David Register, Alec Leamas                     *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -22,6 +16,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
+
+ /** \file comm_drv_n0183_serial.cpp  Implement comm_drv_n0183_serial.h */
 
 // For compilers that support precompilation, includes "wx.h".
 #include <wx/wxprec.h>
@@ -138,8 +134,8 @@ private:
   void ThreadMessage(const wxString& msg);
   bool OpenComPortPhysical(const wxString& com_name, int baud_rate);
   void CloseComPortPhysical();
-  size_t WriteComPortPhysical(char* msg);
-  size_t WriteComPortPhysical(const wxString& string);
+  ssize_t WriteComPortPhysical(char* msg);
+  ssize_t WriteComPortPhysical(const wxString& string);
 
   CommDriverN0183Serial* m_pParentDriver;
   wxString m_PortName;
@@ -480,7 +476,7 @@ void CommDriverN0183SerialThread::ThreadMessage(const wxString& msg) {
   //   if (gFrame) gFrame->GetEventHandler()->AddPendingEvent(event);
 }
 
-size_t CommDriverN0183SerialThread::WriteComPortPhysical(char* msg) {
+ssize_t CommDriverN0183SerialThread::WriteComPortPhysical(char* msg) {
   if (m_serial.isOpen()) {
     ssize_t status;
     try {
@@ -610,8 +606,7 @@ void* CommDriverN0183SerialThread::Entry() {
       strncpy(msg, qmsg, MAX_OUT_QUEUE_MESSAGE_LENGTH - 1);
       free(qmsg);
 
-      if (static_cast<size_t>(-1) == WriteComPortPhysical(msg) &&
-          10 < retries++) {
+      if (-1 == WriteComPortPhysical(msg) && 10 < retries++) {
         // We failed to write the port 10 times, let's close the port so that
         // the reconnection logic kicks in and tries to fix our connection.
         retries = 0;

--- a/model/src/comm_drv_n0183_serial.cpp
+++ b/model/src/comm_drv_n0183_serial.cpp
@@ -1,4 +1,4 @@
- /**************************************************************************
+/**************************************************************************
  *   Copyright (C) 2022 by David Register, Alec Leamas                     *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -17,7 +17,7 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 
- /** \file comm_drv_n0183_serial.cpp  Implement comm_drv_n0183_serial.h */
+/** \file comm_drv_n0183_serial.cpp  Implement comm_drv_n0183_serial.h */
 
 // For compilers that support precompilation, includes "wx.h".
 #include <wx/wxprec.h>
@@ -94,27 +94,31 @@ private:
   mutable std::mutex m_mutex;
 };
 
-#define OUT_QUEUE_LENGTH                20
-#define MAX_OUT_QUEUE_MESSAGE_LENGTH    100
+#define OUT_QUEUE_LENGTH 20
+#define MAX_OUT_QUEUE_MESSAGE_LENGTH 100
 
 wxDEFINE_EVENT(wxEVT_COMMDRIVER_N0183_SERIAL, CommDriverN0183SerialEvent);
 
-CommDriverN0183SerialEvent::CommDriverN0183SerialEvent( wxEventType commandType, int id = 0)
-      : wxEvent(id, commandType){};
+CommDriverN0183SerialEvent::CommDriverN0183SerialEvent(wxEventType commandType,
+                                                       int id = 0)
+    : wxEvent(id, commandType){};
 
 CommDriverN0183SerialEvent::~CommDriverN0183SerialEvent(){};
 
-void CommDriverN0183SerialEvent::SetPayload(std::shared_ptr<std::vector<unsigned char>> data) {
-    m_payload = data;
+void CommDriverN0183SerialEvent::SetPayload(
+    std::shared_ptr<std::vector<unsigned char>> data) {
+  m_payload = data;
 }
-std::shared_ptr<std::vector<unsigned char>> CommDriverN0183SerialEvent::GetPayload() { return m_payload; }
+std::shared_ptr<std::vector<unsigned char>>
+CommDriverN0183SerialEvent::GetPayload() {
+  return m_payload;
+}
 
-  // required for sending with wxPostEvent()
+// required for sending with wxPostEvent()
 wxEvent* CommDriverN0183SerialEvent::Clone() const {
-    CommDriverN0183SerialEvent* newevent =
-        new CommDriverN0183SerialEvent(*this);
-    newevent->m_payload = this->m_payload;
-    return newevent;
+  CommDriverN0183SerialEvent* newevent = new CommDriverN0183SerialEvent(*this);
+  newevent->m_payload = this->m_payload;
+  return newevent;
 };
 
 #ifndef __ANDROID__
@@ -228,24 +232,21 @@ CommDriverN0183Serial::~CommDriverN0183Serial() { Close(); }
 bool CommDriverN0183Serial::Open() {
   wxString comx;
   comx = m_params.GetDSPort().AfterFirst(':');  // strip "Serial:"
-  if (comx.IsEmpty())
-    return false;
+  if (comx.IsEmpty()) return false;
 
   wxString port_uc = m_params.GetDSPort().Upper();
 
-  if( (wxNOT_FOUND != port_uc.Find(_T("USB"))) && (wxNOT_FOUND != port_uc.Find(_T("GARMIN"))) ) {
-    m_GarminHandler = new GarminProtocolHandler( comx, this,  true);
-  }
-  else if( m_params.Garmin ) {
-    m_GarminHandler = new GarminProtocolHandler( comx, this,  false);
-  }
-  else {
-
+  if ((wxNOT_FOUND != port_uc.Find(_T("USB"))) &&
+      (wxNOT_FOUND != port_uc.Find(_T("GARMIN")))) {
+    m_GarminHandler = new GarminProtocolHandler(comx, this, true);
+  } else if (m_params.Garmin) {
+    m_GarminHandler = new GarminProtocolHandler(comx, this, false);
+  } else {
     // strip off any description provided by Windows
     comx = comx.BeforeFirst(' ');
 
 #ifndef __ANDROID__
-   //    Kick off the  RX thread
+    //    Kick off the  RX thread
     SetSecondaryThread(new CommDriverN0183SerialThread(this, comx, m_BaudRate));
     SetThreadRunFlag(1);
     std::thread t(&CommDriverN0183SerialThread::Entry, GetSecondaryThread());
@@ -267,13 +268,12 @@ void CommDriverN0183Serial::Close() {
   // the secondary thread may not stop quickly enough.
   // It can then crash trying to send an event to its "parent".
 
-  Unbind(wxEVT_COMMDRIVER_N0183_SERIAL, &CommDriverN0183Serial::handle_N0183_MSG,
-       this);
+  Unbind(wxEVT_COMMDRIVER_N0183_SERIAL,
+         &CommDriverN0183Serial::handle_N0183_MSG, this);
 
 #ifndef __ANDROID__
   //    Kill off the Secondary RX Thread if alive
   if (m_pSecondary_Thread) {
-
     if (m_bsec_thread_active)  // Try to be sure thread object is still alive
     {
       wxLogMessage(_T("Stopping Secondary Thread"));
@@ -308,11 +308,10 @@ void CommDriverN0183Serial::Close() {
   comx = m_params.GetDSPort().AfterFirst(':');  // strip "Serial:"
   androidStopUSBSerial(comx);
 #endif
-
 }
 
 bool CommDriverN0183Serial::IsGarminThreadActive() {
-  if (m_GarminHandler){
+  if (m_GarminHandler) {
     // TODO expand for serial
 #ifdef __WXMSW__
     if (m_GarminHandler->m_usb_handle != INVALID_HANDLE_VALUE)
@@ -325,12 +324,11 @@ bool CommDriverN0183Serial::IsGarminThreadActive() {
   return false;
 }
 
-void CommDriverN0183Serial::StopGarminUSBIOThread(bool b_pause){
-  if (m_GarminHandler){
+void CommDriverN0183Serial::StopGarminUSBIOThread(bool b_pause) {
+  if (m_GarminHandler) {
     m_GarminHandler->StopIOThread(b_pause);
   }
 }
-
 
 void CommDriverN0183Serial::Activate() {
   CommDriverRegistry::GetInstance().Activate(shared_from_this());
@@ -339,48 +337,39 @@ void CommDriverN0183Serial::Activate() {
 
 bool CommDriverN0183Serial::SendMessage(std::shared_ptr<const NavMsg> msg,
                                         std::shared_ptr<const NavAddr> addr) {
-
   auto msg_0183 = std::dynamic_pointer_cast<const Nmea0183Msg>(msg);
   wxString sentence(msg_0183->payload.c_str());
 
 #ifdef __ANDROID__
-    wxString payload = sentence;
-    if( !sentence.EndsWith(_T("\r\n")) )
-        payload += _T("\r\n");
+  wxString payload = sentence;
+  if (!sentence.EndsWith(_T("\r\n"))) payload += _T("\r\n");
 
-
-    wxString port = m_params.GetStrippedDSPort(); //GetPort().AfterFirst(':');
-    androidWriteSerial( port, payload );
-    return true;
+  wxString port = m_params.GetStrippedDSPort();  // GetPort().AfterFirst(':');
+  androidWriteSerial(port, payload);
+  return true;
 #else
-    if( GetSecondaryThread() ) {
-        if( IsSecThreadActive() )
-        {
-            int retry = 10;
-            while( retry ) {
-                if( GetSecondaryThread()->SetOutMsg( sentence ))
-                    return true;
-                else
-                    retry--;
-            }
-            return false;   // could not send after several tries....
-        }
+  if (GetSecondaryThread()) {
+    if (IsSecThreadActive()) {
+      int retry = 10;
+      while (retry) {
+        if (GetSecondaryThread()->SetOutMsg(sentence))
+          return true;
         else
-            return false;
-    }
-    return true;
+          retry--;
+      }
+      return false;  // could not send after several tries....
+    } else
+      return false;
+  }
+  return true;
 #endif
 }
 
-
-
 void CommDriverN0183Serial::handle_N0183_MSG(
     CommDriverN0183SerialEvent& event) {
-
   // Is this an output-only port?
   // Commonly used for "Send to GPS" function
-  if (m_params.IOSelect == DS_TYPE_OUTPUT)
-    return;
+  if (m_params.IOSelect == DS_TYPE_OUTPUT) return;
 
   auto p = event.GetPayload();
   std::vector<unsigned char>* payload = p.get();
@@ -406,7 +395,6 @@ void CommDriverN0183Serial::handle_N0183_MSG(
   }
 }
 
-
 #ifndef __ANDROID__
 #define DS_RX_BUFFER_SIZE 4096
 
@@ -422,9 +410,9 @@ CommDriverN0183SerialThread::CommDriverN0183SerialThread(
   long lbaud;
   if (strBaudRate.ToLong(&lbaud)) m_baud = (int)lbaud;
   resume_listener.Init(SystemEvents::GetInstance().evt_resume,
-                       [&](ObservedEvt&) {device_waiter.Continue(); });
+                       [&](ObservedEvt&) { device_waiter.Continue(); });
   new_device_listener.Init(SystemEvents::GetInstance().evt_dev_change,
-                           [&](ObservedEvt&) {device_waiter.Continue(); });
+                           [&](ObservedEvt&) { device_waiter.Continue(); });
 }
 
 CommDriverN0183SerialThread::~CommDriverN0183SerialThread(void) {}
@@ -454,19 +442,18 @@ void CommDriverN0183SerialThread::CloseComPortPhysical() {
   }
 }
 
-bool CommDriverN0183SerialThread::SetOutMsg(const wxString &msg)
-{
-  if(out_que.size() < OUT_QUEUE_LENGTH){
+bool CommDriverN0183SerialThread::SetOutMsg(const wxString& msg) {
+  if (out_que.size() < OUT_QUEUE_LENGTH) {
     wxCharBuffer buf = msg.ToUTF8();
-    if(buf.data()){
-      char *qmsg = (char *)malloc(strlen(buf.data()) +1);
+    if (buf.data()) {
+      char* qmsg = (char*)malloc(strlen(buf.data()) + 1);
       strcpy(qmsg, buf.data());
       out_que.push(qmsg);
       return true;
     }
   }
 
-    return false;
+  return false;
 }
 
 void CommDriverN0183SerialThread::ThreadMessage(const wxString& msg) {
@@ -515,7 +502,7 @@ void* CommDriverN0183SerialThread::Entry() {
   static size_t retries = 0;
 
   while ((not_done) && (m_pParentDriver->m_Thread_run_flag > 0)) {
-    if ( m_pParentDriver->m_Thread_run_flag == 0) goto thread_exit;
+    if (m_pParentDriver->m_Thread_run_flag == 0) goto thread_exit;
 
     uint8_t next_byte = 0;
     unsigned int newdata = 0;
@@ -548,13 +535,12 @@ void* CommDriverN0183SerialThread::Entry() {
     }
 
     if (newdata > 0) {
-      for (unsigned int i = 0; i < newdata; i++)
-        circle.put(rdata[i]);
+      for (unsigned int i = 0; i < newdata; i++) circle.put(rdata[i]);
     }
 
     // Process the queue until empty
     while (!circle.empty()) {
-      if ( m_pParentDriver->m_Thread_run_flag == 0) goto thread_exit;
+      if (m_pParentDriver->m_Thread_run_flag == 0) goto thread_exit;
 
       uint8_t take_byte = circle.get();
       while ((take_byte != 0x0a) && !circle.empty()) {
@@ -562,36 +548,35 @@ void* CommDriverN0183SerialThread::Entry() {
         take_byte = circle.get();
       }
 
-      if (circle.empty() && take_byte != 0x0a){
+      if (circle.empty() && take_byte != 0x0a) {
         tmp_vec.push_back(take_byte);
         break;
       }
 
-      if (take_byte == 0x0a){
+      if (take_byte == 0x0a) {
         tmp_vec.push_back(take_byte);
 
         //    Copy the message into a vector for transmittal upstream
         auto buffer = std::make_shared<std::vector<unsigned char>>();
         std::vector<unsigned char>* vec = buffer.get();
 
-        for (size_t i=0; i < tmp_vec.size() ; i++)
+        for (size_t i = 0; i < tmp_vec.size(); i++)
           vec->push_back(tmp_vec.at(i));
 
-            //    Message is ready to parse and send out
-            //    Messages may be coming in as <blah blah><lf><cr>.
-            //    One example device is KVH1000 heading sensor.
-            //    If that happens, the first character of a new captured message
-            //    will the <cr>, and we need to discard it. This is out of spec,
-            //    but we should handle it anyway
+        //    Message is ready to parse and send out
+        //    Messages may be coming in as <blah blah><lf><cr>.
+        //    One example device is KVH1000 heading sensor.
+        //    If that happens, the first character of a new captured message
+        //    will the <cr>, and we need to discard it. This is out of spec,
+        //    but we should handle it anyway
         if (vec->at(0) == '\r') vec->erase(vec->begin());
 
         CommDriverN0183SerialEvent Nevent(wxEVT_COMMDRIVER_N0183_SERIAL, 0);
         Nevent.SetPayload(buffer);
         m_pParentDriver->AddPendingEvent(Nevent);
         tmp_vec.clear();
-
       }
-    } //while
+    }  // while
 
     //      Check for any pending output message
 
@@ -615,7 +600,7 @@ void* CommDriverN0183SerialThread::Entry() {
 
       b_qdata = !out_que.empty();
     }  // while b_qdata
-  }   // while not done.
+  }    // while not done.
 
 thread_exit:
   CloseComPortPhysical();

--- a/model/src/comm_drv_n0183_serial.cpp
+++ b/model/src/comm_drv_n0183_serial.cpp
@@ -236,8 +236,8 @@ bool CommDriverN0183Serial::Open() {
 
   wxString port_uc = m_params.GetDSPort().Upper();
 
-  if ((wxNOT_FOUND != port_uc.Find(_T("USB"))) &&
-      (wxNOT_FOUND != port_uc.Find(_T("GARMIN")))) {
+  if ((wxNOT_FOUND != port_uc.Find("USB")) &&
+      (wxNOT_FOUND != port_uc.Find("GARMIN"))) {
     m_GarminHandler = new GarminProtocolHandler(comx, this, true);
   } else if (m_params.Garmin) {
     m_GarminHandler = new GarminProtocolHandler(comx, this, false);
@@ -261,7 +261,7 @@ bool CommDriverN0183Serial::Open() {
 
 void CommDriverN0183Serial::Close() {
   wxLogMessage(
-      wxString::Format(_T("Closing NMEA Driver %s"), m_portstring.c_str()));
+      wxString::Format("Closing NMEA Driver %s", m_portstring.c_str()));
 
   // FIXME (dave)
   // If port is opened, and then closed immediately,
@@ -276,7 +276,7 @@ void CommDriverN0183Serial::Close() {
   if (m_pSecondary_Thread) {
     if (m_bsec_thread_active)  // Try to be sure thread object is still alive
     {
-      wxLogMessage(_T("Stopping Secondary Thread"));
+      wxLogMessage("Stopping Secondary Thread");
 
       m_Thread_run_flag = 0;
 
@@ -285,9 +285,9 @@ void CommDriverN0183Serial::Close() {
 
       wxString msg;
       if (m_Thread_run_flag < 0)
-        msg.Printf(_T("Stopped in %d sec."), 10 - tsec);
+        msg.Printf("Stopped in %d sec.", 10 - tsec);
       else
-        msg.Printf(_T("Not Stopped after 10 sec."));
+        msg.Printf("Not Stopped after 10 sec.");
       wxLogMessage(msg);
     }
 
@@ -342,7 +342,7 @@ bool CommDriverN0183Serial::SendMessage(std::shared_ptr<const NavMsg> msg,
 
 #ifdef __ANDROID__
   wxString payload = sentence;
-  if (!sentence.EndsWith(_T("\r\n"))) payload += _T("\r\n");
+  if (!sentence.EndsWith("\r\n")) payload += "\r\n";
 
   wxString port = m_params.GetStrippedDSPort();  // GetPort().AfterFirst(':');
   androidWriteSerial(port, payload);
@@ -404,7 +404,7 @@ CommDriverN0183SerialThread::CommDriverN0183SerialThread(
   m_pParentDriver = Launcher;  // This thread's immediate "parent"
 
   m_PortName = PortName;
-  m_FullPortName = _T("Serial:") + PortName;
+  m_FullPortName = "Serial:" + PortName;
 
   m_baud = 4800;  // default
   long lbaud;
@@ -488,7 +488,7 @@ void* CommDriverN0183SerialThread::Entry() {
 
   //    Request the com port from the comm manager
   if (!OpenComPortPhysical(m_PortName, m_baud)) {
-    wxString msg(_T("NMEA input device open failed: "));
+    wxString msg("NMEA input device open failed: ");
     msg.Append(m_PortName);
     ThreadMessage(msg);
     // goto thread_exit; // This means we will not be trying to connect = The

--- a/model/src/comm_out_queue.cpp
+++ b/model/src/comm_out_queue.cpp
@@ -1,0 +1,217 @@
+#include <algorithm>
+#include <cassert>
+#include <stdexcept>
+
+#include <sys/types.h>
+
+#include "model/comm_drv_registry.h"
+#include "model/comm_out_queue.h"
+#include "model/logger.h"
+
+// Both arm and intel are little endian, but better safe than sorry:
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+static const uint64_t kFirstFiveBytes = 0x000000ffffffffff;
+#else
+static const uint64_t kFirstFiveBytes = 0xffffffffff000000;
+#endif
+
+#define PUBX 190459303248   // "PUBX,"
+#define STALK 323401897043  // "STALK"
+
+
+
+/**
+ * Return bytes 1..5 in line as an uint64_t with exceptions for u-blox GNSS and
+ * converted Seatalk.
+ * Note: Some vendor extension messages also do not have 5
+ * character talker ID + message ID, but 6 (PMGNST, PRWIZCH, PSMDST). This is
+ * probably not critical as the last character seems to not be making any
+ * difference in producing a unique ID for the messages commonly seen.
+ */
+static inline uint64_t GetNmeaType(const std::string& line) {
+  size_t skipchars = 1;
+  if (line[0] == 0x5c) {  // Starts with the tag block '\', we need to skip it
+                          // and then also the start delimiter
+    skipchars = line.find(',', 1);
+    if (skipchars == std::string::npos) {
+      skipchars = 1;  // This should never happen, there is no end of the tag
+                      // block, but just in case...
+    }
+  }
+  uint64_t result = *reinterpret_cast<const uint64_t*>(&line[skipchars]);
+  uint64_t result5 = result & kFirstFiveBytes;
+  if (result5 == PUBX || result5 == STALK) {
+    /* PUBX from possibly high-speed u-blox GNSS receivers that are sure to
+       overload slow connections has a 2 digit zero-padded numerical message ID
+       in the first field Similar with STALK, the two digit Seatalk message ID
+       is in the first field Both fit nicely into 8 bytes though... */
+    return result;
+  } else {
+    return result5;
+  }
+}
+
+static void ReportOverrun(const std::string& msg, bool overrun_reported) {
+  auto& registry = CommDriverRegistry::GetInstance();
+  std::string s;
+  if (msg.length() < 6) s = msg; else s = msg.substr(0, 5);
+  DEBUG_LOG << "CommOutQueue: Overrun on: " << msg;
+  if (!overrun_reported) registry.evt_comm_overrun.Notify(msg);
+}
+
+
+CommOutQueue::BufferItem::BufferItem(const std::string& _line)
+    : type(GetNmeaType(_line)),
+      line(_line),
+      stamp(std::chrono::steady_clock::now()) {}
+
+CommOutQueue::BufferItem::BufferItem(const BufferItem& other)
+    : type(other.type),
+      line(other.line),
+      stamp(std::chrono::steady_clock::now()) {}
+
+using duration_ms = std::chrono::duration<unsigned, std::milli>;
+
+CommOutQueue::CommOutQueue(unsigned max_buffered, duration_ms min_msg_gap)
+    : m_size(max_buffered - 1),
+      m_min_msg_gap(min_msg_gap),
+      m_overrun_reported(false) {
+  assert(max_buffered >= 1 && "Illegal buffer size");
+}
+
+bool CommOutQueue::push_back(const std::string& line) {
+  if (line.size() < 7) return false;
+  BufferItem item(line);
+  auto match = [item](const BufferItem& it) { return it.type == item.type; };
+
+  std::lock_guard<std::mutex> lock(m_mutex);
+  int found = std::count_if(m_buffer.begin(), m_buffer.end(), match);
+  if (found > 0) {
+    auto it = std::find_if(m_buffer.begin(), m_buffer.end(), match);
+    assert(it != m_buffer.end());
+    auto timespan = item.stamp - it->stamp;
+    if (timespan < m_min_msg_gap) {
+      m_buffer.erase(it);
+      if (m_rate_limits_logged.find(item.type) != m_rate_limits_logged.end()) {
+        m_rate_limits_logged.insert(item.type);
+        wxLogMessage("Limiting output rate for %u, message: %s", item.type,
+                     line.c_str());
+      }
+    }
+  }
+  if (found > m_size) {
+    // overflow: too many of these kind of messages
+    // are still not processed. Drop so we keep m_size of them.
+    if (!m_overrun_reported) {
+      ReportOverrun(line, m_overrun_reported);
+      m_overrun_reported = true;
+    }
+    int matches = 0;
+    auto match_cnt = [&](const BufferItem& it) {
+      return it.type == item.type && matches++ >= m_size;
+    };
+    m_buffer.erase(std::remove_if(m_buffer.begin(), m_buffer.end(), match_cnt),
+                   m_buffer.end());
+  }
+  m_buffer.insert(m_buffer.begin(), item);
+  return true;
+}
+
+std::string CommOutQueue::pop() {
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  if (m_buffer.size() <= 0)
+    throw std::underflow_error("Attempt to pop() from empty buffer");
+  auto item = m_buffer.back();
+  m_buffer.pop_back();
+  return item.line;
+}
+
+int CommOutQueue::size() const {
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_buffer.size();
+}
+
+bool CommOutQueueSingle::push_back(const std::string& line) {
+  if (line.size() < 7) return false;
+  BufferItem item(line);
+  auto match = [&item](const BufferItem& it) { return it.type == item.type; };
+
+  std::lock_guard<std::mutex> lock(m_mutex);
+  auto found = std::find_if(m_buffer.begin(), m_buffer.end(), match);
+  if (found != m_buffer.end()) {
+    // overflow: this kind of message is still not processed. Drop it
+    m_buffer.erase(std::remove_if(found, m_buffer.end(), match),
+                   m_buffer.end());
+  }
+  m_buffer.push_back(item);
+  return true;
+}
+
+bool MeasuredCommOutQueue::push_back(const std::string& line) {
+  using std::chrono::duration;
+  using std::chrono::steady_clock;
+
+  auto t1 = steady_clock::now();
+  bool ok = CommOutQueue::push_back(line);
+  msg_perf[GetNmeaType(line)].in(line.size(), ok);
+  perf.in(line.size(), ok);
+  auto t2 = steady_clock::now();
+  duration<double, std::micro> us_time = t2 - t1;
+
+  push_time = 0.95 * push_time + 0.05 * us_time.count();  // LP filter.
+  return ok;
+}
+
+std::string MeasuredCommOutQueue::pop() {
+  using std::chrono::duration;
+  using std::chrono::steady_clock;
+
+  auto t1 = steady_clock::now();
+  // auto msg = CommOutQueue::pop(); // We need to update the perf counters,
+  // can't just pop() here
+  std::lock_guard<std::mutex> lock(m_mutex);
+  if (m_buffer.size() <= 0)
+    throw std::underflow_error("Attempt to pop() from empty buffer");
+  auto item = m_buffer.back();
+  m_buffer.pop_back();
+  perf.out(item.line.size(), item.stamp);
+  msg_perf[item.type].out(item.line.size(), item.stamp);
+  auto t2 = steady_clock::now();
+  duration<double, std::micro> us_time = t2 - t1;
+  us_time = t2 - t1;
+
+  pop_time = 0.95 * pop_time + 0.05 * us_time.count();  // LP filter.
+  return item.line;
+}
+
+std::ostream& operator<<(std::ostream& os, const MeasuredCommOutQueue& q) {
+  os << "{";
+  os << "push_time: " << q.push_time << ", ";
+  os << "pop_time: " << q.pop_time << ", ";
+  os << "perf: " << q.perf << ", ";
+  os << "msg_perf: [";
+  for (const auto& kv : q.msg_perf) {
+    os << kv.first << ": " << kv.second << ", ";
+  }
+  os << "]";
+  os << "}";
+  return os;
+};
+
+std::ostream& operator<<(std::ostream& os, const PerfCounter& pc) {
+  os << "{";
+  os << "msgs_in: " << pc.msgs_in << ", ";
+  os << "msgs_out: " << pc.msgs_out << ", ";
+  os << "bytes_in: " << pc.bytes_in << ", ";
+  os << "bytes_out: " << pc.bytes_out << ", ";
+  os << "bps_in: " << pc.bps_in << ", ";
+  os << "mps_in: " << pc.mps_in << ", ";
+  os << "bps_out: " << pc.bps_out << ", ";
+  os << "mps_out: " << pc.mps_out << ", ";
+  os << "in_out_delay_us: " << pc.in_out_delay_us << ", ";
+  os << "overflow_msgs: " << pc.overflow_msgs << ", ";
+  os << "in_queue: " << pc.in_queue;
+  os << "}";
+  return os;
+};

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -198,10 +198,11 @@ endif ()
 target_link_libraries(tests PRIVATE ocpn::gtest)
 include(GoogleTest)
 gtest_add_tests(TARGET tests)
-if (LINUX AND NOT DEFINED ENV{FLATPAK_ID})
-  gtest_add_tests(TARGET ipc-srv-tests)
+gtest_add_tests(TARGET buffer_tests)
+if (LINUX AND NOT DEFINED ENV{FLATPAK_ID} AND NOT OCPN_DISTRO_BUILD)
   # We don't have a session bus available when testing flatpak
-  # so these can just be run in native builds
+  # so these can just be run in native builds.
+  gtest_add_tests(TARGET ipc-srv-tests)
   gtest_add_tests(TARGET dbus_tests)
 endif ()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -132,6 +132,46 @@ if (HAVE_LIBUDEV)
   target_link_libraries(tests PRIVATE ocpn::libudev)
 endif ()
 
+set(BUF_TEST_SRC
+  buffer_tests.cpp
+  ${MODEL_SRC_DIR}/cmdline.cpp
+  ${MODEL_SRC_DIR}/config_vars.cpp
+  ${MODEL_SRC_DIR}/comm_drv_registry.cpp
+  ${MODEL_SRC_DIR}/comm_navmsg.cpp
+  ${MODEL_SRC_DIR}/comm_out_queue.cpp
+  ${MODEL_SRC_DIR}/ocpn_utils.cpp
+  ${MODEL_SRC_DIR}/base_platform.cpp
+  ${MODEL_SRC_DIR}/logger.cpp
+  ${MODEL_SRC_DIR}/ocpn_plugin.cpp
+  ${CMAKE_SOURCE_DIR}/cli/api_shim.cpp
+)
+
+if (APPLE)
+  list(APPEND BUF_TEST_SRC ${MODEL_SRC_DIR}/macutils.c)
+endif ()
+
+add_executable(buffer_tests ${BUF_TEST_SRC})
+
+target_link_libraries(buffer_tests PRIVATE observable::observable)
+target_link_libraries(buffer_tests PRIVATE ${wxWidgets_LIBRARIES})
+target_link_libraries(buffer_tests PRIVATE ocpn::gtest)
+if (MSVC)
+  target_link_libraries(buffer_tests PRIVATE setupapi.lib)
+endif ()
+if (APPLE)
+target_link_libraries(buffer_tests PRIVATE ocpn::filesystem)
+endif ()
+
+
+target_include_directories(buffer_tests PRIVATE
+  ${CMAKE_SOURCE_DIR}/model/include
+  ${CMAKE_SOURCE_DIR}/include
+  ${CMAKE_SOURCE_DIR}/resources
+)
+target_compile_definitions(
+  buffer_tests PUBLIC TESTDATA="${CMAKE_CURRENT_LIST_DIR}/testdata"
+)
+
 if (LINUX)
   add_executable(dbus_tests
     dbus_tests.cpp

--- a/test/buffer_tests.cpp
+++ b/test/buffer_tests.cpp
@@ -118,9 +118,9 @@ TEST(Buffer, RateLimit1) {
   EXPECT_EQ(queue.size(), 20);
 }
 
-#ifndef __APPLE__
-// The MacOS builders seems to have a lot of "too" long sleeps.
-// Disable for now.
+#if !defined(__APPLE__) && !defined (_WIN32)
+// The MacOS builders seems to have a lot of "too" long sleeps,
+// same for  GA windows. Disable for now.
 TEST(Buffer, RateLimit2) {
   CommOutQueue queue(20, 20ms);
   for (int i = 0; i < 20; i++) {

--- a/test/buffer_tests.cpp
+++ b/test/buffer_tests.cpp
@@ -1,0 +1,147 @@
+#include "config.h"
+
+#include <chrono>
+#include <fstream>
+#include <string>
+#include <thread>
+
+#if (defined(__clang_major__) && (__clang_major__ < 15))   // MacOS 1.13
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+#else
+#include <filesystem>
+#include <utility>
+namespace fs = std::filesystem;
+#endif
+
+#include <wx/app.h>
+
+#include <gtest/gtest.h>
+
+#include "model/base_platform.h"
+#include "model/comm_drv_registry.h"
+#include "model/comm_out_queue.h"
+#include "model/logger.h"
+#include "model/ocpn_utils.h"
+
+#include "observable.h"
+
+using namespace std::literals::chrono_literals;
+
+static bool bool_result0;
+static std::string s_result;
+
+static const char* const GPGGA = "$GPGGA 00";
+static const char* const GPGGL = "$GPGGL 00";
+
+class OverrunEvent : public wxAppConsole {
+public:
+
+  OverrunEvent() {
+    bool result = false;
+    ObsListener listener;
+    listener.Init(CommDriverRegistry::GetInstance().evt_comm_overrun,
+		  [&](ObservedEvt&) { result = true; });
+
+    CommOutQueue queue(3);
+    for (int i = 0; i < 20; i++) queue.push_back(GPGGL);
+    EXPECT_EQ(queue.size(), 3);
+    EXPECT_TRUE(HasPendingEvents());
+    ProcessPendingEvents();
+    EXPECT_TRUE(result);
+  };
+};
+
+
+TEST(Buffer, Single) {
+  CommOutQueueSingle queue;
+  for (int i = 0; i < 10; i++) queue.push_back(GPGGA);
+  EXPECT_EQ(queue.size(), 1);
+  EXPECT_EQ(queue.pop(), GPGGA);
+  EXPECT_EQ(queue.size(), 0);
+  EXPECT_THROW({ queue.pop(); }, std::underflow_error);
+  EXPECT_FALSE(queue.push_back("foo"));
+}
+
+TEST(Buffer, Size_3 ) {
+  CommOutQueue queue(3);
+
+  for (int i = 0; i < 20; i++) queue.push_back(GPGGL);
+  EXPECT_EQ(queue.size(), 3);
+
+  std::string line(GPGGA);
+  for (int i = 0; i < 100; i++) {
+    std::string line(GPGGA);
+    ocpn::replace(line, "00", std::to_string(i));
+    queue.push_back(line);
+  }
+  EXPECT_EQ(queue.size(), 6);
+
+  EXPECT_EQ(queue.pop(), GPGGL);
+  EXPECT_EQ(queue.pop(), GPGGL);
+  EXPECT_EQ(queue.pop(), GPGGL);
+  EXPECT_EQ(queue.pop(), "$GPGGA 97");
+  EXPECT_EQ(queue.pop(), "$GPGGA 98");
+  EXPECT_EQ(queue.pop(), "$GPGGA 99");
+  EXPECT_EQ(queue.size(), 0);
+  EXPECT_THROW({ queue.pop(); }, std::underflow_error);
+}
+
+
+
+TEST(Buffer, Hakefjord) {
+  const auto path = fs::path(TESTDATA) / "Hakefjord.log";
+  std::ifstream stream(path.string());
+  MeasuredCommOutQueue queue(3);
+  for (std::string line; std::getline(stream, line); ) {
+    queue.push_back(line);
+  }
+  RecordProperty("buffer size", std::to_string(queue.size()));
+  for (int i = 0; i < 3; i++) queue.push_back(GPGGA);
+  std::string line;
+  do { line = queue.pop(); } while (!ocpn::startswith(line, "$GPGGA"));
+  EXPECT_EQ(line, GPGGA);
+  do { line = queue.pop(); } while (!ocpn::startswith(line, "$GPGGA"));
+  EXPECT_EQ(line, GPGGA);
+  do { line = queue.pop(); } while (!ocpn::startswith(line, "$GPGGA"));
+  EXPECT_EQ(line, GPGGA) ;
+  RecordProperty("push_time", std::to_string(queue.push_time));
+  // writes to test_detail.xml if invoked with --gtest_output.xml
+}
+
+TEST(Buffer, RateLimit1) {
+  CommOutQueue queue(20, 1ms);
+  for (int i = 0; i < 20; i++) {
+    queue.push_back(GPGGL);
+    std::this_thread::sleep_for(2ms);
+  }
+  EXPECT_EQ(queue.size(), 20);
+}
+
+#ifndef __APPLE__
+// The MacOS builders seems to have a lot of "too" long sleeps.
+// Disable for now.
+TEST(Buffer, RateLimit2) {
+  CommOutQueue queue(20, 20ms);
+  for (int i = 0; i < 20; i++) {
+    queue.push_back(GPGGL);
+    std::this_thread::sleep_for(10ms);
+  }
+  EXPECT_EQ(queue.size(), 1);
+  // might fail due to OS gitter i. e., sleep takes "too" long
+}
+#endif
+
+TEST(Buffer, RateAndSizeLimit) {
+  CommOutQueue queue(10, 1ms);
+  for (int i = 0; i < 20; i++) {
+    queue.push_back(GPGGL);
+    std::this_thread::sleep_for(2ms);
+  }
+  EXPECT_EQ(queue.size(), 10);
+  // might fail due to OS gitter i. e., sleep takes "too" long
+}
+
+TEST(Buffer, OverrunEvent) {
+  OverrunEvent event;
+}

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -908,7 +908,7 @@ TEST(Instance, StdInstanceChk) { StdInstanceTest check; }
 
 TEST(Instance, WxInstanceChk) { WxInstanceCheck check; }
 
-#if !defined(FLATPAK) && defined(__unix__)
+#if !defined(FLATPAK) && defined(__unix__) && !defined(OCPN_DISTRO_BUILD)
 TEST(IpcClient, IpcGetEndpoint) { IpcGetEndpoint run_test; }
 
 TEST(IpcClient, Raise) { CliRaise run_test; }


### PR DESCRIPTION
Fixes problems described in #3815 and  #3391:

  - Make sure all data is actually written
  - If overflowing, apply a sane strategy rather than just silently dropping messages at random.
  - Remove the static variable which makes it impossible to have more than one instance.


Closes: #3815
Closes: #3391

Current state: Works for me, including the test case described in #3391