### PR TITLE
Dashboard: fix problem with date invalidation after GPS watchdog timeout

### DIFF
--- a/gui/include/gui/ocpn_frame.h
+++ b/gui/include/gui/ocpn_frame.h
@@ -375,6 +375,13 @@ private:
 
   wxString prev_locale;
 
+  /**
+   * The last time basic navigational data was received, or 0 if no data
+   * has been received.
+   *
+   * @todo Change time_t to wxLongLong, as time_t is susceptible to the
+   * year 2038 problem on 32-bit builds.
+   */
   time_t m_fixtime;
   bool b_autofind;
 

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -5514,11 +5514,17 @@ void MyFrame::OnFrameTimer1(wxTimerEvent &event) {
     GPSData.nSats = g_SatsInView;
 
     wxDateTime tCheck((time_t)m_fixtime);
-
-    if (tCheck.IsValid())
+    if (tCheck.IsValid()) {
+      // As a special case, when no GNSS data is available, m_fixtime is set to
+      // zero. Note wxDateTime(0) is valid, so the zero value is passed to the
+      // plugins. The plugins should check for zero and not use the time in that
+      // case.
       GPSData.FixTime = m_fixtime;
-    else
+    } else {
+      // Note: I don't think this is ever reached, as m_fixtime can never be set
+      // to wxLongLong(wxINT64_MIN), which is the only way to get here.
       GPSData.FixTime = wxDateTime::Now().GetTicks();
+    }
 
     SendPositionFixToAllPlugIns(&GPSData);
   }

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -221,6 +221,8 @@ public:
   double Var;  // Variation, typically from RMC message
   double Hdm;
   double Hdt;
+  // The time obtained from the most recent GNSS message, or the system time if
+  // the GNSS watchdog has expired.
   time_t FixTime;
   int nSats;
 };

--- a/plugins/dashboard_pi/src/clock.h
+++ b/plugins/dashboard_pi/src/clock.h
@@ -44,10 +44,17 @@
 #include "instrument.h"
 extern int g_iUTCOffset;  // get offset from dashboard_pi.cpp
 
+/**
+ * A dashboard instrument that displays the GNSS clock time, if available.
+ *
+ * A dashboard instrument that shows the current time from GNSS source.
+ * Can display in either UTC or local time based on user preference.
+ * Time format is configurable through the format string parameter.
+ */
 class DashboardInstrument_Clock : public DashboardInstrument_Single {
 public:
   DashboardInstrument_Clock(wxWindow *parent, wxWindowID id, wxString title,
-                            InstrumentProperties* Properties,
+                            InstrumentProperties *Properties,
                             DASH_CAP cap_flag = OCPN_DBP_STC_CLK,
                             wxString format = _T("%02i:%02i:%02i UTC"));
 
@@ -58,15 +65,24 @@ public:
   wxString GetDisplayTime(wxDateTime UTCtime);
   bool getUTC() { return bUTC; }
   void setUTC(bool flag) { bUTC = flag; }
-  InstrumentProperties* m_Properties;
+  InstrumentProperties *m_Properties;
 
 private:
   bool bUTC;
 };
 
+/**
+ * A dashboard instrument that displays current moon phase information.
+ *
+ * Calculates and displays:
+ * - Visual moon phase representation
+ * - Current lunar phase
+ * - Hemisphere information
+ */
 class DashboardInstrument_Moon : public DashboardInstrument_Clock {
 public:
-  DashboardInstrument_Moon(wxWindow *parent, wxWindowID id, wxString title, InstrumentProperties* Properties);
+  DashboardInstrument_Moon(wxWindow *parent, wxWindowID id, wxString title,
+                           InstrumentProperties *Properties);
   ~DashboardInstrument_Moon() {}
 
   wxSize GetSize(int orient, wxSize hint);
@@ -81,10 +97,13 @@ private:
   wxString m_hemisphere;
 };
 
+/**
+ * A dashboard instrument that displays sunrise and sunset times.
+ */
 class DashboardInstrument_Sun : public DashboardInstrument_Clock {
 public:
   DashboardInstrument_Sun(wxWindow *parent, wxWindowID id, wxString title,
-                          InstrumentProperties* Properties,
+                          InstrumentProperties *Properties,
                           wxString format = _T( "%02i:%02i:%02i UTC" ));
 
   ~DashboardInstrument_Sun() {}
@@ -105,10 +124,13 @@ private:
                     wxDateTime &sunset);
 };
 
+/**
+ * A dashboard instrument that displays the current computer time.
+ */
 class DashboardInstrument_CPUClock : public DashboardInstrument_Clock {
 public:
   DashboardInstrument_CPUClock(wxWindow *parent, wxWindowID id, wxString title,
-                               InstrumentProperties* Properties,
+                               InstrumentProperties *Properties,
                                wxString format = _T( "%02i:%02i:%02i UTC" ));
 
   ~DashboardInstrument_CPUClock() {}

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -232,9 +232,9 @@ enum {
   ID_DBP_I_PITCH,
   ID_DBP_I_HEEL,
   ID_DBP_D_AWA_TWA,
-  ID_DBP_I_GPSLCL,
-  ID_DBP_I_CPULCL,
-  ID_DBP_I_SUNLCL,
+  ID_DBP_I_GPSLCL,  ///< GNSS Clock formatted in local time.
+  ID_DBP_I_CPULCL,  ///< Computer Clock formatted in local time.
+  ID_DBP_I_SUNLCL,  ///< Sunrise/Sunset time formatted in local time.
   ID_DBP_I_ALTI,
   ID_DBP_D_ALTI,
   ID_DBP_I_VMGW,
@@ -3159,7 +3159,13 @@ void dashboard_pi::SetPositionFixEx(PlugIn_Position_Fix_Ex &pfix) {
     }
   }
   if (mPriDateTime >= 6) {  // We prefer the GPS datetime
-    mUTCDateTime.Set(pfix.FixTime);
+    // If GNSS data is available, the value of pfix.FixTime is the GNSS time in
+    // UTC. If GNSS data is not available, the special value 0 is used to
+    // indicate that the time is not valid.
+    if (pfix.FixTime > 0)
+      mUTCDateTime.Set(pfix.FixTime);
+    else
+      mUTCDateTime = wxInvalidDateTime;
     if (mUTCDateTime.IsValid()) {
       mPriDateTime = 6;
       mUTCDateTime = mUTCDateTime.ToUTC();

--- a/plugins/dashboard_pi/src/dashboard_pi.h
+++ b/plugins/dashboard_pi/src/dashboard_pi.h
@@ -313,6 +313,20 @@ private:
   int mSatsInUse;
   int mSatsInView;
   double mHdm;
+  /**
+   * The current time in UTC.
+   *
+   * Holds the current UTC time, which is obtained from various sources in the
+   * following order of priority:
+   * 1. SignalK navigation.datetime
+   * 2. NMEA ZDA sentence
+   * 3. NMEA RMC sentence
+   * 4. GNSS (Global Navigation Satellite System)
+   * 5. Local system clock
+   *
+   * The priority order ensures that the most accurate and reliable source is
+   * used to set the UTC time.
+   */
   wxDateTime mUTCDateTime;
   int m_config_version;
   wxString m_VDO_accumulator;

--- a/plugins/dashboard_pi/src/instrument.h
+++ b/plugins/dashboard_pi/src/instrument.h
@@ -77,42 +77,44 @@ class DashboardInstrument_Position;
 class DashboardInstrument_Sun;
 
 enum DASH_CAP {
-  OCPN_DBP_STC_LAT = 0,
-  OCPN_DBP_STC_LON,
-  OCPN_DBP_STC_SOG,
-  OCPN_DBP_STC_COG,
-  OCPN_DBP_STC_STW,  // Speed through water
-  OCPN_DBP_STC_HDM,
-  OCPN_DBP_STC_HDT,
-  OCPN_DBP_STC_HMV,  // Magnetic variation
-  OCPN_DBP_STC_BRG,
-  OCPN_DBP_STC_AWA,  // Apparent wind angle
-  OCPN_DBP_STC_AWS,
-  OCPN_DBP_STC_TWA,
-  OCPN_DBP_STC_TWS,
-  OCPN_DBP_STC_DPT,
-  OCPN_DBP_STC_TMP,
-  OCPN_DBP_STC_VMG,
-  OCPN_DBP_STC_VMGW,
-  OCPN_DBP_STC_RSA,
-  OCPN_DBP_STC_SAT,
-  OCPN_DBP_STC_GPS,
-  OCPN_DBP_STC_PLA,  // Cursor latitude
-  OCPN_DBP_STC_PLO,  // Cursor longitude
-  OCPN_DBP_STC_CLK,
-  OCPN_DBP_STC_MON,
-  OCPN_DBP_STC_ATMP,  // AirTemp
-  OCPN_DBP_STC_TWD,
-  OCPN_DBP_STC_TWS2,
-  OCPN_DBP_STC_VLW1,   // Trip Log
-  OCPN_DBP_STC_VLW2,   // Sum Log
-  OCPN_DBP_STC_MDA,    // Barometic pressure
-  OCPN_DBP_STC_MCOG,   // Magnetic Course over Ground
-  OCPN_DBP_STC_PITCH,  // Pitch
-  OCPN_DBP_STC_HEEL,   // Heel
-  OCPN_DBP_STC_ALTI,   // Altitude
-  OCPN_DBP_STC_HUM,    // Humidity
-  OCPN_DBP_STC_WCC,    // Windlass
+  OCPN_DBP_STC_LAT = 0,  ///< Latitude
+  OCPN_DBP_STC_LON,      ///< Longitude
+  OCPN_DBP_STC_SOG,      ///< Speed over ground
+  OCPN_DBP_STC_COG,      ///< Course over ground
+  OCPN_DBP_STC_STW,      ///< Speed through water
+  OCPN_DBP_STC_HDM,      ///< Heading magnetic North
+  OCPN_DBP_STC_HDT,      ///< Heading true North
+  OCPN_DBP_STC_HMV,   ///< Magnetic variation from NMEA device if available (not
+                      ///< from WMM)
+  OCPN_DBP_STC_BRG,   ///< Bearing
+  OCPN_DBP_STC_AWA,   ///< Apparent wind angle
+  OCPN_DBP_STC_AWS,   ///< Apparent wind speed
+  OCPN_DBP_STC_TWA,   ///< True wind angle
+  OCPN_DBP_STC_TWS,   ///< True wind speed
+  OCPN_DBP_STC_DPT,   ///< Depth
+  OCPN_DBP_STC_TMP,   ///< Water temperature
+  OCPN_DBP_STC_VMG,   ///< Velocity made good
+  OCPN_DBP_STC_VMGW,  ///< Velocity made good to windward
+  OCPN_DBP_STC_RSA,   ///< Rudder angle
+  OCPN_DBP_STC_SAT,   ///< Satellite count in use
+  OCPN_DBP_STC_GPS,   ///< GPS status
+  OCPN_DBP_STC_PLA,   ///< Cursor latitude
+  OCPN_DBP_STC_PLO,   ///< Cursor longitude
+  OCPN_DBP_STC_CLK,   ///< Clock
+  OCPN_DBP_STC_MON,   // Does not seem to be used anywhere
+  OCPN_DBP_STC_ATMP,  ///< Air Temperature
+  OCPN_DBP_STC_TWD,   ///< True Wind Direction (from NMEA device if available,
+                      ///< otherwise TWA + magnetic variation)
+  OCPN_DBP_STC_TWS2,  ///< True Wind Speed, same calculation as TWS
+  OCPN_DBP_STC_VLW1,  ///< Trip Log
+  OCPN_DBP_STC_VLW2,  ///< Sum Log
+  OCPN_DBP_STC_MDA,   ///< Barometic pressure
+  OCPN_DBP_STC_MCOG,  ///< Magnetic Course over Ground
+  OCPN_DBP_STC_PITCH,  ///< Pitch
+  OCPN_DBP_STC_HEEL,   ///< Heel
+  OCPN_DBP_STC_ALTI,   ///< Altitude
+  OCPN_DBP_STC_HUM,    ///< Humidity
+  OCPN_DBP_STC_WCC,    ///< Windlass
                        // Insert new instrument capability flags here
   OCPN_DBP_STC_LAST    // This should always be the last enum in this list
 };


### PR DESCRIPTION
Fix for #4082 

Problem: when there is a GPS watchdog timeout, the fixtime is set to `0`, which has a code comment state the date will be invalid. However, the `0` value is valid, i.e. `IsValid()` returns true. There are other parts of the code that were written with the `IsValid()` check.
The dashboard plugin was not checking for the special `0` value.

I considered the alternative to use `wxInvalidDateTime` when no GNSS data is available, but the `time_t FixTime` field is present in the plugin API, hence it cannot be changed to `wxDateTime`.

This PR fixes the following problems in the dashboard plugins. When no GNSS data is available:
1. The GNSS local time is set to "---". Previously, a fixed time such as "16:00:00" was displayed. It was misleading because the widget was displaying `time_t = 0` formatted as a time, without the date.
2. The Sunrise/sunset time is now correct, even if the GNSS data is no longer available. At least it's correct to the extent that the computer clock is correct. Previously, after a GNSS watchdog timeout, the sunrise/sunset was calculated assuming the current date is the epoch date/time (Jan 1 1970). For example, the sunset time was always shown as 18:01 in San Francisco, regardless of the actual time.

Example after GPS watchdog timeout:
<img width="1072" alt="image" src="https://github.com/user-attachments/assets/fdce914d-ea7a-4ec1-8bf4-c727a93a8723">


