### PR TITLE
Adjust parent for AIS pers.track message box

### DIFF
--- a/gui/src/AISTargetQueryDialog.cpp
+++ b/gui/src/AISTargetQueryDialog.cpp
@@ -169,9 +169,7 @@ void AISTargetQueryDialog::OnIdTrkCreateClick(wxCommandEvent &event) {
           pRouteManagerDialog->UpdateTrkListCtrl();
         Refresh(false);
 
-        if (wxID_YES ==
-            OCPNMessageBox(
-                NULL,
+        if (wxID_YES == OCPNMessageBox(gFrame,
                 _("The recently captured track of this target has been "
                   "recorded.\nDo you want to continue recording until the end "
                   "of the current OpenCPN session?"),


### PR DESCRIPTION
Intend to resolve this [CF post](https://www.cruisersforum.com/forums/f134/opencpn-v5-9-2-beta-test-released-287456-5.html#post3917096) issue.
Works on Win10 and hopefully on W11 as well.
Tested on Debian but not MacOS. Parent: "gFrame" is though used elsewhere wo Mac issues reported?