### PR TITLE
Add user speed unit to Options: "Default boat speed"

### DIFF
--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -4077,7 +4077,8 @@ void options::CreatePanel_Display(size_t parent, int border_size,
     wxBoxSizer* defaultBoatSpeedSizer = new wxBoxSizer(wxHORIZONTAL);
     boxDispStatusBar->Add(defaultBoatSpeedSizer, wxALL, group_item_spacing);
     defaultBoatSpeedSizer->Add(
-        new wxStaticText(pDisplayPanel, wxID_ANY, _("Default Boat Speed ")),
+        new wxStaticText(pDisplayPanel, wxID_ANY,
+                    _("Default Boat Speed ") + "(" + getUsrSpeedUnit() + ") "),
         groupLabelFlagsHoriz);
     pSDefaultBoatSpeed =
         new wxTextCtrl(pDisplayPanel, ID_DEFAULT_BOAT_SPEED, _T(""),


### PR DESCRIPTION
Mentioned here: [CF post](https://www.cruisersforum.com/forums/f134/beta-test-technical-30929-191.html#post3891539)
![bild](https://github.com/OpenCPN/OpenCPN/assets/7202854/5f5bb0a4-5fd3-4c4a-abdb-e7823ff637a6)
