### PR TITLE
Reload GSHHS files from disk when user adds GSHHS files or rescans/rebuilds the chart database

### DIFF
--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -4471,6 +4471,8 @@ bool MyFrame::UpdateChartDatabaseInplace(ArrayOfCDI &DirArray, bool b_force,
   wxLogMessage(_T("Starting chart database Update..."));
   wxString gshhg_chart_loc = gWorldMapLocation;
   gWorldMapLocation = wxEmptyString;
+  // The Update() function may set gWorldMapLocation if at least one of the
+  // directories contains GSHHS files.
   ChartData->Update(DirArray, b_force, pprog);
   ChartData->SaveBinary(ChartListFileName);
   wxLogMessage(_T("Finished chart database Update"));
@@ -4489,6 +4491,8 @@ bool MyFrame::UpdateChartDatabaseInplace(ArrayOfCDI &DirArray, bool b_force,
       ChartCanvas *cc = g_canvasArray.Item(i);
       if (cc) cc->ResetWorldBackgroundChart();
     }
+    // Reset the GSHHS singleton which is used to detect land crossing.
+    gshhsCrossesLandReset();
   }
 
   delete pprog;
@@ -6870,9 +6874,11 @@ void MyFrame::applySettingsString(wxString settings) {
 
   if (previous_expert != g_bUIexpert) b_newToolbar = true;
 
-  if (rr & TOOLBAR_CHANGED) b_newToolbar = true;
+  if (rr & TOOLBAR_CHANGED) {
+    b_newToolbar = true;
+  }
 
-    //  We do this is one case only to remove an orphan recovery window
+  //  We do this is one case only to remove an orphan recovery window
 #ifdef __ANDROID__
   if (previous_expert && !g_bUIexpert) {
     androidForceFullRepaint();

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -67,6 +67,7 @@
 #include "SystemCmdSound.h"
 #include "toolbar.h"
 #include "waypointman_gui.h"
+#include "shapefile_basemap.h"
 
 extern PlugInManager* s_ppim;
 extern MyConfig* pConfig;
@@ -105,6 +106,7 @@ extern double g_display_size_mm;
 extern bool g_bopengl;
 extern AisDecoder* g_pAIS;
 extern ChartGroupArray* g_pGroupArray;
+extern ShapeBaseChartSet gShapeBasemap;
 
 // extern ChartGroupArray* g_pGroupArray;
 extern unsigned int g_canvasConfig;
@@ -743,13 +745,18 @@ wxString getUsrTempUnit_Plugin(int unit) { return getUsrTempUnit(unit); }
 
 bool PlugIn_GSHHS_CrossesLand(double lat1, double lon1, double lat2,
                               double lon2) {
+  // TODO: Enable call to gShapeBasemap.CrossesLand after fixing performance
+  // issues. if (gShapeBasemap.IsUsable()) {
+  //   return gShapeBasemap.CrossesLand(lat1, lon1, lat2, lon2);
+  // } else {
+  //  Fall back to the GSHHS data.
   static bool loaded = false;
   if (!loaded) {
     gshhsCrossesLandInit();
     loaded = true;
   }
-
   return gshhsCrossesLand(lat1, lon1, lat2, lon2);
+  //}
 }
 
 void PlugInPlaySound(wxString& sound_file) {


### PR DESCRIPTION
Fix for #4040 and https://github.com/seandepagnier/weather_routing_pi/issues/301

# Changes in this PR
1. When the user configures chart data, selects "rescan" or "rebuild the database": recursively look for a `GSHHG` directory containing GSHHG data.
2. If add/rescan/rebuild operation finds GSHHG data, reload the GSHGG data from files on disk. The data is loaded into the singleton GSHHG reader. That singleton reader is used by the weather routing plugin to detect land. Internally, `gshhsCrossesLandReset` is invoked.

## Code Cleanup:
1. Rename static `reader` variable to `gshhs_singleton`. The variable had the same name as the `GSHHSChart::reader` private member, which was confusing.
4. Add code comments.

# Tests performed
1. Validate the  `<shared data dir>/GSHHS/` directory contains the crude quality GSHHG files that ship with OpenCPN (poly-c-1.dat  wdb_borders_c.b  wdb_rivers_c.b). There should be no other files. The higher quality files are not included in OpenCPN by default. If the user has manually added more files in the default location, then this bug might not be exposed.
2. In Settings -> Charts -> Charts Files, delete all the chart directories. This should reset the `BasemapDir` parameter to the default location, i.e. `<shared data dir>/GSHHS/`. Open `opencpn.conf` and check the `BasemapDir` parameter is set to `/usr/local/share/opencpn/gshhs/` on Ubuntu.
   1. Compute a route using the weather routing plugin. Choose start/end points that are separated by a landmass, ensuring that the computed route must navigate around the coastline.
   2. Validate the weather routing plugin uses crude resolution GSHHG data. An example is provided in https://github.com/seandepagnier/weather_routing_pi/issues/301.

Perform the next test using 1) the current version of OpenCPN and 2) the re-compiled version with the fix in this PR.
1. In Settings -> Charts -> Charts Files, add a directory containing GSHHG files at high resolution. Click OK.
2. The high resolution GSHHG charts should be displayed.
3. Validate value of `BasemapDir` parameter:
   1. Without the fix, `BasemapDir` parameter is still set to the default location, i.e. `<shared data dir>/GSHHS/
   2. With the fix, `BasemapDir` parameter is set to the directory containing the GSHHG files.
5. Compute a route using the weather routing plugin. Choose start/end points that are separated by a landmass, ensuring that the computed route must navigate around the coastline.
   1. Without the fix, the weather routing plugin uses crude resolution GSHHG files, even though the high-resolution files are actually displayed.
   2. With the fix, the weather routing plugin uses the high resolution GSHHG files.


Note:
This exact behavior depends on which directory is added and how the evaluation of this code:
```c++
if (dir_info.fullpath.Find(_T("GSHHG")) != wxNOT_FOUND) {
      if (!wxDir::FindFirst(dir_info.fullpath, "poly-*-1.dat").empty()) 
```

# Open item
1. I've notice there are existing concurrency issues with several global variables such as `gWorldMapLocation`. IMO, the likelihood of hitting the concurrency issue is quite low, unless the user is intentionally trying to trigger the issue. For example, running weather routing computations while repeatedly loading/unloading GSHHG files might cause a concurrency issue, but in practice it's quite unlikely this will happen.
Fixing these concurrency issues would be a larger undertaking with possible changes to the API, so I feel this should be tracked in a separate PR.

https://github.com/OpenCPN/OpenCPN/blob/bebefc8a9f10357b122957ce08b00469048eff36/gui/src/ocpn_frame.cpp#L4559-L4573

2. This PR does not attempt to compare the versions of the GSHHG files. There is an existing code comment stating the files should be compared.
