### PR TITLE
Fix demo plugin build and loading

### DIFF
--- a/model/src/plugin_loader.cpp
+++ b/model/src/plugin_loader.cpp
@@ -83,7 +83,7 @@
 #endif
 
 static const std::vector<std::string> SYSTEM_PLUGINS = {
-    "chartdownloader", "wmm", "dashboard", "grib"};
+    "chartdownloader", "wmm", "dashboard", "grib", "demo"};
 
 /** Return complete PlugInContainer matching pic. */
 static PlugInContainer* GetContainer(const PlugInData& pd,
@@ -98,7 +98,7 @@ static PlugInContainer* GetContainer(const PlugInData& pd,
 /** Return true if path "seems" to contain a system plugin */
 static bool IsSystemPluginPath(const std::string& path) {
   static const std::vector<std::string> kPlugins = {
-      "chartdldr_pi", "wmm_pi", "dashboard_pi", "grib_pi"};
+      "chartdldr_pi", "wmm_pi", "dashboard_pi", "grib_pi", "demo_pi"};
 
   const std::string lc_path = ocpn::tolower(path);
   for (const auto& p : kPlugins)
@@ -109,7 +109,7 @@ static bool IsSystemPluginPath(const std::string& path) {
 /** Return true if name is a valid system plugin name. */
 static bool IsSystemPluginName(const std::string& name) {
   static const std::vector<std::string> kPlugins = {
-      "chartdownloader", "wmm", "dashboard", "grib"};
+      "chartdownloader", "wmm", "dashboard", "grib", "demo"};
   auto found =
       std::find(kPlugins.begin(), kPlugins.end(), ocpn::tolower(name));
   return found != kPlugins.end();

--- a/plugins/demo_pi_sample/CMakeLists.txt
+++ b/plugins/demo_pi_sample/CMakeLists.txt
@@ -138,7 +138,7 @@ INCLUDE_DIRECTORIES(nmea0183)
 
 ADD_LIBRARY(${PACKAGE_NAME} SHARED ${SRC_DEMO} ${SRC_NMEA0183} )
 
-target_link_libraries(${PACKAGE_NAME} PRIVATE ocpn::opencpn )
+target_link_libraries(${PACKAGE_NAME} ocpn::opencpn)
 
 INCLUDE("cmake/PluginInstall.cmake")
 INCLUDE("cmake/PluginLocalization.cmake")

--- a/plugins/demo_pi_sample/src/nmea0183/response.cpp
+++ b/plugins/demo_pi_sample/src/nmea0183/response.cpp
@@ -40,6 +40,8 @@
 ** You can use it any way you like.
 */
 
+extern wxString g_TalkerIdText;
+
 RESPONSE::RESPONSE()
 {
    Talker.Empty();


### PR DESCRIPTION
I wanted to experiment with OpenCPN plugins, so I've started by building the demo plugin but this didn't work out of the box and I had to make the changes in this PR to fix it.

According to #1939 it might still not build under Windows, but this shouldn't make things worse there and at least it builds under Linux now.