### PR TITLE
New COG and HDT predictor options

### DIFF
--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -200,6 +200,14 @@ extern bool g_bDebugCM93;
 extern bool g_bDebugS57;
 
 extern double g_ownship_predictor_minutes;
+extern int g_cog_predictor_style;
+extern wxString g_cog_predictor_color;
+extern int g_cog_predictor_endmarker;
+extern int g_cog_predictor_width;
+extern int g_ownship_HDTpredictor_style;
+extern wxString g_ownship_HDTpredictor_color;
+extern int g_ownship_HDTpredictor_endmarker;
+extern int g_ownship_HDTpredictor_width;
 extern double g_ownship_HDTpredictor_miles;
 
 extern bool g_own_ship_sog_cog_calc;
@@ -561,6 +569,13 @@ int MyConfig::LoadMyConfig() {
   g_bShowChartBar = 1;
   g_defaultBoatSpeed = 6.0;
   g_ownship_predictor_minutes = 5;
+  g_cog_predictor_style = 105;
+  g_cog_predictor_color = _T("rgb(255,0,0)" );
+  g_cog_predictor_endmarker = 1;
+  g_ownship_HDTpredictor_style = 105;
+  g_ownship_HDTpredictor_color = _T("rgb(255,0,0)" );
+  g_ownship_HDTpredictor_endmarker = 1;
+  g_ownship_HDTpredictor_width = 0;
   g_cog_predictor_width = 3;
   g_ownship_HDTpredictor_miles = 1;
   g_n_ownship_min_mm = 2;
@@ -967,7 +982,14 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   Read(_T ( "DefaultBoatSpeed" ), &g_defaultBoatSpeed);
 
   Read(_T ( "OwnshipCOGPredictorMinutes" ), &g_ownship_predictor_minutes);
+  Read(_T ( "OwnshipCOGPredictorStyle" ), &g_cog_predictor_style);
+  Read(_T ( "OwnshipCOGPredictorColor" ), &g_cog_predictor_color);
+  Read(_T ( "OwnshipCOGPredictorEndmarker" ), &g_cog_predictor_endmarker);
   Read(_T ( "OwnshipCOGPredictorWidth" ), &g_cog_predictor_width);
+  Read(_T ( "OwnshipHDTPredictorStyle" ), &g_ownship_HDTpredictor_style);
+  Read(_T ( "OwnshipHDTPredictorColor" ), &g_ownship_HDTpredictor_color);
+  Read(_T ( "OwnshipHDTPredictorEndmarker" ), &g_ownship_HDTpredictor_endmarker);
+  Read(_T ( "OwnshipHDTPredictorWidth" ), &g_ownship_HDTpredictor_width);
   Read(_T ( "OwnshipHDTPredictorMiles" ), &g_ownship_HDTpredictor_miles);
 
   Read(_T ( "OwnShipIconType" ), &g_OwnShipIconType);
@@ -2424,8 +2446,16 @@ void MyConfig::UpdateSettings() {
   Write(_T ( "UseMagAPB" ), g_bMagneticAPB);
 
   Write(_T ( "OwnshipCOGPredictorMinutes" ), g_ownship_predictor_minutes);
+  Write(_T ( "OwnshipCOGPredictorStyle" ), g_cog_predictor_style);
+  Write(_T ( "OwnshipCOGPredictorColor" ), g_cog_predictor_color);
+  Write(_T ( "OwnshipCOGPredictorEndmarker" ), g_cog_predictor_endmarker);
   Write(_T ( "OwnshipCOGPredictorWidth" ), g_cog_predictor_width);
+  Write(_T ( "OwnshipHDTPredictorStyle" ), g_ownship_HDTpredictor_style);
+  Write(_T ( "OwnshipHDTPredictorColor" ), g_ownship_HDTpredictor_color);
+  Write(_T ( "OwnshipHDTPredictorEndmarker" ), g_ownship_HDTpredictor_endmarker);
+  Write(_T ( "OwnshipHDTPredictorWidth" ), g_ownship_HDTpredictor_width);
   Write(_T ( "OwnshipHDTPredictorMiles" ), g_ownship_HDTpredictor_miles);
+
   Write(_T ( "OwnShipIconType" ), g_OwnShipIconType);
   Write(_T ( "OwnShipLength" ), g_n_ownship_length_meters);
   Write(_T ( "OwnShipWidth" ), g_n_ownship_beam_meters);

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -441,6 +441,13 @@ extern HINSTANCE s_hGLU_DLL;  // Handle to DLL
 
 double g_ownship_predictor_minutes;
 double g_ownship_HDTpredictor_miles;
+int g_cog_predictor_style;
+wxString g_cog_predictor_color;
+int g_cog_predictor_endmarker;
+int g_ownship_HDTpredictor_style;
+wxString g_ownship_HDTpredictor_color;
+int g_ownship_HDTpredictor_endmarker;
+int g_ownship_HDTpredictor_width;
 
 bool g_own_ship_sog_cog_calc;
 int g_own_ship_sog_cog_calc_damp_sec;


### PR DESCRIPTION
Added new COG and HDT predictor options, which can be configured by opencpn.ini: OwnshipCOGPredictorStyle (default 105 dash)
OwnshipCOGPredictorColor (default red)
OwnshipCOGPredictorEndmarker (default 1)
OwnshipHDTPredictorStyle (default 105 dash)
OwnshipHDTPredictorColor (default red)
OwnshipHDTPredictorEndmarker (default 1)
OwnshipHDTPredictorWidth (default 0=use COG width)