### PR TITLE
D-board: Prevent IP address from being misinterpreted as Protocol

### DIFF
--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -801,13 +801,14 @@ void dashboard_pi::Notify() {
   // Get the identifiers
   std::vector<std::string> PriorityIDs = GetActivePriorityIdentifiers();
   // Get current satellite priority identifier = item 4
-  std::string satID = PriorityIDs[4];
+  // Exclude "address" after ':' that may equal Protokoll
+  std::string satID = PriorityIDs[4].substr(0, PriorityIDs[4].find(':'));
   if (satID.find("nmea0183") != std::string::npos)
     mPriSatStatus = 3;  // GSV
   else if (satID.find("ignal") != std::string::npos)
     mPriSatStatus = 2;  // SignalK
   else if (satID.find("nmea2000") != std::string::npos) {
-    prioN2kPGNsat = satID;
+    prioN2kPGNsat = PriorityIDs[4];
     mPriSatStatus = 1;  // N2k
   }
 


### PR DESCRIPTION
In Dashboard searching for the satellite info prioritized by OCPN.
Since an IP address can contain equal text as a Protocol we may get a false positive.
Example: My IP "nmea2000 TCP:signalk.stupan.se:1455:127" was identified as a signalk protocol instead of N2k.
Maybe not so common but can happen to others too.