### PR TITLE
Set PluginViewport at Gribdialog init.

### DIFF
--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -169,7 +169,7 @@ GRIBUICtrlBar::GRIBUICtrlBar(wxWindow *parent, wxWindowID id,
     : GRIBUICtrlBarBase(parent, id, title, pos, size, style) {
   pParent = parent;
   pPlugIn = ppi;
-  m_vp = 0;
+  m_vp = &pPlugIn->GetCurrentViewPort() ;
   pReq_Dialog = NULL;
   m_bGRIBActiveFile = NULL;
   m_pTimelineSet = NULL;


### PR DESCRIPTION
Dave,
As per email exchange, this solution works for me. The Gribdialog does have a local copy of the *PluginViewpPort. At init this was set to zero. The local copy is only updated on a Render(GL)Overlay(..) call.
