### PR TITLE
Add range ring(s) around own ship based on time (and SOG)

### DIFF
--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -5725,9 +5725,14 @@ void ChartCanvas::ShipIndicatorsDraw(ocpnDC &dc, int img_height,
   // Draw radar rings if activated
   if (g_bNavAidRadarRingsShown && g_iNavAidRadarRingsNumberVisible > 0) {
     double factor = 1.00;
-    if (g_pNavAidRadarRingsStepUnits == 1)  // nautical miles
+    if (g_pNavAidRadarRingsStepUnits == 1)  // kilometers
       factor = 1 / 1.852;
-
+    else if  (g_pNavAidRadarRingsStepUnits == 2){  // minutes (time)
+      if (std::isnan(gSog))
+        factor = 0.0;
+      else
+        factor = gSog/60;
+    }
     factor *= g_fNavAidRadarRingsStep;
 
     double tlat, tlon;

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -1985,10 +1985,10 @@ void options::CreatePanel_Ownship(size_t parent, int border_size,
       new wxStaticText(itemPanelShip, wxID_STATIC, _("Distance Unit"));
   radarGrid->Add(unitText, 1, wxEXPAND | wxALL, group_item_spacing);
 
-  wxString pDistUnitsStrings[] = {_("Nautical miles"), _("Kilometers")};
+  wxString pDistUnitsStrings[] = {_("Nautical miles"), _("Kilometers"), _("Minutes (time)")};
   m_itemRadarRingsUnits =
       new wxChoice(itemPanelShip, ID_RADARDISTUNIT, wxDefaultPosition,
-                   m_pShipIconType->GetSize(), 2, pDistUnitsStrings);
+                   m_pShipIconType->GetSize(), 3, pDistUnitsStrings);
   radarGrid->Add(m_itemRadarRingsUnits, 0, wxALIGN_RIGHT | wxALL, border_size);
 
   wxStaticText* colourText =


### PR DESCRIPTION
As it was very simple, and I realy like the idea. Range ring(s) depending on time and speed over ground. See picture, where each ring is 24Hours of sailing at current speed. 
![Screenshot_20240427_213331](https://github.com/OpenCPN/OpenCPN/assets/2668258/d5d064b4-6f9f-4cc0-a672-daaecd03ee75)
