### PR TITLE
Fix NMEA log window event handling (#3923)

### DIFF
--- a/gui/include/gui/NMEALogWindow.h
+++ b/gui/include/gui/NMEALogWindow.h
@@ -47,7 +47,9 @@
  */
 class NMEALogWindow : public NmeaLog, public WindowDestroyListener {
 public:
-  static NMEALogWindow &Get();
+  static NMEALogWindow &GetInstance();
+  NMEALogWindow(const NMEALogWindow &) = delete;
+  NMEALogWindow &operator=(const NMEALogWindow &) = delete;
   bool Active() const;
   void Create(wxWindow *parent, int num_lines = 35);
   void Add(const wxString &s);
@@ -66,14 +68,11 @@ public:
   static void Shutdown();
   wxWindow *GetTTYWindow(void) { return static_cast<wxWindow*>(m_window); }
 
-private:  // prevent class from being copied, needed by singleton
+private:
   NMEALogWindow();
-  NMEALogWindow(const NMEALogWindow &) {}
   virtual ~NMEALogWindow(){};
-  NMEALogWindow &operator=(const NMEALogWindow &) { return *this; }
   void UpdateGeometry();
 
-private:
   static NMEALogWindow *instance;
   TTYWindow *m_window;
   int m_width;

--- a/gui/include/gui/NMEALogWindow.h
+++ b/gui/include/gui/NMEALogWindow.h
@@ -30,6 +30,7 @@
 #include <wx/window.h>
 
 #include "model/nmea_log.h"
+#include "observable_evtvar.h"
 
 #include "WindowDestroyListener.h"
 #include "TTYWindow.h"
@@ -67,6 +68,9 @@ public:
   virtual void DestroyWindow();
   static void Shutdown();
   wxWindow *GetTTYWindow(void) { return static_cast<wxWindow*>(m_window); }
+
+  /** Notified when m_window is closing. */
+  EventVar nmea_window_close_evt;
 
 private:
   NMEALogWindow();

--- a/gui/include/gui/NMEALogWindow.h
+++ b/gui/include/gui/NMEALogWindow.h
@@ -25,14 +25,14 @@
 #ifndef __NMEALOGWINDOW_H__
 #define __NMEALOGWINDOW_H__
 
-#include "WindowDestroyListener.h"
+#include <wx/gdicmn.h>
+#include <wx/string.h>
+#include <wx/window.h>
+
 #include "model/nmea_log.h"
 
-class wxWindow;
-class wxString;
-class wxSize;
-class wxPoint;
-class TTYWindow;
+#include "WindowDestroyListener.h"
+#include "TTYWindow.h"
 
 /**
  * This class provides access to the NMEA log/debug window.
@@ -64,7 +64,7 @@ public:
   void Move();
   virtual void DestroyWindow();
   static void Shutdown();
-  wxWindow *GetTTYWindow(void) { return (wxWindow *)window; }
+  wxWindow *GetTTYWindow(void) { return static_cast<wxWindow*>(m_window); }
 
 private:  // prevent class from being copied, needed by singleton
   NMEALogWindow();
@@ -75,11 +75,11 @@ private:  // prevent class from being copied, needed by singleton
 
 private:
   static NMEALogWindow *instance;
-  TTYWindow *window;
-  int width;
-  int height;
-  int pos_x;
-  int pos_y;
+  TTYWindow *m_window;
+  int m_width;
+  int m_height;
+  int m_pos_x;
+  int m_pos_y;
 };
 
 #endif

--- a/gui/include/gui/TTYWindow.h
+++ b/gui/include/gui/TTYWindow.h
@@ -52,12 +52,12 @@ public:
 protected:
   void CreateLegendBitmap();
   WindowDestroyListener *m_window_destroy_listener;
-  TTYScroll *m_pScroll;
-  wxButton *m_buttonPause;
-  wxButton *m_buttonCopy;
-  bool bpause;
+  TTYScroll *m_tty_scroll;
+  wxButton *m_btn_pause;
+  wxButton *m_btn_copy;
+  bool m_is_paused;
   wxBitmap m_bm_legend;
-  wxTextCtrl *m_tFilter;
+  wxTextCtrl *m_filter;
 };
 
 #endif

--- a/gui/include/gui/connection_edit.h
+++ b/gui/include/gui/connection_edit.h
@@ -147,7 +147,7 @@ public:
   void CreateControls();
   void ConnectControls();
 
-  // private:
+private:
   options *m_parent;
   wxScrolledWindow *m_scrolledwin;
 
@@ -208,7 +208,6 @@ public:
 
   ObsListener new_device_listener;
 
-  // DECLARE_EVENT_TABLE()
 protected:
   wxString MORE, LESS;
   wxStaticText *m_more;

--- a/gui/include/gui/connections_dialog.h
+++ b/gui/include/gui/connections_dialog.h
@@ -35,7 +35,7 @@
 #include "model/conn_params.h"
 #include "model/comm_util.h"
 
-#include "observable.h"
+#include "observable_evtvar.h"
 
 class options;
 class ConnectionParamsPanel;
@@ -69,7 +69,7 @@ public:
   void UpdateDatastreams();
   void OnSize(wxSizeEvent &ev);
 
-//private:
+private:
   wxScrolledWindow *m_container;
   options *m_parent;
   ConnectionParams *mSelectedConnection;
@@ -92,6 +92,7 @@ public:
 #else
   wxScrolledWindow *m_scrollWinConnections;
 #endif
+  ObsListener nmea_window_close_listener;
 
 };
 

--- a/gui/include/gui/ocpn_frame.h
+++ b/gui/include/gui/ocpn_frame.h
@@ -398,6 +398,7 @@ private:
   wxTimer ToolbarAnimateTimer;
   int m_nMasterToolCountShown;
   wxTimer m_recaptureTimer;
+  wxWindow* m_options_dlg;
 
   std::unique_ptr<LoadErrorsDlgCtrl> m_load_errors_dlg_ctrl;
 

--- a/gui/include/gui/options.h
+++ b/gui/include/gui/options.h
@@ -31,6 +31,7 @@
 #include <windows.h>
 #endif
 
+#include <functional>
 #include <memory>
 
 #include <wx/listbook.h>
@@ -252,6 +253,7 @@ enum {
 #include <wx/arrimpl.cpp>
 WX_DEFINE_ARRAY_PTR(wxGenericDirCtrl *, ArrayOfDirCtrls);
 
+
 class Uncopyable {
 protected:
   Uncopyable(void) {}
@@ -262,14 +264,8 @@ private:
   Uncopyable &operator=(const Uncopyable &);
 };
 
-#ifndef bert  // wxCHECK_VERSION(2, 9, 0)
-class options : private Uncopyable,
-                public wxDialog
-#else
-class options : private Uncopyable,
-                public wxScrollingDialog
-#endif
-{
+
+class options : public wxDialog {
 public:
   explicit options(wxWindow *parent, wxWindowID id = SYMBOL_OPTIONS_IDNAME,
                    const wxString &caption = SYMBOL_OPTIONS_TITLE,
@@ -277,14 +273,21 @@ public:
                    const wxSize &size = SYMBOL_OPTIONS_SIZE,
                    long style = SYMBOL_OPTIONS_STYLE);
 
+  options(const options&) = delete;
+  options& operator=(const options&) = delete;
+
   ~options(void);
-#if wxCHECK_VERSION(3, 0, 0)
   bool SendIdleEvents(wxIdleEvent &event);
-#endif
   void SetInitialPage(int page_sel, int sub_page = -1);
   void Finish(void);
 
   void OnClose(wxCloseEvent &event);
+
+  /** Set function invoked when closing. */
+  void SetOnCloseCb(std::function<void()> cb) { m_on_close_cb = cb; }
+
+  /**  Clear function invoked when closing. */
+  void ClearOnCloseCb() { m_on_close_cb = []{}; }
 
   void CreateListbookIcons();
   void CreateControls(void);
@@ -682,6 +685,7 @@ private:
 
   wxSize m_sliderSize;
   bool m_bneedNew;
+  std::function<void()> m_on_close_cb;
 
   std::shared_ptr<ConnectionsDialog>comm_dialog;
 

--- a/gui/include/gui/options.h
+++ b/gui/include/gui/options.h
@@ -276,12 +276,19 @@ public:
   options(const options&) = delete;
   options& operator=(const options&) = delete;
 
-  ~options(void);
-  bool SendIdleEvents(wxIdleEvent &event);
-  void SetInitialPage(int page_sel, int sub_page = -1);
-  void Finish(void);
+  ~options();
 
-  void OnClose(wxCloseEvent &event);
+  // Should we show tooltips?
+  static bool ShowToolTips();
+
+  void Finish();
+  void SetInitialSettings();
+  void SetConfigPtr(MyConfig *p) { m_pConfig = p; }
+  void SetDirActionButtons();
+  bool GetNeedNew() { return m_bneedNew; }
+  void SetNeedNew(bool bnew) { m_bneedNew = bnew; }
+  int GetScrollRate() { return m_scrollRate; }
+  void SetForceNewToolbarOnCancel(bool val) { m_bForceNewToolbaronCancel = val; }
 
   /** Set function invoked when closing. */
   void SetOnCloseCb(std::function<void()> cb) { m_on_close_cb = cb; }
@@ -289,127 +296,140 @@ public:
   /**  Clear function invoked when closing. */
   void ClearOnCloseCb() { m_on_close_cb = []{}; }
 
-  void CreateListbookIcons();
-  void CreateControls(void);
-  size_t CreatePanel(const wxString &title);
+  void SetInitialPage(int page_sel, int sub_page = -1);
   wxScrolledWindow *AddPage(size_t parent, const wxString &title);
   bool DeletePluginPage(wxScrolledWindow *page);
+
   void SetColorScheme(ColorScheme cs);
   void RecalculateSize(int hint_x, int hint_y);
+  void UpdateOptionsUnits();
 
   void SetInitChartDir(const wxString &dir) { m_init_chart_dir = dir; }
-  void SetInitialSettings(void);
-  void SetInitialVectorSettings(void);
+  void AddChartDir(const wxString &dir);
+  void UpdateChartDirList();
+  void UpdateDisplayedChartDirList(ArrayOfCDI p);
 
   void SetCurrentDirList(ArrayOfCDI p) { m_CurrentDirList = p; }
   void SetWorkDirListPtr(ArrayOfCDI *p) { m_pWorkDirList = p; }
-  ArrayOfCDI *GetWorkDirListPtr(void) { return m_pWorkDirList; }
+  ArrayOfCDI *GetWorkDirListPtr() { return m_pWorkDirList; }
 
-  void AddChartDir(const wxString &dir);
+  void UpdateWorkArrayFromDisplayPanel();
+  ArrayOfCDI GetSelectedChartDirs();
+  ArrayOfCDI GetUnSelectedChartDirs();
 
-  void UpdateDisplayedChartDirList(ArrayOfCDI p);
-  void UpdateOptionsUnits(void);
+  void OnConfigMouseSelected(wxMouseEvent &event);
+  void OnCanvasConfigSelectClick(int ID, bool selected);
 
-  void SetConfigPtr(MyConfig *p) { m_pConfig = p; }
-  void OnDebugcheckbox1Click(wxCommandEvent &event);
-  void OnDirctrlSelChanged(wxTreeEvent &event);
-  void OnButtonaddClick(wxCommandEvent &event);
-  void OnButtondeleteClick(wxCommandEvent &event);
-  void OnButtonParseENC(wxCommandEvent &event);
-  void OnButtoncompressClick(wxCommandEvent &event);
-  void OnButtonmigrateClick(wxCommandEvent &event);
-  void OnButtonEcdisHelp(wxCommandEvent &event);
-  void OnRadioboxSelected(wxCommandEvent &event);
+  wxPoint lastWindowPos;
+  wxSize lastWindowSize;
+  size_t m_pageDisplay, m_pageConnections, m_pageCharts, m_pageShips;
+  int lastPage, lastSubPage;
+  size_t m_pageUI, m_pagePlugins;
+  wxBoxSizer *itemBoxSizerPanelPlugins;
+  wxCheckBox *pUpdateCheckBox, *pScanCheckBox;
+  wxWindow *pParent;
+
+  /** Notified with a OCPN_Sound* pointer when sound has completed. */
+  EventVar m_on_sound_done;
+
+private:
+  void Init();
+  void SetInitialVectorSettings();
+  void CreateControls();
+  void CreateListbookIcons();
+  size_t CreatePanel(const wxString &title);
+  void CreatePanel_MMSI(size_t parent, int border_size, int group_item_spacing);
+  void CreatePanel_AIS(size_t parent, int border_size, int group_item_spacing);
+  void CreatePanel_Ownship(size_t parent, int border_size,
+                           int group_item_spacing);
+  void CreatePanel_NMEA(size_t parent, int border_size, int group_item_spacing);
+  void CreatePanel_ChartsLoad(size_t parent, int border_size,
+                              int group_item_spacing);
+  void CreatePanel_VectorCharts(size_t parent, int border_size,
+                                int group_item_spacing);
+  void CreatePanel_TidesCurrents(size_t parent, int border_size,
+                                 int group_item_spacing);
+  void CreatePanel_ChartGroups(size_t parent, int border_size,
+                               int group_item_spacing);
+  void CreatePanel_Display(size_t parent, int border_size,
+                           int group_item_spacing);
+  void CreatePanel_UI(size_t parent, int border_size, int group_item_spacing);
+  void CreatePanel_Units(size_t parent, int border_size,
+                         int group_item_spacing);
+  void CreatePanel_Sounds(size_t parent, int border_size,
+                          int group_item_spacing);
+  void CreatePanel_Advanced(size_t parent, int border_size,
+                            int group_item_spacing);
+  void CreatePanel_Configs(size_t parent, int border_size,
+                           int group_item_spacing);
+  void CreatePanel_Routes(size_t parent, int border_size,
+                          int group_item_spacing);
+
+  bool SendIdleEvents(wxIdleEvent &event);
+
+  void SetConfigButtonState();
+  void ClearConfigList();
+  void BuildConfigList();
+
+  void DoOnPageChange(size_t page);
+  void OnAlertAudioEnableButtonClick(wxCommandEvent &event);
+  void OnAlertEnableButtonClick(wxCommandEvent &event);
   void OnApplyClick(wxCommandEvent &event);
-  void OnXidOkClick(wxCommandEvent &event);
+  void OnApplyConfig(wxCommandEvent &event);
+  void OnButtonaddClick(wxCommandEvent &event);
+  void OnButtonClearClick(wxCommandEvent &event);
+  void OnButtoncompressClick(wxCommandEvent &event);
+  void OnButtondeleteClick(wxCommandEvent &event);
+  void OnButtonEcdisHelp(wxCommandEvent &event);
+  void OnButtonGroups(wxCommandEvent &event);
+  void OnButtonmigrateClick(wxCommandEvent &event);
+  void OnButtonParseENC(wxCommandEvent &event);
+  void OnButtonSelectClick(wxCommandEvent &event);
+  void OnButtonSelectSound(wxCommandEvent &event);
+  void OnButtonSetStd(wxCommandEvent &event);
+  void OnButtonTestSound(wxCommandEvent &event);
   void OnCancelClick(wxCommandEvent &event);
+  void OnCharHook(wxKeyEvent &event);
+  void OnChartDirListSelect(wxCommandEvent &event);
+  void OnChartsPageChange(wxListbookEvent &event);
   void OnChooseFont(wxCommandEvent &event);
-  void OnFontChoice(wxCommandEvent &event);
+  void OnClose(wxCloseEvent &event);
   void OnCPAWarnClick(wxCommandEvent &event);
-  void OnSyncCogPredClick(wxCommandEvent &event);
+  void OnCreateConfig(wxCommandEvent &event);
+  void OnDebugcheckbox1Click(wxCommandEvent &event);
+  void OnDeleteConfig(wxCommandEvent &event);
+  void OnDialogInit(wxInitDialogEvent& event);
+  void OnDirctrlSelChanged(wxTreeEvent &event);
+  void OnDisplayCategoryRadioButton(wxCommandEvent &event);
+  void OnEditConfig(wxCommandEvent &event);
+  void OnFontChoice(wxCommandEvent &event);
+  void OnGLClicked(wxCommandEvent &event);
+  void OnInsertTideDataLocation(wxCommandEvent &event);
+  void OnOpenGLOptions(wxCommandEvent &event);
+  void OnPageChange(wxListbookEvent &event);
+  void OnRadarringSelect(wxCommandEvent &event);
+  void OnRadioboxSelected(wxCommandEvent &event);
+  void OnRemoveTideDataLocation(wxCommandEvent &event);
+  void OnShipTypeSelect(wxCommandEvent &event);
+  void OnShowGpsWindowCheckboxClick(wxCommandEvent &event);
   void OnSizeAutoButton(wxCommandEvent &event);
   void OnSizeManualButton(wxCommandEvent &event);
+  void OnSubNBPageChange(wxNotebookEvent &event);
+  void OnSyncCogPredClick(wxCommandEvent &event);
+  void OnTopNBPageChange(wxNotebookEvent &event);
+  void OnUnitsChoice(wxCommandEvent &event);
+  void OnWaypointRangeRingSelect(wxCommandEvent &event);
+  void OnXidOkClick(wxCommandEvent &event);
+  void OnZTCCheckboxClick(wxCommandEvent &event);
 
 #if defined(__WXGTK__) || defined(__WXQT__)
   void OnChooseFontColor(wxCommandEvent &event);
 #endif
-  void OnGLClicked(wxCommandEvent &event);
-  void OnOpenGLOptions(wxCommandEvent &event);
-  void OnDisplayCategoryRadioButton(wxCommandEvent &event);
-  void OnButtonClearClick(wxCommandEvent &event);
-  void OnButtonSelectClick(wxCommandEvent &event);
-  void OnButtonSetStd(wxCommandEvent &event);
 
-  void OnPageChange(wxListbookEvent &event);
-  void OnTopNBPageChange(wxNotebookEvent &event);
-  void OnSubNBPageChange(wxNotebookEvent &event);
-  void DoOnPageChange(size_t page);
+  wxButton *m_ApplyButton;
+  wxButton *m_OKButton;
+  wxButton *m_CancelButton;
 
-  wxString SelectSoundFile();
-  void OnButtonSelectSound(wxCommandEvent &event);
-  void OnButtonTestSound(wxCommandEvent &event);
-
-  void OnShowGpsWindowCheckboxClick(wxCommandEvent &event);
-  void OnZTCCheckboxClick(wxCommandEvent &event);
-  void OnRadarringSelect(wxCommandEvent &event);
-  void OnWaypointRangeRingSelect(wxCommandEvent &event);
-  void OnShipTypeSelect(wxCommandEvent &event);
-  void OnButtonGroups(wxCommandEvent &event);
-  void OnInsertTideDataLocation(wxCommandEvent &event);
-  void OnRemoveTideDataLocation(wxCommandEvent &event);
-  void OnCharHook(wxKeyEvent &event);
-  void OnChartsPageChange(wxListbookEvent &event);
-  void OnChartDirListSelect(wxCommandEvent &event);
-  void OnUnitsChoice(wxCommandEvent &event);
-
-  void UpdateWorkArrayFromDisplayPanel(void);
-  ArrayOfCDI GetSelectedChartDirs();
-  ArrayOfCDI GetUnSelectedChartDirs();
-  void SetDirActionButtons();
-
-  void OnCreateConfig(wxCommandEvent &event);
-  void OnEditConfig(wxCommandEvent &event);
-  void OnDeleteConfig(wxCommandEvent &event);
-  void OnApplyConfig(wxCommandEvent &event);
-  void SetConfigButtonState();
-  void ClearConfigList();
-  void BuildConfigList();
-  void OnConfigMouseSelected(wxMouseEvent &event);
-  void OnDialogInit(wxInitDialogEvent& event);
-
-
-  bool GetNeedNew() { return m_bneedNew; }
-  void SetNeedNew(bool bnew) { m_bneedNew = bnew; }
-  int GetScrollRate() { return m_scrollRate; }
-  void SetForceNewToolbarOnCancel(bool val) { m_bForceNewToolbaronCancel = val; }
-
-  wxArrayString *GetSerialArray(){ return m_pSerialArray; }
-
-  // Should we show tooltips?
-  static bool ShowToolTips(void);
-
-#ifdef __OCPN__OPTIONS_USE_LISTBOOK__
-  wxListbook *m_pListbook;
-#else
-  wxNotebook *m_pListbook;
-#endif
-
-  size_t m_pageDisplay, m_pageConnections, m_pageCharts, m_pageShips;
-  size_t m_pageUI, m_pagePlugins;
-  int lastPage, lastSubPage;
-  wxPoint lastWindowPos;
-  wxSize lastWindowSize;
-  wxButton *m_ApplyButton, *m_OKButton, *m_CancelButton;
-
-  ChartGroupArray *m_pGroupArray;
-  int m_groups_changed;
-
-  // Sizer flags
-  wxSizerFlags inputFlags, verticleInputFlags, labelFlags, groupInputFlags;
-  wxSizerFlags groupLabelFlags, groupLabelFlagsHoriz;
-
-  // For general options
-  wxScrolledWindow *pDisplayPanel;
   wxCheckBox *pShowStatusBar, *pShowMenuBar, *pShowChartBar, *pShowCompassWin;
   wxCheckBox *pPrintShowIcon, *pCDOOutlines, *pSDepthUnits, *pSDisplayGrid;
   wxCheckBox *pAutoAnchorMark, *pCDOQuilting, *pCBRaster, *pCBVector;
@@ -420,8 +440,75 @@ public:
   wxTextCtrl *pCOGUPUpdateSecs, *m_pText_OSCOG_Predictor, *pScreenMM;
   wxTextCtrl *pToolbarHideSecs, *m_pText_OSHDT_Predictor;
 
-  wxTextCtrl *pCmdSoundString;
+#ifdef __OCPN__OPTIONS_USE_LISTBOOK__
+  wxListbook *m_pListbook;
+#else
+  wxNotebook *m_pListbook;
+#endif
 
+  ChartGroupArray *m_pGroupArray;
+  int m_groups_changed;
+  bool b_haveWMM;
+  bool b_oldhaveWMM;
+
+  int k_plugins;
+  bool m_bForceNewToolbaronCancel;
+
+  wxArrayPtrVoid OBJLBoxArray;
+  wxString m_init_chart_dir;
+  wxArrayString *m_pSerialArray;
+
+  ArrayOfCDI m_CurrentDirList, *m_pWorkDirList;
+  MyConfig *m_pConfig;
+
+  // Sizer flags
+  wxSizerFlags inputFlags, verticleInputFlags, labelFlags, groupInputFlags;
+  wxSizerFlags groupLabelFlags, groupLabelFlagsHoriz;
+
+  // For general options
+  wxScrolledWindow *pDisplayPanel;
+  wxString SelectSoundFile();
+  void UpdateTemplateTitleText();
+  void CheckDeviceAccess(wxString &path);
+  int m_returnChanges;
+  wxListCtrl *tcDataSelected;
+  std::vector<int> marinersStdXref;
+  ChartGroupsUI *groupsPanel;
+  wxImageList *m_topImgList;
+
+  wxCheckBox* m_persist_active_route_chkbox;
+  wxScrolledWindow *m_pNMEAForm;
+  void resetMarStdList(bool bsetConfig, bool bsetStd);
+
+  ObservableListener compat_os_listener;
+  ObsListener m_sound_done_listener;
+
+  ColorScheme m_cs;
+  int m_screenConfig;
+
+  wxNotebookPage *m_groupsPage;
+  wxFont *dialogFont;
+  wxFont smallFont;
+  //  wxFont *dialogFont;
+  wxSize m_small_button_size;
+
+  bool m_bcompact;
+  int m_fontHeight, m_scrollRate;
+  bool m_bfontChanged;
+  bool m_bVectorInit;
+
+  wxBoxSizer *m_boxSizerConfigs;
+  wxColour m_panelBackgroundUnselected;
+  wxString m_selectedConfigPanelGUID;
+  wxSize m_colourPickerDefaultSize;
+
+  wxSize m_sliderSize;
+  bool m_bneedNew;
+  std::function<void()> m_on_close_cb;
+
+  std::shared_ptr<ConnectionsDialog>comm_dialog;
+
+  wxTextCtrl *pCmdSoundString;
   wxChoice *m_pShipIconType, *m_pcTCDatasets;
   wxSlider *m_pSlider_Zoom_Raster, *m_pSlider_GUI_Factor, *m_pSlider_Chart_Factor,
       *m_pSlider_Ship_Factor, *m_pSlider_Text_Factor, *m_pSlider_ENCText_Factor;
@@ -435,20 +522,6 @@ public:
   wxRadioButton *pCBCourseUp, *pCBNorthUp, *pRBSizeAuto, *pRBSizeManual;
   int k_tides;
 
-  // For the Display\Units page
-  wxStaticText *itemStaticTextUserVar;
-  wxStaticText *itemStaticTextUserVar2;
-  wxButton *m_configDeleteButton, *m_configApplyButton;
-
-  void OnAISRolloverClick(wxCommandEvent &event);
-  void UpdateChartDirList();
-
-  void OnCanvasConfigSelectClick(int ID, bool selected);
-
-
-  bool b_haveWMM;
-  bool b_oldhaveWMM;
-  ColorScheme m_cs;
 
   // For "S57" page
   wxBoxSizer *vectorPanel;
@@ -466,34 +539,6 @@ public:
   wxTextCtrl *m_ShallowCtl, *m_SafetyCtl, *m_DeepCtl;
   wxStaticText *m_depthUnitsShal, *m_depthUnitsSafe, *m_depthUnitsDeep;
   int k_vectorcharts;
-
-  // For "Units" page
-  wxChoice *pSDMMFormat, *pDistanceFormat, *pSpeedFormat, *pDepthUnitSelect,
-      *pTempFormat, *pWindSpeedFormat;
-  wxCheckBox *pCBTrueShow, *pCBMagShow;
-  wxTextCtrl *pMagVar;
-
-  // For "Charts" page
-  wxStaticBoxSizer *activeSizer;
-  wxBoxSizer *chartPanel;
-  wxTextCtrl *pSelCtl;
-
-  ArrayOfCDI ActiveChartArray;
-
-  wxStaticBox *itemActiveChartStaticBox;
-  wxCheckBox *pUpdateCheckBox, *pScanCheckBox;
-  wxButton *pParseENCButton;
-  wxButton *m_removeBtn, *m_compressBtn;
-  wxButton *m_migrateBtn;
-  int k_charts;
-  int m_nCharWidthMax;
-  wxBoxSizer *boxSizerCharts;
-  wxScrolledWindow *m_scrollWinChartList;
-  wxScrolledWindow* chartPanelWin;
-  wxBoxSizer* cmdButtonSizer;
-  wxStaticBox* loadedBox;
-  std::vector<OCPNChartDirPanel *> panelVector;
-  wxArrayString activeChartList;
 
   // For the "Charts->Display Options" page
   wxScrolledWindow *m_ChartDisplayPage;
@@ -518,6 +563,7 @@ public:
       *m_pText_Scale_Priority;
   wxTextCtrl *m_pText_ACK_Timeout, *m_pText_Show_Target_Name_Scale;
   wxTextCtrl *m_pText_RealtPred_Speed;
+  void OnAISRolloverClick(wxCommandEvent &event);
 
   // For Display->Configs page...
   wxScrolledWindow *m_DisplayConfigsPage;
@@ -525,6 +571,33 @@ public:
   CanvasConfigSelect *m_sconfigSelect_single;
   CanvasConfigSelect *m_sconfigSelect_twovertical;
   wxStaticText *m_Text_def_boat_speed;
+
+  // For "Units" page
+  wxChoice *pSDMMFormat, *pDistanceFormat, *pSpeedFormat, *pDepthUnitSelect,
+      *pTempFormat, *pWindSpeedFormat;
+  wxCheckBox *pCBTrueShow, *pCBMagShow;
+  wxTextCtrl *pMagVar;
+
+  // For "Charts" page
+  wxStaticBoxSizer *activeSizer;
+  wxBoxSizer *chartPanel;
+  wxTextCtrl *pSelCtl;
+
+  ArrayOfCDI ActiveChartArray;
+
+  wxStaticBox *itemActiveChartStaticBox;
+  wxButton *pParseENCButton;
+  wxButton *m_removeBtn, *m_compressBtn;
+  wxButton *m_migrateBtn;
+  int k_charts;
+  int m_nCharWidthMax;
+  wxBoxSizer *boxSizerCharts;
+  wxScrolledWindow *m_scrollWinChartList;
+  wxScrolledWindow* chartPanelWin;
+  wxBoxSizer* cmdButtonSizer;
+  wxStaticBox* loadedBox;
+  std::vector<OCPNChartDirPanel *> panelVector;
+  wxArrayString activeChartList;
 
   // For Configuration Template panel
   wxScrolledWindow *m_scrollWinConfigList;
@@ -553,6 +626,11 @@ public:
   wxStaticText *m_textSample;
   bool m_bVisitLang;
 
+  // For the Display\Units page
+  wxStaticText *itemStaticTextUserVar;
+  wxStaticText *itemStaticTextUserVar2;
+  wxButton *m_configDeleteButton, *m_configApplyButton;
+
   // For "AIS Options"
   wxComboBox *m_itemAISListBox;
 
@@ -561,13 +639,12 @@ public:
   AddPluginPanel *m_AddPluginPanel;
   CatalogMgrPanel *m_PluginCatalogMgrPanel;
   wxScrolledWindow *itemPanelPlugins;
-  wxBoxSizer *itemBoxSizerPanelPlugins;
   wxFlexGridSizer *radarGrid, *waypointradarGrid;
   wxChoice *pNavAidRadarRingsNumberVisible, *pWaypointRangeRingsNumber;
   OCPNColourPickerCtrl *m_colourOwnshipRangeRingColour;
   wxChoice *m_itemRadarRingsUnits, *m_itemWaypointRangeRingsUnits;
   OCPNColourPickerCtrl *m_colourTrackLineColour;
-  ;
+
   wxChoice *pTrackPrecision;
   wxTextCtrl *pNavAidRadarRingsStep, *pWaypointRangeRingsStep;
   wxCheckBox *pSogCogFromLLCheckBox;
@@ -580,7 +657,6 @@ public:
   wxCheckBox *pTrackDaily, *pTrackHighlite;
   wxStaticText *pStatic_CallSign;
 
-#if wxCHECK_VERSION(2, 9, 0)
 #if wxUSE_TIMEPICKCTRL
 #ifdef __WXGTK__
   TimeCtrl *pTrackRotateTime;
@@ -588,22 +664,10 @@ public:
   wxTimePickerCtrl *pTrackRotateTime;
 #endif
 #endif
-#endif
   wxRadioButton *pTrackRotateComputerTime, *pTrackRotateUTC, *pTrackRotateLMT;
   OCPNColourPickerCtrl *m_colourWaypointRangeRingsColour;
   wxChoice *pSoundDeviceIndex;
   wxStaticText *stSoundDeviceIndex;
-
-  wxArrayPtrVoid OBJLBoxArray;
-  wxString m_init_chart_dir;
-  wxArrayString *m_pSerialArray;
-
-  ArrayOfCDI m_CurrentDirList, *m_pWorkDirList;
-  MyConfig *m_pConfig;
-  wxWindow *pParent;
-
-  int k_plugins;
-  bool m_bForceNewToolbaronCancel;
 
   // Sounds panel
 
@@ -615,79 +679,8 @@ public:
   void OnUXAudioEnableButtonClickSART(wxCommandEvent &event);
   void OnUXAudioEnableButtonClickDSC(wxCommandEvent &event);
 
-  /** Notified with a OCPN_Sound* pointer when sound has completed. */
-  EventVar m_on_sound_done;
-  ObsListener m_sound_done_listener;
 
-private:
-  void Init(void);
-  void CreatePanel_MMSI(size_t parent, int border_size, int group_item_spacing);
-  void CreatePanel_AIS(size_t parent, int border_size, int group_item_spacing);
-  void CreatePanel_Ownship(size_t parent, int border_size,
-                           int group_item_spacing);
-  void CreatePanel_NMEA(size_t parent, int border_size, int group_item_spacing);
-  void CreatePanel_ChartsLoad(size_t parent, int border_size,
-                              int group_item_spacing);
-  void CreatePanel_VectorCharts(size_t parent, int border_size,
-                                int group_item_spacing);
-  void CreatePanel_TidesCurrents(size_t parent, int border_size,
-                                 int group_item_spacing);
-  void CreatePanel_ChartGroups(size_t parent, int border_size,
-                               int group_item_spacing);
-  void CreatePanel_Display(size_t parent, int border_size,
-                           int group_item_spacing);
-  void CreatePanel_UI(size_t parent, int border_size, int group_item_spacing);
-  void CreatePanel_Units(size_t parent, int border_size,
-                         int group_item_spacing);
-  void CreatePanel_Sounds(size_t parent, int border_size,
-                          int group_item_spacing);
-  void CreatePanel_Advanced(size_t parent, int border_size,
-                            int group_item_spacing);
-  void CreatePanel_Configs(size_t parent, int border_size,
-                           int group_item_spacing);
-  void CreatePanel_Routes(size_t parent, int border_size,
-                          int group_item_spacing);
 
-  void OnAlertEnableButtonClick(wxCommandEvent &event);
-  void OnAlertAudioEnableButtonClick(wxCommandEvent &event);
-
-  void UpdateTemplateTitleText();
-  void CheckDeviceAccess(wxString &path);
-  int m_returnChanges;
-  wxListCtrl *tcDataSelected;
-  std::vector<int> marinersStdXref;
-  ChartGroupsUI *groupsPanel;
-  wxImageList *m_topImgList;
-
-  wxCheckBox* m_persist_active_route_chkbox;
-  wxScrolledWindow *m_pNMEAForm;
-  void resetMarStdList(bool bsetConfig, bool bsetStd);
-
-  ObservableListener compat_os_listener;
-
-  int m_screenConfig;
-
-  wxNotebookPage *m_groupsPage;
-  wxFont *dialogFont;
-  wxFont smallFont;
-  //  wxFont *dialogFont;
-  wxSize m_small_button_size;
-
-  bool m_bcompact;
-  int m_fontHeight, m_scrollRate;
-  bool m_bfontChanged;
-  bool m_bVectorInit;
-
-  wxBoxSizer *m_boxSizerConfigs;
-  wxColour m_panelBackgroundUnselected;
-  wxString m_selectedConfigPanelGUID;
-  wxSize m_colourPickerDefaultSize;
-
-  wxSize m_sliderSize;
-  bool m_bneedNew;
-  std::function<void()> m_on_close_cb;
-
-  std::shared_ptr<ConnectionsDialog>comm_dialog;
 
   DECLARE_EVENT_TABLE()
 };

--- a/gui/src/NMEALogWindow.cpp
+++ b/gui/src/NMEALogWindow.cpp
@@ -34,7 +34,7 @@ extern OCPNPlatform *g_Platform;
 
 NMEALogWindow *NMEALogWindow::instance = NULL;
 
-NMEALogWindow &NMEALogWindow::Get() {
+NMEALogWindow &NMEALogWindow::GetInstance() {
   if (instance == NULL) {
     instance = new NMEALogWindow;
   }

--- a/gui/src/NMEALogWindow.cpp
+++ b/gui/src/NMEALogWindow.cpp
@@ -135,6 +135,7 @@ void NMEALogWindow::DestroyWindow() {
     UpdateGeometry();
     m_window->Destroy();
     m_window = NULL;
+    nmea_window_close_evt.Notify();
   }
 }
 

--- a/gui/src/NMEALogWindow.cpp
+++ b/gui/src/NMEALogWindow.cpp
@@ -42,7 +42,7 @@ NMEALogWindow &NMEALogWindow::Get() {
 }
 
 NMEALogWindow::NMEALogWindow()
-    : window(NULL), width(0), height(0), pos_x(0), pos_y(0) {}
+    : m_window(NULL), m_width(0), m_height(0), m_pos_x(0), m_pos_y(0) {}
 
 void NMEALogWindow::Shutdown() {
   if (instance) {
@@ -51,97 +51,97 @@ void NMEALogWindow::Shutdown() {
   }
 }
 
-bool NMEALogWindow::Active() const { return window != NULL; }
+bool NMEALogWindow::Active() const { return m_window != NULL; }
 
 void NMEALogWindow::Create(wxWindow *parent, int num_lines) {
-  if (window == NULL) {
-    window = new TTYWindow(parent, num_lines, this);
-    window->SetTitle(_("NMEA Debug Window"));
+  if (m_window == NULL) {
+    m_window = new TTYWindow(parent, num_lines, this);
+    m_window->SetTitle(_("NMEA Debug Window"));
 
     // Make sure the window is well on the screen
-    pos_x = wxMax(pos_x, 40);
-    pos_y = wxMax(pos_y, 40);
+    m_pos_x = wxMax(m_pos_x, 40);
+    m_pos_y = wxMax(m_pos_y, 40);
 
-    window->SetSize(pos_x, pos_y, width, height);
+    m_window->SetSize(m_pos_x, m_pos_y, m_width, m_height);
   }
-  window->Show();
+  m_window->Show();
 }
 
 void NMEALogWindow::Add(const wxString &s) {
-  if (window) window->Add(s);
+  if (m_window) m_window->Add(s);
 }
 
 void NMEALogWindow::Refresh(bool do_refresh) {
-  if (window) window->Refresh(do_refresh);
+  if (m_window) m_window->Refresh(do_refresh);
 }
 
 void NMEALogWindow::SetSize(const wxSize &size) {
-  width = size.GetWidth();
-  width = wxMax(width, 400 * g_Platform->GetDisplayDensityFactor());
-  width = wxMin(width, g_Platform->getDisplaySize().x - 20);
-  height = size.GetHeight();
-  height = wxMax(height, 300 * g_Platform->GetDisplayDensityFactor());
-  height = wxMin(height, g_Platform->getDisplaySize().y - 20);
+  m_width = size.GetWidth();
+  m_width = wxMax(m_width, 400 * g_Platform->GetDisplayDensityFactor());
+  m_width = wxMin(m_width, g_Platform->getDisplaySize().x - 20);
+  m_height = size.GetHeight();
+  m_height = wxMax(m_height, 300 * g_Platform->GetDisplayDensityFactor());
+  m_height = wxMin(m_height, g_Platform->getDisplaySize().y - 20);
 }
 
 void NMEALogWindow::SetPos(const wxPoint &pos) {
-  pos_x = pos.x;
-  pos_y = pos.y;
+  m_pos_x = pos.x;
+  m_pos_y = pos.y;
 }
 
 int NMEALogWindow::GetSizeW() {
   UpdateGeometry();
-  return width;
+  return m_width;
 }
 
 int NMEALogWindow::GetSizeH() {
   UpdateGeometry();
-  return height;
+  return m_height;
 }
 
 int NMEALogWindow::GetPosX() {
   UpdateGeometry();
-  return pos_x;
+  return m_pos_x;
 }
 
 int NMEALogWindow::GetPosY() {
   UpdateGeometry();
-  return pos_y;
+  return m_pos_y;
 }
 
 void NMEALogWindow::SetSize(int w, int h) {
-  width = w;
-  width = wxMax(width, 400 * g_Platform->GetDisplayDensityFactor());
-  width = wxMin(width, g_Platform->getDisplaySize().x - 20);
+  m_width = w;
+  m_width = wxMax(m_width, 400 * g_Platform->GetDisplayDensityFactor());
+  m_width = wxMin(m_width, g_Platform->getDisplaySize().x - 20);
 
-  height = h;
-  height = wxMax(height, 300 * g_Platform->GetDisplayDensityFactor());
-  height = wxMin(height, g_Platform->getDisplaySize().y - 20);
+  m_height = h;
+  m_height = wxMax(m_height, 300 * g_Platform->GetDisplayDensityFactor());
+  m_height = wxMin(m_height, g_Platform->getDisplaySize().y - 20);
   //    qDebug() << w << h << width << height;
 }
 
 void NMEALogWindow::SetPos(int x, int y) {
-  pos_x = x;
-  pos_y = y;
+  m_pos_x = x;
+  m_pos_y = y;
 }
 
 void NMEALogWindow::CheckPos(int display_width, int display_height) {
-  if ((pos_x < 0) || (pos_x > display_width)) pos_x = 5;
-  if ((pos_y < 0) || (pos_y > display_height)) pos_y = 5;
+  if ((m_pos_x < 0) || (m_pos_x > display_width)) m_pos_x = 5;
+  if ((m_pos_y < 0) || (m_pos_y > display_height)) m_pos_y = 5;
 }
 
 void NMEALogWindow::DestroyWindow() {
-  if (window) {
+  if (m_window) {
     UpdateGeometry();
-    window->Destroy();
-    window = NULL;
+    m_window->Destroy();
+    m_window = NULL;
   }
 }
 
 void NMEALogWindow::Move() {
-  if (window) {
-    window->Move(pos_x, pos_y);
-    window->Raise();
+  if (m_window) {
+    m_window->Move(m_pos_x, m_pos_y);
+    m_window->Raise();
   }
 }
 
@@ -153,8 +153,8 @@ void NMEALogWindow::Move() {
  * of the window.
  */
 void NMEALogWindow::UpdateGeometry() {
-  if (window) {
-    SetSize(window->GetSize());
-    SetPos(window->GetPosition());
+  if (m_window) {
+    SetSize(m_window->GetSize());
+    SetPos(m_window->GetPosition());
   }
 }

--- a/gui/src/TTYWindow.cpp
+++ b/gui/src/TTYWindow.cpp
@@ -43,11 +43,11 @@ BEGIN_EVENT_TABLE(TTYWindow, wxFrame)
 EVT_CLOSE(TTYWindow::OnCloseWindow)
 END_EVENT_TABLE()
 
-TTYWindow::TTYWindow() : m_window_destroy_listener(NULL), m_pScroll(NULL) {}
+TTYWindow::TTYWindow() : m_window_destroy_listener(NULL), m_tty_scroll(NULL) {}
 
 TTYWindow::TTYWindow(wxWindow* parent, int n_lines,
                      WindowDestroyListener* listener)
-    : m_window_destroy_listener(listener), m_pScroll(NULL) {
+    : m_window_destroy_listener(listener), m_tty_scroll(NULL) {
   wxFrame::Create(
       parent, -1, _T("Title"), wxDefaultPosition, wxDefaultSize,
       wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER | wxFRAME_FLOAT_ON_PARENT);
@@ -55,16 +55,16 @@ TTYWindow::TTYWindow(wxWindow* parent, int n_lines,
   wxBoxSizer* bSizerOuterContainer = new wxBoxSizer(wxVERTICAL);
   SetSizer(bSizerOuterContainer);
 
-  m_tFilter = new wxTextCtrl(this, wxID_ANY);
+  m_filter = new wxTextCtrl(this, wxID_ANY);
 
-  m_pScroll = new TTYScroll(this, n_lines, *m_tFilter);
-  m_pScroll->Scroll(-1, 1000);  // start with full scroll down
+  m_tty_scroll = new TTYScroll(this, n_lines, *m_filter);
+  m_tty_scroll->Scroll(-1, 1000);  // start with full scroll down
 
-  bSizerOuterContainer->Add(m_pScroll, 1, wxEXPAND, 5);
+  bSizerOuterContainer->Add(m_tty_scroll, 1, wxEXPAND, 5);
 
   wxStaticBox* psbf = new wxStaticBox(this, wxID_ANY, _("Filter"));
   wxStaticBoxSizer* sbSizer2 = new wxStaticBoxSizer(psbf, wxVERTICAL);
-  sbSizer2->Add(m_tFilter, 1, wxALL | wxEXPAND, 5);
+  sbSizer2->Add(m_filter, 1, wxALL | wxEXPAND, 5);
   bSizerOuterContainer->Add(sbSizer2, 0, wxEXPAND, 5);
 
   wxBoxSizer* bSizerBottomContainer = new wxBoxSizer(wxHORIZONTAL);
@@ -81,30 +81,30 @@ TTYWindow::TTYWindow(wxWindow* parent, int n_lines,
   wxStaticBox* buttonBox = new wxStaticBox(this, wxID_ANY, wxEmptyString);
   wxStaticBoxSizer* bbSizer1 = new wxStaticBoxSizer(buttonBox, wxVERTICAL);
 
-  m_buttonPause = new wxButton(this, wxID_ANY, _("Pause"), wxDefaultPosition,
+  m_btn_pause = new wxButton(this, wxID_ANY, _("Pause"), wxDefaultPosition,
                                wxDefaultSize, 0);
-  m_buttonCopy = new wxButton(this, wxID_ANY, _("Copy"), wxDefaultPosition,
+  m_btn_copy = new wxButton(this, wxID_ANY, _("Copy"), wxDefaultPosition,
                               wxDefaultSize, 0);
-  m_buttonCopy->SetToolTip(_("Copy NMEA Debug window to clipboard."));
+  m_btn_copy->SetToolTip(_("Copy NMEA Debug window to clipboard."));
 
-  bbSizer1->Add(m_buttonPause, 0, wxALL, 5);
-  bbSizer1->Add(m_buttonCopy, 0, wxALL, 5);
+  bbSizer1->Add(m_btn_pause, 0, wxALL, 5);
+  bbSizer1->Add(m_btn_copy, 0, wxALL, 5);
   bSizerBottomContainer->Add(bbSizer1, 1, wxALL | wxEXPAND, 5);
 
-  m_buttonCopy->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
+  m_btn_copy->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
                         wxCommandEventHandler(TTYWindow::OnCopyClick), NULL,
                         this);
-  m_buttonPause->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
+  m_btn_pause->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
                          wxCommandEventHandler(TTYWindow::OnPauseClick), NULL,
                          this);
 
-  bpause = false;
+  m_is_paused = false;
 }
 
 TTYWindow::~TTYWindow() {
-  if (m_pScroll) {
-    delete m_pScroll;
-    m_pScroll = NULL;
+  if (m_tty_scroll) {
+    delete m_tty_scroll;
+    m_tty_scroll = NULL;
   }
 }
 
@@ -170,19 +170,19 @@ void TTYWindow::CreateLegendBitmap() {
 }
 
 void TTYWindow::OnPauseClick(wxCommandEvent& event) {
-  if (!bpause) {
-    bpause = true;
-    m_pScroll->Pause(true);
-    m_buttonPause->SetLabel(_("Resume"));
+  if (!m_is_paused) {
+    m_is_paused = true;
+    m_tty_scroll->Pause(true);
+    m_btn_pause->SetLabel(_("Resume"));
   } else {
-    bpause = false;
-    m_pScroll->Pause(false);
+    m_is_paused = false;
+    m_tty_scroll->Pause(false);
 
-    m_buttonPause->SetLabel(_("Pause"));
+    m_btn_pause->SetLabel(_("Pause"));
   }
 }
 
-void TTYWindow::OnCopyClick(wxCommandEvent& event) { m_pScroll->Copy(); }
+void TTYWindow::OnCopyClick(wxCommandEvent& event) { m_tty_scroll->Copy(); }
 
 void TTYWindow::OnCloseWindow(wxCloseEvent& event) {
   if (m_window_destroy_listener) {
@@ -193,5 +193,5 @@ void TTYWindow::OnCloseWindow(wxCloseEvent& event) {
 }
 
 void TTYWindow::Add(const wxString& line) {
-  if (m_pScroll) m_pScroll->Add(line);
+  if (m_tty_scroll) m_tty_scroll->Add(line);
 }

--- a/gui/src/TTYWindow.cpp
+++ b/gui/src/TTYWindow.cpp
@@ -169,7 +169,7 @@ void TTYWindow::CreateLegendBitmap() {
   dc.SelectObject(wxNullBitmap);
 }
 
-void TTYWindow::OnPauseClick(wxCommandEvent& event) {
+void TTYWindow::OnPauseClick(wxCommandEvent&) {
   if (!m_is_paused) {
     m_is_paused = true;
     m_tty_scroll->Pause(true);
@@ -182,9 +182,9 @@ void TTYWindow::OnPauseClick(wxCommandEvent& event) {
   }
 }
 
-void TTYWindow::OnCopyClick(wxCommandEvent& event) { m_tty_scroll->Copy(); }
+void TTYWindow::OnCopyClick(wxCommandEvent&) { m_tty_scroll->Copy(); }
 
-void TTYWindow::OnCloseWindow(wxCloseEvent& event) {
+void TTYWindow::OnCloseWindow(wxCloseEvent&) {
   if (m_window_destroy_listener) {
     m_window_destroy_listener->DestroyWindow();
   } else {

--- a/gui/src/connection_edit.cpp
+++ b/gui/src/connection_edit.cpp
@@ -1822,14 +1822,15 @@ void ConnectionEditDialog::OnCbAdvanced(wxCommandEvent& event) {
 
 void ConnectionEditDialog::OnShowGpsWindowCheckboxClick(wxCommandEvent& event) {
   if (!m_cbNMEADebug->GetValue()) {
-    NMEALogWindow::Get().DestroyWindow();
+    NMEALogWindow::GetInstance().DestroyWindow();
   } else {
-    NMEALogWindow::Get().Create((wxWindow*)(m_parent->pParent), 35);
+    NMEALogWindow::GetInstance().Create((wxWindow*)(m_parent->pParent), 35);
 
     // Try to ensure that the log window is a least a little bit visible
-    wxRect logRect(
-        NMEALogWindow::Get().GetPosX(), NMEALogWindow::Get().GetPosY(),
-        NMEALogWindow::Get().GetSizeW(), NMEALogWindow::Get().GetSizeH());
+    wxRect logRect(NMEALogWindow::GetInstance().GetPosX(),
+                   NMEALogWindow::GetInstance().GetPosY(),
+                   NMEALogWindow::GetInstance().GetSizeW(),
+                   NMEALogWindow::GetInstance().GetSizeH());
 
 #if 0
     if (m_container->GetRect().Contains(logRect)) {

--- a/gui/src/connections_dialog.cpp
+++ b/gui/src/connections_dialog.cpp
@@ -62,6 +62,9 @@ ConnectionsDialog::ConnectionsDialog(wxScrolledWindow* container,
                                      options* parent) {
   m_container = container;
   m_parent = parent;
+  nmea_window_close_listener.Init(
+          NMEALogWindow::GetInstance().nmea_window_close_evt,
+          [&] (ObservedEvt&) { m_cbNMEADebug->SetValue(false); });
 
   Init();
 }

--- a/gui/src/connections_dialog.cpp
+++ b/gui/src/connections_dialog.cpp
@@ -71,8 +71,8 @@ ConnectionsDialog::~ConnectionsDialog() {}
 void ConnectionsDialog::SetInitialSettings(void) {
 
   m_cbNMEADebug->SetValue(false);
-  if (NMEALogWindow::Get().GetTTYWindow()) {
-    if (NMEALogWindow::Get().GetTTYWindow()->IsShown()) {
+  if (NMEALogWindow::GetInstance().GetTTYWindow()) {
+    if (NMEALogWindow::GetInstance().GetTTYWindow()->IsShown()) {
       m_cbNMEADebug->SetValue(true);
     }
   }
@@ -150,7 +150,7 @@ void ConnectionsDialog::Init() {
   m_cbNMEADebug =
       new wxCheckBox(m_container, wxID_ANY, _("Show NMEA Debug Window"),
                      wxDefaultPosition, wxDefaultSize, 0);
-  m_cbNMEADebug->SetValue(NMEALogWindow::Get().Active());
+  m_cbNMEADebug->SetValue(NMEALogWindow::GetInstance().Active());
   bSizer161->Add(m_cbNMEADebug, 0, wxALL, cb_space);
 
   m_cbFurunoGP3X =
@@ -499,21 +499,22 @@ void ConnectionsDialog::OnEditDatasourceClick(wxCommandEvent& event) {
 
 void ConnectionsDialog::OnShowGpsWindowCheckboxClick(wxCommandEvent& event) {
   if (!m_cbNMEADebug->GetValue()) {
-    NMEALogWindow::Get().DestroyWindow();
+    NMEALogWindow::GetInstance().DestroyWindow();
   } else {
-    NMEALogWindow::Get().Create((wxWindow*)(m_parent->pParent), 35);
+    NMEALogWindow::GetInstance().Create((wxWindow*)(m_parent->pParent), 35);
 
     // Try to ensure that the log window is a least a little bit visible
-    wxRect logRect(
-        NMEALogWindow::Get().GetPosX(), NMEALogWindow::Get().GetPosY(),
-        NMEALogWindow::Get().GetSizeW(), NMEALogWindow::Get().GetSizeH());
+    wxRect logRect(NMEALogWindow::GetInstance().GetPosX(),
+                   NMEALogWindow::GetInstance().GetPosY(),
+                   NMEALogWindow::GetInstance().GetSizeW(),
+                   NMEALogWindow::GetInstance().GetSizeH());
 
     if (m_container->GetRect().Contains(logRect)) {
-      NMEALogWindow::Get().SetPos(
+      NMEALogWindow::GetInstance().SetPos(
           m_container->GetRect().x / 2,
           (m_container->GetRect().y +
            (m_container->GetRect().height - logRect.height) / 2));
-      NMEALogWindow::Get().Move();
+      NMEALogWindow::GetInstance().Move();
     }
 
     m_parent->Raise();
@@ -591,5 +592,3 @@ void ConnectionsDialog::OnPriorityDialog(wxCommandEvent& event) {
   pdlg->ShowModal();
   delete pdlg;
 }
-
-

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -1016,11 +1016,11 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   // We allow 0-99 backups ov navobj.xml
   Read(_T ( "KeepNavobjBackups" ), &g_navobjbackups);
 
-  NMEALogWindow::Get().SetSize(Read(_T("NMEALogWindowSizeX"), 600L),
+  NMEALogWindow::GetInstance().SetSize(Read(_T("NMEALogWindowSizeX"), 600L),
                                Read(_T("NMEALogWindowSizeY"), 400L));
-  NMEALogWindow::Get().SetPos(Read(_T("NMEALogWindowPosX"), 10L),
+  NMEALogWindow::GetInstance().SetPos(Read(_T("NMEALogWindowPosX"), 10L),
                               Read(_T("NMEALogWindowPosY"), 10L));
-  NMEALogWindow::Get().CheckPos(display_width, display_height);
+  NMEALogWindow::GetInstance().CheckPos(display_width, display_height);
 
   // Boolean to cater for legacy Input COM Port filer behaviour, i.e. show msg
   // filtered but put msg on bus.
@@ -2450,10 +2450,10 @@ void MyConfig::UpdateSettings() {
 
   Write(_T ( "ChartQuilting" ), g_bQuiltEnable);
 
-  Write(_T ( "NMEALogWindowSizeX" ), NMEALogWindow::Get().GetSizeW());
-  Write(_T ( "NMEALogWindowSizeY" ), NMEALogWindow::Get().GetSizeH());
-  Write(_T ( "NMEALogWindowPosX" ), NMEALogWindow::Get().GetPosX());
-  Write(_T ( "NMEALogWindowPosY" ), NMEALogWindow::Get().GetPosY());
+  Write(_T ( "NMEALogWindowSizeX" ), NMEALogWindow::GetInstance().GetSizeW());
+  Write(_T ( "NMEALogWindowSizeY" ), NMEALogWindow::GetInstance().GetSizeH());
+  Write(_T ( "NMEALogWindowPosX" ), NMEALogWindow::GetInstance().GetPosX());
+  Write(_T ( "NMEALogWindowPosY" ), NMEALogWindow::GetInstance().GetPosY());
 
   Write(_T ( "PreserveScaleOnX" ), g_bPreserveScaleOnX);
 

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -1194,7 +1194,7 @@ bool MyApp::OnInit() {
   //      Init the Route Manager
 
  g_pRouteMan = new Routeman(RoutePropDlg::GetDlgCtx(), RoutemanGui::GetDlgCtx(),
-                            NMEALogWindow::Get());
+                   NMEALogWindow::GetInstance());
 
   //      Init the Selectable Route Items List
   pSelect = new Select();

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -706,8 +706,9 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, const wxPoint &pos,
 
   //    Establish my children
   struct MuxLogCallbacks log_callbacks;
-  log_callbacks.log_is_active = []() { return NMEALogWindow::Get().Active(); };
-  log_callbacks.log_message = [](const std::string& s) { NMEALogWindow::Get().Add(s); };
+  log_callbacks.log_is_active = []() { return NMEALogWindow::GetInstance().Active(); };
+  log_callbacks.log_message = [](const std::string& s) {
+    NMEALogWindow::GetInstance().Add(s); };
   g_pMUX = new Multiplexer(log_callbacks, g_b_legacy_input_filter_behaviour);
 
   struct AisDecoderCallbacks  ais_callbacks;
@@ -4170,8 +4171,8 @@ int MyFrame::DoOptionsDialog() {
       dynamic_cast<AISTargetAlertDialog*>(g_pais_alert_dialog_active);
   if (alert_dlg_active) alert_dlg_active->Raise();
 
-  if (NMEALogWindow::Get().Active())
-    NMEALogWindow::Get().GetTTYWindow()->Raise();
+  if (NMEALogWindow::GetInstance().Active())
+    NMEALogWindow::GetInstance().GetTTYWindow()->Raise();
 
 #ifdef __ANDROID__
   if (g_pi_manager) g_pi_manager->NotifyAuiPlugIns();
@@ -6879,8 +6880,8 @@ void MyFrame::applySettingsString(wxString settings) {
 
   Refresh(false);
 
-  if (NMEALogWindow::Get().Active())
-    NMEALogWindow::Get().GetTTYWindow()->Raise();
+  if (NMEALogWindow::GetInstance().Active())
+    NMEALogWindow::GetInstance().GetTTYWindow()->Raise();
 }
 
 #ifdef wxHAS_POWER_EVENTS

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -3962,7 +3962,20 @@ int MyFrame::DoOptionsDialog() {
     }
   }
 
-  int rr = g_options->ShowModal();
+  // options opens a modeless nmea debug window and cannot use ShowModal()
+  // OTOH, here are dragons: options is overall written to be recreated from
+  // scratch for each invocation. Hence this "semi-modal"  approach for now
+  // See also #3923
+  {
+    bool done = false;
+    g_options->SetOnCloseCb([&done] { done = true; });
+    g_options->Show();
+    while (!done) {
+      wxYield();
+    }
+    g_options->ClearOnCloseCb();
+    g_options->Hide();
+  }
 
 #ifdef __ANDROID__
   androidEnableBackButton(true);
@@ -4001,7 +4014,7 @@ int MyFrame::DoOptionsDialog() {
 #endif
 
   bool ret_val = false;
-  rr = g_options->GetReturnCode();
+  int rr = g_options->GetReturnCode();
 
   if (g_last_ChartScaleFactor != g_ChartScaleFactor) rr |= S52_CHANGED;
 

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -7518,8 +7518,7 @@ void options::Finish(void) {
   pConfig->Write("OptionsSizeX", lastWindowSize.x);
   pConfig->Write("OptionsSizeY", lastWindowSize.y);
 
-  SetReturnCode(m_returnChanges);
-  EndModal(m_returnChanges);
+  m_on_close_cb();
 }
 
 ArrayOfCDI options::GetSelectedChartDirs() {
@@ -7959,9 +7958,7 @@ void options::OnCancelClick(wxCommandEvent& event) {
   pConfig->Write("OptionsSizeX", lastWindowSize.x);
   pConfig->Write("OptionsSizeY", lastWindowSize.y);
 
-  int rv = 0;
-  if (m_bForceNewToolbaronCancel) rv = TOOLBAR_CHANGED;
-  EndModal(rv);
+  m_on_close_cb();
 }
 
 void options::OnClose(wxCloseEvent& event) {
@@ -7977,7 +7974,7 @@ void options::OnClose(wxCloseEvent& event) {
   pConfig->Write("OptionsSizeX", lastWindowSize.x);
   pConfig->Write("OptionsSizeY", lastWindowSize.y);
 
-  EndModal(0);
+  m_on_close_cb();
 }
 
 void options::OnFontChoice(wxCommandEvent& event) {

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -1492,7 +1492,8 @@ EVT_CHAR_HOOK(options::OnCharHook)
 END_EVENT_TABLE()
 
 options::options(wxWindow* parent, wxWindowID id, const wxString& caption,
-                 const wxPoint& pos, const wxSize& size, long style) {
+                 const wxPoint& pos, const wxSize& size, long style)
+     : pTrackRotateTime(0) {
   Init();
 
   pParent = parent;
@@ -7093,7 +7094,7 @@ void options::OnApplyClick(wxCommandEvent& event) {
   g_track_rotate_time = 0;
 #if wxUSE_TIMEPICKCTRL
   int h, m, s;
-  if (pTrackRotateTime->GetTime(&h, &m, &s))
+  if (pTrackRotateTime && pTrackRotateTime->GetTime(&h, &m, &s))
     g_track_rotate_time = h * 3600 + m * 60 + s;
 #endif
 

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -224,7 +224,7 @@ extern bool g_bQuiltEnable;
 extern bool g_bFullScreenQuilt;
 extern bool g_bConfirmObjectDelete;
 
-#if wxUSE_XLOCALE || !wxCHECK_VERSION(3, 0, 0)
+#if wxUSE_XLOCALE
 extern wxLocale* plocale_def_lang;
 #endif
 
@@ -293,7 +293,7 @@ extern wxString GetShipNameFromFile(int);
 WX_DEFINE_ARRAY_PTR(ChartCanvas*, arrayofCanvasPtr);
 extern arrayofCanvasPtr g_canvasArray;
 
-#if wxUSE_XLOCALE || !wxCHECK_VERSION(3, 0, 0)
+#if wxUSE_XLOCALE
 static int lang_list[] = {
     wxLANGUAGE_DEFAULT, wxLANGUAGE_ABKHAZIAN, wxLANGUAGE_AFAR,
     wxLANGUAGE_AFRIKAANS, wxLANGUAGE_ALBANIAN, wxLANGUAGE_AMHARIC,
@@ -396,12 +396,8 @@ void prepareSlider(wxSlider* slider) {
 #endif
 
 // sort callback for Connections list  Sort by priority.
-#if wxCHECK_VERSION(2, 9, 0)
 int wxCALLBACK SortConnectionOnPriority(wxIntPtr item1, wxIntPtr item2,
                                         wxIntPtr list)
-#else
-int wxCALLBACK SortConnectionOnPriority(long item1, long item2, long list)
-#endif
 {
   wxListCtrl* lc = reinterpret_cast<wxListCtrl*>(list);
 
@@ -1547,12 +1543,10 @@ options::~options(void) {
 }
 
 // with AIS it's called very often
-#if wxCHECK_VERSION(3, 0, 0)
 bool options::SendIdleEvents(wxIdleEvent& event) {
   if (IsShown()) return wxDialog::SendIdleEvents(event);
   return false;
 }
-#endif
 
 void options::RecalculateSize(int hint_x, int hint_y) {
   if (!g_bresponsive) {
@@ -2060,7 +2054,6 @@ void options::CreatePanel_Ownship(size_t parent, int border_size,
 
   trackSizer1->Add(0, 0, 1, wxEXPAND, 0);
 
-#if wxCHECK_VERSION(2, 9, 0)
 #if wxUSE_TIMEPICKCTRL
   pTrackDaily->SetLabel(_("Automatic Daily Tracks at"));
 #ifdef __WXGTK__
@@ -2068,12 +2061,6 @@ void options::CreatePanel_Ownship(size_t parent, int border_size,
       new TimeCtrl(itemPanelShip, ID_TRACKROTATETIME,
                    wxDateTime((time_t)g_track_rotate_time).ToUTC(),
                    wxDefaultPosition, wxDefaultSize, 0);
-#else
-  pTrackRotateTime =
-      new wxTimePickerCtrl(itemPanelShip, ID_TRACKROTATETIME,
-                           wxDateTime((time_t)g_track_rotate_time).ToUTC(),
-                           wxDefaultPosition, wxDefaultSize, 0);
-#endif
   trackSizer1->Add(pTrackRotateTime, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT,
                    border_size);
 #endif
@@ -2919,7 +2906,6 @@ void options::CreatePanel_Advanced(size_t parent, int border_size,
 
     // OpenGL Options
 #ifdef ocpnUSE_GL
-
     wxBoxSizer* OpenGLSizer = new wxBoxSizer(wxVERTICAL);
     itemBoxSizerUI->Add(OpenGLSizer, 0, 0, 0);
 
@@ -2935,17 +2921,13 @@ void options::CreatePanel_Advanced(size_t parent, int border_size,
 
     pOpenGL->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                      wxCommandEventHandler(options::OnGLClicked), NULL, this);
-
-
-
 #ifdef __ANDROID__
     pOpenGL->Hide();
     bOpenGL->Hide();
 #endif
-
     itemBoxSizerUI->Add(0, border_size * 3);
     itemBoxSizerUI->Add(0, border_size * 3);
-#endif
+#endif   // ocpnUSE_GL
 
     //  Course Up display update period
     wxStaticText* crat = new wxStaticText(m_ChartDisplayPage, wxID_ANY,
@@ -3722,15 +3704,8 @@ void options::CreatePanel_VectorCharts(size_t parent, int border_size,
     btnRow2->Add(itemButtonSetStd, 1, wxALL | wxEXPAND, group_item_spacing);
     marinersSizer->Add(btnRow2);
 
-    // #if defined(__WXMSW__) || defined(__WXOSX__)
-    //     wxString* ps57CtlListBoxStrings = NULL;
-    //     ps57CtlListBox = new wxCheckListBox(
-    //         ps57Ctl, ID_CHECKLISTBOX, wxDefaultPosition, wxSize(250, 350), 0,
-    //         ps57CtlListBoxStrings, wxLB_SINGLE | wxLB_HSCROLL | wxLB_SORT);
-    // #else
     ps57CtlListBox = new OCPNCheckedListCtrl(
         ps57Ctl, ID_CHECKLISTBOX, wxDefaultPosition, wxSize(250, 350));
-    // #endif
 
     marinersSizer->Add(ps57CtlListBox, 1, wxALL | wxEXPAND, group_item_spacing);
   }
@@ -7116,12 +7091,10 @@ void options::OnApplyClick(wxCommandEvent& event) {
   g_bTrackDaily = pTrackDaily->GetValue();
 
   g_track_rotate_time = 0;
-#if wxCHECK_VERSION(2, 9, 0)
 #if wxUSE_TIMEPICKCTRL
   int h, m, s;
   if (pTrackRotateTime->GetTime(&h, &m, &s))
     g_track_rotate_time = h * 3600 + m * 60 + s;
-#endif
 #endif
 
   if (pTrackRotateUTC->GetValue())


### PR DESCRIPTION
  - Make options to sort of a "semi-modal" dialog which allows for the NMEA log window to process events.
  - Hook up the NMEA log window close event  so  the "Show NMEA Debug window" is updated when user closes window.
  - While on it: some general clean up i affected files.

Closes: #3923