### PR TITLE
Fix broken URL in the `INSTALL` file

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -52,7 +52,7 @@ Opencpn uses the cmake system. On Linux, the build is performed using:
     $ make -j 4
     $ sudo make install
 
-See the manual at https://opencpn-manuals.github.io/main/ocpn-dev-manual/
+See the manual at https://opencpn-manuals.github.io/main/opencpn-dev/
 for build instructions on other platforms.
 
 


### PR DESCRIPTION
Fix the broken URL for build instructions on Windows/Mac/... platforms.
The existing link does not exist.