### PR TITLE
udev_rule_mgr: Make "device not found" dialog modeless  (#3922).

### DIFF
--- a/gui/include/gui/udev_rule_mgr.h
+++ b/gui/include/gui/udev_rule_mgr.h
@@ -39,4 +39,7 @@ bool CheckDongleAccess(wxWindow* parent);
  */
 bool CheckSerialAccess(wxWindow* parent, const std::string device);
 
+/** Destroy all open "Device not found" dialog windows. */
+void DestroyDeviceNotFoundDialogs();
+
 #endif  // UDEV_RULE_MGR_H__

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -135,6 +135,10 @@
 #include "waypointman_gui.h"
 #include "CanvasOptions.h"
 
+#if defined( __linux__) && !defined(__ANDROID__)
+#include "udev_rule_mgr.h"
+#endif
+
 #ifdef __ANDROID__
 #include "androidUTIL.h"
 #endif
@@ -795,6 +799,10 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, const wxPoint &pos,
 
 MyFrame::~MyFrame() {
   FrameTimer1.Stop();
+#if defined(__linux__) && !defined(__ANDROID__)
+  DestroyDeviceNotFoundDialogs();
+#endif
+
   delete ChartData;
   // delete pCurrentStack;
 

--- a/gui/src/udev_rule_mgr.cpp
+++ b/gui/src/udev_rule_mgr.cpp
@@ -21,6 +21,13 @@
 
 #include "config.h"
 
+#include <algorithm>
+#include <cassert>
+#include <sstream>
+#include <vector>
+
+#include <stdlib.h>
+
 #include <wx/button.h>
 #include <wx/checkbox.h>
 #include <wx/dcclient.h>
@@ -92,8 +99,87 @@ To do after installing the rule according to instructions:
 static const char* const DEVICE_NOT_FOUND =
     _("The device @device@ can not be found (disconnected?)");
 
+static const char* const INSTRUCTIONS = "@pkexec@ cp @PATH@ /etc/udev/rules.d";
+
+/** The modeless "Device not found" dialog. */
+class DeviceNotFoundDlg : public wxFrame {
+public:
+  /** Construct and show a dialog for given device. */
+  static void Create(wxWindow* parent, const std::string& device) {
+    wxWindow* dlg = new DeviceNotFoundDlg(parent, device);
+    dlg->Show();
+  }
+
+  /** Destroy all open dialog windows, overall destructor helper. */
+  static void DestroyOpenWindows() {
+    for (const auto& name : open_windows) {
+      auto window = wxWindow::FindWindowByName(name);
+      if (window) window->Destroy();
+    }
+    open_windows.clear();
+  }
+
+private:
+  static std::vector<std::string> open_windows;
+
+  class ButtonsSizer : public wxStdDialogButtonSizer {
+  public:
+    ButtonsSizer(DeviceNotFoundDlg* parent) : wxStdDialogButtonSizer() {
+      auto button = new wxButton(parent, wxID_OK);
+      AddButton(button);
+      Realize();
+    }
+  };
+
+  DeviceNotFoundDlg(wxWindow* parent, const std::string& device)
+      : wxFrame(parent, wxID_ANY, _("Opencpn: device not found"),
+                wxDefaultPosition, wxDefaultSize,
+                wxDEFAULT_FRAME_STYLE | wxFRAME_FLOAT_ON_PARENT) {
+    std::stringstream ss;
+    ss << "dlg-id-" << rand();
+    SetName(ss.str());
+    open_windows.push_back(ss.str());
+
+    Bind(wxEVT_CLOSE_WINDOW, [&](wxCloseEvent& e) {
+      OnClose();
+      e.Skip();
+    });
+    Bind(wxEVT_COMMAND_BUTTON_CLICKED, [&](wxCommandEvent&) { OnClose(); });
+
+    auto vbox = new wxBoxSizer(wxVERTICAL);
+    SetSizer(vbox);
+    auto flags = wxSizerFlags().Expand().Border();
+    std::string txt(DEVICE_NOT_FOUND);
+    ocpn::replace(txt, "@device@", device);
+    vbox->Add(0, 0, 1);  // vertical space
+    vbox->Add(new wxStaticText(this, wxID_ANY, txt), flags);
+    vbox->Add(0, 0, 1);
+    vbox->Add(new wxStaticLine(this), wxSizerFlags().Expand());
+    vbox->Add(new ButtonsSizer(this), flags);
+    Layout();
+    CenterOnScreen();
+    SetFocus();
+  }
+
+  void OnClose() {
+    const std::string name(GetName().ToStdString());
+    auto found =
+        std::find_if(open_windows.begin(), open_windows.end(),
+                     [name](const std::string& s) { return s == name; });
+    assert(found != std::end(open_windows) &&
+           "Cannot find dialog in window list");
+    open_windows.erase(found);
+    Destroy();
+  }
+};
+
+std::vector<std::string> DeviceNotFoundDlg::open_windows;
+
+void DestroyDeviceNotFoundDialogs() { DeviceNotFoundDlg::DestroyOpenWindows(); }
+
 /** The "Dont show this message next time" checkbox. */
-struct HideCheckbox : public wxCheckBox {
+class HideCheckbox : public wxCheckBox {
+public:
   HideCheckbox(wxWindow* parent, const char* label, bool* state)
       : wxCheckBox(parent, wxID_ANY, label, wxDefaultPosition, wxDefaultSize,
                    wxALIGN_LEFT),
@@ -108,7 +194,8 @@ private:
 };
 
 /**  Line with  "Don't show this message..." checkbox  */
-struct HidePanel : wxPanel {
+class HidePanel : public wxPanel {
+public:
   HidePanel(wxWindow* parent, const char* label, bool* state)
       : wxPanel(parent) {
     auto hbox = new wxBoxSizer(wxHORIZONTAL);
@@ -118,8 +205,6 @@ struct HidePanel : wxPanel {
     Show();
   }
 };
-
-static const char* const INSTRUCTIONS = "@pkexec@ cp @PATH@ /etc/udev/rules.d";
 
 /** A clickable triangle which controls child window hide/show. */
 class HideShowPanel : public wxPanel {
@@ -165,6 +250,7 @@ public:
     hbox->Add(m_arrow);
 
     auto vbox = new wxBoxSizer(wxVERTICAL);
+
     vbox->Add(hbox);
     flags = flags.Border(wxLEFT);
     vbox->Add(m_child, flags.ReserveSpaceEvenIfHidden());
@@ -385,9 +471,7 @@ bool CheckSerialAccess(wxWindow* parent, const std::string device) {
     return true;
   }
   if (!ocpn::exists(device)) {
-    std::string msg(DEVICE_NOT_FOUND);
-    ocpn::replace(msg, "@device@", device);
-    OCPNMessageBox(parent, msg, _("OpenCPN device error"));
+    DeviceNotFoundDlg::Create(parent, device);
     return false;
   }
   int result = 0;


### PR DESCRIPTION
Instead of a modal dialog which blocks the startup use a modeless frame. Track the open instances to make it possible to destroy them if they still exists whne exiting opencpn.

Closes: #3922