### PR TITLE
mDNS cache reimplementation

### DIFF
--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -256,6 +256,10 @@ void SendToPeerDlg::CreateControls(const wxString&) {
   }
 
   if (m_PeerListBox->GetCount()) m_PeerListBox->SetSelection(0);
+  m_PeerListBox->Bind(
+         wxEVT_TEXT,
+         [&](wxCommandEvent&) {
+             m_SendButton->Enable(m_PeerListBox->GetValue() != ""); });
 
   comm_box_sizer->Add(m_PeerListBox, 0, wxEXPAND | wxALL, 5);
 
@@ -293,6 +297,7 @@ void SendToPeerDlg::CreateControls(const wxString&) {
                               wxDefaultPosition, wxDefaultSize, 0);
   itemBoxSizer16->Add(m_SendButton, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
   m_SendButton->SetDefault();
+  m_SendButton->Enable(!m_PeerListBox->IsListEmpty());
 }
 
 void SendToPeerDlg::SetMessage(wxString msg) {
@@ -355,7 +360,6 @@ void SendToPeerDlg::OnTimerScanTick(wxTimerEvent&) {
     m_ScanTickTimer.Stop();
     g_Platform->HideBusySpinner();
     m_RescanButton->Enable();
-    m_SendButton->Enable();
     m_SendButton->SetDefault();
     m_pgauge->Hide();
     m_bScanOnCreate = false;
@@ -377,6 +381,7 @@ void SendToPeerDlg::OnTimerScanTick(wxTimerEvent&) {
       }
     }
     if (m_PeerListBox->GetCount()) m_PeerListBox->SetSelection(0);
+    m_SendButton->Enable(m_PeerListBox->GetCount() > 0);
   }
 }
 

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -260,7 +260,7 @@ void SendToPeerDlg::CreateControls(const wxString&) {
          wxEVT_TEXT,
          [&](wxCommandEvent&) {
              m_SendButton->Enable(m_PeerListBox->GetValue() != ""); });
-
+  m_PeerListBox->Enable(!m_bScanOnCreate);
   comm_box_sizer->Add(m_PeerListBox, 0, wxEXPAND | wxALL, 5);
 
   wxBoxSizer* itemBoxSizer3 = new wxBoxSizer(wxVERTICAL);
@@ -362,6 +362,7 @@ void SendToPeerDlg::OnTimerScanTick(wxTimerEvent&) {
     m_RescanButton->Enable();
     m_SendButton->SetDefault();
     m_pgauge->Hide();
+    m_PeerListBox->Enable(true);
     m_bScanOnCreate = false;
 
     // Clear the combo box

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -31,6 +31,7 @@
 #include "model/config_vars.h"
 #include "model/mdns_cache.h"
 #include "model/mDNS_query.h"
+#include "model/ocpn_utils.h"
 #include "model/peer_client.h"
 #include "model/route.h"
 #include "model/route_point.h"
@@ -309,6 +310,9 @@ void SendToPeerDlg::OnSendClick(wxCommandEvent&) {
   // Set up transfer data
   PeerData peer_data(progress);
   ParsePeer(m_PeerListBox->GetValue(), peer_data);
+  auto addr_port = ocpn::split(peer_data.dest_ip_address, ":");
+  if (addr_port.size() == 1) addr_port.push_back("8443");
+  MdnsCache::GetInstance().Add(addr_port[0], addr_port[1]);
   peer_data.routes = m_RouteList;
   peer_data.tracks = m_TrackList;
   peer_data.routepoints = m_RoutePointList;

--- a/gui/src/canvasMenu.cpp
+++ b/gui/src/canvasMenu.cpp
@@ -44,6 +44,7 @@
 #include "model/config_vars.h"
 #include "model/cutil.h"
 #include "model/georef.h"
+#include "model/mdns_cache.h"
 #include "model/mDNS_query.h"
 #include "model/nav_object_database.h"
 #include "model/own_ship.h"
@@ -124,8 +125,6 @@ extern bool g_bBasicMenus;
 extern TrackPropDlg *pTrackPropDialog;
 extern bool g_FlushNavobjChanges;
 extern ColorScheme global_color_scheme;
-extern std::vector<std::shared_ptr<ocpn_DNS_record_t>> g_DNS_cache;
-extern wxDateTime g_DNS_cache_time;
 
 //    Constants for right click menus
 enum {
@@ -1752,14 +1751,8 @@ void CanvasMenuHandler::PopupMenuHandler(wxCommandEvent &event) {
         // Perform initial scan, if necessary
 
         // Check for stale cache...
-        bool bDNScacheStale = true;
-        wxDateTime tnow = wxDateTime::Now();
-        if (g_DNS_cache_time.IsValid()) {
-          wxTimeSpan delta = tnow.Subtract(g_DNS_cache_time);
-          if (delta.GetMinutes() < 5) bDNScacheStale = false;
-        }
-
-        if ((g_DNS_cache.size() == 0) || bDNScacheStale)
+        MdnsCache::GetInstance().Validate();
+        if (MdnsCache::GetInstance().GetCache().empty())
           dlg.SetScanOnCreate(true);
 
         dlg.SetScanTime(5);  // seconds
@@ -1803,14 +1796,8 @@ void CanvasMenuHandler::PopupMenuHandler(wxCommandEvent &event) {
         // Perform initial scan, if necessary
 
         // Check for stale cache...
-        bool bDNScacheStale = true;
-        wxDateTime tnow = wxDateTime::Now();
-        if (g_DNS_cache_time.IsValid()) {
-          wxTimeSpan delta = tnow.Subtract(g_DNS_cache_time);
-          if (delta.GetMinutes() < 5) bDNScacheStale = false;
-        }
-
-        if ((g_DNS_cache.size() == 0) || bDNScacheStale)
+        MdnsCache::GetInstance().Validate();
+        if (MdnsCache::GetInstance().GetCache().empty())
           dlg.SetScanOnCreate(true);
 
         dlg.SetScanTime(5);  // seconds
@@ -1942,14 +1929,8 @@ void CanvasMenuHandler::PopupMenuHandler(wxCommandEvent &event) {
         // Perform initial scan, if necessary
 
         // Check for stale cache...
-        bool bDNScacheStale = true;
-        wxDateTime tnow = wxDateTime::Now();
-        if (g_DNS_cache_time.IsValid()) {
-          wxTimeSpan delta = tnow.Subtract(g_DNS_cache_time);
-          if (delta.GetMinutes() < 5) bDNScacheStale = false;
-        }
-
-        if ((g_DNS_cache.size() == 0) || bDNScacheStale)
+        MdnsCache::GetInstance().Validate();
+        if (MdnsCache::GetInstance().GetCache().empty())
           dlg.SetScanOnCreate(true);
 
         dlg.SetScanTime(5);  // seconds

--- a/gui/src/routemanagerdialog.cpp
+++ b/gui/src/routemanagerdialog.cpp
@@ -42,6 +42,7 @@
 #include "model/ais_decoder.h"
 #include "model/config_vars.h"
 #include "model/georef.h"
+#include "model/mdns_cache.h"
 #include "model/mDNS_query.h"
 #include "model/navutil_base.h"
 #include "model/own_ship.h"
@@ -93,8 +94,6 @@ extern MyFrame *gFrame;
 extern bool g_bShowLayers;
 extern wxString g_default_wp_icon;
 extern OCPNPlatform *g_Platform;
-extern std::vector<std::shared_ptr<ocpn_DNS_record_t>> g_DNS_cache;
-extern wxDateTime g_DNS_cache_time;
 
 // Helper for conditional file name separator
 void appendOSDirSlash(wxString *pString);
@@ -1612,16 +1611,9 @@ void RouteManagerDialog::OnRteSendToPeerClick(wxCommandEvent &event) {
         // Perform initial scan, if necessary
 
         // Check for stale cache...
-        bool bDNScacheStale = true;
-        wxDateTime tnow = wxDateTime::Now();
-        if (g_DNS_cache_time.IsValid()){
-          wxTimeSpan delta = tnow.Subtract(g_DNS_cache_time);
-          if (delta.GetMinutes() < 5)
-            bDNScacheStale = false;
-        }
-
-        if ((g_DNS_cache.size() == 0) || bDNScacheStale)
-           dlg.SetScanOnCreate(true);
+        MdnsCache::GetInstance().Validate();
+        if (MdnsCache::GetInstance().GetCache().empty())
+          dlg.SetScanOnCreate(true);
 
         dlg.SetScanTime(5);     // seconds
         dlg.Create(NULL, -1, _("Send Route(s) to OpenCPN Peer") + _T( "..." ), _T(""));
@@ -1652,16 +1644,9 @@ void RouteManagerDialog::OnWptSendToPeerClick(wxCommandEvent &event) {
         // Perform initial scan, if necessary
 
         // Check for stale cache...
-        bool bDNScacheStale = true;
-        wxDateTime tnow = wxDateTime::Now();
-        if (g_DNS_cache_time.IsValid()){
-          wxTimeSpan delta = tnow.Subtract(g_DNS_cache_time);
-          if (delta.GetMinutes() < 5)
-            bDNScacheStale = false;
-        }
-
-        if ((g_DNS_cache.size() == 0) || bDNScacheStale)
-           dlg.SetScanOnCreate(true);
+        MdnsCache::GetInstance().Validate();
+        if (MdnsCache::GetInstance().GetCache().empty())
+          dlg.SetScanOnCreate(true);
 
         dlg.SetScanTime(5);     // seconds
         dlg.Create(NULL, -1, _("Send Waypoint(s) to OpenCPN Peer") + _T( "..." ), _T(""));
@@ -1692,16 +1677,9 @@ void RouteManagerDialog::OnTrkSendToPeerClick(wxCommandEvent &event) {
         // Perform initial scan, if necessary
 
         // Check for stale cache...
-        bool bDNScacheStale = true;
-        wxDateTime tnow = wxDateTime::Now();
-        if (g_DNS_cache_time.IsValid()){
-          wxTimeSpan delta = tnow.Subtract(g_DNS_cache_time);
-          if (delta.GetMinutes() < 5)
-            bDNScacheStale = false;
-        }
-
-        if ((g_DNS_cache.size() == 0) || bDNScacheStale)
-           dlg.SetScanOnCreate(true);
+        MdnsCache::GetInstance().Validate();
+        if (MdnsCache::GetInstance().GetCache().empty())
+          dlg.SetScanOnCreate(true);
 
         dlg.SetScanTime(5);     // seconds
         dlg.Create(NULL, -1, _("Send Track(s) to OpenCPN Peer") + _T( "..." ), _T(""));
@@ -2666,7 +2644,7 @@ void RouteManagerDialog::OnWptPropertiesClick(wxCommandEvent &event) {
     }
     item = m_pWptListCtrl->GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
   }
-      
+
   if (wptlist.size() == 0) return;
 
   WptShowPropertiesDialog(wptlist, GetParent());

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -81,6 +81,7 @@ set(
   ${MODEL_HDR_DIR}/logger.h
   ${MODEL_HDR_DIR}/MarkIcon.h
   ${MODEL_HDR_DIR}/mDNS_query.h
+  ${MODEL_HDR_DIR}/mdns_cache.h
   ${MODEL_HDR_DIR}/mDNS_service.h
   ${MODEL_HDR_DIR}/meteo_points.h
   ${MODEL_HDR_DIR}/multiplexer.h
@@ -168,6 +169,7 @@ set(SRC
   ${MODEL_SRC_DIR}/local_api.cpp
   ${MODEL_SRC_DIR}/logger.cpp
   ${MODEL_SRC_DIR}/mDNS_query.cpp
+  ${MODEL_SRC_DIR}/mdns_cache.cpp
   ${MODEL_SRC_DIR}/mDNS_service.cpp
   ${MODEL_SRC_DIR}/multiplexer.cpp
   ${MODEL_SRC_DIR}/nav_object_database.cpp

--- a/model/include/model/mdns_cache.h
+++ b/model/include/model/mdns_cache.h
@@ -56,13 +56,15 @@ public:
 
   /**
    * Add new entry to the cache
-   * @return true if entry was added, false if it already existed.
+   * @return true if entry was added, false if entry with same ip
+   * address already exists.
    */
   bool Add(const Entry& entry);
 
   /**
    * Add new entry to the cache
-   * @return true if entry was added, false if it already existed.
+   * @return true if entry was added, false if entry with same ip
+   * address already exists.
    */
   bool Add(const std::string& service, const std::string& host,
            const std::string& _ip, const std::string& _port);

--- a/model/include/model/mdns_cache.h
+++ b/model/include/model/mdns_cache.h
@@ -1,0 +1,87 @@
+
+/***************************************************************************
+ *   Copyright (C) 2024  Alec Leamas                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+/**
+ * Singleton cache for hosts looked up using mdns. A critical region accessed
+ * both by timer routines and the main thread.
+ *
+ * Entries are added by the various Add() signatures. The Validate() method
+ * removes all entries where to host does not respond to a http request on
+ * on port 8443.
+ */
+
+#ifndef MDNS_CACHE_H
+#define MDNS_CACHE_H
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+class MdnsCache {
+public:
+  struct Entry {
+    std::string service_instance;
+    std::string hostname;
+    std::string ip;
+    std::string port;
+    Entry(const std::string& service, const std::string host,
+          const std::string& _ip, const std::string _port)
+        : service_instance(service), hostname(host), ip(_ip), port(_port) {}
+  };
+
+  static MdnsCache& GetInstance();
+
+  MdnsCache& operator=(MdnsCache&) = delete;
+  MdnsCache(const MdnsCache&) = delete;
+
+  /** Check that all entries are accessible, remove stale ones. */
+  void Validate();
+
+  /**
+   * Add new entry to the cache
+   * @return true if entry was added, false if it already existed.
+   */
+  bool Add(const Entry& entry);
+
+  /**
+   * Add new entry to the cache
+   * @return true if entry was added, false if it already existed.
+   */
+  bool Add(const std::string& service, const std::string& host,
+           const std::string& _ip, const std::string& _port);
+
+  /**
+   * Add a manual entry where only IP and port is known.
+   * @return true if entry was added, false if entry with same ip
+   * address already exists.
+   */
+  bool Add(const std::string& _ip,  const std::string& _port);
+
+  /** Return read-only cached entries reference. */
+  const std::vector<Entry>& GetCache() const { return m_cache; }
+
+private:
+  mutable std::mutex m_mutex;
+  std::vector<Entry> m_cache;
+
+  MdnsCache() = default;
+};
+
+#endif  // MDNS_CACHE_H

--- a/model/src/mDNS_query.cpp
+++ b/model/src/mDNS_query.cpp
@@ -75,13 +75,13 @@ static int has_ipv4;
 static int has_ipv6;
 
 static void log_printf(const char* fmt, ...) {
-    if (getenv("OCPN_MDNS_DEBUG")
-        || wxLog::GetActiveTarget()->GetLogLevel() >= wxLOG_Debug) {
-      va_list ap;
-      va_start(ap, fmt);
-      vprintf(fmt, ap);
-      va_end(ap);
-    }
+  if (getenv("OCPN_MDNS_DEBUG") ||
+      wxLog::GetActiveTarget()->GetLogLevel() >= wxLOG_Debug) {
+    va_list ap;
+    va_start(ap, fmt);
+    vprintf(fmt, ap);
+    va_end(ap);
+  }
 }
 
 static int ocpn_query_callback(int sock, const struct sockaddr* from,
@@ -111,9 +111,9 @@ static int ocpn_query_callback(int sock, const struct sockaddr* from,
         mdns_record_parse_ptr(data, size, record_offset, record_length,
                               namebuffer, sizeof(namebuffer));
     log_printf("%.*s : %s %.*s PTR %.*s rclass 0x%x ttl %u length %d\n",
-           MDNS_STRING_FORMAT(fromaddrstr), entrytype,
-           MDNS_STRING_FORMAT(entrystr), MDNS_STRING_FORMAT(namestr), rclass,
-           ttl, (int)record_length);
+               MDNS_STRING_FORMAT(fromaddrstr), entrytype,
+               MDNS_STRING_FORMAT(entrystr), MDNS_STRING_FORMAT(namestr),
+               rclass, ttl, (int)record_length);
 
     std::string srv(namestr.str, namestr.length);
     size_t rh = srv.find("opencpn-object");
@@ -126,8 +126,7 @@ static int ocpn_query_callback(int sock, const struct sockaddr* from,
 
     //  Search for this record in the cache
     auto func = [srv, ip](const std::shared_ptr<ocpn_DNS_record_t> record) {
-      return (!record->service_instance.compare(srv)) &&
-             (ip == record->ip);
+      return (!record->service_instance.compare(srv)) && (ip == record->ip);
     };
     auto found = std::find_if(g_DNS_cache.begin(), g_DNS_cache.end(), func);
 
@@ -233,7 +232,7 @@ int send_mdns_query(mdns_query_t* query, size_t count, size_t timeout_secs,
     return -1;
   }
   log_printf("Opened %d socket%s for mDNS query\n", num_sockets,
-         num_sockets ? "s" : "");
+             num_sockets ? "s" : "");
 
   size_t capacity = 2048;
   void* buffer = malloc(capacity);
@@ -449,7 +448,8 @@ std::vector<std::string> get_local_ipv4_addresses() {
   struct ifaddrs* ifaddr = 0;
   struct ifaddrs* ifa = 0;
 
-  if (getifaddrs(&ifaddr) < 0) log_printf("Unable to get interface addresses\n");
+  if (getifaddrs(&ifaddr) < 0)
+    log_printf("Unable to get interface addresses\n");
 
   int first_ipv4 = 1;
   int first_ipv6 = 1;

--- a/model/src/mdns_cache.cpp
+++ b/model/src/mdns_cache.cpp
@@ -64,6 +64,10 @@ bool MdnsCache::Add(const std::string& service, const std::string& host,
   return Add(Entry(service, host, _ip, _port));
 }
 
+bool MdnsCache::Add(const std::string& _ip, const std::string& _port) {
+  return Add(Entry("opencpn", "unknown", _ip, _port));
+}
+
 void MdnsCache::Validate() {
   std::unique_lock lock(m_mutex);
   for (auto it = m_cache.begin(); it != m_cache.end();) {

--- a/model/src/mdns_cache.cpp
+++ b/model/src/mdns_cache.cpp
@@ -1,0 +1,76 @@
+/**************************************************************************
+ *   Copyright (C) 2024 Alec Leamas                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+/** \file  mdns_cache.cpp Implement mdns_cache.h */
+
+#include <algorithm>
+
+#include <curl/curl.h>
+
+#include "model/logger.h"
+#include "model/mdns_cache.h"
+
+/**
+ * Check if we can connect to given host/port, does not
+ * care if we cannot recieve data.
+ */
+static bool Ping(const std::string& url, long port = 8443L) {
+  CURL* c = curl_easy_init();
+  curl_easy_setopt(c, CURLOPT_URL, url.c_str());
+  curl_easy_setopt(c, CURLOPT_PORT, port);
+  curl_easy_setopt(c, CURLOPT_TIMEOUT_MS, 2000L);
+  CURLcode result = curl_easy_perform(c);
+  curl_easy_cleanup(c);
+  bool ok = result == CURLE_RECV_ERROR || result == CURLE_OK;
+  DEBUG_LOG << "Checked mdns host: " << url << ": "
+            << (ok ? "ok" : curl_easy_strerror(result));
+  return ok;
+}
+
+MdnsCache& MdnsCache::GetInstance() {
+  static MdnsCache mdns_cache;
+  return mdns_cache;
+}
+
+bool MdnsCache::Add(const Entry& entry) {
+  std::unique_lock lock(m_mutex);
+  auto found = std::find_if(m_cache.begin(), m_cache.end(),
+                            [entry](Entry& e) { return e.ip == entry.ip; });
+  DEBUG_LOG << "Added mdns cache entry, ip: " << entry.ip
+            << ", status: " << (found == m_cache.end() ? "true" : "false");
+  if (found != m_cache.end()) return false;
+  m_cache.push_back(entry);
+  return true;
+}
+
+bool MdnsCache::Add(const std::string& service, const std::string& host,
+                    const std::string& _ip, const std::string& _port) {
+  return Add(Entry(service, host, _ip, _port));
+}
+
+void MdnsCache::Validate() {
+  std::unique_lock lock(m_mutex);
+  for (auto it = m_cache.begin(); it != m_cache.end();) {
+    if (!Ping(it->ip)) {
+      m_cache.erase(it);
+    } else {
+      it++;
+    }
+  }
+}


### PR DESCRIPTION
An  attempt  to handle #4071. Here is:

  - The caching is refactored to a proper  singleton instance.
  - Added mutexes to cope with possible collisions between the timer and main threads.
  - New strategy, see below
  - Manual entries are also cached.

The strategy is to keep all discovered hosts without time based checks. Instead, the cache is validated before use: All hosts are checked for connectivity and removed if they cannot be accessed.

The net result is that once a host is discovered it will be kept in cache as long as it is there. This also means that to detect new hosts which becomes available after the initial scan user must push the "Scan Again" button.

Closes: #4071