### PR TITLE
Fix assert failure due to using uninitialized wxMemoryDC

### DIFF
--- a/plugins/dashboard_pi/src/gps.cpp
+++ b/plugins/dashboard_pi/src/gps.cpp
@@ -299,7 +299,6 @@ void DashboardInstrument_GPS::DrawFrame(wxGCDC* dc) {
                m_scaleBase + 2 * m_scaleDelta);
   dc->DrawLine(3, m_scaleBase + 3 * m_scaleDelta, size.x - 3,
                m_scaleBase + 3 * m_scaleDelta);
-  tdc.SetTextForeground(cl);
 }
 
 void DashboardInstrument_GPS::DrawBackground(wxGCDC* dc) {


### PR DESCRIPTION
Don't call SetTextForeground() after calling SelectObject(wxNullBitmap) on a wxMemoryDC, as the latter makes the DC unusable -- and changing the text colour here seems completely unnecessary anyhow, as the DC is not used any longer.

This prevents each frame redraw from resulting in an assert, which made the plugin unusable when the asserts were active.

----

I've run into this while just playing the program and wanted to fix it as getting asserts all the time made the plugin unusable. AFAICS, this call isn't needed at all, I thought the intention might have been to call `SetTextForeground()` on `dc` instead, but this call is already present above in the same function, so I've just removed it.