### PR TITLE
Fix various problems in mbtiles

### DIFF
--- a/gui/src/mbtiles/TileQueue.hpp
+++ b/gui/src/mbtiles/TileQueue.hpp
@@ -25,12 +25,10 @@ public:
   /// method is thread safe.
   /// @return A pointer to a tile descriptor
   mbTileDescriptor *Pop() {
-    mbTileDescriptor *tile;
     m_tileCounter.Wait();
-    m_queueMutex.Lock();
-    tile = m_tileList.at(0);
+    wxMutexLocker lock(m_queueMutex);
+    mbTileDescriptor *tile = m_tileList.at(0);
     m_tileList.erase(m_tileList.cbegin());
-    m_queueMutex.Unlock();
     return tile;
   }
 
@@ -38,9 +36,10 @@ public:
   /// @return Queue size in tiles
   uint32_t GetSize() {
     uint32_t size;
-    m_queueMutex.Lock();
+    wxMutexLocker lock(m_queueMutex);
+
     size = m_tileList.size();
-    m_queueMutex.Unlock();
+
     return size;
   }
 

--- a/gui/src/mbtiles/WorkerThread.hpp
+++ b/gui/src/mbtiles/WorkerThread.hpp
@@ -63,7 +63,6 @@ private:
   /// @return Always 0
   virtual ExitCode Entry() {
     mbTileDescriptor *tile;
-    SetName("mbtiles-worker");
 
     do {
       // Wait for the next job

--- a/gui/src/mbtiles/mbtiles.cpp
+++ b/gui/src/mbtiles/mbtiles.cpp
@@ -61,7 +61,7 @@
 #include "glChartCanvas.h"
 #include "ocpn_frame.h"
 #ifdef ocpnUSE_GL
-    #include "shaders.h"
+#include "shaders.h"
 #endif
 #include "mbtiles.h"
 #include "model/config_vars.h"
@@ -95,44 +95,12 @@ extern int g_chart_zoom_modifier_raster;
 #define LON_UNDEF NAN
 #define LAT_UNDEF NAN
 
-// The OpenStreetMaps zommlevel translation tables
-//  https://wiki.openstreetmap.org/wiki/Zoom_levels
-
-/*Level   Degree  Area          m / pixel       ~Scale          # Tiles
-0       360     whole world     156,412         1:500 million   1
-1       180                     78,206          1:250 million   4
-2       90                      39,103          1:150 million   16
-3       45                      19,551          1:70 million    64
-4       22.5                    9,776           1:35 million    256
-5       11.25                   4,888           1:15 million    1,024
-6       5.625                   2,444           1:10 million    4,096
-7       2.813                   1,222           1:4 million     16,384
-8       1.406                   610.984         1:2 million     65,536
-9       0.703   wide area       305.492         1:1 million     262,144
-10      0.352                   152.746         1:500,000       1,048,576
-11      0.176   area            76.373          1:250,000       4,194,304
-12      0.088                   38.187          1:150,000       16,777,216
-13      0.044  village or town  19.093          1:70,000        67,108,864
-14      0.022                   9.547           1:35,000        268,435,456
-15      0.011                   4.773           1:15,000        1,073,741,824
-16      0.005   small road      2.387           1:8,000         4,294,967,296
-17      0.003                   1.193           1:4,000         17,179,869,184
-18      0.001                   0.596           1:2,000         68,719,476,736
-19      0.0005                  0.298           1:1,000         274,877,906,944
-*/
-
 // A "nominal" scale value, by zoom factor.  Estimated at equator, with monitor
 // pixel size of 0.3mm
-static const double OSM_zoomScale[] = {5e8,   2.5e8, 1.5e8, 7.0e7, 3.5e7, 1.5e7,
-                                       1.0e7, 4.0e6, 2.0e6, 1.0e6, 5.0e5, 2.5e5,
-                                       1.5e5, 7.0e4, 3.5e4, 1.5e4, 8.0e3, 4.0e3,
-                                       2.0e3, 1.0e3, 5.0e2, 2.5e2};
+static double OSM_zoomScale[22];
 
 //  Meters per pixel, by zoom factor
-static const double OSM_zoomMPP[] = {
-    156412, 78206,   39103,   19551,  9776,   4888,   2444,  1222,
-    610,    305.492, 152.746, 76.373, 38.187, 19.093, 9.547, 4.773,
-    2.387,  1.193,   0.596,   0.298,  0.149,  0.075};
+static double OSM_zoomMPP[22];
 
 extern MyFrame *gFrame;
 
@@ -185,6 +153,14 @@ private:
 // ============================================================================
 
 ChartMBTiles::ChartMBTiles() {
+  // Compute scale & MPP for each zoom level
+  OSM_zoomScale[0] = 4.0030e+07;
+  OSM_zoomMPP[0] = 156370;
+  for (int i = 1; i < (int)(sizeof(OSM_zoomScale) / sizeof(double)); i++) {
+    OSM_zoomScale[i] = OSM_zoomScale[i - 1] / 2;
+    OSM_zoomMPP[i] = OSM_zoomMPP[i - 1] / 2;
+  }
+
   //    Init some private data
   m_workerThread = nullptr;
   m_ChartFamily = CHART_FAMILY_RASTER;
@@ -670,7 +646,7 @@ bool ChartMBTiles::getTileTexture(mbTileDescriptor *tile) {
     return false;
   } else if (tile->m_teximage == 0) {
     if (tile->m_requested == false) {
-      // The tile has not loaded and decompressed previously : request it
+      // The tile has not been loaded and decompressed yet : request it
       // to the worker thread
       m_workerThread->RequestTile(tile);
     }
@@ -678,9 +654,6 @@ bool ChartMBTiles::getTileTexture(mbTileDescriptor *tile) {
   } else {
     // The tile has been decompressed to memory : load it into OpenGL texture
     // memory
-    if (tile->glTextureName > 0) {
-      glDeleteTextures(1, &tile->glTextureName);
-    }
 #ifndef __OCPN__ANDROID__
     glEnable(GL_COLOR_MATERIAL);
 #endif


### PR DESCRIPTION
Several problems were fixed in this pull request : 

- In case of heavily loaded system, OpenCPN was freezing and needed to be killed
- Sometimes, OpenCPN was freezing when exiting
- There was a small error in the scale table in mbtiles.cpp leading to incorect zoom level to be selected (almost unoticeable practically)

The fixes : 
- Mbtiles worker thread was using the WxWidgets *Render()*  API to force redrawing the map after all tiles were successfully decompressed. However this API is not thread safe and this was leading to very strange and ultimately crashing behaviors. This has been replaced by a call to *CallAfter* which is thread safe.
- There was a bad usage of mutexes and conditions to kill the thread on exit which was leading to deadlocks : mutex and conditions have been removed to use a simpler polling mecanism.
- The previous scale table used by mbtiles.c to select the best zoom level for a given scale was wrong. It was taken from an OpenStreetMap wiki which has wrongly rounded the value for some reason. The scale values are now calculated at mbtiles init.