### PR TITLE
Remove confusion for SignalK Server address

### DIFF
--- a/gui/include/gui/connection_edit.h
+++ b/gui/include/gui/connection_edit.h
@@ -53,6 +53,7 @@ public:
   const wxString DEFAULT_GPSD_PORT = "2947";
   const wxString DEFAULT_SIGNALK_PORT = "3000";
   const wxString DEFAULT_IP_ADDRESS = "0.0.0.0";
+  const wxString DEFAULT_SIGNALK_IP_ADDRESS = "localhost";
 
   ConnectionEditDialog();
  // ConnectionEditDialog(wxScrolledWindow *container, options *parent);

--- a/gui/src/connection_edit.cpp
+++ b/gui/src/connection_edit.cpp
@@ -1850,7 +1850,7 @@ void ConnectionEditDialog::OnNetProtocolSelected(wxCommandEvent& event) {
     if (IsDefaultPort(m_tNetPort->GetValue())) {
       m_tNetPort->SetValue(DEFAULT_SIGNALK_PORT);
     }
-    m_tNetAddress->SetValue(DEFAULT_IP_ADDRESS);
+    m_tNetAddress->SetValue(DEFAULT_SIGNALK_IP_ADDRESS);
   } else if (m_rbNetProtoTCP->GetValue()) {
     if (IsDefaultPort(m_tNetPort->GetValue())) {
       m_tNetPort->SetValue(DEFAULT_TCP_PORT);


### PR DESCRIPTION
Ideally the "Discover Now" button should be re-introduced or the text control should have a meaningful hint.

The current use of 0.0.0.0 as the default SignalK Server address is both incorrect and potentially misleading

As per issue #3874 this adds "localhost" as the default SignalK Server address.