### PR TITLE
DB: Correct the position of secondary text data in dials.

### DIFF
--- a/plugins/dashboard_pi/src/dial.cpp
+++ b/plugins/dashboard_pi/src/dial.cpp
@@ -422,7 +422,7 @@ void DashboardInstrument_Dial::DrawData(wxGCDC* dc, double value, wxString unit,
       break;
     case DIAL_POSITION_BOTTOMRIGHT:
       TextPoint.x = size.x - width - 1;
-      TextPoint.y = size.x - height;
+      TextPoint.y = GetDataBottom(size.y) - height;
       break;
     case DIAL_POSITION_BOTTOMMIDDLE:
       if (!std::isnan(value)){


### PR DESCRIPTION
Found a copy-pasta error in DB dial object.