### PR TITLE
Global config parameter for selecting local time or UTC

### DIFF
--- a/android/androidUTIL.cpp
+++ b/android/androidUTIL.cpp
@@ -2689,8 +2689,7 @@ bool androidStartGPS(wxEvtHandler *consumer) {
   wxLogMessage(s);
   if (s.Upper().Find(_T("DISABLED")) != wxNOT_FOUND) {
     OCPNMessageBox(
-        NULL,
-        _("Your android device has an internal GPS, but it is disabled.\n\
+        NULL, _("Your android device has an internal GPS, but it is disabled.\n\
                        Please visit android Settings/Location dialog to enable GPS"),
         _T("OpenCPN"), wxOK);
 
@@ -4417,7 +4416,7 @@ int doAndroidPersistState() {
         node = node->GetNext();
       }
 
-      wxString name = now.Format();
+      wxString name = ocpn::toUsrDateTimeFormat(now);
       name.Prepend(_("Anchorage created "));
       RoutePoint *pWP =
           new RoutePoint(gLat, gLon, _T("anchorage"), name, _T(""));

--- a/gui/include/gui/TrackPropDlg.h
+++ b/gui/include/gui/TrackPropDlg.h
@@ -140,8 +140,17 @@ protected:
   wxTextCtrl* m_tTimeEnroute;
   wxStaticText* m_stShowTime;
   wxRadioButton* m_rbShowTimeUTC;
+  /** Use system timezone to format date/time, i.e. timezone configured in the
+   * operating system. */
   wxRadioButton* m_rbShowTimePC;
+  /** Use Local Mean Time (LMT) at the location to format date/time. */
   wxRadioButton* m_rbShowTimeLocal;
+  /**
+   * Honor OpenCPN global setting to format date/time. This is the default value
+   * to ensure consistent behavior with all date/time displays across the entire
+   * application.
+   */
+  wxRadioButton* m_rbShowTimeGlobalSettings;
   OCPNTrackListCtrl* m_lcPoints;
   wxScrolledWindow* m_panelAdvanced;
   wxStaticText* m_stDescription;
@@ -218,6 +227,10 @@ public:
 };
 
 class OCPNTrackListCtrl : public wxListCtrl {
+protected:
+  /** Return the longitude at the start point of the track. */
+  double getStartPointLongitude() const;
+
 public:
   OCPNTrackListCtrl(wxWindow* parent, wxWindowID id, const wxPoint& pos,
                     const wxSize& size, long style);

--- a/gui/include/gui/navutil.h
+++ b/gui/include/gui/navutil.h
@@ -57,12 +57,14 @@ extern wxString formatAngle(double angle);
 #define UTCINPUT 0  //!< Date/time in UTC.
 #define LTINPUT 1   //!< Date/time using PC local timezone.
 #define LMTINPUT 2  //!< Date/time using the remote location LMT time.
+#define GLOBAL_SETTINGS_INPUT \
+  3  //!< Date/time according to global OpenCPN settings.
 
 /**
  * Convert the date/time in UTC to the given format.
  * @param ts The input timestamp in UTC.
  * @param format The desired output format:
- *        0 = UTC, 1 = Local@PC, 2 = LMT@Location.
+ *        0 = UTC, 1 = Local@PC, 2 = LMT@Location, 3 = Global settings.
  * @param lon The longitude for LMT calculation. Default is NaN.
  * @return wxDateTime The converted timestamp in the specified format.
  */
@@ -72,7 +74,7 @@ wxDateTime toUsrDateTime(const wxDateTime ts, const int format,
  * Convert a date/time from a given input format to UTC.
  * @param ts The input timestamp in the specified format.
  * @param format The input timestamp format:
- *        0 = UTC, 1 = Local@PC, 2 = LMT@Location.
+ *        0 = UTC, 1 = Local@PC, 2 = LMT@Location, 3 = Global settings.
  * @param lon The longitude for LMT calculation. Default is NaN.
  * @return wxDateTime The converted timestamp in UTC.
  */

--- a/gui/include/gui/options.h
+++ b/gui/include/gui/options.h
@@ -219,7 +219,9 @@ enum {
   ID_AISALERTAUDIO,
   ID_AISALERTDIALOG,
   ID_TEMPUNITSCHOICE,
-  ID_BUTTONMIGRATE
+  ID_BUTTONMIGRATE,
+  ID_TIMEZONE_UTC,
+  ID_TIMEZONE_LOCAL_TIME
 };
 
 /* Define an int bit field for dialog return value
@@ -418,7 +420,16 @@ public:
   wxCheckBox *pZoomButtons, *pChartBarEX;
   wxTextCtrl *pCOGUPUpdateSecs, *m_pText_OSCOG_Predictor, *pScreenMM;
   wxTextCtrl *pToolbarHideSecs, *m_pText_OSHDT_Predictor, *m_pTxt_OwnMMSI;
+  // Radio buttons to control the date/time format.
+  // In the future, other date/time formats may be added here. For example:
+  // 1. Local Mean Time (LMT) at the location.
+  // 2. Custom timezone, such as for route planning purpose.
 
+  /** Specify date/time should be formatted in timezone as configured in the
+   * operating system. */
+  wxRadioButton *pTimezoneLocalTime;
+  /** Specify date/time should be formatted in UTC. */
+  wxRadioButton *pTimezoneUTC;
   wxTextCtrl *pCmdSoundString;
 
   wxChoice *m_pShipIconType, *m_pcTCDatasets;

--- a/gui/src/ConfigMgr.cpp
+++ b/gui/src/ConfigMgr.cpp
@@ -883,6 +883,8 @@ bool ConfigMgr::SaveTemplate(wxString fileName) {
   conf->Write(_T ( "TrackRotateTimeType" ), g_track_rotate_time_type);
   conf->Write(_T ( "HighlightTracks" ), g_bHighliteTracks);
 
+  conf->Write(_T ( "DateTimeFormat" ), g_datetime_format);
+
   conf->Write(_T ( "InitialStackIndex" ), g_restore_stackindex);
   conf->Write(_T ( "InitialdBIndex" ), g_restore_dbindex);
 
@@ -1375,6 +1377,8 @@ bool ConfigMgr::CheckTemplate(wxString fileName) {
   CHECK_INT(_T ( "TrackRotateAt" ), &g_track_rotate_time);
   CHECK_INT(_T ( "TrackRotateTimeType" ), &g_track_rotate_time_type);
   CHECK_INT(_T ( "HighlightTracks" ), &g_bHighliteTracks);
+
+  CHECK_STR(_T ( "DateTimeFormat" ), g_datetime_format);
 
   CHECK_FLT(_T ( "PlanSpeed" ), &g_PlanSpeed, 0.1)
 

--- a/gui/src/RoutePropDlg.cpp
+++ b/gui/src/RoutePropDlg.cpp
@@ -238,14 +238,14 @@ RoutePropDlg::RoutePropDlg(wxWindow* parent, wxWindowID id,
   bSizerTime->Add(m_stTimeZone, 0, wxALL, 5);
 
   // Timezone for departure time and ETA display.
-  wxString m_choiceTimezoneChoices[] = {_("UTC"), _("Local@PC"),
-                                        _("LMT@Location")};
+  wxString m_choiceTimezoneChoices[] = {
+      _("UTC"), _("Local Time"), _("LMT@Location"), _("Honor Global Settings")};
   int m_choiceTimezoneNChoices =
       sizeof(m_choiceTimezoneChoices) / sizeof(wxString);
   m_choiceTimezone =
       new wxChoice(m_pnlBasic, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                    m_choiceTimezoneNChoices, m_choiceTimezoneChoices, 0);
-  m_choiceTimezone->SetSelection(0);
+  m_choiceTimezone->SetSelection(3 /*Honor Global Settings*/);
   m_choiceTimezone->SetMaxSize(wxSize(GetCharWidth() * 12, -1));
 
   bSizerTime->Add(m_choiceTimezone, 0, wxALL, 5);

--- a/gui/src/TrackPropDlg.cpp
+++ b/gui/src/TrackPropDlg.cpp
@@ -49,6 +49,14 @@
 #include "androidUTIL.h"
 #endif
 
+#define UTCINPUT 0  //!< Format date/time in UTC.
+#define LTINPUT \
+  1  //!< Format date/time using timezone configured in the operating system.
+#define LMTINPUT \
+  2  //!< Format date/time using Local Mean Time (LMT) at a given point.
+/** Format date/time according to global OpenCPN settings. */
+#define GLOBAL_SETTINGS_INPUT 3
+
 #define INPUT_FORMAT 1
 #define DISPLAY_FORMAT 2
 #define TIMESTAMP_FORMAT 3
@@ -59,32 +67,6 @@ extern Routeman* g_pRouteMan;
 extern RouteManagerDialog* pRouteManagerDialog;
 extern MyConfig* pConfig;
 extern MyFrame* gFrame;
-
-wxString timestamp2s(wxDateTime ts, int tz_selection, long LMT_offset,
-                     int format) {
-  wxString s = _T("");
-  wxString f;
-  if (format == INPUT_FORMAT)
-    f = _T("%x %H:%M");
-  else if (format == TIMESTAMP_FORMAT)
-    f = _T("%x %H:%M:%S");
-  else
-    f = _T(" %x %H:%M");
-  switch (tz_selection) {
-    case UTCINPUT:
-      s.Append(ts.Format(f));
-      if (format != INPUT_FORMAT) s.Append(_T(" UT"));
-      break;
-    case LTINPUT:
-      s.Append(ts.FromUTC().Format(f));
-      break;
-    case LMTINPUT:
-      wxTimeSpan lmt(0, 0, (int)LMT_offset, 0);
-      s.Append(ts.Add(lmt).Format(f));
-      if (format != INPUT_FORMAT) s.Append(_T(" LMT"));
-  }
-  return (s);
-}
 
 ///////////////////////////////////////////////////////////////////////////
 bool TrackPropDlg::instanceFlag = false;
@@ -187,6 +169,11 @@ TrackPropDlg::TrackPropDlg(wxWindow* parent, wxWindowID id,
         wxEVT_COMMAND_RADIOBUTTON_SELECTED,
         wxCommandEventHandler(TrackPropDlg::OnShowTimeTZ), NULL, this);
 
+  if (m_rbShowTimeGlobalSettings)
+    m_rbShowTimeGlobalSettings->Connect(
+        wxEVT_COMMAND_RADIOBUTTON_SELECTED,
+        wxCommandEventHandler(TrackPropDlg::OnShowTimeTZ), NULL, this);
+
   m_pMyLinkList = NULL;
 }
 
@@ -253,8 +240,26 @@ TrackPropDlg::~TrackPropDlg() {
     m_rbShowTimeLocal->Disconnect(
         wxEVT_COMMAND_RADIOBUTTON_SELECTED,
         wxCommandEventHandler(TrackPropDlg::OnShowTimeTZ), NULL, this);
+  if (m_rbShowTimeGlobalSettings)
+    m_rbShowTimeGlobalSettings->Disconnect(
+        wxEVT_COMMAND_RADIOBUTTON_SELECTED,
+        wxCommandEventHandler(TrackPropDlg::OnShowTimeTZ), NULL, this);
 
   instanceFlag = false;
+}
+
+static wxString getDatetimeTimezoneSelector(int selection) {
+  switch (selection) {
+    case UTCINPUT:
+      return "UTC";
+    case LTINPUT:
+      return "Local Time";
+    case LMTINPUT:
+      return "LMT";
+    case GLOBAL_SETTINGS_INPUT:
+    default:
+      return wxEmptyString;
+  }
 }
 
 void TrackPropDlg::OnActivate(wxActivateEvent& event) {
@@ -297,12 +302,14 @@ void TrackPropDlg::RecalculateSize(void) {
 
 static void addColumns(wxListCtrl* lctrl, int dx) {
   lctrl->InsertColumn(0, _("Leg"), wxLIST_FORMAT_LEFT, dx * 6);
-  lctrl->InsertColumn(1, _("Distance"), wxLIST_FORMAT_LEFT, dx * 10);
+  lctrl->InsertColumn(1, _("Distance"), wxLIST_FORMAT_LEFT, dx * 11);
   lctrl->InsertColumn(2, _("Bearing"), wxLIST_FORMAT_LEFT, dx * 8);
-  lctrl->InsertColumn(3, _("Latitude"), wxLIST_FORMAT_LEFT, dx * 11);
-  lctrl->InsertColumn(4, _("Longitude"), wxLIST_FORMAT_LEFT, dx * 11);
-  // Width of timestamp is typically 19 characters: 'MM/DD/YYYY HH:MM:SS'.
-  lctrl->InsertColumn(5, _("Timestamp"), wxLIST_FORMAT_LEFT, dx * 19);
+  // Width of lat/lon may be up to 15 characters: 'DDD° MM.MMMM' W'.
+  lctrl->InsertColumn(3, _("Latitude"), wxLIST_FORMAT_LEFT, dx * 15);
+  lctrl->InsertColumn(4, _("Longitude"), wxLIST_FORMAT_LEFT, dx * 15);
+  // Width of timestamp may  be be up to 26 characters: 'MM/DD/YYYY HH:MM:SS PM
+  // UTC'.
+  lctrl->InsertColumn(5, _("Timestamp"), wxLIST_FORMAT_LEFT, dx * 26);
   lctrl->InsertColumn(6, _("Speed"), wxLIST_FORMAT_CENTER, dx * 8);
 
   lctrl->SetMinSize(wxSize(-1, 50));
@@ -438,7 +445,8 @@ void TrackPropDlg::CreateControlsCompact() {
      wxRIGHT | wxBOTTOM, 5 );
   */
 
-  wxString pDispTimeZone[] = {_("UTC"), _("Local @ PC"), _("LMT @ Location")};
+  wxString pDispTimeZone[] = {_("UTC"), _("Local Time"), _("LMT@Location"),
+                              _("Honor Global Settings")};
 
   wxStaticText* itemStaticText12b =
       new wxStaticText(itemDialog1, wxID_STATIC, _("Time shown as"),
@@ -452,15 +460,21 @@ void TrackPropDlg::CreateControlsCompact() {
       m_rbShowTimeUTC, 0,
       wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
-  m_rbShowTimePC = new wxRadioButton(itemDialog1, wxID_ANY, _("Local @ PC"));
+  m_rbShowTimePC = new wxRadioButton(itemDialog1, wxID_ANY, _("Local Time"));
   itemBoxSizer2->Add(
       m_rbShowTimePC, 0,
       wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
   m_rbShowTimeLocal =
-      new wxRadioButton(itemDialog1, wxID_ANY, _("LMT @ Location"));
+      new wxRadioButton(itemDialog1, wxID_ANY, _("LMT@Location"));
   itemBoxSizer2->Add(
       m_rbShowTimeLocal, 0,
+      wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+
+  m_rbShowTimeGlobalSettings =
+      new wxRadioButton(itemDialog1, wxID_ANY, _("Honor Global Settings"));
+  itemBoxSizer2->Add(
+      m_rbShowTimeGlobalSettings, 0,
       wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 
   wxFlexGridSizer* itemFlexGridSizer6b = new wxFlexGridSizer(3, 2, 0, 0);
@@ -816,20 +830,27 @@ void TrackPropDlg::CreateControls(void) {
                       wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT,
                       5);
 
-  m_rbShowTimePC = new wxRadioButton(m_panel0, wxID_ANY, _("Local @ PC"),
+  m_rbShowTimePC = new wxRadioButton(m_panel0, wxID_ANY, _("Local Time"),
                                      wxDefaultPosition, wxDefaultSize, 0);
   bSizerShowTime->Add(m_rbShowTimePC, 0,
                       wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT,
                       5);
 
   m_rbShowTimeLocal =
-      new wxRadioButton(m_panel0, wxID_ANY, _("LMT @ Track Start"),
+      new wxRadioButton(m_panel0, wxID_ANY, _("LMT@Track Start"),
                         wxDefaultPosition, wxDefaultSize, 0);
   bSizerShowTime->Add(m_rbShowTimeLocal, 0,
                       wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT,
                       5);
 
-  m_rbShowTimePC->SetValue(true);
+  m_rbShowTimeGlobalSettings =
+      new wxRadioButton(m_panel0, wxID_ANY, _("Honor Global Settings"),
+                        wxDefaultPosition, wxDefaultSize, 0);
+  bSizerShowTime->Add(m_rbShowTimeGlobalSettings, 0,
+                      wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxLEFT | wxRIGHT,
+                      5);
+
+  m_rbShowTimeGlobalSettings->SetValue(true);
 
   sbSizerPoints->Add(bSizerShowTime, 0, wxEXPAND, 5);
 
@@ -1695,8 +1716,12 @@ void TrackPropDlg::OnShowTimeTZ(wxCommandEvent& event) {
     m_lcPoints->m_tz_selection = UTCINPUT;
   else if (m_rbShowTimePC && m_rbShowTimePC->GetValue())
     m_lcPoints->m_tz_selection = LTINPUT;
-  else
+  else if (m_rbShowTimeLocal && m_rbShowTimeLocal->GetValue())
     m_lcPoints->m_tz_selection = LMTINPUT;
+  else if (m_rbShowTimeGlobalSettings && m_rbShowTimeGlobalSettings->GetValue())
+    m_lcPoints->m_tz_selection = GLOBAL_SETTINGS_INPUT;
+  else
+    throw std::logic_error("Unexpected time zone selection");
   m_lcPoints->DeleteAllItems();
   InitializeList();
 }
@@ -1779,11 +1804,19 @@ OCPNTrackListCtrl::OCPNTrackListCtrl(wxWindow* parent, wxWindowID id,
                                      long style)
     : wxListCtrl(parent, id, pos, size, style) {
   m_parent = parent;
-  m_tz_selection = LTINPUT;
+  m_tz_selection = GLOBAL_SETTINGS_INPUT;
   m_LMT_Offset = 0;
 }
 
 OCPNTrackListCtrl::~OCPNTrackListCtrl() {}
+
+double OCPNTrackListCtrl::getStartPointLongitude() const {
+  if (m_pTrack->GetnPoints()) {
+    TrackPoint* prp = m_pTrack->GetPoint(0);
+    if (prp) return prp->m_lon;
+  }
+  return NAN;
+}
 
 wxString OCPNTrackListCtrl::OnGetItemText(long item, long column) const {
   wxString ret;
@@ -1837,10 +1870,13 @@ wxString OCPNTrackListCtrl::OnGetItemText(long item, long column) const {
 
     case 5: {
       wxDateTime timestamp = this_point->GetCreateTime();
-      if (timestamp.IsValid())
-        ret = timestamp2s(timestamp, m_tz_selection, m_LMT_Offset,
-                          TIMESTAMP_FORMAT);
-      else
+      if (timestamp.IsValid()) {
+        DateTimeFormatOptions opts =
+            DateTimeFormatOptions()
+                .SetTimezone(getDatetimeTimezoneSelector(m_tz_selection))
+                .SetLongitude(getStartPointLongitude());
+        ret = ocpn::toUsrDateTimeFormat(timestamp, opts);
+      } else
         ret = _T("----");
     } break;
 

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -89,6 +89,7 @@
 #include "observable_globvar.h"
 #include "ocpndc.h"
 #include "ocpn_frame.h"
+#include "ocpn_plugin.h"
 #include "OCPNPlatform.h"
 #include "OCPN_Sound.h"
 #include "s52plib.h"
@@ -586,6 +587,7 @@ int MyConfig::LoadMyConfig() {
   g_n_arrival_circle_radius = 0.05;
   g_plus_minus_zoom_factor = 2.0;
   g_mouse_zoom_sensitivity = 1.5;
+  g_datetime_format = "UTC";
 
   g_AISShowTracks_Mins = 20;
   g_AISShowTracks_Limit = 300.0;
@@ -1014,6 +1016,8 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   Read(_T ( "TrackRotateAt" ), &g_track_rotate_time);
   Read(_T ( "TrackRotateTimeType" ), &g_track_rotate_time_type);
   Read(_T ( "HighlightTracks" ), &g_bHighliteTracks);
+
+  Read(_T ( "DateTimeFormat" ), &g_datetime_format);
 
   wxString stps;
   Read(_T ( "PlanSpeed" ), &stps);
@@ -2517,6 +2521,7 @@ void MyConfig::UpdateSettings() {
   Write(_T ( "TrackRotateTimeType" ), g_track_rotate_time_type);
   Write(_T ( "HighlightTracks" ), g_bHighliteTracks);
 
+  Write(_T ( "DateTimeFormat" ), g_datetime_format);
   Write(_T ( "InitialStackIndex" ), g_restore_stackindex);
   Write(_T ( "InitialdBIndex" ), g_restore_dbindex);
 
@@ -3391,8 +3396,21 @@ wxDateTime toUsrDateTime(const wxDateTime ts, const int format,
   if (!ts.IsValid()) {
     return ts;
   }
+  int effective_format = format;
+  if (effective_format == GLOBAL_SETTINGS_INPUT) {
+    if (::g_datetime_format == "UTC") {
+      effective_format = UTCINPUT;
+    } else if (::g_datetime_format == "LMT") {
+      effective_format = LMTINPUT;
+    } else if (::g_datetime_format == "Local Time") {
+      effective_format = LTINPUT;
+    } else {
+      // Default to UTC
+      effective_format = UTCINPUT;
+    }
+  }
   wxDateTime dt;
-  switch (format) {
+  switch (effective_format) {
     case LMTINPUT:  // LMT@Location
       if (std::isnan(lon)) {
         dt = wxInvalidDateTime;
@@ -3418,8 +3436,21 @@ wxDateTime fromUsrDateTime(const wxDateTime ts, const int format,
   if (!ts.IsValid()) {
     return ts;
   }
+  int effective_format = format;
+  if (effective_format == GLOBAL_SETTINGS_INPUT) {
+    if (::g_datetime_format == "UTC") {
+      effective_format = UTCINPUT;
+    } else if (::g_datetime_format == "LMT") {
+      effective_format = LMTINPUT;
+    } else if (::g_datetime_format == "Local Time") {
+      effective_format = LTINPUT;
+    } else {
+      // Default to UTC
+      effective_format = UTCINPUT;
+    }
+  }
   wxDateTime dt;
-  switch (format) {
+  switch (effective_format) {
     case LMTINPUT:  // LMT@Location
       if (std::isnan(lon)) {
         dt = wxInvalidDateTime;

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -117,6 +117,7 @@
 #include "navutil.h"
 #include "NMEALogWindow.h"
 #include "ocpn_app.h"
+#include "ocpn_plugin.h"
 #include "OCPN_AUIManager.h"
 #include "ocpn_frame.h"
 #include "OCPNPlatform.h"
@@ -3018,10 +3019,8 @@ void MyFrame::ActivateMOB(void) {
   //    The MOB point
   wxDateTime mob_time = wxDateTime::Now();
   wxString mob_label(_("MAN OVERBOARD"));
-  mob_label += _(" at ");
-  mob_label += mob_time.FormatTime();
   mob_label += _(" on ");
-  mob_label += mob_time.FormatISODate();
+  mob_label += ocpn::toUsrDateTimeFormat(mob_time);
 
   RoutePoint *pWP_MOB =
       new RoutePoint(gLat, gLon, _T ( "mob" ), mob_label, wxEmptyString);
@@ -3082,7 +3081,7 @@ void MyFrame::ActivateMOB(void) {
 
   wxString mob_message(_("MAN OVERBOARD"));
   mob_message += _(" Time: ");
-  mob_message += mob_time.Format();
+  mob_message += ocpn::toUsrDateTimeFormat(mob_time);
   mob_message += _("  Position: ");
   mob_message += toSDMM(1, gLat);
   mob_message += _T("   ");
@@ -6738,10 +6737,8 @@ void MyFrame::ActivateAISMOBRoute(const AisTargetData *ptarget) {
   //    The MOB point
   wxDateTime mob_time = wxDateTime::Now();
   wxString mob_label(_("AIS MAN OVERBOARD"));
-  mob_label += _(" at ");
-  mob_label += mob_time.FormatTime();
   mob_label += _(" on ");
-  mob_label += mob_time.FormatISODate();
+  mob_label += ocpn::toUsrDateTimeFormat(mob_time);
 
   RoutePoint *pWP_MOB = new RoutePoint(ptarget->Lat, ptarget->Lon, _T ( "mob" ),
                                        mob_label, wxEmptyString);
@@ -6797,7 +6794,7 @@ void MyFrame::ActivateAISMOBRoute(const AisTargetData *ptarget) {
 
   wxString mob_message(_("AIS MAN OVERBOARD"));
   mob_message += _(" Time: ");
-  mob_message += mob_time.Format();
+  mob_message += ocpn::toUsrDateTimeFormat(mob_time);
   mob_message += _("  Ownship Position: ");
   mob_message += toSDMM(1, gLat);
   mob_message += _T("   ");
@@ -6838,7 +6835,7 @@ void MyFrame::UpdateAISMOBRoute(const AisTargetData *ptarget) {
 
     wxString mob_message(_("AIS MAN OVERBOARD UPDATE"));
     mob_message += _(" Time: ");
-    mob_message += mob_time.Format();
+    mob_message += ocpn::toUsrDateTimeFormat(mob_time);
     mob_message += _("  Ownship Position: ");
     mob_message += toSDMM(1, gLat);
     mob_message += _T("   ");

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -94,6 +94,7 @@ typedef __LA_INT64_T la_int64_t;  //  "older" libarchive versions support
 #include "model/comm_navmsg_bus.h"
 #include "model/comm_vars.h"
 #include "model/config_vars.h"
+#include "model/datetime.h"
 #include "model/downloader.h"
 #include "model/georef.h"
 #include "model/json_event.h"
@@ -5303,6 +5304,11 @@ _OCPN_DLStatus OCPN_downloadFile(const wxString& url,
 #else
   return OCPN_DL_FAILED;
 #endif
+}
+
+wxString toUsrDateTimeFormat_Plugin(const wxDateTime date_time,
+                                    const DateTimeFormatOptions& options) {
+  return ocpn::toUsrDateTimeFormat(date_time, options);
 }
 
 //  Non-Blocking download of single file

--- a/gui/src/routemanagerdialog.cpp
+++ b/gui/src/routemanagerdialog.cpp
@@ -185,8 +185,9 @@ static int wxCALLBACK SortTracksOnDate(wxIntPtr item1, wxIntPtr item2,
 int wxCALLBACK SortTracksOnDate(long item1, long item2, long list)
 #endif
 {
-  return SortRouteTrack(sort_track_date_dir, ((Track *)item1)->GetDate(),
-                        ((Track *)item2)->GetDate());
+  // Sort date/time using ISO format, which is sortable as a string.
+  return SortRouteTrack(sort_track_date_dir, ((Track *)item1)->GetIsoDateTime(),
+                        ((Track *)item2)->GetIsoDateTime());
 }
 
 static int sort_wp_key;
@@ -2064,7 +2065,9 @@ void RouteManagerDialog::UpdateTrkListCtrl() {
     long idx = m_pTrkListCtrl->InsertItem(li);
 
     m_pTrkListCtrl->SetItem(idx, colTRKNAME, trk->GetName(true));
-    m_pTrkListCtrl->SetItem(idx, colTRKDATE, trk->GetDate(true));
+    // Populate the track start date/time, formatted using the global timezone
+    // settings.
+    m_pTrkListCtrl->SetItem(idx, colTRKDATE, trk->GetDateTime());
 
     wxString len;
     len.Printf(wxT("%5.2f"), trk->Length());

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -2701,6 +2701,154 @@ extern DECL_EXP wxString getUsrSpeedUnit_Plugin(int unit = -1);
  * @return Localized unit string ("°C" or "°F")
  */
 extern DECL_EXP wxString getUsrTempUnit_Plugin(int unit = -1);
+
+/**
+ * Configuration options for date and time formatting.
+ *
+ * This structure holds formatting options that determine how dates and times
+ * are displayed throughout the application. It allows configuring format
+ * strings, timezone settings, and geographic reference for local time
+ * calculations.
+ *
+ * The format settings use standard date/time format specifiers (like strftime)
+ * for creating custom date/time representations based on user preferences.
+ * Timezone settings allow displaying times in UTC, system local time, or a
+ * custom zone based on the vessel's current position.
+ */
+struct DateTimeFormatOptions {
+  DateTimeFormatOptions() = default;
+  /**
+   * The format string for date/time.
+   *
+   * The following predefined format strings are supported:
+   * - "$long_date": Thursday December 31, 2021.
+   * - "$short_date": 12/31/2021.
+   * - "$weekday_short_date": Thu 12/31/2021.
+   * - "$hour_minutes_seconds": 15:34:56 zero-padded.
+   * - "$hour_minutes": 15:34 zero-padded.
+   * - "$long_date_time": Thursday December 31, 2021 12:34:56.
+   * - "$short_date_time": 12/31/2021 15:34:56.
+   * - "$weekday_short_date_time": Thu 12/31/2021 15:34:56.
+   *
+   * The default is $weekday_short_date_time.
+   *
+   * The descriptors are resolved to localized date/time string representations.
+   * For example, $short_date is resolved to "12/31/2021" in the US locale and
+   * "31/12/2021" in the UK locale.
+   */
+  wxString format_string = "$weekday_short_date_time";
+  /**
+   * The timezone to use when formatting the date/time. Supported options are:
+   * - Empty string (default): the date/time is formatted according to
+   *   the OpenCPN global settings. This should be used to ensure consistency
+   *   of the date/time representation across the entire application.
+   * - "UTC": the date/time is formatted in UTC, regardless of the OpenCPN
+   *   global settings.
+   * - "Local Time": the date/time is formatted in the local time, regardless of
+   *   the OpenCPN global settings.
+   *
+   * @note In the future, additional timezone options may be supported:
+   * - "LMT": the date/time is formatted in local mean time. In this
+   *   case, longitude is required.
+   * - Valid timezone name: the date/time is formatted in that timezone.
+   */
+  wxString time_zone = wxEmptyString;
+  /**
+   * The longitude to use when formatting the date/time in Local Mean Time
+   * (LMT). The longitude is required when the time_zone is set to "LMT".
+   */
+  double longitude = NAN;
+
+  int version = 1;  // For future compatibility checks
+
+  /**
+   * Sets the date/time format pattern string.
+   *
+   * @param format String containing date/time format specifiers.
+   *
+   * This method configures the format pattern used when displaying dates and
+   * times. The following predefined format strings are supported:
+   * - "$long_date": Thursday December 31, 2021.
+   * - "$short_date": 12/31/2021.
+   * - "$weekday_short_date": Thu 12/31/2021.
+   * - "$hour_minutes_seconds": 15:34:56 zero-padded.
+   * - "$hour_minutes": 15:34 zero-padded.
+   * - "$long_date_time": Thursday December 31, 2021 12:34:56.
+   * - "$short_date_time": 12/31/2021 15:34:56.
+   * - "$weekday_short_date_time": Thu 12/31/2021 15:34:56.
+   *
+   * The default is $weekday_short_date_time.
+   */
+  DateTimeFormatOptions &SetFormatString(const wxString &fmt) {
+    format_string = fmt;
+    return *this;
+  }
+
+  /**
+   * Sets the timezone mode for date/time display
+   *
+   * @param timezone Specifies the timezone mode:
+   * - Empty string (default): the date/time is formatted according to
+   *   the OpenCPN global settings. This should be used to ensure consistency
+   *   of the date/time representation across the entire application.
+   * - "UTC": the date/time is formatted in UTC, regardless of the OpenCPN
+   *   global settings.
+   * - "Local Time": the date/time is formatted in the local time, regardless of
+   *   the OpenCPN global settings.
+   *
+   * This method configures how time values are adjusted for timezone display.
+   * - When set to empty or UTC, all times are shown in universal time without
+   *   adjustment.
+   * - When set to "Local Time", times are adjusted to match the
+   *   timezone settings of the computer running OpenCPN.
+   */
+  DateTimeFormatOptions &SetTimezone(const wxString &tz) {
+    time_zone = tz;
+    return *this;
+  }
+
+  /**
+   * Sets the reference longitude for Local Mean Time (LMT) calculations.
+   *
+   * @param lon Longitude in decimal degrees (-180 to +180)
+   *
+   * When timezone mode is set to local time at vessel position,
+   * this method provides the longitude used to calculate the Local Mean Time
+   * (LMT).
+   *
+   * LMT is calculated based on the sun's position relative to the local
+   * meridian, with solar noon occurring when the sun crosses the meridian. Each
+   * 15 degrees of longitude represents approximately 1 hour of time difference.
+   *
+   * Unlike standard timezone offsets which use fixed boundaries, LMT provides a
+   * continuous time representation based precisely on the vessel's longitude,
+   * useful for celestial navigation and traditional maritime timekeeping.
+   */
+  DateTimeFormatOptions &SetLongitude(double lon) {
+    longitude = lon;
+    return *this;
+  }
+};
+
+/**
+ * Format a wxDateTime to a localized string representation, conforming to the
+ * global date/time format and timezone settings.
+ *
+ * The function uses the timezone configuration to format the date/time either
+ * in UTC, local time, or local mean time (LMT) based on the longitude.
+ *
+ * @note This function should be used instead of wxDateTime.Format() to ensure
+ * consistent date/time formatting across the entire application.
+ *
+ * @param date_time The date/time to format.
+ * @param options The date/time format options.
+ * @return wxString The formatted date/time string.
+ *
+ */
+extern DECL_EXP wxString toUsrDateTimeFormat_Plugin(
+    const wxDateTime date_time,
+    const DateTimeFormatOptions &options = DateTimeFormatOptions());
+
 /**
  * Generates a new globally unique identifier (GUID).
  *

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -72,6 +72,7 @@ set(
   ${MODEL_HDR_DIR}/conn_params.h
   ${MODEL_HDR_DIR}/conn_states.h
   ${MODEL_HDR_DIR}/cutil.h
+  ${MODEL_HDR_DIR}/datetime.h
   ${MODEL_HDR_DIR}/downloader.h
   ${MODEL_HDR_DIR}/ds_porttype.h
   ${MODEL_HDR_DIR}/garmin_protocol_mgr.h
@@ -173,6 +174,7 @@ set(SRC
   ${MODEL_SRC_DIR}/conn_params.cpp
   ${MODEL_SRC_DIR}/conn_states.cpp
   ${MODEL_SRC_DIR}/cutil.cpp
+  ${MODEL_SRC_DIR}/datetime.cpp
   ${MODEL_SRC_DIR}/downloader.cpp
   ${MODEL_SRC_DIR}/ds_porttype.cpp
   ${MODEL_SRC_DIR}/garmin_protocol_mgr.cpp

--- a/model/include/model/config_vars.h
+++ b/model/include/model/config_vars.h
@@ -96,6 +96,30 @@ extern wxString g_hostname;
 extern wxString g_SART_sound_file;
 extern wxString g_TalkerIdText;
 extern wxString g_winPluginDir;  // Base plugin directory on Windows.
+/**
+ * Date/time format to use when formatting date/time strings.
+ * This is a global setting that affects all date/time formatting in OpenCPN.
+ *
+ * @details Supported values are:
+ * - "UTC": Format date/time in Coordinated Universal Time (UTC).
+ * - "Local Time": Format date/time using the operating system timezone
+ * configuration.
+ *
+ * @note Future support could potentially include:
+ * - "LMT": Format date/time using the solar mean time at a given location.
+ * - Valid IANA TZ name: Format date/time using the specified timezone.
+ *   This could be useful when planning a route in a timezone other than
+ *   what is configured in the operating system.
+ *   See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for valid
+ *   names.
+ * - Custom date/time format: Allow the user to specify a custom date/time
+ * format string.
+ *
+ * @note This configuration parameter stores the English name without
+ * translation. Widgets may provide a localized version of this value when
+ * displaying it to the user.
+ */
+extern wxString g_datetime_format;
 
 wxConfigBase* TheBaseConfig();
 void InitBaseConfig(wxConfigBase* cfg);

--- a/model/include/model/datetime.h
+++ b/model/include/model/datetime.h
@@ -1,0 +1,48 @@
+/***************************************************************************
+ *   Copyright (C) 2023 by David Register                                  *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+#ifndef DATETIME_API_H__
+#define DATETIME_API_H__
+
+#include <wx/wx.h>
+
+#include "ocpn_plugin.h"
+
+extern wxString g_datetime_format;
+
+namespace ocpn {
+
+/**
+ * Format a date/time to a localized string representation, conforming to the
+ * formatting options.
+ *
+ * @param date_time The date/time to format.
+ * @param options The date/time format options.
+ * @return wxString The formatted date/time string.
+ *
+ * @note This function should be used instead of wxDateTime.Format() to ensure
+ * consistent date/time formatting across the entire application, including
+ * plugins.
+ */
+wxString toUsrDateTimeFormat(
+    const wxDateTime date_time,
+    const ::DateTimeFormatOptions &options = ::DateTimeFormatOptions());
+}  // namespace ocpn
+
+#endif  // DATETIME_API_H__

--- a/model/include/model/route.h
+++ b/model/include/model/route.h
@@ -42,9 +42,10 @@
 #define WIDTH_UNDEFINED -1
 
 #define ROUTE_DEFAULT_SPEED 5.0
-#define RTE_TIME_DISP_UTC _T("UTC")
-#define RTE_TIME_DISP_PC _T("PC")
-#define RTE_TIME_DISP_LOCAL _T("LOCAL")
+#define RTE_TIME_DISP_UTC "UTC"
+#define RTE_TIME_DISP_PC "PC"
+#define RTE_TIME_DISP_LOCAL "LOCAL"
+#define RTE_TIME_DISP_GLOBAL "GLOBAL SETTING"
 #define RTE_UNDEF_DEPARTURE wxInvalidDateTime
 
 class WayPointman;  // FIXME (leamas) why? routeman.h defines this.

--- a/model/include/model/track.h
+++ b/model/include/model/track.h
@@ -32,6 +32,7 @@
 #include <list>
 #include <vector>
 
+#include "model/datetime.h"
 #include "bbox.h"
 #include "hyperlink.h"
 #include "route.h"
@@ -106,36 +107,26 @@ public:
 
   void ClearHighlights();
 
+  /* Return the name of the track, or the start date/time of the track if no
+   * name has been set. */
   wxString GetName(bool auto_if_empty = false) const {
     if (!auto_if_empty || !m_TrackNameString.IsEmpty()) {
       return m_TrackNameString;
     } else {
-      wxString name;
-      TrackPoint *rp = NULL;
-      if ((int)TrackPoints.size() > 0) rp = TrackPoints[0];
-      if (rp && rp->GetCreateTime().IsValid())
-        name = rp->GetCreateTime().FormatISODate() + _T(" ") +
-               rp->GetCreateTime()
-                   .FormatISOTime();  // name = rp->m_CreateTime.Format();
-      else
-        name = _("(Unnamed Track)");
-      return name;
+      return GetDateTime(_("(Unnamed Track)"));
     }
   }
   void SetName(const wxString name) { m_TrackNameString = name; }
 
-  wxString GetDate(bool auto_if_empty = false) const {
-    wxString name;
-    TrackPoint *rp = NULL;
-    if ((int)TrackPoints.size() > 0) rp = TrackPoints[0];
-    if (rp && rp->GetCreateTime().IsValid())
-      name = rp->GetCreateTime().FormatISODate() + _T(" ") +
-             rp->GetCreateTime()
-                 .FormatISOTime();  // name = rp->m_CreateTime.Format();
-    else
-      name = _("(Unknown Date)");
-    return name;
-  }
+  /* Return the start date/time of the track, formatted as ISO 8601 timestamp.
+   * The separator between date and time is a space character. */
+  wxString GetIsoDateTime(
+      const wxString label_for_invalid_date = _("(Unknown Date)")) const;
+
+  /* Return the start date/time of the track, formatted using the global
+   * timezone settings. */
+  wxString GetDateTime(
+      const wxString label_for_invalid_date = _("(Unknown Date)")) const;
 
   wxString m_GUID;
   bool m_bIsInLayer;

--- a/model/src/config_vars.cpp
+++ b/model/src/config_vars.cpp
@@ -91,6 +91,7 @@ wxString g_hostname;
 wxString g_SART_sound_file;
 wxString g_TalkerIdText;
 wxString g_winPluginDir;
+wxString g_datetime_format;
 
 static wxConfigBase* the_base_config = 0;
 

--- a/model/src/datetime.cpp
+++ b/model/src/datetime.cpp
@@ -1,0 +1,113 @@
+/***************************************************************************
+ *   Copyright (C) 2023 by David Register                                  *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+#include "model/datetime.h"
+
+#include "ocpn_plugin.h"
+
+#if wxCHECK_VERSION(3, 1, 6)
+#include <wx/uilocale.h>
+#endif
+
+namespace ocpn {
+
+// date/time in the desired time zone format.
+wxString toUsrDateTimeFormat(const wxDateTime date_time,
+                             const DateTimeFormatOptions& options) {
+  wxDateTime t(date_time);
+  wxString effective_time_zone = options.time_zone;
+  if (effective_time_zone == wxEmptyString) {
+    effective_time_zone = ::g_datetime_format;
+  }
+  if (effective_time_zone == wxEmptyString) {
+    effective_time_zone = "UTC";
+  }
+  // Define a map for custom format specifiers.
+  std::vector<std::pair<wxString, wxString>> formatMap = {
+#if wxCHECK_VERSION(3, 1, 6)
+      // Note: the GetInfo() method may return special unicode characters, such
+      // as
+      // narrow no-break space (U+202F).
+      {"$long_date_time",
+       wxUILocale::GetCurrent().GetInfo(wxLOCALE_LONG_DATE_FMT) + " " +
+           wxUILocale::GetCurrent().GetInfo(wxLOCALE_TIME_FMT)},
+      {"$long_date", wxUILocale::GetCurrent().GetInfo(wxLOCALE_LONG_DATE_FMT)},
+      {"$weekday_short_date_time",
+       "%a " + wxUILocale::GetCurrent().GetInfo(wxLOCALE_SHORT_DATE_FMT) + " " +
+           wxUILocale::GetCurrent().GetInfo(wxLOCALE_TIME_FMT)},
+      {"$weekday_short_date",
+       "%a " + wxUILocale::GetCurrent().GetInfo(wxLOCALE_SHORT_DATE_FMT)},
+      {"short_date_time",
+       wxUILocale::GetCurrent().GetInfo(wxLOCALE_SHORT_DATE_FMT) + " " +
+           wxUILocale::GetCurrent().GetInfo(wxLOCALE_TIME_FMT)},
+      {"$short_date",
+       wxUILocale::GetCurrent().GetInfo(wxLOCALE_SHORT_DATE_FMT)},
+      {"$hour_minutes_seconds",
+       wxUILocale::GetCurrent().GetInfo(wxLOCALE_TIME_FMT)},
+#else
+      {"$long_date_time", "%x %X"},
+      {"$long_date", "%x"},  // There is no descriptor for localized long date.
+                             // Fallback to short date.
+      {"$weekday_short_date_time", "%a %x %X"},
+      {"$weekday_short_date", "%a %x"},
+      {"$short_date_time", "%x %X"},
+      {"$short_date", "%x"},
+      {"$hour_minutes_seconds", "%X"},
+#endif
+      {"$hour_minutes", "%H:%M"},
+  };
+  wxString format = options.format_string;
+  if (format == wxEmptyString) {
+    format = "$weekday_short_date_time";
+  }
+  // Replace custom specifiers with actual format strings
+  for (const auto& pair : formatMap) {
+    format.Replace(pair.first, pair.second);
+  }
+  wxString ret;
+  if (effective_time_zone == "Local Time") {
+    wxDateTime now = wxDateTime::Now();
+    if ((now == (now.ToGMT())) &&
+        t.IsDST())  // bug in wxWingets 3.0 for UTC meridien ?
+      t.Add(wxTimeSpan(1, 0, 0, 0));
+    // Get the abbreviated name of the timezone configured in the operating
+    // system. Formatting with the actual timezone (rather than "LOC") makes the
+    // labels unambiguous, even if the user changes the timezone settings in the
+    // operating system. For example "2021-10-31 01:30:00 EDT" is unambiguous,
+    // while "2021-10-31 01:30:00 LOC" is not.
+    wxString tzName = t.Format("%Z");
+    ret = t.Format(format, wxDateTime::Local) + " " + tzName;
+  } else if (effective_time_zone == "UTC") {
+    ret = t.Format(format, wxDateTime::UTC) + " " + _("UTC");
+  } else if (effective_time_zone == "LMT") {
+    // Local mean solar time at the current location.
+    if (std::isnan(options.longitude)) {
+      t = wxInvalidDateTime;
+    } else {
+      t.Add(wxTimeSpan(0, 0, wxLongLong(options.longitude * 3600. / 15.)));
+    }
+    ret = t.Format(format, wxDateTime::UTC) + " " + _("LMT");
+  } else {
+    // Fallback to UTC if the timezone is not recognized.
+    ret = t.Format(format, wxDateTime::UTC) + " " + _("UTC");
+  }
+  return ret;
+}
+
+}  // namespace ocpn

--- a/model/src/track.cpp
+++ b/model/src/track.cpp
@@ -95,6 +95,7 @@ millions of points.
 #include "model/own_ship.h"
 #include "model/routeman.h"
 #include "model/select.h"
+#include "ocpn_plugin.h"
 
 std::vector<Track *> g_TrackList;
 
@@ -975,4 +976,26 @@ double Track::GetXTE(TrackPoint *fm1, TrackPoint *fm2, TrackPoint *to) {
   return GetXTE(fm1->m_lat, fm1->m_lon, fm2->m_lat, fm2->m_lon, to->m_lat,
                 to->m_lon);
   ;
+}
+
+wxString Track::GetIsoDateTime(const wxString label_for_invalid_date) const {
+  wxString name;
+  TrackPoint *rp = NULL;
+  if ((int)TrackPoints.size() > 0) rp = TrackPoints[0];
+  if (rp && rp->GetCreateTime().IsValid())
+    name = rp->GetCreateTime().FormatISOCombined(' ');
+  else
+    name = label_for_invalid_date;
+  return name;
+}
+
+wxString Track::GetDateTime(const wxString label_for_invalid_date) const {
+  wxString name;
+  TrackPoint *rp = NULL;
+  if ((int)TrackPoints.size() > 0) rp = TrackPoints[0];
+  if (rp && rp->GetCreateTime().IsValid())
+    name = ocpn::toUsrDateTimeFormat(rp->GetCreateTime());
+  else
+    name = label_for_invalid_date;
+  return name;
 }

--- a/plugins/grib_pi/src/GribTable.cpp
+++ b/plugins/grib_pi/src/GribTable.cpp
@@ -41,7 +41,7 @@ extern double m_cursor_lat, m_cursor_lon;
 GRIBTable::GRIBTable(GRIBUICtrlBar &parent)
     : GRIBTableBase(&parent), m_pGDialog(&parent) {}
 
-void GRIBTable::InitGribTable(int zone, ArrayOfGribRecordSets *rsa,
+void GRIBTable::InitGribTable(const wxString zone, ArrayOfGribRecordSets *rsa,
                               int NowIndex) {
   m_pGribTable->m_gParent = this;
   m_pIndex = NowIndex;
@@ -70,11 +70,11 @@ void GRIBTable::InitGribTable(int zone, ArrayOfGribRecordSets *rsa,
   for (unsigned i = 0; i < rsa->GetCount(); i++) {
     // populate time labels
     time = rsa->Item(i).m_Reference_Time;
-    m_pGribTable->SetColLabelValue(
-        i, GetTimeRowsStrings(time, zone, 1)
-               .Append(_T("\n"))
-               .Append(
-                   GetTimeRowsStrings(rsa->Item(i).m_Reference_Time, zone, 0)));
+    DateTimeFormatOptions opts =
+        DateTimeFormatOptions()
+            .SetFormatString("$short_date\n$hour_minutes")
+            .SetTimezone(zone);
+    m_pGribTable->SetColLabelValue(i, toUsrDateTimeFormat_Plugin(time, opts));
     nrows = -1;
     GribTimelineRecordSet *pTimeset = m_pGDialog->GetTimeLineRecordSet(time);
     if (pTimeset == 0) continue;
@@ -628,36 +628,4 @@ wxString GRIBTable::GetCurrent(GribRecord **recordarray, int datatype,
             GribOverlaySettings::CURRENT, vkn);
   }
   return skn;
-}
-
-wxString GRIBTable::GetTimeRowsStrings(wxDateTime date_time, int time_zone,
-                                       int type) {
-  wxDateTime t(date_time);
-  switch (time_zone) {
-    case 0:
-      if ((wxDateTime::Now() == (wxDateTime::Now().ToGMT())) &&
-          t.IsDST())  // bug in wxWingets 3.0 for UTC meridien ?
-        t.Add(wxTimeSpan(1, 0, 0, 0));
-      switch (type) {
-        case 0:
-          return t.Format(_T(" %H:%M  "), wxDateTime::Local) + _T("LOC");
-        case 1:
-          if (GetLocaleCanonicalName() == _T("en_US"))
-            return t.Format(_T(" %a-%m/%d/%y  "), wxDateTime::Local);
-          else
-            return t.Format(_T(" %a-%d/%m/%y  "), wxDateTime::Local);
-      }
-    case 1:
-      switch (type) {
-        case 0:
-          return t.Format(_T(" %H:%M  "), wxDateTime::UTC) + _T("UTC");
-        case 1:
-          if (GetLocaleCanonicalName() == _T("en_US"))
-            return t.Format(_T(" %a-%m/%d/%y  "), wxDateTime::UTC);
-          else
-            return t.Format(_T(" %a-%d/%m/%y  "), wxDateTime::UTC);
-      }
-    default:
-      return wxEmptyString;
-  }
 }

--- a/plugins/grib_pi/src/GribTable.h
+++ b/plugins/grib_pi/src/GribTable.h
@@ -77,12 +77,13 @@ public:
   /**
    * Initialize the GRIB data table.
    *
-   * @param zone Time zone for displaying timestamps (0=local, 1=UTC)
-   * @param rsa Array of GRIB record sets containing the weather data
-   * @param NowIndex Index of the current time point to highlight
+   * @param zone Time zone for displaying timestamps.
+   * @param rsa Array of GRIB record sets containing the weather data.
+   * @param NowIndex Index of the current time point to highlight.
    */
-  void InitGribTable(int zone, ArrayOfGribRecordSets *rsa);
-  void InitGribTable(int zone, ArrayOfGribRecordSets *rsa, int NowIndex);
+  void InitGribTable(const wxString zone, ArrayOfGribRecordSets *rsa);
+  void InitGribTable(const wxString zone, ArrayOfGribRecordSets *rsa,
+                     int NowIndex);
   /**
    * Set the table size and position relative to viewport.
    *
@@ -113,7 +114,6 @@ private:
   wxString GetCAPE(GribRecord **recordarray);
   wxString GetCompRefl(GribRecord **recordarray);
   wxString GetCurrent(GribRecord **recordarray, int datatype, double &wdir);
-  wxString GetTimeRowsStrings(wxDateTime date_time, int time_zone, int type);
 
   void OnClose(wxCloseEvent &event);
   void OnOKButton(wxCommandEvent &event);

--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -2172,12 +2172,13 @@ GribPreferencesDialogBase::GribPreferencesDialogBase(
   m_rbStartOptions->SetSelection(0);
   bSizerPrefsMain->Add(m_rbStartOptions, 0, wxALL | wxEXPAND, 5);
 
-  wxString m_rbTimeFormatChoices[] = {_("Local Time"), _("UTC")};
+  wxString m_rbTimeFormatChoices[] = {_("Local Time"), _("UTC"),
+                                      _("Honor Global Settings")};
   int m_rbTimeFormatNChoices = sizeof(m_rbTimeFormatChoices) / sizeof(wxString);
   m_rbTimeFormat = new wxRadioBox(
       scrollWin, wxID_ANY, _("Time Options"), wxDefaultPosition, wxDefaultSize,
       m_rbTimeFormatNChoices, m_rbTimeFormatChoices, 1, wxRA_SPECIFY_COLS);
-  m_rbTimeFormat->SetSelection(1);
+  m_rbTimeFormat->SetSelection(2 /*Honor Global Settings*/);
   bSizerPrefsMain->Add(m_rbTimeFormat, 0, wxALL | wxEXPAND, 5);
 
 #ifdef __WXMSW__
@@ -2305,13 +2306,14 @@ GribPreferencesDialogBase::GribPreferencesDialogBase(
   m_rbStartOptions->SetSelection(0);
   sbSizer9->Add(m_rbStartOptions, 0, wxALL | wxEXPAND, 5);
 
-  wxString m_rbTimeFormatChoices[] = {_("Local Time"), _("UTC")};
+  wxString m_rbTimeFormatChoices[] = {_("Local Time"), _("UTC"),
+                                      _("Honor Global Settings")};
   int m_rbTimeFormatNChoices = sizeof(m_rbTimeFormatChoices) / sizeof(wxString);
   m_rbTimeFormat =
       new wxRadioBox(itemScrollWin, wxID_ANY, _("Time Options"),
                      wxDefaultPosition, wxDefaultSize, m_rbTimeFormatNChoices,
                      m_rbTimeFormatChoices, 1, wxRA_SPECIFY_COLS);
-  m_rbTimeFormat->SetSelection(1);
+  m_rbTimeFormat->SetSelection(2);
   sbSizer9->Add(m_rbTimeFormat, 0, wxALL | wxEXPAND, 5);
 
   wxBoxSizer* m_sdbButtonSizer = new wxBoxSizer(wxHORIZONTAL);

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -768,7 +768,7 @@ bool grib_pi::LoadConfig(void) {
   pConf->Read(_T( "DrawBarbedArrowHead" ), &m_bDrawBarbedArrowHead, 1);
   pConf->Read(_T( "ZoomToCenterAtInit"), &m_bZoomToCenterAtInit, 1);
   pConf->Read(_T( "ShowGRIBIcon" ), &m_bGRIBShowIcon, 1);
-  pConf->Read(_T( "GRIBTimeZone" ), &m_bTimeZone, 1);
+  pConf->Read(_T( "GRIBTimeZone" ), &m_bTimeZone, 2);
   pConf->Read(_T( "CopyFirstCumulativeRecord" ), &m_bCopyFirstCumRec, 1);
   pConf->Read(_T( "CopyMissingWaveRecord" ), &m_bCopyMissWaveRec, 1);
 #ifdef __WXMSW__

--- a/plugins/grib_pi/src/grib_pi.h
+++ b/plugins/grib_pi/src/grib_pi.h
@@ -136,7 +136,16 @@ public:
 
   wxPoint GetCtrlBarXY() { return m_CtrlBarxy; }
   wxPoint GetCursorDataXY() { return m_CursorDataxy; }
-  int GetTimeZone() { return m_bTimeZone; }
+  const wxString GetTimezoneSelector() {
+    switch (m_bTimeZone) {
+      case 0:
+        return "UTC";
+      case 1:
+        return "Local Time";
+      default:
+        return wxEmptyString;
+    }
+  }
   void SetTimeZone(int tz);
   int GetStartOptions() { return m_bStartOptions; }
   /**

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -18,7 +18,10 @@ endif ()
 
 set(MODEL_SRC_DIR ${CMAKE_SOURCE_DIR}/model/src)
 
-set(SRC tests.cpp ${CMAKE_SOURCE_DIR}/cli/api_shim.cpp)
+set(SRC
+  tests.cpp
+  ${CMAKE_SOURCE_DIR}/cli/api_shim.cpp
+)
 
 if (LINUX)
   list(APPEND SRC n2k_tests.cpp)

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -28,6 +28,7 @@
 #include "model/comm_drv_registry.h"
 #include "model/comm_navmsg_bus.h"
 #include "model/config_vars.h"
+#include "model/datetime.h"
 #include "model/ipc_api.h"
 #include "model/logger.h"
 #include "model/multiplexer.h"
@@ -1108,4 +1109,86 @@ TEST(SemanticVersion, Basic) {
   EXPECT_TRUE(v2 > v1);
   v2 = SemanticVersion::parse("1.2.3").to_string();
   EXPECT_TRUE(v1 == v2);
+}
+
+class TToStringTest : public ::testing::Test {};
+
+TEST_F(TToStringTest, LMTTimeZoneOneHourEast) {
+  wxDateTime testDate(22, wxDateTime::Jan, 2023, 7, 0, 0);
+  testDate.MakeFromTimezone(wxDateTime::UTC);
+  DateTimeFormatOptions opts = DateTimeFormatOptions()
+                                   .SetFormatString("%A, %B %d, %Y %I:%M:%S %p")
+                                   .SetTimezone("LMT")
+                                   .SetLongitude(15.0);  // 15 degrees East
+  wxString result = ocpn::toUsrDateTimeFormat(testDate, opts);
+  // The time changes by 1 hour for every 15 degrees of longitude.
+  EXPECT_EQ(result, "Sunday, January 22, 2023 08:00:00 AM LMT")
+      << "Actual result: " << result;
+}
+
+TEST_F(TToStringTest, LMTTimeZone30MinEast) {
+  wxDateTime testDate(22, wxDateTime::Jan, 2023, 7, 0, 0);
+  testDate.MakeFromTimezone(wxDateTime::UTC);
+  DateTimeFormatOptions opts = DateTimeFormatOptions()
+                                   .SetFormatString("%A, %B %d, %Y %I:%M:%S %p")
+                                   .SetTimezone("LMT")
+                                   .SetLongitude(7.5);  // 7.5 degrees East
+  wxString result = ocpn::toUsrDateTimeFormat(testDate, opts);
+  // This should shift the time 30 minutes later.
+  EXPECT_EQ(result, "Sunday, January 22, 2023 07:30:00 AM LMT")
+      << "Actual result: " << result;
+}
+
+TEST_F(TToStringTest, LMTTimeZoneWest) {
+  wxDateTime testDate(22, wxDateTime::Jan, 2023, 7, 0, 0);
+  testDate.MakeFromTimezone(wxDateTime::UTC);
+  DateTimeFormatOptions opts = DateTimeFormatOptions()
+                                   .SetFormatString("%A, %B %d, %Y %I:%M:%S %p")
+                                   .SetTimezone("LMT")
+                                   .SetLongitude(-37.5);  // 37.5 degrees West
+  wxString result = ocpn::toUsrDateTimeFormat(testDate, opts);
+  // This should shift the time 2 hours and 30 minutes earlier.
+  EXPECT_EQ(result, "Sunday, January 22, 2023 04:30:00 AM LMT")
+      << "Actual result: " << result;
+}
+
+TEST_F(TToStringTest, CustomFormatStringEnUS) {
+  wxDateTime testDate(22, wxDateTime::Jan, 2023, 12, 45, 57);
+  testDate.MakeFromTimezone(wxDateTime::UTC);
+  DateTimeFormatOptions opts =
+      DateTimeFormatOptions().SetFormatString("%A, %B %d, %Y %I:%M:%S %p");
+  wxString result = ocpn::toUsrDateTimeFormat(testDate, opts);
+  EXPECT_EQ(result, "Sunday, January 22, 2023 12:45:57 PM UTC");
+}
+
+TEST_F(TToStringTest, CustomFormatStringUTC) {
+  wxDateTime testDate(22, wxDateTime::Jan, 2023, 12, 45, 57);
+  testDate.MakeFromTimezone(wxDateTime::UTC);
+  DateTimeFormatOptions opts = DateTimeFormatOptions()
+                                   .SetFormatString("%Y-%m-%d %H:%M:%S")
+                                   .SetTimezone("UTC");
+  wxString result = ocpn::toUsrDateTimeFormat(testDate, opts);
+  EXPECT_EQ(result, "2023-01-22 12:45:57 UTC");
+}
+
+TEST_F(TToStringTest, CustomFormatStringEST) {
+  wxDateTime testDate(22, wxDateTime::Jan, 2023, 12, 45, 57);
+  testDate.MakeFromTimezone(wxDateTime::EDT);
+  DateTimeFormatOptions opts = DateTimeFormatOptions()
+                                   .SetFormatString("%Y-%m-%d %H:%M:%S")
+                                   .SetTimezone("UTC");
+  wxString result = ocpn::toUsrDateTimeFormat(testDate, opts);
+  EXPECT_EQ(result, "2023-01-22 16:45:57 UTC");
+}
+
+TEST_F(TToStringTest, CustomTimeZone) {
+  wxDateTime testDate(1, wxDateTime::Jan, 2023, 12, 0, 0);
+  testDate.MakeFromTimezone(wxDateTime::UTC);
+  DateTimeFormatOptions opts = DateTimeFormatOptions()
+                                   .SetFormatString("%Y-%m-%d %H:%M:%S")
+                                   .SetTimezone("EST");
+  wxString result = ocpn::toUsrDateTimeFormat(testDate, opts);
+  // As of now, the function doesn't handle custom timezone strings, so it
+  // should default to UTC.
+  EXPECT_TRUE(result.EndsWith("UTC"));
 }


### PR DESCRIPTION
# Overview

This PR introduces a consistent approach to date/time formatting throughout OpenCPN. It adds a global configuration parameter for selecting between UTC and local timezone display, accessible through the Options dialog.

# Benefits

Consistent date/time formatting reduces cognitive load and provides a better first-time experience. Users can set the global setting once and all timestamps are formatted accordingly. When users need to switch between UTC and "Local Time", then can easily do so by changing the date/time format in one place.

The date/time format and labels are more consistent and less ambiguous:
- Use abbreviated time zone like "PST" instead of "LOC" or "LC" or "PC"
- Ensure labels are consistent across dialogs.

# Detailed Changes

A new `toUsrDateTimeFormat()` function centralizes formatting logic both for core components and plugins, ensuring consistent display while honoring locale settings. The Track and Route Properties dialog now includes an option to "Honor Global Settings" (the new default), while maintaining existing timezone choices. This implementation addresses long-standing issues where timestamps appeared in inconsistent formats across different UI components. The GRIB plugin has been updated to integrate with this system, and unit tests verify proper timezone calculations including Local Mean Time based on longitude.

1. Add a `ToUsrDateTimeFormat` function to format date/time using the preferred locale and timezone.
   1. The purpose of the function is to format date/time in a consistent manner wherever date/time is displayed in the UI, whether it's a core component (e.g. MOB) or plugins (grib, weather routing...).
   2. The function is declared in the model directory and the plugin API such that it can be used both internally by core components (e.g. MOB function) and plugins.
   4. The date/time is formatted using **UTC** or **Local time**, or according to the global `DateTimeFormat` setting.
   5. Format the date using the configured locale. For example, in the US the date should be formatted as MDY, not DMY. Almost everywhere else, it should be formatted as DMY.
   6. When formatting date/time using local time, write the abbreviated time zone instead of just "LOC". For example, "PDT" instead of "LOC". This makes the date/time less ambiguous, especially if the user changes time zones over time.
   7. Add unit tests for the `ToUsrDateTimeFormat` function.
1. Add a `DateTimeFormat` global configuration parameter that specifies the timezone to use when formatting dates and time.
   1. Two options are supported:
      1. "UTC".
      2. "Local Time": format date/time using the timezone configured in the operating system.
1. Find code locations where date/time is formatted and replace with call to `ToUsrDateTimeFormat` function. Previously the date/time was written in some labels, but it wasn't clear what was the timezone. These labels are now inheriting the global date/time setting.
   1. "Man overboard" displays dates using the Global timezone settings. The name of the "timezone" is displayed, e.g. LOC or UTC.
   2. "Tracks":
      1. Column width: distance, lat/lon, timestamp.
      2. Add "Honor Global Settings" radio button and make it the default selection (such that track timestamps inherit the OpenCPN global settings).
      3. Start track time honors global date/time setting
   3. Routes
   4. Name of anchorage point in Android is based on date/time.

1. Change the Grib plugin:
   1. Add a new "Honor Global Setting" option to get the timezone information from the global settings. In the grib plugin preferences, the date and time setting can be set to "UTC", "Local Time" or "Honor Global Setting".
   8. Set the default value of date and time settings to "Honor Global Setting", but only for new installs. Existing installs retain their current configuration.

# Tests

The tests cover all UI components that have been enhanced to support the new global date/time formatting option.

- [x] Verify global timezone settings in Options dialog
   - [x] Verify Display → General has a "Date and Time" setting.
   - [x] Check that the "Date and Time" setting shows both "Local Time" and "UTC" options
   - [x] Verify "UTC" is the default option
   - [x] Confirm that changing between "Local Time" and "UTC" persists after restart
   - [x] Verify the setting is saved to the `opencpn.ini` configuration file with key `DateTimeFormat`

- [x] Test date/time formatting with UTC setting
   - [x] Verify MOB (Man Overboard) markers show time in UTC format in the chart overlay for new MOB events. Example: `MAN OVERBOARD on Tue 03/25/2025 10:32:08 PM UTC`
   - [x] In "Route & Mark Manager → Marks", verify MOB (Man Overboard) markers show time in UTC format
   - [x] In "Route & Mark Manager → Tracks", check that Track timestamps display in UTC format for new and pre-existing tracks.
      - [x] Track Name if none specified
      - [x] Start Date
      - [x] Recorded point timestamp in "Track Properties"
   - [x] In "Route & Mark Manager → Routes", confirm Route "ETA" is displayed in UTC format

- [x] Test date/time formatting with Local Time setting
   - [x] Verify MOB markers show time in local timezone format with timezone abbreviation in the chart overlay for new MOB events. Example: `MAN OVERBOARD on Tue 03/25/2025 03:32:45 PM PDT`
   - [x] In "Route & Mark Manager → Marks", verify MOB (Man Overboard) markers show time in local timezone format with timezone abbreviation
   - [x] In "Route & Mark Manager → Tracks", check that Track timestamps display in local timezone format for new and pre-existing tracks.
      - [x] Track Name if none specified
      - [x] Start Date
      - [x] Recorded point timestamp in "Track Properties"
   - [x] In "Route & Mark Manager → Routes", confirm Route "ETA" is displayed in local timezone format

- [x] Test Track Properties dialog timezone options ("Route & Mark Manager → Tracks")
   - [x] Verify the dialog shows "Time" formatting options: "UTC", "Local Time", "LMT@Start Track", "Honor Global Settings"
   - [x] Check that "Honor Global Settings" is the default value
   - [x] Confirm that changing "Time" setting updates the track timestamps immediately
   - [x] Verify each setting correctly formats timestamps as expected

- [x] Test Route Properties dialog timezone options  ("Route & Mark Manager → Route")
   - [x] Verify the dialog shows "Time" options: "UTC", "Local Time", "LMT@Location", "Honor Global Settings"
   - [x] Check that "Honor Global Settings" is the default value
   - [x] Verify the "ETA" and "ETD" columns are displayed with date/time format as specified in the "Time" formatting options.
   - [x] Check that changing "Time" settings updates the "ETA" and "ETD" column date/time format correctly

- [x] Test GRIB plugin timezone integration
   - [x] Verify GRIB plugin preferences dialog shows "UTC", "Local Time", and "Honor Global Settings" options
   - [x] Set to "Honor Global Settings" and change global setting to check if GRIB timestamps update - GRIB window must be closed then reopened for global setting to take effect.
   - [x] Test the "Weather Table" view with each date/time setting. Right click on the chart  and select "Weather Table". Verify the timestamps are formatting according to the preferences.
   - [x] Verify timestamps in GRIB timeline control update properly with timezone changes

## Test Notes

- The date/time format of pre-existing MOBs marks does not change when the user changes the global date/time setting. This is because currently, the MOB date/time is stored as a string. It is not stored as a `wxDateTime` object.
- In the MOB date/time display, the string includes either "UTC" or the timezone, e.g. "PDT". If the timezone setting is changed in the operating system, OpenCPN will still have an exact record of the MOB event.

# Display Options Screenshot

<img width="949" alt="image" src="https://github.com/user-attachments/assets/30e35844-02a2-4323-97a6-73a6e5b3d0f5">

# Follow-up Work

1. Plugins that are not included in OpenCPN core can take advantage of the new plugin API.  
2. The `DateTimeFormat` parameter is a string, such that more options could be supported in the future. For example, it could be set to "Local Mean Time", or a specific IANA TZ name, e.g. "America/Los_Angeles". This could be used when the user wants to plan a route in OpenCPN for a timezone which is not the same as the time zone configured in the OS, as suggested in #3481
3. I did not modify the dashboard plugin. The dashboard plugin uses the label "LCL" for local time. That would benefit from formatting the date using the abbreviated timezone name, e.g. "PST". Further discussion needs to be done on how to specify the date/time format selection for the dashboard widgets.

# Notes

1. The wxDateTime::Format() implementation has specific handling for MaxOS date/time formatting:
https://github.com/wxWidgets/wxWidgets/blob/ed13a6d873207f52c8447e960536698d9114111d/src/common/datetimefmt.cpp#L321-L330
