### PR TITLE
Use OpenCPN/<version> as User-Agent

### DIFF
--- a/libs/wxcurl/CMakeLists.txt
+++ b/libs/wxcurl/CMakeLists.txt
@@ -47,6 +47,7 @@ endif ()
 target_include_directories(WXCURL
     PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
     PUBLIC ${CURL_INCLUDE_DIRS}
+    PRIVATE ${CMAKE_BINARY_DIR}/include
 )
 target_link_libraries(WXCURL ${CURL_LIBRARIES})# ${wxWidgets_LIBRARIES})
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang|AppleClang|GNU")

--- a/libs/wxcurl/src/base.cpp
+++ b/libs/wxcurl/src/base.cpp
@@ -13,6 +13,8 @@
 // Headers
 //////////////////////////////////////////////////////////////////////
 
+#include "config.h"
+
 #include "wx/wxprec.h"
 
 #ifndef WX_PRECOMP
@@ -831,9 +833,7 @@ void wxCurlBase::SetCurlHandleToDefaults(const wxString& relativeURL)
         SetOpt(CURLOPT_HEADERFUNCTION, wxcurl_header_func);
         SetOpt(CURLOPT_WRITEHEADER, &m_szResponseHeader);
         SetOpt(CURLOPT_ERRORBUFFER, m_szDetailedErrorBuffer);
-        SetOpt(CURLOPT_USERAGENT, "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:35.0) Gecko/20100101 Firefox/35.0\r\n" \
-                    "Accept: */*\r\n" \
-                    "Connection: keep-alive"); //Pretend we are a normal browser
+        SetOpt(CURLOPT_USERAGENT, "OpenCPN/" PACKAGE_VERSION);
         SetOpt(CURLOPT_FOLLOWLOCATION, 1L);
 #ifdef __WXMSW__
         SetOpt(CURLOPT_CAINFO, "curl-ca-bundle.crt"); //Use our local certificate list on Windows


### PR DESCRIPTION
OpenCPN uses an ancient Firefox User-Agent to "pretend we are a normal browser".

This PR changes this OpenCPN/<version>, e.g. OpenCPN/5.9.0, so services used by OpenCPN (chartsources, GRIB-services) can recognize this traffic as coming from OpenCPN.