### PR TITLE
Connection Dialog UI fixes

### DIFF
--- a/gui/src/connections_dialog.cpp
+++ b/gui/src/connections_dialog.cpp
@@ -212,11 +212,11 @@ void ConnectionsDialog::Init() {
   bSizer18 = new wxBoxSizer(wxHORIZONTAL);
   m_sbSizerLB->Add(bSizer18, 0, wxEXPAND, 5);
 
-  m_buttonAdd = new wxButton(m_container, wxID_ANY, _("Add Connection"),
+  m_buttonAdd = new wxButton(m_container, wxID_ANY, _("Add Connection..."),
                              wxDefaultPosition, wxDefaultSize, 0);
   bSizer18->Add(m_buttonAdd, 0, wxALL, 5);
 
-  m_buttonEdit = new wxButton(m_container, wxID_ANY, _("Edit Connection"),
+  m_buttonEdit = new wxButton(m_container, wxID_ANY, _("Edit Connection..."),
                               wxDefaultPosition, wxDefaultSize, 0);
   m_buttonEdit->Enable(FALSE);
   bSizer18->Add(m_buttonEdit, 0, wxALL, 5);

--- a/gui/src/connections_dialog.cpp
+++ b/gui/src/connections_dialog.cpp
@@ -167,7 +167,7 @@ void ConnectionsDialog::Init() {
 
   m_cbAPBMagnetic =
       new wxCheckBox(m_container, wxID_ANY,
-                     _("Use magnetic bearings in output sentence ECAPB"),
+                     _("Use magnetic bearings in output sentence APB"),
                      wxDefaultPosition, wxDefaultSize, 0);
   m_cbAPBMagnetic->SetValue(g_bMagneticAPB);
   bSizer161->Add(m_cbAPBMagnetic, 0, wxALL, cb_space);


### PR DESCRIPTION
For the option "Use magnetic bearings in output sentence ECAPB, no need to prepend the "EC" talker id, as the talker Id can now be changed and persisted.

Per user guidelines, both "Add Connection" and "Edit Connection" raise a dialog so they should be appended with "..." to indicate this.