### PR TITLE
Better log messages and error handling if tarball does not contain metadata.xml

### DIFF
--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -3947,7 +3947,7 @@ void CatalogMgrPanel::OnTarballButton(wxCommandEvent& event) {
   PluginMetadata metadata;
   bool ok = handler->ExtractMetadata(path.ToStdString(), metadata);
   if (!ok) {
-    OCPNMessageBox(this, _("Error extracting metadata from tarball."),
+    OCPNMessageBox(this, _("Error extracting metadata from tarball (missing metadata.xml?)"),
                    _("OpenCPN Plugin Import Error"));
     return;
   }

--- a/model/include/model/plugin_handler.h
+++ b/model/include/model/plugin_handler.h
@@ -189,9 +189,31 @@ private:
   bool InstallPlugin(const std::string& path, std::string& filelist,
                      const std::string metadata_path, bool only_metadata);
 
+  /**
+   * Internal helper function to extract a tarball into platform-specific user directories.
+   *
+   *   @param path: Path to tarball.
+   *   @param filelist: On return contains a list of files installed.
+   *   @param metadata_path: If non-empty, location where to extract plugin metadata.xml file.
+   *   @param only_metadata: If true don't install any files, just extract
+   *                         the metadata.xml file.
+   *   @return true if tarball could be extracted and contains metadata.xml file.
+   *           false otherwise.
+   */
   bool explodeTarball(struct archive* src, struct archive* dest,
                       std::string& filelist, const std::string& metadata_path,
                       bool only_metadata);
+  /**
+   * Extract a tarball into platform-specific user directories.
+   *
+   *   @param path: Path to tarball.
+   *   @param filelist: On return contains a list of files installed.
+   *   @param metadata_path: If non-empty, location where to extract plugin metadata.xml file.
+   *   @param only_metadata: If true don't install any files, just extract
+   *                         the metadata.xml file.
+   *   @return true if tarball could be extracted and contains metadata.xml file.
+   *           false otherwise.
+   */
   bool extractTarball(const std::string path, std::string& filelist,
                       const std::string metadata_path = "",
                       bool only_metadata = false);

--- a/model/src/catalog_parser.cpp
+++ b/model/src/catalog_parser.cpp
@@ -115,7 +115,6 @@ bool ParsePlugin(const std::string& xml, PluginMetadata& plugin) {
 }
 
 bool ParseCatalog(const std::string xml, CatalogCtx* ctx) {
-  bool ok = true;
   PluginMetadata* plugin = 0;
 
   pugi::xml_document doc;

--- a/model/src/plugin_handler.cpp
+++ b/model/src/plugin_handler.cpp
@@ -206,9 +206,9 @@ public:
     m_abi_version = metadata.target_version;
     m_major_version = ocpn::split(m_abi_version.c_str(), ".")[0];
     m_name = metadata.name;
-    wxLogDebug("Plugin: setting up, name: %s", m_name);
-    wxLogDebug("Plugin: init: abi: %s, abi_version: %s, major ver: %s", m_abi,
-               m_abi_version, m_major_version);
+    DEBUG_LOG << "Plugin: setting up, name: " << m_name;
+    DEBUG_LOG << "Plugin: init: abi: " << m_abi << ", abi_version: " << m_abi_version <<
+                 ", major ver: " << m_major_version;
   }
   const std::string& abi() const { return m_abi; }
   const std::string& abi_version() const { return m_abi_version; }
@@ -229,8 +229,8 @@ public:
     m_abi = compatOs->name();
     m_abi_version = compatOs->version();
     m_major_version = ocpn::split(m_abi_version.c_str(), ".")[0];
-    wxLogDebug("Host: init: abi: %s, abi_version: %s, major ver: %s", m_abi,
-               m_abi_version, m_major_version);
+    DEBUG_LOG << "Host: init: abi: " << m_abi << ", abi_version: " << m_abi_version <<
+                 ", major ver: " << m_major_version;
   }
 
   bool is_version_compatible(const Plugin& plugin) const {
@@ -270,7 +270,7 @@ public:
         "debian-armhf;sid;ubuntu-armhf;24.04"};  // clang-format: on
 
     if (ocpn::startswith(plugin.abi(), "debian")) {
-      wxLogDebug("Checking for debian plugin on a ubuntu host");
+      DEBUG_LOG << "Checking for debian plugin on a ubuntu host";
       const std::string compat_version = plugin.abi() + ";" +
                                          plugin.major_version() + ";" + m_abi +
                                          ";" + m_abi_version;
@@ -362,7 +362,7 @@ bool PluginHandler::isCompatible(const PluginMetadata& metadata, const char* os,
 
   Plugin plugin(metadata);
   if (plugin.abi() == "all") {
-    wxLogDebug("Returning true for plugin abi \"all\"");
+    DEBUG_LOG << "Returning true for plugin abi \"all\"";
     return true;
   }
   auto compatOS = CompatOs::getInstance();
@@ -371,17 +371,16 @@ bool PluginHandler::isCompatible(const PluginMetadata& metadata, const char* os,
   auto found = std::find(simple_abis.begin(), simple_abis.end(), plugin.abi());
   if (found != simple_abis.end()) {
     bool ok = plugin.abi() == host.abi();
-    wxLogDebug("Returning %s for %s", (ok ? "ok" : "fail"), host.abi());
-    wxLogDebug(" ");
+    DEBUG_LOG << "Returning " << (ok ? "ok" : "fail") << " for " << host.abi();
     return ok;
   }
   bool rv = false;
   if (host.abi() == plugin.abi() && host.is_version_compatible(plugin)) {
     rv = true;
-    wxLogDebug("Found matching abi version %s", plugin.abi_version());
+    DEBUG_LOG << "Found matching abi version " << plugin.abi_version();
   } else if (host.is_debian_plugin_compatible(plugin)) {
     rv = true;
-    wxLogDebug("Found Debian version matching Ubuntu host");
+    DEBUG_LOG << "Found Debian version matching Ubuntu host";
   }
   // macOS is an exception as packages with universal binaries can support both
   // x86_64 and arm64 at the same time
@@ -436,7 +435,7 @@ static void saveFilelist(std::string filelist, std::string name) {
   string listpath = PluginHandler::fileListPath(name);
   ofstream diskfiles(listpath);
   if (!diskfiles.is_open()) {
-    wxLogWarning("Cannot create installed files list.");
+    MESSAGE_LOG << "Cannot create installed files list.";
     return;
   }
   diskfiles << filelist;
@@ -447,7 +446,7 @@ static void saveDirlist(std::string name) {
   string path = dirListPath(name);
   ofstream dirs(path);
   if (!dirs.is_open()) {
-    wxLogWarning("Cannot create installed files list.");
+    MESSAGE_LOG << "Cannot create installed files list.";
     return;
   }
   pathmap_t pathmap = getInstallPaths();
@@ -462,7 +461,7 @@ static void saveVersion(const std::string& name, const std::string& version) {
   string path = PluginHandler::versionPath(name);
   ofstream stream(path);
   if (!stream.is_open()) {
-    wxLogWarning("Cannot create version file.");
+    MESSAGE_LOG << "Cannot create version file.";
     return;
   }
   stream << version << endl;
@@ -484,7 +483,7 @@ static int copy_data(struct archive* ar, struct archive* aw) {
     r = archive_write_data_block(aw, buff, size, offset);
     if (r < ARCHIVE_OK) {
       std::string s(archive_error_string(aw));
-      wxLogWarning("Error copying install data: %s", archive_error_string(aw));
+      MESSAGE_LOG << "Error copying install data: " << archive_error_string(aw);
       return (r);
     }
   }
@@ -536,7 +535,7 @@ static bool win_entry_set_install_path(struct archive_entry* entry,
   } else if (archive_entry_filetype(entry) == AE_IFREG) {
     wxString msg(_T("PluginHandler::Invalid install path on file: "));
     msg += wxString(path.c_str());
-    wxLogDebug(msg);
+    DEBUG_LOG << msg;
     return false;
   }
   wxString s(path);
@@ -569,7 +568,7 @@ static bool flatpak_entry_set_install_path(struct archive_entry* entry,
       archive_entry_filetype(entry) == AE_IFREG) {
     wxString msg(_T("PluginHandler::Invalid install path on file: "));
     msg += wxString(path.c_str());
-    wxLogDebug(msg);
+    DEBUG_LOG << msg;
     return false;
   }
   string dest = installPaths[location] + "/" + suffix;
@@ -608,7 +607,7 @@ static bool linux_entry_set_install_path(struct archive_entry* entry,
       archive_entry_filetype(entry) == AE_IFREG) {
     wxString msg(_T("PluginHandler::Invalid install path on file: "));
     msg += wxString(path.c_str());
-    wxLogDebug(msg);
+    DEBUG_LOG << msg;
     return false;
   }
 
@@ -672,7 +671,7 @@ static bool apple_entry_set_install_path(struct archive_entry* entry,
   if (dest == "" && archive_entry_filetype(entry) == AE_IFREG) {
     wxString msg(_T("PluginHandler::Invalid install path on file: "));
     msg += wxString(path.c_str());
-    wxLogDebug(msg);
+    DEBUG_LOG << msg;
     return false;
   }
   archive_entry_set_pathname(entry, dest.c_str());
@@ -710,7 +709,7 @@ static bool android_entry_set_install_path(struct archive_entry* entry,
       archive_entry_filetype(entry) == AE_IFREG) {
     wxString msg(_T("PluginHandler::Invalid install path on file: "));
     msg += wxString(path.c_str());
-    wxLogDebug(msg);
+    DEBUG_LOG << msg;
     return false;
   }
 
@@ -748,8 +747,8 @@ static bool entry_set_install_path(struct archive_entry* entry,
   } else if (osSystemId & wxOS_MAC) {
     rv = apple_entry_set_install_path(entry, installPaths);
   } else {
-    wxLogMessage("set_install_path() invoked, unsupported platform %s",
-                 wxPlatformInfo::Get().GetOperatingSystemDescription());
+    MESSAGE_LOG << "set_install_path() invoked, unsupported platform " <<
+                 wxPlatformInfo::Get().GetOperatingSystemDescription();
     rv = false;
   }
 #endif
@@ -767,7 +766,7 @@ bool PluginHandler::archive_check(int r, const char* msg, struct archive* a) {
     std::string s(msg);
 
     if (archive_error_string(a)) s = s + ": " + archive_error_string(a);
-    wxLogMessage(s.c_str());
+    MESSAGE_LOG << s;
     last_error_msg = s;
   }
   return r >= ARCHIVE_WARN;
@@ -779,10 +778,14 @@ bool PluginHandler::explodeTarball(struct archive* src, struct archive* dest,
                                    bool only_metadata) {
   struct archive_entry* entry = 0;
   pathmap_t pathmap = getInstallPaths();
+  bool is_metadata_ok = false;
   while (true) {
     int r = archive_read_next_header(src, &entry);
     if (r == ARCHIVE_EOF) {
-      return true;
+      if (!is_metadata_ok) {
+        MESSAGE_LOG << "Plugin tarball does not contain metadata.xml";
+      }
+      return is_metadata_ok;
     }
     if (!archive_check(r, "archive read header error", src)) {
       return false;
@@ -790,8 +793,13 @@ bool PluginHandler::explodeTarball(struct archive* src, struct archive* dest,
     std::string path = archive_entry_pathname(entry);
     bool is_metadata = std::string::npos != path.find("metadata.xml");
     if (is_metadata) {
-      if (metadata_path == "") continue;
-      archive_entry_set_pathname(entry, metadata_path.c_str());
+      is_metadata_ok = true;
+      if (metadata_path == "") {
+        continue;
+      } else {
+        archive_entry_set_pathname(entry, metadata_path.c_str());
+        DEBUG_LOG << "Extracted metadata.xml to " << metadata_path;
+      }
     } else if (!entry_set_install_path(entry, pathmap))
       continue;
     if (strlen(archive_entry_pathname(entry)) == 0) {
@@ -845,6 +853,7 @@ bool PluginHandler::explodeTarball(struct archive* src, struct archive* dest,
  *   @param metadata_path: if non-empty, location where to store metadata,
  *   @param only_metadata: If true don't install any files, just extract
  *                         metadata.
+ *   @return true if tarball contains metadata.xml file, false otherwise.
  *
  */
 bool PluginHandler::extractTarball(const std::string path,
@@ -858,7 +867,7 @@ bool PluginHandler::extractTarball(const std::string path,
   if (r != ARCHIVE_OK) {
     std::ostringstream os;
     os << "Cannot read installation tarball: " << path;
-    wxLogWarning(os.str().c_str());
+    MESSAGE_LOG << os.str();
     last_error_msg = os.str();
     return false;
   }
@@ -908,7 +917,7 @@ static std::string computeMetadataPath(void) {
   path += SEP;
   path += "ocpn-plugins.xml";
   if (!ocpn::exists(path)) {
-    wxLogWarning("Non-existing plugins file: %s", path);
+    MESSAGE_LOG << "Non-existing plugins file: " << path;
   }
   return path;
 }
@@ -916,10 +925,10 @@ static std::string computeMetadataPath(void) {
 static void parseMetadata(const std::string path, CatalogCtx& ctx) {
   using namespace std;
 
-  wxLogMessage("PluginHandler: using metadata path: %s", path);
+  MESSAGE_LOG << "PluginHandler: using metadata path: " << path;
   ctx.depth = 0;
   if (!ocpn::exists(path)) {
-    wxLogWarning("Non-existing plugins metadata file: %s", path.c_str());
+    MESSAGE_LOG << "Non-existing plugins metadata file: " << path;
     return;
   }
   ifstream ifpath(path);
@@ -935,6 +944,7 @@ bool PluginHandler::InstallPlugin(const std::string& path,
   if (!extractTarball(path, filelist, metadata_path, only_metadata)) {
     std::ostringstream os;
     os << "Cannot unpack plugin tarball at : " << path;
+    MESSAGE_LOG << os.str();
     if (filelist != "") cleanup(filelist, "unknown_name");
     last_error_msg = os.str();
     return false;
@@ -963,7 +973,7 @@ std::string PluginHandler::getMetadataPath() {
     return metadataPath;
   }
   metadataPath = computeMetadataPath();
-  wxLogDebug("Using metadata path: %s", metadataPath.c_str());
+  DEBUG_LOG << "Using metadata path: " << metadataPath;
   return metadataPath;
 }
 
@@ -1021,13 +1031,15 @@ static void PurgeEmptyDirs(const std::string& root) {
 
 void PluginHandler::cleanup(const std::string& filelist,
                             const std::string& plugname) {
-  wxLogMessage("Cleaning up failed install of %s", plugname.c_str());
+  MESSAGE_LOG << "Cleaning up failed install of " << plugname;
 
   std::vector<std::string> paths = LoadLinesFromFile(filelist);
   for (const auto& path : paths) {
     if (isRegularFile(path.c_str())) {
       int r = remove(path.c_str());
-      if (r != 0) wxLogWarning("Cannot remove file %s: %s", path, strerror(r));
+      if (r != 0) {
+        MESSAGE_LOG << "Cannot remove file " << path << ": " << strerror(r);
+      }
     }
   }
   for (const auto& path : paths) PurgeEmptyDirs(path);
@@ -1135,6 +1147,7 @@ bool PluginHandler::installPlugin(PluginMetadata plugin, std::string path) {
   if (!extractTarball(path, filelist)) {
     std::ostringstream os;
     os << "Cannot unpack plugin: " << plugin.name << " at " << path;
+    MESSAGE_LOG << os.str();
     last_error_msg = os.str();
     PluginHandler::cleanup(filelist, plugin.name);
     return false;
@@ -1151,7 +1164,7 @@ bool PluginHandler::installPlugin(PluginMetadata plugin) {
   char fname[4096];
 
   if (tmpnam(fname) == NULL) {
-    wxLogWarning("Cannot create temporary file");
+    MESSAGE_LOG << "Cannot create temporary file";
     path = "";
     return false;
   }
@@ -1180,22 +1193,32 @@ bool PluginHandler::ExtractMetadata(const std::string& path,
   std::string temp_path(tmpnam(0));
   if (!extractTarball(path, filelist, temp_path, true)) {
     std::ostringstream os;
-    os << "Cannot unpack plugin tarball at : " << path;
+    os << "Cannot unpack plugin " << metadata.name << " tarball at: " << path;
+    MESSAGE_LOG << os.str();
     if (filelist != "") cleanup(filelist, "unknown_name");
     last_error_msg = os.str();
     return false;
   }
-  if (!isRegularFile(temp_path.c_str())) return false;
+  if (!isRegularFile(temp_path.c_str())) {
+    // This could happen if the tarball does not contain the metadata.xml file
+    // or the metadata.xml file could not be extracted.
+    return false;
+  }
 
   struct CatalogCtx ctx;
   std::ifstream istream(temp_path);
   std::stringstream buff;
   buff << istream.rdbuf();
-  remove(temp_path.c_str());
-
+  int r = remove(temp_path.c_str());
+  if (r != 0) {
+    MESSAGE_LOG << "Cannot remove file " << temp_path << ":" << strerror(r);
+  }
   auto xml = std::string("<plugins>") + buff.str() + "</plugins>";
   ParseCatalog(xml, &ctx);
   metadata = ctx.plugins[0];
+  if (metadata.name.empty()) {
+    MESSAGE_LOG << "Plugin metadata is empty";
+  }
   return !metadata.name.empty();
 }
 
@@ -1203,7 +1226,7 @@ bool PluginHandler::ClearInstallData(const std::string plugin_name) {
   auto ix = PlugInIxByName(plugin_name,
                            PluginLoader::getInstance()->GetPlugInArray());
   if (ix != -1) {
-    wxLogWarning("Attempt to remove installation data for loaded plugin");
+    MESSAGE_LOG << "Attempt to remove installation data for loaded plugin";
     return false;
   }
   return DoClearInstallData(plugin_name);
@@ -1212,8 +1235,7 @@ bool PluginHandler::ClearInstallData(const std::string plugin_name) {
 bool PluginHandler::DoClearInstallData(const std::string plugin_name) {
   std::string path = PluginHandler::fileListPath(plugin_name);
   if (!ocpn::exists(path)) {
-    wxLogWarning("Cannot find installation data for %s (%s)",
-                 plugin_name.c_str(), path.c_str());
+    MESSAGE_LOG << "Cannot find installation data for " << plugin_name << " (" << path << ")";
     return false;
   }
   std::vector<std::string> plug_paths = LoadLinesFromFile(path);
@@ -1221,14 +1243,14 @@ bool PluginHandler::DoClearInstallData(const std::string plugin_name) {
     if (isRegularFile(p.c_str())) {
       int r = remove(p.c_str());
       if (r != 0) {
-        wxLogWarning("Cannot remove file %s: %s", p.c_str(), strerror(r));
+        MESSAGE_LOG << "Cannot remove file " << p << ": " << strerror(r);
       }
     }
   }
   for (const auto& p : plug_paths) PurgeEmptyDirs(p);
   int r = remove(path.c_str());
   if (r != 0) {
-    wxLogWarning("Cannot remove file %s: %s", path.c_str(), strerror(r));
+    MESSAGE_LOG << "Cannot remove file " << path << ": " << strerror(r);
   }
   // Best effort tries, failures are OK.
   remove(dirListPath(plugin_name).c_str());
@@ -1243,8 +1265,7 @@ bool PluginHandler::uninstall(const std::string plugin_name) {
   auto loader = PluginLoader::getInstance();
   auto ix = PlugInIxByName(plugin_name, loader->GetPlugInArray());
   if (ix < 0) {
-    wxLogMessage("trying to uninstall non-existing plugin %s",
-                 plugin_name.c_str());
+    MESSAGE_LOG << "trying to uninstall non-existing plugin " << plugin_name;
     return false;
   }
   auto pic = loader->GetPlugInArray()->Item(ix);
@@ -1350,7 +1371,7 @@ static void LoadPluginMapFile(PluginMap& map, const std::string& path) {
   std::ifstream f;
   f.open(path);
   if (f.fail()) {
-    wxLogWarning("Cannot open %s: %s", path.c_str(), strerror(errno));
+    MESSAGE_LOG << "Cannot open " << path << ": " << strerror(errno);
     return;
   }
   std::stringstream buf;
@@ -1413,10 +1434,9 @@ bool PluginHandler::installPluginFromCache(PluginMetadata plugin) {
 #endif
 
   if (cacheFile != "") {
-    wxLogMessage("Installing %s from local cache", tarballFile.c_str());
+    MESSAGE_LOG << "Installing " << tarballFile << " from local cache";
     bool bOK = installPlugin(plugin, cacheFile);
     if (!bOK) {
-      wxLogWarning("Cannot install tarball file %s", cacheFile.c_str());
       evt_download_failed.Notify(cacheFile);
       return false;
     }

--- a/po/opencpn.pot
+++ b/po/opencpn.pot
@@ -7118,7 +7118,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_ar_SA.po
+++ b/po/opencpn_ar_SA.po
@@ -7023,7 +7023,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_bg_BG.po
+++ b/po/opencpn_bg_BG.po
@@ -7024,7 +7024,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_ca_ES.po
+++ b/po/opencpn_ca_ES.po
@@ -7031,7 +7031,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_cs_CZ.po
+++ b/po/opencpn_cs_CZ.po
@@ -7044,7 +7044,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_da_DK.po
+++ b/po/opencpn_da_DK.po
@@ -7098,7 +7098,7 @@ msgid "Select tarball file"
 msgstr "Vælg tarball- fil"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_de_DE.po
+++ b/po/opencpn_de_DE.po
@@ -7104,7 +7104,7 @@ msgid "Select tarball file"
 msgstr "Tarball Datei auswählen"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr "Fehler beim Entpacken von Metadaten aus Tarball."
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_el_GR.po
+++ b/po/opencpn_el_GR.po
@@ -7105,7 +7105,7 @@ msgid "Select tarball file"
 msgstr "Επιλογή αρχείου tarball"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_en_GB.po
+++ b/po/opencpn_en_GB.po
@@ -7105,8 +7105,8 @@ msgid "Select tarball file"
 msgstr "Select tarball file"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
-msgstr "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
+msgstr "Error extracting metadata from tarball (missing metadata.xml?)"
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955
 #: gui/src/pluginmanager.cpp:3963

--- a/po/opencpn_es_ES.po
+++ b/po/opencpn_es_ES.po
@@ -7105,7 +7105,7 @@ msgid "Select tarball file"
 msgstr "Seleccionar archivo tarball"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr "Error al extraer metadatos del tarball."
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_et_EE.po
+++ b/po/opencpn_et_EE.po
@@ -7105,7 +7105,7 @@ msgid "Select tarball file"
 msgstr "Vali tarball-fail"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr "Viga meta-andmete väljastamisel arhiivist."
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_fi_FI.po
+++ b/po/opencpn_fi_FI.po
@@ -7109,7 +7109,7 @@ msgid "Select tarball file"
 msgstr "Valitse arkistotiedosto"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr "Metatietojen purkaminen arkistotiedostosta epäonnistui."
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_fil_PH.po
+++ b/po/opencpn_fil_PH.po
@@ -7043,7 +7043,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_fr_FR.po
+++ b/po/opencpn_fr_FR.po
@@ -7107,7 +7107,7 @@ msgid "Select tarball file"
 msgstr "Sélectionner une archive"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr "Erreur lors de l'extraction des métadonnées depuis l'archive"
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_gl_ES.po
+++ b/po/opencpn_gl_ES.po
@@ -7063,7 +7063,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_he_IL.po
+++ b/po/opencpn_he_IL.po
@@ -7054,7 +7054,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_hi_IN.po
+++ b/po/opencpn_hi_IN.po
@@ -7041,7 +7041,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_hu_HU.po
+++ b/po/opencpn_hu_HU.po
@@ -7061,7 +7061,7 @@ msgid "Select tarball file"
 msgstr "Válaszd ki a tar fájlt."
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_id_ID.po
+++ b/po/opencpn_id_ID.po
@@ -7043,7 +7043,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_is_IS.po
+++ b/po/opencpn_is_IS.po
@@ -7022,7 +7022,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_it_IT.po
+++ b/po/opencpn_it_IT.po
@@ -7106,7 +7106,7 @@ msgid "Select tarball file"
 msgstr "Seleziona archivio"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_ja_JP.po
+++ b/po/opencpn_ja_JP.po
@@ -7048,7 +7048,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_ko_KR.po
+++ b/po/opencpn_ko_KR.po
@@ -7061,7 +7061,7 @@ msgid "Select tarball file"
 msgstr "tarball압축 파일 선택"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_mr_IN.po
+++ b/po/opencpn_mr_IN.po
@@ -7022,7 +7022,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_nb_NO.po
+++ b/po/opencpn_nb_NO.po
@@ -7105,7 +7105,7 @@ msgid "Select tarball file"
 msgstr "Velg tarball fil"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_nl_NL.po
+++ b/po/opencpn_nl_NL.po
@@ -7106,7 +7106,7 @@ msgid "Select tarball file"
 msgstr "Selecteer tarball bestand"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr "Fout bij het uitpakken van metadata uit tar bestand."
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_pl_PL.po
+++ b/po/opencpn_pl_PL.po
@@ -7073,7 +7073,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_pt_BR.po
+++ b/po/opencpn_pt_BR.po
@@ -7091,7 +7091,7 @@ msgid "Select tarball file"
 msgstr "Selecionar arquivo tarball"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_pt_PT.po
+++ b/po/opencpn_pt_PT.po
@@ -7105,7 +7105,7 @@ msgid "Select tarball file"
 msgstr "Selecione um ficheiro tarball"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_ro_RO.po
+++ b/po/opencpn_ro_RO.po
@@ -7022,7 +7022,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_ru_RU.po
+++ b/po/opencpn_ru_RU.po
@@ -7100,7 +7100,7 @@ msgid "Select tarball file"
 msgstr "Выбрать файл архива"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr "Ошибка извлечения метаданных из tarball."
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_sv_SE.po
+++ b/po/opencpn_sv_SE.po
@@ -7110,7 +7110,7 @@ msgid "Select tarball file"
 msgstr "Välj tarball fil"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr "Fel vid tolkning av metadata från tarball."
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_th_TH.po
+++ b/po/opencpn_th_TH.po
@@ -7023,7 +7023,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_tr_TR.po
+++ b/po/opencpn_tr_TR.po
@@ -7052,7 +7052,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_vi_VN.po
+++ b/po/opencpn_vi_VN.po
@@ -7036,7 +7036,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_zh_CN.po
+++ b/po/opencpn_zh_CN.po
@@ -7063,7 +7063,7 @@ msgid "Select tarball file"
 msgstr "选择存档文件"
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955

--- a/po/opencpn_zh_TW.po
+++ b/po/opencpn_zh_TW.po
@@ -7030,7 +7030,7 @@ msgid "Select tarball file"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3949
-msgid "Error extracting metadata from tarball."
+msgid "Error extracting metadata from tarball (missing metadata.xml?)"
 msgstr ""
 
 #: gui/src/pluginmanager.cpp:3950 gui/src/pluginmanager.cpp:3955


### PR DESCRIPTION
When a plugin tarball does not contain the metadata.xml file, the UI displays a message stating "Error extracting metadata from tarball". There is no message in the opencpn.log file indicating why the plugin could not be imported.

During development, some generated plugin tarballs do not contain the `metadata.xml` file. For example, see #4038.

This PR adds log messages. For example:

```
22:31:50.999 MESSAGE plugin_handler.cpp:797 Plugin tarball does not contain metadata.xml
22:31:50.999 MESSAGE plugin_handler.cpp:1208 Cannot unpack plugin  tarball at:  xxxx/weather_routing_pi/build/weather_routing_pi-1.15.18.6-darwin-wx315-x86_64-14.6.1.tar.gz
```

In addition, the error message is changed:
Before:
"Error extracting metadata from tarball"

After:
"Cannot load plugin, tarball does not contain metadata.xml file"

**Rationale**: the first time I got this error message, I wasn't sure what kind of *metadata extraction* operation had failed. An "error extracting metadata" could have meant the program was able to find metadata in the tarball, but failed to extract it on disk. The actual problem is **missing** metadata, but it wasn't clear the program was looking for a file named `metadata.xml` in the tarball. That's because metadata can be in many formats, e.g. it could have been metadata embedded in various files within the tarball.
The new message aims to make the error message more explicit, which should help users to troubleshoot.

<img width="411" alt="image" src="https://github.com/user-attachments/assets/4fee3986-a64e-488a-b45f-ee769f6268f6">

