### PR TITLE
Links: Clean up linux links handling - #3868

### DIFF
--- a/gui/include/gui/gui_lib.h
+++ b/gui/include/gui/gui_lib.h
@@ -1,10 +1,4 @@
-/***************************************************************************
- *
- * Project:  OpenCPN
- * Purpose:  OpenCPN Main wxWidgets Program
- * Author:   David Register
- *
- ***************************************************************************
+ /**************************************************************************
  *   Copyright (C) 2010 by David S. Register                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -23,8 +17,10 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 
-#ifndef MESSAGEBOX_H
-#define MESSAGEBOX_H
+ /** \file gui_lib.h General purpose GUI support. */
+
+#ifndef GUI_LIB_H__
+#define GUI_LIB_H__
 
 #include <wx/font.h>
 #include <wx/html/htmlwin.h>
@@ -33,6 +29,13 @@
 #include <wx/timer.h>
 #include <wx/window.h>
 #include <wx/utils.h>
+
+/** Non-editable TextCtrl, used like wxStaticText but is copyable. */
+class CopyableText : public wxTextCtrl {
+public:
+  CopyableText(wxWindow* parent, const char* text);
+};
+
 
 wxFont* GetOCPNScaledFont(wxString item, int default_size = 0);
 wxFont GetOCPNGUIScaledFont(wxString item);
@@ -145,4 +148,4 @@ public:
 };
 
 
-#endif  // MESSAGE_BOX_H
+#endif  // GUI_LIB_H__

--- a/gui/src/gui_lib.cpp
+++ b/gui/src/gui_lib.cpp
@@ -1,10 +1,4 @@
-/***************************************************************************
- *
- * Project:  OpenCPN
- * Purpose:  OpenCPN Main wxWidgets Program
- * Author:   David Register
- *
- ***************************************************************************
+ /**************************************************************************
  *   Copyright (C) 2010 by David S. Register                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -22,6 +16,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
+
+/** \file gui_lib.cpp Implements gui_lib.h */
 
 #include <wx/artprov.h>
 #include <wx/dialog.h>
@@ -43,6 +39,15 @@
 extern bool g_bresponsive;
 extern OCPNPlatform* g_Platform;
 extern int g_GUIScaleFactor;
+
+CopyableText::CopyableText(wxWindow* parent, const char* text)
+    : wxTextCtrl(parent, wxID_ANY, text, wxDefaultPosition,
+                 wxDefaultSize, wxBORDER_NONE) {
+  SetEditable(false);
+  wxStaticText tmp(parent, wxID_ANY, text);
+  SetBackgroundColour(tmp.GetBackgroundColour());
+}
+
 
 wxFont* GetOCPNScaledFont(wxString item, int default_size) {
   wxFont* dFont = FontMgr::Get().GetFont(item, default_size);

--- a/gui/src/udev_rule_mgr.cpp
+++ b/gui/src/udev_rule_mgr.cpp
@@ -288,7 +288,7 @@ public:
     using namespace std;
     string cmd(INSTRUCTIONS);
     ocpn::replace(cmd, "@PATH@", m_rule_path);
-    ocpn::replace(cmd, "@pkexec@", "pkexec");
+    ocpn::replace(cmd, "@pkexec@", "sudo");
     ifstream f(m_rule_path);
     auto rule =
         string(istreambuf_iterator<char>(f), istreambuf_iterator<char>());

--- a/gui/src/udev_rule_mgr.cpp
+++ b/gui/src/udev_rule_mgr.cpp
@@ -178,8 +178,7 @@ private:
   wxTextCtrl* GetCmd(wxWindow* parent, const char* tmpl) {
     std::string cmd(tmpl);
     ocpn::replace(cmd, "@PATH@", GetDongleRule());
-    auto ctrl = new wxTextCtrl(this, wxID_ANY, cmd);
-    ctrl->SetEditable(false);
+    auto ctrl = new CopyableText(this, cmd.c_str());
     ctrl->SetMinSize(parent->GetTextExtent(cmd + "aaa"));
     return ctrl;
   }

--- a/gui/src/udev_rule_mgr.cpp
+++ b/gui/src/udev_rule_mgr.cpp
@@ -59,6 +59,9 @@ The device @DEVICE@ exists but cannot be used due to missing permissions.
 
 This problem can be fixed by installing a udev rules file. Once installed,
 the rules file will fix the permissions problem.
+)");
+
+static const char* const DEVICE_LINK_INTRO = _(R"(
 
 It will also create a new device called @SYMLINK@. It is recommended to use
 @SYMLINK@ instead of @DEVICE@ to avoid problems with changing device names,
@@ -334,17 +337,21 @@ public:
 /** Return an intro based on DEVICE_INTRO with proper substitutions. */
 static std::string GetDeviceIntro(const char* device, std::string symlink) {
   std::string intro(DEVICE_INTRO);
+
+  std::string dev_name(device);
+  ocpn::replace(dev_name, "/dev/", "");
+  if (!ocpn::startswith(dev_name, "ttyS")) {
+    intro += DEVICE_LINK_INTRO;
+  }
+  if (getenv("FLATPAK_ID")) {
+    intro += FLATPAK_INTRO_TRAILER;
+  }
   ocpn::replace(symlink, "/dev/", "");
   while (intro.find("@SYMLINK@") != std::string::npos) {
     ocpn::replace(intro, "@SYMLINK@", symlink);
   }
-  std::string dev_name(device);
-  ocpn::replace(dev_name, "/dev/", "");
   while (intro.find("@DEVICE@") != std::string::npos) {
     ocpn::replace(intro, "@DEVICE@", dev_name.c_str());
-  }
-  if (getenv("FLATPAK_ID")) {
-    intro += FLATPAK_INTRO_TRAILER;
   }
   return intro;
 }

--- a/model/include/model/ocpn_utils.h
+++ b/model/include/model/ocpn_utils.h
@@ -47,6 +47,8 @@ std::string join(std::vector<std::string> v, char c);
 std::string tolower(const std::string& s);
 
 std::vector<std::string> split(const char* s, const std::string& delimiter);
+std::vector<std::string> split(const std::string& s,
+                               const std::string& delimiter);
 
 bool exists(const std::string& path);
 

--- a/model/src/linux_devices.cpp
+++ b/model/src/linux_devices.cpp
@@ -70,7 +70,7 @@ ATTRS{idVendor}=="@vendor@", ATTRS{idProduct}=="@product@", \
 )--";
 
 static const char* const DEVICE_RULE_TTYS = R"--(
-KERNEL=="ttyS@s_index@", MODE="0666", SYMLINK+="@symlink@"
+KERNEL=="ttyS@s_index@", MODE="0666"
 )--";
 
 static const char* const DONGLE_RULE_NAME = "65-ocpn-dongle.rules";

--- a/model/src/ocpn_utils.cpp
+++ b/model/src/ocpn_utils.cpp
@@ -65,6 +65,11 @@ std::vector<std::string> split(const char* token_string,
   return tokens;
 }
 
+std::vector<std::string> split(const std::string& string,
+                               const std::string& delimiter) {
+  return split(string.c_str(), delimiter);
+}
+
 bool exists(const std::string& name) {
 #ifdef __MSVC__
   return (_access(name.c_str(), 0) != -1);

--- a/model/src/ser_ports.cpp
+++ b/model/src/ser_ports.cpp
@@ -353,8 +353,10 @@ static wxArrayString* EnumerateUdevSerialPorts(void) {
   struct udev* udev = udev_new();
   auto dev_items = enumerate_udev_ports(udev);
   wxArrayString* ports = new wxArrayString;
-  for (auto item : dev_items) {
-    ports->Add((item.path + " - " + item.info).c_str());
+  for (const auto& item : dev_items) {
+    std::string port(item.path);
+    if (item.info.size() > 0) port += std::string(" - ") + item.info;
+    ports->Add(port);
   }
   return ports;
 }


### PR DESCRIPTION
Don't create links for stable device names ttyS*, avoid displaying multiple links to the same device and add some GUI polish. 

Also add a hopefully generally useful  CopyableText class, used as wxStaticText but based on wxTextCtrl and thus copyable.

Closes: #3868