### PR TITLE
Add tooltip for the compass widget and MUIBar

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -883,6 +883,7 @@ set(GUI_HDRS
     ${GUI_HDR_DIR}/tty_scroll.h
     ${GUI_HDR_DIR}/udev_rule_mgr.h
     ${GUI_HDR_DIR}/undo.h
+    ${GUI_HDR_DIR}/tooltip.h
     ${GUI_HDR_DIR}/update_mgr.h
     ${GUI_HDR_DIR}/usb_devices.h
     ${GUI_HDR_DIR}/viewport.h
@@ -1005,6 +1006,7 @@ set(GUI_SRC
     ${GUI_SRC_DIR}/tty_scroll.cpp
     ${GUI_SRC_DIR}/udev_rule_mgr.cpp
     ${GUI_SRC_DIR}/undo.cpp
+    ${GUI_SRC_DIR}/tooltip.cpp
     ${GUI_SRC_DIR}/update_mgr.cpp
     ${GUI_SRC_DIR}/viewport.cpp
     ${GUI_SRC_DIR}/waypointman_gui.cpp

--- a/gui/include/gui/chcanv.h
+++ b/gui/include/gui/chcanv.h
@@ -257,8 +257,8 @@ public:
   bool SetVPScale(double sc, bool b_refresh = true);
   bool SetVPProjection(int projection);
   /**
-   * Set the viewport center point.
    * Centers the view on a specific lat/lon position.
+   *
    * @param lat Latitude in degrees
    * @param lon Longitude in degrees
    * @return true if view was changed successfully
@@ -1239,6 +1239,11 @@ private:
 
   ocpnCompass *m_Compass;
   bool m_bShowGPS;
+  /**
+   * Track whether a previous wxMouseEvent was in the m_Compass area.
+   * This is used to determine whether to display tooltips for the compass.
+   */
+  bool m_mouseWasInCompass;
 
   wxRect m_mainlast_tb_rect;
   int m_restore_dbindex;

--- a/gui/include/gui/compass.h
+++ b/gui/include/gui/compass.h
@@ -71,6 +71,7 @@ private:
   void CreateBmp(bool bnew = false);
   void CreateTexture();
   void UpdateTexture();
+  void SetToolTip(const wxString &tooltip);
 
   ChartCanvas *m_parent;
   wxBitmap m_StatBmp;
@@ -95,6 +96,8 @@ private:
   bool m_bshowGPS;
   ColorScheme m_cs;
   bool m_texOK;
+  /** The string value to display in the compass tooltip. */
+  wxString m_tooltip;
 
 #ifdef ocpnUSE_GL
   unsigned int m_texobj;

--- a/gui/include/gui/navutil.h
+++ b/gui/include/gui/navutil.h
@@ -127,7 +127,6 @@ void DimeControl(wxWindow *ctrl);
 void DimeControl(wxWindow *ctrl, wxColour col, wxColour col1,
                  wxColour back_color, wxColour text_color, wxColour uitext,
                  wxColour udkrd, wxColour gridline);
-wxColor GetDimedColor(const wxColor &c);
 
 bool WptIsInRouteList(RoutePoint *pr);
 RoutePoint *WaypointExists(const wxString &name, double lat, double lon);

--- a/gui/include/gui/toolbar.h
+++ b/gui/include/gui/toolbar.h
@@ -31,6 +31,7 @@
 #include "styles.h"
 #include <vector>
 #include "ocpndc.h"
+#include "tooltip.h"
 
 class ocpnFloatingToolbarDialog;                  // forward
 extern ocpnFloatingToolbarDialog *g_MainToolbar;  ///< Global instance
@@ -344,7 +345,6 @@ protected:
   wxColour m_toolOutlineColour;
   wxColour m_background_color;
 
-  ToolTipWin *m_pToolTipWin;
   ocpnToolBarTool *m_last_ro_tool;
 
   ColorScheme m_currentColorScheme;

--- a/gui/include/gui/tooltip.h
+++ b/gui/include/gui/tooltip.h
@@ -1,0 +1,205 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by OpenCPN developer team                          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+#ifndef _TOOLTIP_H__
+#define _TOOLTIP_H__
+
+#include <wx/frame.h>
+#include <wx/timer.h>
+#include <wx/bitmap.h>
+#include "color_types.h"
+
+class ChartCanvas;
+
+/**
+ * Tooltip with color scheme support and high-visibility mode.
+ *
+ * This class is typically not instantiated directly by developers.
+ * Use TooltipManager::Get().ShowTooltip()
+ */
+class Tooltip : public wxFrame {
+public:
+  Tooltip(wxWindow *parent);
+  ~Tooltip();
+
+  /** Set the tooltip text to display */
+  void SetString(const wxString &text);
+  /**
+   * Position tooltip relative to a window rectangle with automatic screen
+   * boundary detection. The window rectangle should be in the same coordinate
+   * system as the tooltip's parent.
+   * The tooltip position is automatically adjusted to stay within screen
+   * bounds.
+   *
+   * @param windowRect Rectangle of the window in parent's client coordinates
+   * (physical pixels)
+   * @param offsetX Horizontal offset from window's right edge in physical
+   * pixels
+   * @param offsetY Vertical offset from window's top edge in physical pixels
+   */
+  void SetRelativePosition(const wxRect &windowRect, int offsetX = 2,
+                           int offsetY = 0);
+  /** Enable/disable high visibility mode */
+  void SetHiviz(bool hiviz);
+  /** Set the color scheme for tooltip appearance */
+  void SetColorScheme(ColorScheme cs);
+
+  /**
+   * Set the tooltip position in absolute screen coordinates (physical pixels).
+   * Position (0,0) represents the top-left corner of the primary display.
+   * All coordinates are in physical pixels, which may differ from logical
+   * pixels on high-DPI displays.
+   */
+  void SetAbsolutePosition(const wxPoint &pt);
+
+  /** Create the tooltip bitmap. */
+  void SetBitmap();
+  /** Get the rendered size of the tooltip. */
+  wxSize GetRenderedSize() const;
+
+  /**
+   * Show the tooltip with optional delay in milliseconds.
+   * The tooltip is positioned according to the previously set position
+   * (via SetAbsolutePosition or SetRelativePosition).
+   *
+   * @param delay_ms Delay in milliseconds before showing the tooltip (0 =
+   * immediate)
+   */
+  void ShowTooltip(int delay_ms = 0);
+  /** Hide the tooltip immediately */
+  void HideTooltip();
+
+  // Event handlers
+  void OnPaint(wxPaintEvent &event);
+  void OnTimer(wxTimerEvent &event);
+
+private:
+  void CreateBitmap();
+  void CalculateOptimalPosition();
+
+  wxString m_string;
+  wxSize m_size;
+  /** Final tooltip position in absolute screen coordinates (physical pixels)
+   * after boundary adjustments. */
+  wxPoint m_position;
+  /** Requested tooltip position before boundary detection and
+   * adjustments. */
+  wxPoint m_requestedPosition;
+  wxBitmap *m_pbm;
+  wxColour m_back_color;
+  wxColour m_text_color;
+  ColorScheme m_cs;
+  bool m_hiviz;
+
+  wxTimer m_showTimer;
+  bool m_showPending;
+
+  DECLARE_EVENT_TABLE()
+};
+
+/**
+ * Coordinates tooltip display across OpenCPN components.
+ * Ensures only one tooltip is shown at a time.
+ *
+ * Developer usage:
+ *
+ * 1. Standard UI widgets (buttons, checkboxes, dropdowns, etc.):
+ *    Keep using: widget->SetToolTip("Help text");
+ *    These work automatically with existing wxWidgets tooltip system.
+ *
+ * 2. Chart canvas and custom-drawn widgets:
+ *    Use: TooltipManager::Get().ShowTooltipAtPosition(parent, "Text",
+ * screenPosition); Required for widgets that don't use standard wxWidgets
+ * painting, such as ChartCanvas where charts are rendered directly to device
+ * context.
+ *    - screenPosition: Absolute screen coordinates (physical pixels)
+ *    - Use wxGetMousePosition() to show tooltip at current mouse cursor
+ */
+class TooltipManager {
+public:
+  /** Get the singleton instance */
+  static TooltipManager &Get();
+
+  /**
+   * Show tooltip for a window using automatic positioning relative to the
+   * window. The tooltip is positioned automatically next to the window
+   * (typically to the right) with automatic screen boundary detection. This is
+   * the recommended method for most use cases.
+   *
+   * @param window Window to show tooltip for (position calculated
+   * automatically)
+   * @param text Text to display in the tooltip
+   * @param hiviz Enable high visibility mode for better contrast
+   */
+  void ShowTooltipForWindow(wxWindow *window, const wxString &text,
+                            bool hiviz = false);
+  /**
+   * Show tooltip at specified position in absolute screen coordinates (physical
+   * pixels). Position (0,0) represents the top-left corner of the primary
+   * display. All coordinates are in physical pixels, which may differ from
+   * logical pixels on high-DPI displays. Use this when you need precise control
+   * over tooltip placement.
+   *
+   * @param parent Parent window for the tooltip
+   * @param text Text to display in the tooltip
+   * @param position Absolute screen position in physical pixels where tooltip
+   * should appear
+   * @param hiviz Enable high visibility mode for better contrast
+   */
+  void ShowTooltipAtPosition(wxWindow *parent, const wxString &text,
+                             const wxPoint &position, bool hiviz = false);
+
+  /** Hide the current tooltip */
+  void HideTooltip();
+  /** Hide all tooltips */
+  void HideAllTooltips();
+  /** Set color scheme for all tooltips */
+  void SetColorScheme(ColorScheme cs);
+  /** Enable or disable tooltip system */
+  void EnableTooltips(bool enable);
+  /** Check if tooltips are enabled */
+  bool AreTooltipsEnabled() const { return m_enabled; }
+
+  /** Check if a tooltip is currently shown */
+  bool IsShown() const;
+
+  /** Set delay before showing tooltips */
+  void SetShowDelay(int ms) { m_showDelay = ms; }
+  /** Set delay before hiding tooltips */
+  void SetHideDelay(int ms) { m_hideDelay = ms; }
+
+private:
+  TooltipManager();
+  ~TooltipManager();
+
+  Tooltip *GetOrCreateTooltip(wxWindow *parent);
+  void CleanupTooltip();
+
+  Tooltip *m_currentTooltip;
+  wxWindow *m_currentParent;
+  ColorScheme m_colorScheme;
+  bool m_enabled;
+  int m_showDelay;
+  int m_hideDelay;
+
+  // Singleton instance
+  static TooltipManager *s_instance;
+};
+
+#endif  // _TOOLTIP_H__

--- a/gui/src/TCWin.cpp
+++ b/gui/src/TCWin.cpp
@@ -204,11 +204,13 @@ TCWin::TCWin(ChartCanvas *parent, int x, int y, void *pvIDX) {
   pblack_3 = wxThePenList->FindOrCreatePen(
       wxSystemSettings::GetColour(wxSYS_COLOUR_BTNSHADOW),
       wxMax(1, (int)(m_tcwin_scaler + 0.5)), wxPENSTYLE_SOLID);
-  // System time vertical line
+  // System time vertical line - solid red line showing current system time
+  // position on tide/current chart
   pred_2 = wxThePenList->FindOrCreatePen(
       wxColor(230, 54, 54), wxMax(4, (int)(4 * m_tcwin_scaler + 0.5)),
       wxPENSTYLE_SOLID);
-  // Selected time vertical line (from GRIB plugin or timeline widget)
+  // Selected time vertical line - dotted blue line showing timeline widget or
+  // GRIB time selection on chart
   pred_time = wxThePenList->FindOrCreatePen(
       wxColour(0, 100, 255), wxMax(4, (int)(4 * m_tcwin_scaler + 0.5)),
       wxPENSTYLE_DOT);
@@ -399,8 +401,10 @@ void TCWin::PaintChart(wxDC &dc, const wxRect &chartRect) {
   pblack_2->SetColour(this->GetForegroundColour());
   pltgray->SetColour(this->GetBackgroundColour());
   pltgray2->SetColour(this->GetBackgroundColour());
-  pred_2->SetColour(GetDimedColor(wxColor(230, 54, 54)));
-  pred_time->SetColour(GetDimedColor(wxColour(0, 100, 255)));
+  pred_2->SetColour(
+      GetGlobalColor("URED"));  // System time indicator - universal red
+  pred_time->SetColour(
+      GetGlobalColor("UINFB"));  // Selected time indicator - information blue
 
   // Box the graph
   dc.SetPen(*pblack_1);

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -7593,13 +7593,15 @@ bool ChartCanvas::MouseEventOverlayWindows(wxMouseEvent &event) {
     if (m_Compass && m_Compass->IsShown()) {
       wxRect logicalRect = m_Compass->GetLogicalRect();
       bool isInCompass = logicalRect.Contains(event.GetPosition());
-      if (isInCompass) {
+      if (isInCompass || m_mouseWasInCompass) {
         if (m_Compass->MouseEvent(event)) {
           cursor_region = CENTER;
           if (!g_btouch) SetCanvasCursor(event);
+          m_mouseWasInCompass = isInCompass;
           return true;
         }
       }
+      m_mouseWasInCompass = isInCompass;
     }
 
     if (m_notification_button && m_notification_button->IsShown()) {

--- a/gui/src/mui_bar.cpp
+++ b/gui/src/mui_bar.cpp
@@ -45,6 +45,7 @@
 #include "ocpn_platform.h"
 #include "pluginmanager.h"
 #include "styles.h"
+#include "tooltip.h"
 
 #ifdef ocpnUSE_GL
 #include "gl_chart_canvas.h"
@@ -798,7 +799,85 @@ bool MUIBar::MouseEvent(wxMouseEvent& event) {
   //    Check the regions
   wxRect r = wxRect(m_screenPos, m_size);
   if (r.Contains(x, y)) {
-    // Check buttons
+    // Check for tooltip display on hover/move events
+    if (event.Moving() || event.Entering()) {
+      bool tooltipShown = false;
+
+      // Check follow button tooltip
+      if (m_followButton) {
+        wxRect rfollow(m_followButton->m_position.x,
+                       m_followButton->m_position.y, m_followButton->m_size.x,
+                       m_followButton->m_size.y);
+        rfollow.Offset(m_screenPos);
+        if (rfollow.Contains(x, y)) {
+          wxPoint screenPos = wxGetMousePosition();
+          screenPos.x += 15;
+          screenPos.y += 15;
+          TooltipManager::Get().ShowTooltipAtPosition(
+              m_parentCanvas, _("Follow Ship"), screenPos);
+          tooltipShown = true;
+        }
+      }
+
+      // Check menu button tooltip
+      if (!tooltipShown) {
+        wxRect rmenu(m_menuButton->m_position.x, m_menuButton->m_position.y,
+                     m_menuButton->m_size.x, m_menuButton->m_size.y);
+        rmenu.Offset(m_screenPos);
+        if (rmenu.Contains(x, y)) {
+          wxPoint screenPos = wxGetMousePosition();
+          screenPos.x += 15;
+          screenPos.y += 15;
+          TooltipManager::Get().ShowTooltipAtPosition(
+              m_parentCanvas, _("Options Menu"), screenPos);
+          tooltipShown = true;
+        }
+      }
+
+      // Check zoom buttons tooltips if enabled
+      if (!tooltipShown && g_bShowMuiZoomButtons) {
+        wxRect rzin(m_zinButton->m_position.x, m_zinButton->m_position.y,
+                    m_zinButton->m_size.x, m_zinButton->m_size.y);
+        rzin.Offset(m_screenPos);
+        if (rzin.Contains(x, y)) {
+          wxPoint screenPos = wxGetMousePosition();
+          screenPos.x += 15;
+          screenPos.y += 15;
+          TooltipManager::Get().ShowTooltipAtPosition(m_parentCanvas,
+                                                      _("Zoom In"), screenPos);
+          tooltipShown = true;
+        } else {
+          wxRect rzout(m_zoutButton->m_position.x, m_zoutButton->m_position.y,
+                       m_zoutButton->m_size.x, m_zoutButton->m_size.y);
+          rzout.Offset(m_screenPos);
+          if (rzout.Contains(x, y)) {
+            wxPoint screenPos = wxGetMousePosition();
+            screenPos.x += 15;
+            screenPos.y += 15;
+            TooltipManager::Get().ShowTooltipAtPosition(
+                m_parentCanvas, _("Zoom Out"), screenPos);
+            tooltipShown = true;
+          }
+        }
+      }
+
+      // Check scale button tooltip
+      if (!tooltipShown && m_scaleButton) {
+        wxRect rscale(m_scaleButton->m_position.x, m_scaleButton->m_position.y,
+                      m_scaleButton->m_size.x, m_scaleButton->m_size.y);
+        rscale.Offset(m_screenPos);
+        if (rscale.Contains(x, y)) {
+          wxPoint screenPos = wxGetMousePosition();
+          screenPos.x += 15;
+          screenPos.y += 15;
+          TooltipManager::Get().ShowTooltipAtPosition(
+              m_parentCanvas, _("Chart Scale"), screenPos);
+          tooltipShown = true;
+        }
+      }
+    }
+
+    // Check buttons for clicks
     if (event.LeftDown()) {
       if (g_bShowMuiZoomButtons) {
         wxRect rzin(m_zinButton->m_position.x, m_zinButton->m_position.y,
@@ -851,6 +930,11 @@ bool MUIBar::MouseEvent(wxMouseEvent& event) {
       }
     }
     return true;
+  } else {
+    // Mouse is outside MUIBar - hide any tooltips
+    if (event.Moving() || event.Leaving()) {
+      TooltipManager::Get().HideTooltip();
+    }
   }
   return false;
 }

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -3259,23 +3259,3 @@ void DimeControl(wxWindow *ctrl, wxColour col, wxColour window_back_color,
     }
   }
 }
-
-#define LUMIMOSITY_NIGHT (-0.8)
-#define LUMIMOSITY_DUSK (-0.5)
-
-wxColor GetDimedColor(const wxColor &c) {
-  switch (global_color_scheme) {
-    case ColorScheme::GLOBAL_COLOR_SCHEME_NIGHT:
-      return (wxColor(
-          wxMax(0, wxMin(c.Red() + c.Red() * LUMIMOSITY_NIGHT, 255)),
-          wxMax(0, wxMin(c.Green() + c.Green() * LUMIMOSITY_NIGHT, 255)),
-          wxMax(0, wxMin(c.Blue() + c.Blue() * LUMIMOSITY_NIGHT, 255))));
-    case ColorScheme::GLOBAL_COLOR_SCHEME_DUSK:
-      return (
-          wxColor(wxMax(0, wxMin(c.Red() + c.Red() * LUMIMOSITY_DUSK, 255)),
-                  wxMax(0, wxMin(c.Green() + c.Green() * LUMIMOSITY_DUSK, 255)),
-                  wxMax(0, wxMin(c.Blue() + c.Blue() * LUMIMOSITY_DUSK, 255))));
-    default:
-      return c;
-  }
-}

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -7112,52 +7112,106 @@ bool MyFrame::AddDefaultPositionPlugInTools() {
 wxColour GetGlobalColor(wxString colorName);  // -> color_handler
 
 static const char *usercolors[] = {
-    "Table:DAY", "GREEN1;120;255;120;", "GREEN2; 45;150; 45;",
-    "GREEN3;200;220;200;", "GREEN4;  0;255;  0;", "BLUE1; 170;170;255;",
+    //======================================================================
+    // Table:DAY - Bright daylight color scheme (full visibility mode)
+    //======================================================================
+    "Table:DAY",
+
+    // Standard palette colors - general purpose UI elements
+    "GREEN1;120;255;120;", "GREEN2; 45;150; 45;", "GREEN3;200;220;200;",
+    "GREEN4;  0;255;  0;", "GREEN5;170;254;  0;", "BLUE1; 170;170;255;",
     "BLUE2;  45; 45;170;", "BLUE3;   0;  0;255;", "GREY1; 200;200;200;",
-    "GREY2; 230;230;230;", "RED1;  220;200;200;", "UBLCK;   0;  0;  0;",
-    "UWHIT; 255;255;255;", "URED;  255;  0;  0;", "UGREN;   0;255;  0;",
-    "YELO1; 243;229; 47;", "YELO2; 128; 80;  0;", "TEAL1;   0;128;128;",
-    "GREEN5;170;254;  0;", "COMPT; 245;247;244",
+    "GREY2; 230;230;230;", "RED1;  220;200;200;", "YELO1; 243;229; 47;",
+    "YELO2; 128; 80;  0;", "TEAL1;   0;128;128;",
+
+    // Basic UI colors
+    "UBLCK;   0;  0;  0;",  // Universal black for text/lines
+    "UWHIT; 255;255;255;",  // Universal white for backgrounds
+    "URED;  255;  0;  0;",  // Own vessel color, AIS targets, predictor lines
+    "UGREN;   0;255;  0;",  // Universal green for general purpose green
+    "COMPT; 245;247;244",   // Compass rose background/details
+
+// Dialog system colors
 #ifdef __WXOSX__
-    "DILG0; 255;255;255;",  // Dialog Background white
+    "DILG0; 255;255;255;",  // Dialog window background (macOS)
 #else
-    "DILG0; 238;239;242;",  // Dialog Background white
+    "DILG0; 238;239;242;",  // Dialog window background (other platforms)
 #endif
-    "DILG1; 212;208;200;",  // Dialog Background
-    "DILG2; 255;255;255;",  // Control Background
-    "DILG3;   0;  0;  0;",  // Text
-    "UITX1;   0;  0;  0;",  // Menu Text, derived from UINFF
+    "DILG1; 212;208;200;",  // Background color for selected items
+    "DILG2; 255;255;255;",  // Control backgrounds for text boxes and input
+                            // fields
+    "DILG3;   0;  0;  0;",  // Dialog text color in dialogs and controls
+    /**
+     * Text color optimized for progressively darker backgrounds (pairs with
+     * DILG0). Gets progressively lighter as background darkens to maintain
+     * contrast. Ideal for tooltips, overlays, and any text over DILG0
+     * background. */
+    "DILG4;   0;  0;  0;",
+    "UITX1;   0;  0;  0;",  // Menu text color
 
-    "CHGRF; 163; 180; 183;", "UINFM; 197;  69; 195;", "UINFG; 104; 228;  86;",
-    "UINFF; 125; 137; 140;", "UINFR; 241;  84; 105;", "SHIPS;   7;   7;   7;",
-    "CHYLW; 244; 218;  72;", "CHWHT; 212; 234; 238;",
+    // Chart and information display colors
+    "CHGRF; 163; 180; 183;",  // Chart gray foreground (grid lines, secondary
+                              // text)
+    "CHYLW; 244; 218;  72;",  // Chart yellow (AIS name invalid, warnings)
+    "CHWHT; 212; 234; 238;",  // Chart white (AIS outlines, contrast elements)
 
-    "UDKRD; 124; 16;  0;",
-    "UARTE; 200;  0;  0;",  // Active Route, Grey on Dusk/Night
+    // Information status colors
+    "UINFM; 197;  69; 195;",  // Magenta - special indicators, chart magenta
+                              // features
+    "UINFG; 104; 228;  86;",  // Green - status indicators, tide/current
+                              // graphics
+    "UINFR; 241;  84; 105;",  // Red - alerts, errors, danger markers
+    "UINFF; 125; 137; 140;",  // Default foreground - general UI elements
+    "SHIPS;   7;   7;   7;",  // Other vessels/AIS target fills
 
-    "NODTA; 163; 180; 183;", "CHBLK;   7;   7;   7;", "SNDG1; 125; 137; 140;",
-    "SNDG2;   7;   7;   7;", "SCLBR; 235; 125;  54;", "UIBDR; 125; 137; 140;",
-    "UINFB;  58; 120; 240;", "UINFD;   7;   7;   7;", "UINFO; 235; 125;  54;",
-    "PLRTE; 220;  64;  37;", "CHMGD; 197; 69; 195;", "UIBCK; 212; 234; 238;",
+    // Route and navigation colors
+    "UDKRD; 124; 16;  0;",  // Dark red variant - reduced visibility alternative
+                            // to URED
+    "UARTE; 200;  0;  0;",  // Active route color (bright red in day mode)
 
-    "DASHB; 255;255;255;",  // Dashboard Instr background
-    "DASHL; 175;175;175;",  // Dashboard Instr Label
-    "DASHF;  50; 50; 50;",  // Dashboard Foreground
-    "DASHR; 200;  0;  0;",  // Dashboard Red
-    "DASHG;   0;200;  0;",  // Dashboard Green
-    "DASHN; 200;120;  0;",  // Dashboard Needle
-    "DASH1; 204;204;255;",  // Dashboard Illustrations
-    "DASH2; 122;131;172;",  // Dashboard Illustrations
-    "COMP1; 211;211;211;",  // Compass Window Background
+    // Chart data and measurement colors
+    "NODTA; 163; 180; 183;",  // No data available areas
+    "CHBLK;   7;   7;   7;",  // Chart black - text, lines, piano keys
+    "SNDG1; 125; 137; 140;",  // Sounding text (depth numbers) - primary
+    "SNDG2;   7;   7;   7;",  // Sounding text (depth numbers) - secondary
+    "SCLBR; 235; 125;  54;",  // Scale bar markings and text
 
-    "GREY3;  40; 40; 40;",  // MUIBar/TB background
-    "BLUE4; 100;100;200;",  // Canvas Focus Bar
-    "VIO01; 171; 33;141;", "VIO02; 209;115;213;",
-    "BLUEBACK; 212;234;238;",  // DEPDW, looks like deep ocean
-    "LANDBACK; 201;185;122;",
-    //<color name="LANDA" r="201" g="185" b="122"/>
+    // UI framework colors
+    "UIBDR; 125; 137; 140;",  // UI borders, status bar background
+    "UIBCK; 212; 234; 238;",  // Highlight backgrounds, info windows
+    "UINFB;  58; 120; 240;",  // Information blue - active/selected states, tide
+                              // markers
+    "UINFD;   7;   7;   7;",  // Information dark - borders, inactive elements
+    "UINFO; 235; 125;  54;",  // Information orange - warnings, highlights
 
+    // Route planning colors
+    "PLRTE; 220;  64;  37;",  // Planned route color (not yet active)
+    "CHMGD; 197; 69; 195;",  // Chart magenta - special chart features, AIS MMSI
+                             // text
+
+    // Dashboard instrument colors
+    "DASHB; 255;255;255;",  // Dashboard instrument background
+    "DASHL; 175;175;175;",  // Dashboard instrument labels and graduations
+    "DASHF;  50; 50; 50;",  // Dashboard foreground text and indicators
+    "DASHR; 200;  0;  0;",  // Dashboard red indicators (alarms, danger zones)
+    "DASHG;   0;200;  0;",  // Dashboard green indicators (normal status)
+    "DASHN; 200;120;  0;",  // Dashboard needle/pointer color
+    "DASH1; 204;204;255;",  // Dashboard graphic elements - primary
+    "DASH2; 122;131;172;",  // Dashboard graphic elements - secondary
+    "COMP1; 211;211;211;",  // Compass window background
+
+    // Window and canvas elements
+    "GREY3;  40; 40; 40;",     // MUI toolbar background
+    "BLUE4; 100;100;200;",     // Canvas focus indicator bar
+    "VIO01; 171; 33;141;",     // Violet - vector chart special elements
+    "VIO02; 209;115;213;",     // Violet variant - vector chart features
+    "BLUEBACK; 212;234;238;",  // Deep water background color for basemap
+    "LANDBACK; 201;185;122;",  // Land mass background color for basemap
+
+    //======================================================================
+    // Table:DUSK - Reduced brightness for twilight conditions
+    // Colors defined above are automatically dimmed for dusk visibility
+    //======================================================================
     "Table:DUSK", "GREEN1; 60;128; 60;", "GREEN2; 22; 75; 22;",
     "GREEN3; 80;100; 80;", "GREEN4;  0;128;  0;", "BLUE1;  80; 80;160;",
     "BLUE2;  30; 30;120;", "BLUE3;   0;  0;128;", "GREY1; 100;100;100;",
@@ -7174,9 +7228,11 @@ static const char *usercolors[] = {
     "DILG1; 110;110;110;",  // Dialog Background
     "DILG2;   0;  0;  0;",  // Control Background
     "DILG3; 130;130;130;",  // Text
-    "UITX1;  41; 46; 46;",  // Menu Text, derived from UINFF
-    "UDKRD;  80;  0;  0;",
-    "UARTE;  64; 64; 64;",  // Active Route, Grey on Dusk/Night
+    "DILG4;   0;  0;  0;",
+    "UITX1;  41; 46; 46;",  // Menu text color
+    "UDKRD;  80;  0;  0;",  // Dark red variant - reduced visibility alternative
+                            // to URED
+    "UARTE;  64; 64; 64;",  // Active route color (grey for dusk/night modes)
 
     "NODTA;  41;  46;  46;", "CHBLK;  54;  60;  61;", "SNDG1;  41;  46;  46;",
     "SNDG2;  71;  78;  79;", "SCLBR;  75;  38;  19;", "UIBDR;  54;  60;  61;",
@@ -7198,6 +7254,10 @@ static const char *usercolors[] = {
     "VIO01; 128; 25;108;", "VIO02; 171; 33;141;", "BLUEBACK; 186;213;235;",
     "LANDBACK; 201;185;122;",
 
+    //======================================================================
+    // Table:NIGHT - Dark adapted colors preserving night vision
+    // Colors are further dimmed and shifted toward red spectrum
+    //======================================================================
     "Table:NIGHT", "GREEN1; 30; 80; 30;", "GREEN2; 15; 60; 15;",
     "GREEN3; 12; 23;  9;", "GREEN4;  0; 64;  0;", "BLUE1;  60; 60;100;",
     "BLUE2;  22; 22; 85;", "BLUE3;   0;  0; 40;", "GREY1;  48; 48; 48;",
@@ -7209,9 +7269,11 @@ static const char *usercolors[] = {
     "DILG1;  80; 80; 80;",  // Dialog Background
     "DILG2;   0;  0;  0;",  // Control Background
     "DILG3;  65; 65; 65;",  // Text
-    "UITX1;  31; 34; 35;",  // Menu Text, derived from UINFF
-    "UDKRD;  50;  0;  0;",
-    "UARTE;  64; 64; 64;",  // Active Route, Grey on Dusk/Night
+    "DILG4; 220;220;220;",
+    "UITX1;  31; 34; 35;",  // Menu text color
+    "UDKRD;  50;  0;  0;",  // Dark red variant - reduced visibility alternative
+                            // to URED
+    "UARTE;  64; 64; 64;",  // Active route color (grey for dusk/night modes)
 
     "CHGRF;  16; 18; 18;", "UINFM;  52; 18; 52;", "UINFG;  22; 24;  7;",
     "UINFF;  31; 34; 35;", "UINFR;  59; 17; 10;", "SHIPS;  37; 41; 41;",

--- a/gui/src/tooltip.cpp
+++ b/gui/src/tooltip.cpp
@@ -1,0 +1,397 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by OpenCPN developer team                          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+#include "tooltip.h"
+#include "chcanv.h"
+#include "color_handler.h"
+#include "font_mgr.h"
+#include "ocpn_platform.h"
+#include "ocpn_frame.h"
+#include "navutil.h"
+
+extern OCPNPlatform *g_Platform;
+extern MyFrame *gFrame;
+extern bool g_btouch;
+
+// Define timer event ID
+#define TOOLTIP_TIMER_ID 10002
+
+//----------------------------------------------------------------------------
+// Tooltip Implementation
+//----------------------------------------------------------------------------
+
+BEGIN_EVENT_TABLE(Tooltip, wxFrame)
+EVT_PAINT(Tooltip::OnPaint)
+EVT_TIMER(TOOLTIP_TIMER_ID, Tooltip::OnTimer)
+END_EVENT_TABLE()
+
+Tooltip::Tooltip(wxWindow *parent)
+    : wxFrame(parent, wxID_ANY, "", wxPoint(0, 0), wxSize(1, 1),
+              wxNO_BORDER | wxFRAME_FLOAT_ON_PARENT | wxFRAME_NO_TASKBAR),
+      m_showTimer(this, TOOLTIP_TIMER_ID) {
+  m_pbm = nullptr;
+  m_hiviz = false;
+  m_showPending = false;
+
+  // Initialize colors using SetColorScheme to avoid duplicate code
+  SetColorScheme(GLOBAL_COLOR_SCHEME_RGB);
+
+  SetBackgroundStyle(wxBG_STYLE_CUSTOM);
+  SetBackgroundColour(m_back_color);
+  Hide();
+}
+
+Tooltip::~Tooltip() { delete m_pbm; }
+
+void Tooltip::SetString(const wxString &text) { m_string = text; }
+
+void Tooltip::SetAbsolutePosition(const wxPoint &pt) {
+  m_position = pt;
+  m_requestedPosition = pt;
+}
+
+void Tooltip::SetHiviz(bool hiviz) { m_hiviz = hiviz; }
+
+void Tooltip::SetColorScheme(ColorScheme cs) {
+  m_cs = cs;
+  m_back_color =
+      GetGlobalColor("DILG0");  // Background gets progressively darker
+  m_text_color = GetGlobalColor("DILG4");  // Text gets progressively lighter
+}
+
+void Tooltip::SetRelativePosition(const wxRect &windowRect, int offsetX,
+                                  int offsetY) {
+  // Calculate initial position to the right of the window
+  wxPoint pos;
+  pos.x = windowRect.x + windowRect.width + offsetX;
+  pos.y = windowRect.y + offsetY;
+
+  // Get tooltip size for boundary checking
+  wxSize tooltipSize = GetRenderedSize();
+  wxSize screenSize = wxGetDisplaySize();
+
+  // Convert to screen coordinates if needed
+  wxPoint screenPos = pos;
+  if (GetParent() && GetParent() != wxTheApp->GetTopWindow()) {
+    screenPos = GetParent()->ClientToScreen(pos);
+  }
+
+  // Adjust horizontal position if tooltip would go off screen
+  if (screenPos.x + tooltipSize.x > screenSize.x) {
+    // Try positioning to the left of the window instead
+    pos.x = windowRect.x - tooltipSize.x - offsetX;
+    if (GetParent() && GetParent() != wxTheApp->GetTopWindow()) {
+      screenPos = GetParent()->ClientToScreen(pos);
+    } else {
+      screenPos = pos;
+    }
+
+    // If still off screen, clamp to screen edge
+    if (screenPos.x < 0) {
+      screenPos.x = offsetX;
+    }
+  }
+
+  // Adjust vertical position if tooltip would go off screen
+  if (screenPos.y + tooltipSize.y > screenSize.y) {
+    // Try positioning above the window instead
+    pos.y = windowRect.y - tooltipSize.y - offsetY;
+    if (GetParent() && GetParent() != wxTheApp->GetTopWindow()) {
+      screenPos = GetParent()->ClientToScreen(pos);
+    } else {
+      screenPos = pos;
+    }
+
+    // If still off screen, clamp to screen edge
+    if (screenPos.y < 0) {
+      screenPos.y = offsetY;
+    }
+  }
+
+  // SetAbsolutePosition expects screen coordinates
+  SetAbsolutePosition(screenPos);
+}
+
+wxSize Tooltip::GetRenderedSize() const {
+  if (m_string.IsEmpty()) {
+    return wxSize(0, 0);
+  }
+
+  wxScreenDC cdc;
+  double scaler = g_Platform->GetDisplayDIPMult(const_cast<Tooltip *>(this));
+
+  wxFont *plabelFont = FontMgr::Get().GetFont(_("ToolTips"));
+  wxFont sFont = plabelFont->Scaled(1.0 / scaler);
+
+  int w, h;
+  cdc.GetMultiLineTextExtent(m_string, &w, &h, nullptr, &sFont);
+  int sizeX = w + GetCharWidth() * 2;
+  int sizeY = h + GetCharHeight() / 2;
+
+  sizeX *= scaler;
+  sizeY *= scaler;
+
+  return wxSize(sizeX, sizeY);
+}
+
+void Tooltip::CreateBitmap() {
+  if (m_string.IsEmpty()) return;
+
+  wxScreenDC cdc;
+  double scaler = g_Platform->GetDisplayDIPMult(this);
+
+  wxFont *plabelFont = FontMgr::Get().GetFont(_("ToolTips"));
+  wxFont sFont = plabelFont->Scaled(1.0 / scaler);
+
+  int w, h;
+  cdc.GetMultiLineTextExtent(m_string, &w, &h, nullptr, &sFont);
+
+  m_size.x = w + GetCharWidth() * 2;
+  m_size.y = h + GetCharHeight() / 2;
+
+  m_size.x *= scaler;
+  m_size.y *= scaler;
+
+  wxMemoryDC mdc;
+
+  delete m_pbm;
+  m_pbm = new wxBitmap(m_size.x, m_size.y, -1);
+  mdc.SelectObject(*m_pbm);
+
+  wxPen pborder(m_text_color);
+  wxBrush bback(m_back_color);
+  mdc.SetPen(pborder);
+  mdc.SetBrush(bback);
+
+  // High visibility mode for night/dusk color schemes
+  if (m_hiviz) {
+    if ((m_cs == GLOBAL_COLOR_SCHEME_DUSK) ||
+        (m_cs == GLOBAL_COLOR_SCHEME_NIGHT)) {
+      wxBrush hv_back(wxColour(200, 200, 200));
+      mdc.SetBrush(hv_back);
+    }
+  }
+
+  mdc.DrawRectangle(0, 0, m_size.x, m_size.y);
+
+  // Draw the text
+  mdc.SetFont(sFont);
+  mdc.SetTextForeground(m_text_color);
+  mdc.SetTextBackground(m_back_color);
+
+  int offx = GetCharWidth();
+  int offy = GetCharHeight() / 4;
+  offx *= scaler;
+  offy *= scaler;
+  mdc.DrawText(m_string, offx, offy);
+
+  SetClientSize(m_size.x, m_size.y);
+}
+
+void Tooltip::SetBitmap() {
+  CreateBitmap();
+  CalculateOptimalPosition();
+  SetSize(m_position.x, m_position.y, m_size.x, m_size.y);
+}
+
+void Tooltip::CalculateOptimalPosition() {
+  if (!GetParent()) return;
+
+  wxPoint screenPos = m_requestedPosition;
+
+  // Adjust position to keep tooltip on screen
+  wxSize tooltipSize = GetRenderedSize();
+  wxSize screenSize = wxGetDisplaySize();
+
+  if (screenPos.x + tooltipSize.x > screenSize.x) {
+    screenPos.x = screenSize.x - tooltipSize.x - 10;
+  }
+  if (screenPos.y + tooltipSize.y > screenSize.y) {
+    screenPos.y = screenSize.y - tooltipSize.y - 10;
+  }
+
+  if (screenPos.x < 0) screenPos.x = 10;
+  if (screenPos.y < 0) screenPos.y = 10;
+
+  m_position = screenPos;
+}
+
+void Tooltip::ShowTooltip(int delay_ms) {
+  if (m_string.IsEmpty()) return;
+
+  if (delay_ms > 0) {
+    m_showPending = true;
+    m_showTimer.Start(delay_ms, wxTIMER_ONE_SHOT);
+  } else {
+    SetBitmap();
+    Show();
+#ifndef __WXOSX__
+    if (gFrame) gFrame->Raise();
+#endif
+  }
+}
+
+void Tooltip::HideTooltip() {
+  m_showTimer.Stop();
+  m_showPending = false;
+  Hide();
+}
+
+void Tooltip::OnPaint(wxPaintEvent &event) {
+  int width, height;
+  GetClientSize(&width, &height);
+  wxPaintDC dc(this);
+
+  if (m_string.Len() && m_pbm) {
+    wxMemoryDC mdc;
+    mdc.SelectObject(*m_pbm);
+    dc.Blit(0, 0, width, height, &mdc, 0, 0);
+  }
+}
+
+void Tooltip::OnTimer(wxTimerEvent &event) {
+  if (event.GetId() == TOOLTIP_TIMER_ID && m_showPending) {
+    m_showPending = false;
+    SetBitmap();
+    Show();
+#ifndef __WXOSX__
+    if (gFrame) gFrame->Raise();
+#endif
+  }
+}
+
+//----------------------------------------------------------------------------
+// TooltipManager Implementation
+//----------------------------------------------------------------------------
+
+TooltipManager *TooltipManager::s_instance = nullptr;
+
+TooltipManager::TooltipManager()
+    : m_currentTooltip(nullptr),
+      m_currentParent(nullptr),
+      m_colorScheme(GLOBAL_COLOR_SCHEME_RGB),
+      m_enabled(true),
+      m_showDelay(500),
+      m_hideDelay(5000) {}
+
+TooltipManager::~TooltipManager() { CleanupTooltip(); }
+
+TooltipManager &TooltipManager::Get() {
+  if (!s_instance) {
+    s_instance = new TooltipManager();
+  }
+  return *s_instance;
+}
+
+void TooltipManager::ShowTooltipAtPosition(wxWindow *parent,
+                                           const wxString &text,
+                                           const wxPoint &position,
+                                           bool hiviz) {
+  if (!m_enabled || text.IsEmpty()) return;
+
+  // Hide any existing tooltip
+  HideTooltip();
+
+  // Create or reuse tooltip
+  m_currentTooltip = GetOrCreateTooltip(parent);
+  m_currentParent = parent;
+
+  // Configure tooltip
+  m_currentTooltip->SetString(text);
+  m_currentTooltip->SetAbsolutePosition(position);
+  m_currentTooltip->SetHiviz(hiviz);
+  m_currentTooltip->SetColorScheme(m_colorScheme);
+
+  // Show with delay
+  m_currentTooltip->ShowTooltip(m_showDelay);
+}
+
+void TooltipManager::ShowTooltipForWindow(wxWindow *window,
+                                          const wxString &text, bool hiviz) {
+  if (!window) return;
+
+  // Hide any existing tooltip
+  HideTooltip();
+
+  // Create or reuse tooltip
+  m_currentTooltip = GetOrCreateTooltip(window->GetParent());
+  m_currentParent = window->GetParent();
+
+  // Configure tooltip
+  m_currentTooltip->SetString(text);
+  m_currentTooltip->SetHiviz(hiviz);
+  m_currentTooltip->SetColorScheme(m_colorScheme);
+
+  // Use enhanced positioning with automatic boundary detection
+  wxRect windowRect = window->GetRect();
+  m_currentTooltip->SetRelativePosition(windowRect, 2, 0);
+
+  // Show with delay
+  m_currentTooltip->ShowTooltip(m_showDelay);
+}
+
+void TooltipManager::HideTooltip() {
+  if (m_currentTooltip) {
+    m_currentTooltip->HideTooltip();
+  }
+}
+
+void TooltipManager::HideAllTooltips() {
+  HideTooltip();
+  CleanupTooltip();
+}
+
+void TooltipManager::SetColorScheme(ColorScheme cs) {
+  m_colorScheme = cs;
+  if (m_currentTooltip) {
+    m_currentTooltip->SetColorScheme(cs);
+  }
+}
+
+void TooltipManager::EnableTooltips(bool enable) {
+  m_enabled = enable;
+  if (!enable) {
+    HideAllTooltips();
+  }
+}
+
+bool TooltipManager::IsShown() const {
+  return m_currentTooltip && m_currentTooltip->IsShown();
+}
+
+Tooltip *TooltipManager::GetOrCreateTooltip(wxWindow *parent) {
+  if (m_currentTooltip && m_currentParent == parent) {
+    return m_currentTooltip;
+  }
+
+  CleanupTooltip();
+
+  m_currentTooltip = new Tooltip(parent);
+  m_currentParent = parent;
+
+  return m_currentTooltip;
+}
+
+void TooltipManager::CleanupTooltip() {
+  if (m_currentTooltip) {
+    m_currentTooltip->Destroy();
+    m_currentTooltip = nullptr;
+    m_currentParent = nullptr;
+  }
+}

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -223,18 +223,23 @@ class wxGLCanvas;
 //    Some PlugIn API interface object class definitions
 //----------------------------------------------------------------------------------------------------------
 /**
- * Enumeration of color schemes.
+ * Color schemes for different lighting conditions.
+ *
+ * @note: When implementing SetColorScheme(), use GetGlobalColor() with
+ * predefined color names for automatic adaptation across all schemes.
  */
 enum PI_ColorScheme {
-  PI_GLOBAL_COLOR_SCHEME_RGB,    //!< RGB color scheme, unmodified colors
-  PI_GLOBAL_COLOR_SCHEME_DAY,    //!< Day color scheme, optimized for bright
-                                 //!< ambient light
-  PI_GLOBAL_COLOR_SCHEME_DUSK,   //!< Dusk color scheme, optimized for low
-                                 //!< ambient light
-  PI_GLOBAL_COLOR_SCHEME_NIGHT,  //!< Night color scheme, optimized for dark
-                                 //!< conditions with minimal impact on night
-                                 //!< vision
-  PI_N_COLOR_SCHEMES  //!< Number of color schemes, used for bounds checking
+  /** RGB color scheme, unmodified colors. */
+  PI_GLOBAL_COLOR_SCHEME_RGB,
+  /** Day color scheme, optimized for bright ambient light. */
+  PI_GLOBAL_COLOR_SCHEME_DAY,
+  /** Dusk color scheme, optimized for low ambient light. */
+  PI_GLOBAL_COLOR_SCHEME_DUSK,
+  /** Night/dark color scheme, optimized for dark conditions with minimal impact
+     on night vision. */
+  PI_GLOBAL_COLOR_SCHEME_NIGHT,
+  /** Number of color schemes, used for bounds checking. */
+  PI_N_COLOR_SCHEMES
 };
 
 /**
@@ -555,11 +560,11 @@ public:
    * (day/dusk/night). Chart plugins should update their rendering colors and
    * styles to match the specified scheme.
    *
-   * @param cs Color scheme to use:
-   *        - PI_GLOBAL_COLOR_SCHEME_RGB (0): RGB color scheme
-   *        - PI_GLOBAL_COLOR_SCHEME_DAY (1): Day color scheme
-   *        - PI_GLOBAL_COLOR_SCHEME_DUSK (2): Dusk/twilight color scheme
-   *        - PI_GLOBAL_COLOR_SCHEME_NIGHT (3): Night/dark color scheme
+   * @param cs New color scheme to use:
+   *   - PI_GLOBAL_COLOR_SCHEME_RGB: RGB color scheme
+   *   - PI_GLOBAL_COLOR_SCHEME_DAY: Day color scheme
+   *   - PI_GLOBAL_COLOR_SCHEME_DUSK: Dusk/twilight color scheme
+   *   - PI_GLOBAL_COLOR_SCHEME_NIGHT: Night/dark color scheme
    * @param bApplyImmediate True to immediately refresh display, False to defer
    *
    * @note If bApplyImmediate is true, any cached rendering should be
@@ -1653,9 +1658,12 @@ public:
    * modes. Plugins should update their UI colors to match the new scheme.
    *
    * @param cs New color scheme to use:
-   *   - PI_GLOBAL_COLOR_SCHEME_DAY
-   *   - PI_GLOBAL_COLOR_SCHEME_DUSK
-   *   - PI_GLOBAL_COLOR_SCHEME_NIGHT
+   *   - PI_GLOBAL_COLOR_SCHEME_RGB: Unmodified RGB colors
+   *   - PI_GLOBAL_COLOR_SCHEME_DAY: Optimized for bright conditions
+   *   - PI_GLOBAL_COLOR_SCHEME_DUSK: Optimized for low light
+   *   - PI_GLOBAL_COLOR_SCHEME_NIGHT: Optimized for dark conditions
+   *
+   * @note Follow the patterns documented in the PI_ColorScheme enum.
    */
   virtual void SetColorScheme(PI_ColorScheme cs);
 
@@ -2567,13 +2575,19 @@ extern "C" DECL_EXP wxFileConfig *GetOCPNConfigObject(void);
 extern "C" DECL_EXP void RequestRefresh(wxWindow *);
 
 /**
- * Gets a global color value.
+ * Gets a functionally-named color for a specific UI purpose.
  *
- * Retrieves color values from OpenCPN's color scheme system.
+ * Retrieves colors by their functional role (e.g., "DILG3" for text, "URED"
+ * for vessels) that automatically adapt to current lighting conditions
+ * (Day/Dusk/Night modes).
  *
- * @param colorName Name of the color to retrieve
- * @param pcolour Pointer to wxColour to receive the color value
- * @return True if color was found, false if not
+ * @param colorName Functional color identifier.
+ * @param pcolour Pointer to wxColour to receive the adapted color value.
+ * @return True if color was found and retrieved successfully, false if color
+ *         name is unknown (returns grey fallback color).
+ *
+ * @see gui/src/ocpn_frame.cpp for color scheme definitions and available color
+ * names.
  */
 extern "C" DECL_EXP bool GetGlobalColor(wxString colorName, wxColour *pcolour);
 


### PR DESCRIPTION
# Changes in this PR

1. Display a tooltip when the user mouses over the compass/gnss widget (after the standard ~1.5s delay). It wasn't very obvious what the blue/red/pink colors mean, especially when the user is trying OpenCPN without being connected to a GPS receiver.
2. Fix #4211.

**North up:**

Tooltip screenshot with two different color schemes:
<img width="171" height="132" alt="image" src="https://github.com/user-attachments/assets/e3f7948f-c81d-427e-9917-651028726571" /> <img width="163" height="129" alt="image" src="https://github.com/user-attachments/assets/75634a3c-e346-4181-95ab-60211172b6f7" />


**Course up:**
<img width="144" height="110" alt="image" src="https://github.com/user-attachments/assets/9aed3ea6-ba49-4714-a691-beba8fb42332" />

**Heading up:**
<img width="155" height="118" alt="image" src="https://github.com/user-attachments/assets/9a58069b-9dd1-4fd1-b15e-a616728c55bf" />

**Dual canvas layout:**
<img width="426" height="133" alt="image" src="https://github.com/user-attachments/assets/cdb38ca9-a49e-4719-8cbd-4595b11f77cc" />

**MUIBar:**
<img width="382" height="118" alt="image" src="https://github.com/user-attachments/assets/265408fb-d625-45dd-b846-f174929109e5" />

# About the tooltip look and feel

The tooltips are rendered using a customer `Tooltip` class, which is a refactor of the preexisting `ToolTipWin` class. The `Tooltip` class has been generalized to support regular widgets and the canvas. It supports color schemes (day, night, dawn, dusk) and high visibility. The tooltip rendering is consistent across all platforms (mac, linux, windows)
