### PR TITLE
Options color picker controls. Tweak hight to Windows screen scaling

### DIFF
--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -1705,7 +1705,8 @@ void options::Init(void) {
   int width, height;
   dc.GetTextExtent(_T("H"), &width, &height, NULL, NULL, dialogFont);
 
-  m_colourPickerDefaultSize = wxSize(4 * height, height * 2);
+  m_colourPickerDefaultSize =
+      wxSize(4 * height, height* 2 * OCPN_GetWinDIPScaleFactor());
 
   m_bcompact = false;
 


### PR DESCRIPTION
The color controls are to big on a scaled Windows screen. I suppose the bitmaps ground for these controls need adjustments.

![bild](https://github.com/OpenCPN/OpenCPN/assets/7202854/73b4932f-d024-4b9b-ac2a-e1b6fc0836cf)

Tweaked:

![bild](https://github.com/OpenCPN/OpenCPN/assets/7202854/2bb6957a-8584-47c0-acd6-169f799265a2)
