### PR TITLE
Loader fix

### DIFF
--- a/android/androidUTIL.cpp
+++ b/android/androidUTIL.cpp
@@ -4365,7 +4365,7 @@ int doAndroidPersistState() {
   }
 
   //    Deactivate the PlugIns, allowing them to save state
-  PluginLoader::getInstance()->DeactivateAllPlugIns();
+  PluginLoader::GetInstance()->DeactivateAllPlugIns();
 
   /*
    Automatically drop an anchorage waypoint, if enabled
@@ -4475,7 +4475,7 @@ int doAndroidPersistState() {
 
   if (ChartData) ChartData->PurgeCachePlugins();
 
-  PluginLoader::getInstance()->UnLoadAllPlugIns();
+  PluginLoader::GetInstance()->UnLoadAllPlugIns();
   if (g_pi_manager) {
     delete g_pi_manager;
     g_pi_manager = NULL;

--- a/buildandroid/android/src/com/google/android/vending/licensing/AESObfuscator.java
+++ b/buildandroid/android/src/com/google/android/vending/licensing/AESObfuscator.java
@@ -61,7 +61,7 @@ public class AESObfuscator implements Obfuscator {
             SecretKey secret = new SecretKeySpec(tmp.getEncoded(), "AES");
             mEncryptor = Cipher.getInstance(CIPHER_ALGORITHM);
             mEncryptor.init(Cipher.ENCRYPT_MODE, secret, new IvParameterSpec(IV));
-            mDecryptor = Cipher.getInstance(CIPHER_ALGORITHM);
+            mDecryptor = Cipher.GetInstance(CIPHER_ALGORITHM);
             mDecryptor.init(Cipher.DECRYPT_MODE, secret, new IvParameterSpec(IV));
         } catch (GeneralSecurityException e) {
             // This can't happen on a compatible Android device.

--- a/buildandroid/android/src/com/google/android/vending/licensing/LicenseChecker.java
+++ b/buildandroid/android/src/com/google/android/vending/licensing/LicenseChecker.java
@@ -107,7 +107,7 @@ public class LicenseChecker implements ServiceConnection {
     private static PublicKey generatePublicKey(String encodedPublicKey) {
         try {
             byte[] decodedKey = Base64.decode(encodedPublicKey);
-            KeyFactory keyFactory = KeyFactory.getInstance(KEY_FACTORY_ALGORITHM);
+            KeyFactory keyFactory = KeyFactory.GetInstance(KEY_FACTORY_ALGORITHM);
 
             return keyFactory.generatePublic(new X509EncodedKeySpec(decodedKey));
         } catch (NoSuchAlgorithmException e) {

--- a/buildandroid/android/src/com/google/android/vending/licensing/LicenseValidator.java
+++ b/buildandroid/android/src/com/google/android/vending/licensing/LicenseValidator.java
@@ -94,7 +94,7 @@ class LicenseValidator {
                 responseCode == LICENSED_OLD_KEY) {
             // Verify signature.
             try {
-                Signature sig = Signature.getInstance(SIGNATURE_ALGORITHM);
+                Signature sig = Signature.GetInstance(SIGNATURE_ALGORITHM);
                 sig.initVerify(publicKey);
                 sig.update(signedData.getBytes());
 

--- a/buildandroid/android/src/org/qtproject/qt5/android/bindings/QtActivity.java
+++ b/buildandroid/android/src/org/qtproject/qt5/android/bindings/QtActivity.java
@@ -1139,7 +1139,7 @@ public class QtActivity extends Activity implements ActionBar.OnNavigationListen
     {
         String ret = "";
 
-        GoogleApiAvailability av = GoogleApiAvailability.getInstance();
+        GoogleApiAvailability av = GoogleApiAvailability.GetInstance();
         if(av != null)
             ret = av.getOpenSourceSoftwareLicenseInfo (this);
 

--- a/cli/console.cpp
+++ b/cli/console.cpp
@@ -186,7 +186,7 @@ public:
     using namespace std;
     wxImage::AddHandler(new wxPNGHandler());
     g_BasePlatform->GetSharedDataDir();  // See #2619
-    PluginLoader::getInstance()->LoadAllPlugIns(false);
+    PluginLoader::GetInstance()->LoadAllPlugIns(false);
     auto plugins = PluginHandler::getInstance()->getInstalled();
     for (const auto& p : plugins) {
       if (p.version == "0.0") continue;
@@ -210,7 +210,7 @@ public:
   void uninstall_plugin(const std::string& plugin) {
     using namespace std;
     g_BasePlatform->GetSharedDataDir();  // See #2619
-    PluginLoader::getInstance()->LoadAllPlugIns(false);
+    PluginLoader::GetInstance()->LoadAllPlugIns(false);
     auto plugins = PluginHandler::getInstance()->getInstalled();
     vector<PluginMetadata> found;
     copy_if(plugins.begin(), plugins.end(), back_inserter(found),
@@ -284,7 +284,7 @@ public:
   }
 
   bool load_plugin(const std::string& plugin) {
-    auto loader = PluginLoader::getInstance();
+    auto loader = PluginLoader::GetInstance();
     wxImage::AddHandler(new wxPNGHandler());
     g_BasePlatform->GetSharedDataDir();  // See #2619
     wxDEFINE_EVENT(EVT_FILE_NOTFOUND, wxCommandEvent);

--- a/gui/src/download_mgr.cpp
+++ b/gui/src/download_mgr.cpp
@@ -202,7 +202,7 @@ public:
   InstallButton(wxWindow* parent, PluginMetadata metadata)
       : wxPanel(parent), m_metadata(metadata), m_remove(false) {
     PlugInContainer* found = PlugInByName(
-        metadata.name, PluginLoader::getInstance()->GetPlugInArray());
+        metadata.name, PluginLoader::GetInstance()->GetPlugInArray());
     std::string label(_("Install"));
     if (found) {
       label = getUpdateLabel(found, metadata);
@@ -231,7 +231,7 @@ public:
     if (!cacheResult) {
       auto downloader = new GuiDownloader(this, m_metadata);
       downloader->run(this, m_remove);
-      auto loader = PluginLoader::getInstance();
+      auto loader = PluginLoader::GetInstance();
       auto pic = PlugInByName(m_metadata.name, loader->GetPlugInArray());
       if (!pic) {
         wxLogMessage("Installation of %s failed", m_metadata.name.c_str());

--- a/gui/src/load_errors_dlg.cpp
+++ b/gui/src/load_errors_dlg.cpp
@@ -152,7 +152,7 @@ static void Run(wxWindow* parent, const std::vector<LoadError>& errors) {
 }
 
 LoadErrorsDlgCtrl::LoadErrorsDlgCtrl(wxWindow* parent) : m_parent(parent) {
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
 
   load_complete_listener.Listen(loader->evt_plugin_loadall_finalize, this,
                                 EVT_LOAD_COMPLETE);

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -728,7 +728,7 @@ void SetSystemColors(ColorScheme cs);
 
 static bool LoadAllPlugIns(bool load_enabled) {
   g_Platform->ShowBusySpinner();
-  bool b = PluginLoader::getInstance()->LoadAllPlugIns(load_enabled);
+  bool b = PluginLoader::GetInstance()->LoadAllPlugIns(load_enabled);
   g_Platform->HideBusySpinner();
   return b;
 }
@@ -1547,7 +1547,7 @@ bool MyApp::OnInit() {
   auto style = g_StyleManager->GetCurrentStyle();
   auto bitmap = new wxBitmap(style->GetIcon("default_pi", 32, 32));
   if (bitmap->IsOk())
-    PluginLoader::getInstance()->SetPluginDefaultIcon(bitmap);
+    PluginLoader::GetInstance()->SetPluginDefaultIcon(bitmap);
   else
     wxLogWarning("Cannot initiate plugin default jigsaw icon.");
 

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -381,7 +381,7 @@ void SetSystemColors(ColorScheme cs);
 
 static bool LoadAllPlugIns(bool load_enabled) {
   AbstractPlatform::ShowBusySpinner();
-  bool b = PluginLoader::getInstance()->LoadAllPlugIns(load_enabled);
+  bool b = PluginLoader::GetInstance()->LoadAllPlugIns(load_enabled);
   AbstractPlatform::HideBusySpinner();
   return b;
 }
@@ -1771,7 +1771,7 @@ void MyFrame::OnCloseWindow(wxCloseEvent &event) {
   pConfig->UpdateSettings();
 
   //    Deactivate the PlugIns
-  auto plugin_loader = PluginLoader::getInstance();
+  auto plugin_loader = PluginLoader::GetInstance();
   if (plugin_loader) {
     plugin_loader->DeactivateAllPlugIns();
   }
@@ -1858,8 +1858,8 @@ void MyFrame::OnCloseWindow(wxCloseEvent &event) {
 
   if (ChartData) ChartData->PurgeCachePlugins();
 
-  if (PluginLoader::getInstance())
-    PluginLoader::getInstance()->UnLoadAllPlugIns();
+  if (PluginLoader::GetInstance())
+    PluginLoader::GetInstance()->UnLoadAllPlugIns();
 
   if (g_pi_manager) {
     delete g_pi_manager;
@@ -4753,7 +4753,7 @@ void MyFrame::OnInitTimer(wxTimerEvent &event) {
       if (m_initializing) break;
       m_initializing = true;
       AbstractPlatform::ShowBusySpinner();
-      PluginLoader::getInstance()->LoadAllPlugIns(true);
+      PluginLoader::GetInstance()->LoadAllPlugIns(true);
       AbstractPlatform::HideBusySpinner();
       //            RequestNewToolbars();
       RequestNewMasterToolbar();
@@ -5814,7 +5814,7 @@ void MyFrame::OnFrameTimer1(wxTimerEvent &event) {
   //    refresh thus, ensuring at least 1 Hz. callback.
   bool brq_dynamic = false;
   if (g_pi_manager) {
-    auto *pplugin_array = PluginLoader::getInstance()->GetPlugInArray();
+    auto *pplugin_array = PluginLoader::GetInstance()->GetPlugInArray();
     for (unsigned int i = 0; i < pplugin_array->GetCount(); i++) {
       PlugInContainer *pic = pplugin_array->Item(i);
       if (pic->m_enabled && pic->m_init_state) {
@@ -5938,7 +5938,7 @@ void MyFrame::OnFrameTimer1(wxTimerEvent &event) {
 
 double MyFrame::GetMag(double a, double lat, double lon) {
   double Variance = std::isnan(gVar) ? g_UserVar : gVar;
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
   if (loader && loader->IsPlugInAvailable(_T("WMM"))) {
     // Request variation at a specific lat/lon
 
@@ -7854,8 +7854,8 @@ void ApplyLocale() {
   //  Compliant Plugins will reload their locale message catalog during the
   //  Init() method. So it is sufficient to simply deactivate, and then
   //  re-activate, all "active" plugins.
-  PluginLoader::getInstance()->DeactivateAllPlugIns();
-  PluginLoader::getInstance()->UpdatePlugIns();
+  PluginLoader::GetInstance()->DeactivateAllPlugIns();
+  PluginLoader::GetInstance()->UpdatePlugIns();
 
   //         // Make sure the perspective saved in the config file is
   //         "reasonable"

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -691,7 +691,7 @@ void OCPNChartDirPanel::OnPaint(wxPaintEvent& event) {
 
 static bool LoadAllPlugIns(bool load_enabled) {
   g_Platform->ShowBusySpinner();
-  bool b = PluginLoader::getInstance()->LoadAllPlugIns(load_enabled);
+  bool b = PluginLoader::GetInstance()->LoadAllPlugIns(load_enabled);
   g_Platform->HideBusySpinner();
   return b;
 }
@@ -1519,7 +1519,7 @@ options::options(wxWindow* parent, wxWindowID id, const wxString& caption,
   GlobalVar<wxString> compat_os(&g_compatOS);
   compat_os_listener.Listen(compat_os, this, EVT_COMPAT_OS_CHANGE);
   Bind(EVT_COMPAT_OS_CHANGE, [&](wxCommandEvent&) {
-    PluginLoader::getInstance()->LoadAllPlugIns(false);
+    PluginLoader::GetInstance()->LoadAllPlugIns(false);
     m_pPlugInCtrl->ReloadPluginPanels();
   });
   auto action = [&](wxCommandEvent& evt) {
@@ -1664,7 +1664,7 @@ void options::Init(void) {
   m_pagePlugins = -1;
   m_pageConnections = -1;
 
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
   b_haveWMM = loader && loader->IsPlugInAvailable(_T("WMM"));
   b_oldhaveWMM = b_haveWMM;
 
@@ -6031,7 +6031,7 @@ void options::SetInitialSettings(void) {
   m_font_element_array.Clear();
 
   b_oldhaveWMM = b_haveWMM;
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
   b_haveWMM = loader && loader->IsPlugInAvailable(_T("WMM"));
 
   // Canvas configuration
@@ -7119,7 +7119,7 @@ void options::ApplyChanges(wxCommandEvent& event) {
   g_bShowTrue = pCBTrueShow->GetValue();
   g_bShowMag = pCBMagShow->GetValue();
 
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
   b_haveWMM = loader && loader->IsPlugInAvailable(_T("WMM"));
   if (!b_haveWMM && !b_oldhaveWMM) {
     pMagVar->GetValue().ToDouble(&g_UserVar);
@@ -7520,7 +7520,7 @@ void options::ApplyChanges(wxCommandEvent& event) {
   // PlugIn Manager Panel
 
   // Pick up any changes to selections
-  if (PluginLoader::getInstance()->UpdatePlugIns())
+  if (PluginLoader::GetInstance()->UpdatePlugIns())
     m_returnChanges |= TOOLBAR_CHANGED;
 
   // And keep config in sync
@@ -8429,7 +8429,7 @@ void options::DoOnPageChange(size_t page) {
   } else if (m_pagePlugins == i) {  // 7 is the index of "Plugins" page
     // load the disabled plugins finally because the user might want to enable
     // them
-    auto loader = PluginLoader::getInstance();
+    auto loader = PluginLoader::GetInstance();
     if (LoadAllPlugIns(false)) {
       delete m_pPlugInCtrl;
       m_pPlugInCtrl = NULL;

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -488,20 +488,20 @@ static std::vector<PluginMetadata> getUpdates(const char* name) {
 /** Remove plugin and update GUI elements. */
 static void gui_uninstall(const PlugInData* pic, const char* plugin) {
   g_Platform->ShowBusySpinner();
-  PluginLoader::getInstance()->DeactivatePlugIn(*pic);
-  PluginLoader::getInstance()->SetEnabled(pic->m_common_name, false);
-  PluginLoader::getInstance()->UpdatePlugIns();
+  PluginLoader::GetInstance()->DeactivatePlugIn(*pic);
+  PluginLoader::GetInstance()->SetEnabled(pic->m_common_name, false);
+  PluginLoader::GetInstance()->UpdatePlugIns();
 
   wxLogMessage("Uninstalling %s", plugin);
   PluginHandler::getInstance()->uninstall(plugin);
-  PluginLoader::getInstance()->UpdatePlugIns();
+  PluginLoader::GetInstance()->UpdatePlugIns();
   g_Platform->HideBusySpinner();
 }
 
 static bool LoadAllPlugIns(bool load_enabled, bool keep_orphans = false) {
   g_Platform->ShowBusySpinner();
   bool b =
-      PluginLoader::getInstance()->LoadAllPlugIns(load_enabled, keep_orphans);
+      PluginLoader::GetInstance()->LoadAllPlugIns(load_enabled, keep_orphans);
   g_Platform->HideBusySpinner();
   return b;
 }
@@ -509,7 +509,7 @@ static bool LoadAllPlugIns(bool load_enabled, bool keep_orphans = false) {
 /** Unload and uninstall plugin with given name. */
 static void UninstallPlugin(const std::string& name) {
   auto handler = PluginHandler::getInstance();
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
   auto finder = [name](const PluginMetadata pm) { return pm.name == name; };
   const auto& installed = handler->getInstalled();
   auto found = std::find_if(installed.begin(), installed.end(), finder);
@@ -612,7 +612,7 @@ static void run_update_dialog(PluginListPanel* parent, const PlugInData* pic,
           // Undocumented debug hook
           continue;
         }
-        auto loader = PluginLoader::getInstance();
+        auto loader = PluginLoader::GetInstance();
         if (!loader->CheckPluginCompatibility(str)) {
           wxString msg =
               _("The plugin is not compatible with this version of OpenCPN, "
@@ -730,7 +730,7 @@ void pluginUtilHandler::OnPluginUtilAction(wxCommandEvent& event) {
   // Perform the indicated action according to the verb...
   switch (panel->GetAction()) {
     case ActionVerb::UPGRADE_TO_MANAGED_VERSION: {
-      auto loader = PluginLoader::getInstance();
+      auto loader = PluginLoader::GetInstance();
 
       // capture the plugin name
       std::string pluginName = actionPIC->m_managed_metadata.name;
@@ -782,7 +782,7 @@ void pluginUtilHandler::OnPluginUtilAction(wxCommandEvent& event) {
     }
 
     case ActionVerb::UNINSTALL_MANAGED_VERSION: {
-      PluginLoader::getInstance()->DeactivatePlugIn(*actionPIC);
+      PluginLoader::GetInstance()->DeactivatePlugIn(*actionPIC);
 
       // Capture the confirmation dialog contents before the plugin goes away
       wxString message;
@@ -797,7 +797,7 @@ void pluginUtilHandler::OnPluginUtilAction(wxCommandEvent& event) {
           actionPIC->m_managed_metadata.name);
 
       //  Reload all plugins, which will bring in the action results.
-      auto loader = PluginLoader::getInstance();
+      auto loader = PluginLoader::GetInstance();
       LoadAllPlugIns(false);
       plugin_list_panel->ReloadPluginPanels();
 
@@ -1038,7 +1038,7 @@ wxDEFINE_EVENT(EVT_UPDATE_CHART_TYPES, wxCommandEvent);
 wxDEFINE_EVENT(EVT_PLUGIN_LOADALL_FINALIZE, wxCommandEvent);
 
 void PlugInManager::HandlePluginLoaderEvents() {
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
 
   evt_blacklisted_plugin_listener.Listen(loader->evt_blacklisted_plugin, this,
                                          EVT_BLACKLISTED_PLUGIN);
@@ -1100,7 +1100,7 @@ wxDEFINE_EVENT(EVT_DOWNLOAD_FAILED, wxCommandEvent);
 wxDEFINE_EVENT(EVT_DOWNLOAD_OK, wxCommandEvent);
 
 void PlugInManager::HandlePluginHandlerEvents() {
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
 
   evt_download_failed_listener.Listen(loader->evt_update_chart_types, this,
                                       EVT_DOWNLOAD_FAILED);
@@ -1123,7 +1123,7 @@ void PlugInManager::HandlePluginHandlerEvents() {
 bool PlugInManager::CallLateInit(void) {
   bool bret = true;
 
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = (*plugin_array)[i];
 
@@ -1187,7 +1187,7 @@ void PlugInManager::OnPluginDeactivate(const PlugInContainer* pic) {
 bool PlugInManager::IsAnyPlugInChartEnabled() {
   //  Is there a PlugIn installed and active that implements PlugIn Chart
   //  type(s)?
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = (*plugin_array)[i];
     if (pic->m_enabled && pic->m_init_state) {
@@ -1200,8 +1200,8 @@ bool PlugInManager::IsAnyPlugInChartEnabled() {
 }
 
 void PlugInManager::UpdateManagedPlugins() {
-  PluginLoader::getInstance()->UpdateManagedPlugins(false);
-  PluginLoader::getInstance()->SortPlugins(ComparePlugins);
+  PluginLoader::GetInstance()->UpdateManagedPlugins(false);
+  PluginLoader::GetInstance()->SortPlugins(ComparePlugins);
 
   if (m_listPanel) m_listPanel->ReloadPluginPanels();
   g_options->itemBoxSizerPanelPlugins->Layout();
@@ -1211,7 +1211,7 @@ bool PlugInManager::UpDateChartDataTypes() {
   bool bret = false;
   if (NULL == ChartData) return bret;
 
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
 
@@ -1260,7 +1260,7 @@ void PlugInManager::SetPluginOrder(wxString serialized_names) {
 
 wxString PlugInManager::GetPluginOrder() {
   wxString plugins = wxEmptyString;
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     plugins.Append(plugin_array->Item(i)->m_common_name);
     if (i < plugin_array->GetCount() - 1) plugins.Append(';');
@@ -1272,7 +1272,7 @@ bool PlugInManager::UpdateConfig() {
   //    pConfig->SetPath( _T("/PlugIns/") );
   //    pConfig->Write( _T("PluginOrder"), GetPluginOrder() );
 
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
 
@@ -1327,7 +1327,7 @@ bool PlugInManager::RenderAllCanvasOverlayPlugIns(ocpnDC& dc,
                                                   const ViewPort& vp,
                                                   int canvasIndex,
                                                   int priority) {
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state) {
@@ -1502,7 +1502,7 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns(wxGLContext* pcontext,
                                                     const ViewPort& vp,
                                                     int canvasIndex,
                                                     int priority) {
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state) {
@@ -1575,7 +1575,7 @@ bool PlugInManager::RenderAllGLCanvasOverlayPlugIns(wxGLContext* pcontext,
 }
 
 void PlugInManager::SendViewPortToRequestingPlugIns(ViewPort& vp) {
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state) {
@@ -1588,11 +1588,11 @@ void PlugInManager::SendViewPortToRequestingPlugIns(ViewPort& vp) {
 }
 
 void NotifySetupOptionsPlugin(const PlugInData* pd) {
-  PluginLoader::getInstance()->NotifySetupOptionsPlugin(pd);
+  PluginLoader::GetInstance()->NotifySetupOptionsPlugin(pd);
 }
 
 void PlugInManager::NotifySetupOptions() {
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     NotifySetupOptionsPlugin(pic);
@@ -1604,7 +1604,7 @@ void PlugInManager::ClosePlugInPanel(const PlugInContainer* pic,
   if (pic->m_enabled && pic->m_init_state) {
     if ((pic->m_cap_flag & INSTALLS_TOOLBOX_PAGE) && pic->m_toolbox_panel) {
       pic->m_pplugin->OnCloseToolboxPanel(0, ok_apply_cancel);
-      auto loader = PluginLoader::getInstance();
+      auto loader = PluginLoader::GetInstance();
       loader->SetToolboxPanel(pic->m_common_name, false);
       loader->SetSetupOptions(pic->m_common_name, false);
     }
@@ -1612,7 +1612,7 @@ void PlugInManager::ClosePlugInPanel(const PlugInContainer* pic,
 }
 
 void PlugInManager::CloseAllPlugInPanels(int ok_apply_cancel) {
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic) {
@@ -1680,7 +1680,7 @@ void PlugInManager::SetCanvasContextMenuItemGrey(int item, bool grey,
 }
 
 void PlugInManager::SendResizeEventToAllPlugIns(int x, int y) {
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state)
@@ -1689,7 +1689,7 @@ void PlugInManager::SendResizeEventToAllPlugIns(int x, int y) {
 }
 
 void PlugInManager::SetColorSchemeForAllPlugIns(ColorScheme cs) {
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state)
@@ -1701,7 +1701,7 @@ void PlugInManager::PrepareAllPluginContextMenus() {
   int canvasIndex = gFrame->GetCanvasIndexUnderMouse();
   if (canvasIndex < 0) return;
 
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state) {
@@ -1816,7 +1816,7 @@ void PlugInManager::SendS52ConfigToAllPlugIns(bool bReconfig) {
 }
 
 void PlugInManager::NotifyAuiPlugIns(void) {
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state &&
@@ -2031,7 +2031,7 @@ opencpn_plugin* PlugInManager::FindToolOwner(const int id) {
 wxString PlugInManager::GetToolOwnerCommonName(const int id) {
   opencpn_plugin* ppi = FindToolOwner(id);
   if (ppi) {
-    auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+    auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
     for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
       PlugInContainer* pic = plugin_array->Item(i);
       if (pic && (pic->m_pplugin == ppi)) return pic->m_common_name;
@@ -2089,7 +2089,7 @@ wxBitmap* PlugInManager::BuildDimmedToolBitmap(wxBitmap* pbmp_normal,
 
 wxArrayString PlugInManager::GetPlugInChartClassNameArray(void) {
   wxArrayString array;
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic && pic->m_enabled && pic->m_init_state &&
@@ -2487,7 +2487,7 @@ void PluginListPanel::SelectByName(wxString& name) {
 /** Return sorted list of all  installed  plugins. */
 std::vector<const PlugInData*> GetInstalled() {
   std::vector<const PlugInData*> result;
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
   for (size_t i = 0; i < loader->GetPlugInArray()->GetCount(); i++) {
     auto const item = loader->GetPlugInArray()->Item(i);
     if (item->m_managed_metadata.name.empty()) {
@@ -2515,7 +2515,7 @@ static bool IsPluginLoaded(const std::string& name) {
         std::find(installed.begin(), installed.end(), ocpn::tolower(name));
     return found != installed.end();
   } else {
-    auto loaded = PluginLoader::getInstance()->GetPlugInArray();
+    auto loaded = PluginLoader::GetInstance()->GetPlugInArray();
     for (size_t i = 0; i < loaded->GetCount(); i++) {
       if (loaded->Item(i)->m_common_name.ToStdString() == name) return true;
     }
@@ -2530,7 +2530,7 @@ void PluginListPanel::ReloadPluginPanels() {
     return;
   }
 
-  auto plugins = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugins = PluginLoader::GetInstance()->GetPlugInArray();
   m_PluginItems.Clear();
 
   wxWindowList kids = GetChildren();
@@ -3306,12 +3306,12 @@ void PluginPanel::OnPluginPreferences(wxCommandEvent& event) {
       (m_plugin.m_cap_flag & WANTS_PREFERENCES)) {
 #ifdef __ANDROID__
     androidDisableRotation();
-    PluginLoader::getInstance()->ShowPreferencesDialog(m_plugin,
+    PluginLoader::GetInstance()->ShowPreferencesDialog(m_plugin,
                                                        GetGrandParent());
     // GrandParent will be the entire list panel, not the plugin panel.
     // Ensures better centering on small screens
 #else
-    PluginLoader::getInstance()->ShowPreferencesDialog(m_plugin, this);
+    PluginLoader::GetInstance()->ShowPreferencesDialog(m_plugin, this);
 #endif
   }
 }
@@ -3323,7 +3323,7 @@ void PluginPanel::OnPluginEnableToggle(wxCommandEvent& event) {
   if (m_plugin.m_status == PluginStatus::System) {
     // Force pluginmanager to reload all panels. Not kosher --
     // the EventVar should really only be notified from within PluginLoader.
-    PluginLoader::getInstance()->evt_pluglist_change.Notify();
+    PluginLoader::GetInstance()->evt_pluglist_change.Notify();
   }
 }
 
@@ -3355,8 +3355,8 @@ static void SetWindowFontStyle(wxWindow* window, wxFontStyle style) {
 
 void PluginPanel::SetEnabled(bool enabled) {
   if (m_is_safe_panel) return;
-  PluginLoader::getInstance()->SetEnabled(m_plugin.m_common_name, enabled);
-  PluginLoader::getInstance()->UpdatePlugIns();
+  PluginLoader::GetInstance()->SetEnabled(m_plugin.m_common_name, enabled);
+  PluginLoader::GetInstance()->UpdatePlugIns();
   NotifySetupOptionsPlugin(&m_plugin);
   if (!enabled && !m_bSelected) {
     SetWindowFontStyle(m_pName, wxFONTSTYLE_ITALIC);
@@ -4278,7 +4278,7 @@ wxString GetWritableDocumentsDir(void) {
 
 wxString GetPlugInPath(opencpn_plugin* pplugin) {
   wxString ret_val;
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
   for (unsigned int i = 0; i < loader->GetPlugInArray()->GetCount(); i++) {
     PlugInContainer* pic = loader->GetPlugInArray()->Item(i);
     if (pic->m_pplugin == pplugin) {

--- a/gui/src/routemanagerdialog.cpp
+++ b/gui/src/routemanagerdialog.cpp
@@ -2619,7 +2619,7 @@ void RouteManagerDialog::OnWptNewClick(wxCommandEvent &event) {
   pConfig->AddNewWayPoint(pWP, -1);  // use auto next num
   gFrame->RefreshAllCanvas();
 
-  // g_pMarkInfoDialog = MarkInfoImpl::getInstance( GetParent() );
+  // g_pMarkInfoDialog = MarkInfoImpl::GetInstance( GetParent() );
   // There is on global instance of the MarkProp Dialog
   if (!g_pMarkInfoDialog) g_pMarkInfoDialog = new MarkInfoDlg(GetParent());
 

--- a/gui/src/update_mgr.cpp
+++ b/gui/src/update_mgr.cpp
@@ -202,7 +202,7 @@ class InstallButton : public wxPanel {
 public:
   InstallButton(wxWindow* parent, PluginMetadata metadata)
       : wxPanel(parent), m_metadata(metadata), m_remove(false) {
-    auto loader = PluginLoader::getInstance();
+    auto loader = PluginLoader::GetInstance();
     PlugInContainer* found =
         PlugInByName(metadata.name, loader->GetPlugInArray());
     std::string label(_("Install"));

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -5158,6 +5158,8 @@ class DECL_EXP PlugIn_Route_Ex {
 public:
   PlugIn_Route_Ex(void);
   ~PlugIn_Route_Ex(void);
+  PlugIn_Route_Ex(const PlugIn_Route_Ex&) = default;
+  PlugIn_Route_Ex& operator=(PlugIn_Route_Ex&) = default;
 
   wxString m_NameString;   //!< User-visible name of the route
   wxString m_StartString;  //!< Description of route start point

--- a/model/include/model/plugin_loader.h
+++ b/model/include/model/plugin_loader.h
@@ -156,6 +156,12 @@ class PluginLoader {
 public:
   static PluginLoader* getInstance();
   virtual ~PluginLoader() = default;
+
+  /**
+   * Mark a library file (complete path) as loadable i. e., remove possible
+   * stamp
+   */
+  static void MarkAsLoadable(const std::string& library_path);
   /**
    *  Update PlugInContainer status using data from PluginMetadata and manifest.
    */

--- a/model/include/model/plugin_loader.h
+++ b/model/include/model/plugin_loader.h
@@ -1,13 +1,6 @@
-/***************************************************************************
- *
- *
- * Project:  OpenCPN
- * Purpose:  PlugIn Manager Object
- * Author:   David Register
- *
- ***************************************************************************
- *   Copyright (C) 2010-2023 by David S. Register                          *
- *   Copyright (C) 2023 Alec Leamas
+/**************************************************************************
+ *   Copyright (C) 2010 - 2023 by David S. Register                        *
+ *   Copyright (C) 2023 - 2025  Alec Leamas                                *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -24,6 +17,11 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
+
+/**
+ * \file
+ * Low level code to load plugins from disk, notably the PluginLoader class
+ */
 
 #ifndef PLUGIN_LOADER_H_GUARD
 #define PLUGIN_LOADER_H_GUARD
@@ -59,7 +57,6 @@ enum class PluginStatus {
 };
 
 class PlugInContainer;  // forward
-class PlugInData;       // forward
 
 /** Basic data for a loaded plugin, trivially copyable */
 class PlugInData {
@@ -108,6 +105,7 @@ public:
   destroy_t* m_destroy_fn;
 };
 
+/** Error condition when loading a plugin. */
 class LoadError {
 public:
   enum class Type {
@@ -139,7 +137,7 @@ WX_DEFINE_ARRAY_PTR(PlugInContainer*, ArrayOfPlugIns);
  *
  * The general usage pattern to process events, here using EVT_LOAD_PLUGIN:
  *
- *   PluginLoader::getInstance()->evt_load_plugin.listen(this, EVT_LOAD_PLUGIN)
+ *   PluginLoader::GetInstance()->evt_load_plugin.listen(this, EVT_LOAD_PLUGIN)
  *   Bind(EVT_LOAD_PLUGIN, [&](ObservedEvt ev) {
  *          code to run on event...
  *   });
@@ -150,11 +148,11 @@ WX_DEFINE_ARRAY_PTR(PlugInContainer*, ArrayOfPlugIns);
  * function. There is a also a generic std::shared_ptr available as using
  * GetSharedPtr();
  *
- * Examples: PlugInManager::PlugInManager() in pluginmanager.cpp
+ * See: PlugInManager::PlugInManager() in pluginmanager.cpp
  */
 class PluginLoader {
 public:
-  static PluginLoader* getInstance();
+  static PluginLoader* GetInstance();
   virtual ~PluginLoader() = default;
 
   /**
@@ -184,10 +182,12 @@ public:
   EventVar evt_unreadable_plugin;
 
   /**
-   *  Carries a malloc'ed read-only copy of a PlugInContainer owned by listener.
+   *  Carries a malloc'ed read-only copy of a PlugInContainer owned: by
+   * listener.
    */
   EventVar evt_deactivate_plugin;
 
+  /** Notified without data after all plugins loaded ot updated. */
   EventVar evt_update_chart_types;
 
   /**
@@ -196,6 +196,7 @@ public:
    */
   EventVar evt_plugin_loadall_finalize;
 
+  /** FIXME (leamas) not notified. */
   EventVar evt_version_incompatible_plugin;
 
   /**

--- a/model/src/ocpn_plugin.cpp
+++ b/model/src/ocpn_plugin.cpp
@@ -67,7 +67,7 @@ static wxBitmap* LoadSVG(const wxString filename, unsigned int width,
 
 
 wxBitmap* opencpn_plugin::GetPlugInBitmap() {
-  auto bitmap =  PluginLoader::getInstance()->GetPluginDefaultIcon();
+  auto bitmap =  PluginLoader::GetInstance()->GetPluginDefaultIcon();
   return const_cast<wxBitmap*>(bitmap);
 }
 

--- a/model/src/plugin_comm.cpp
+++ b/model/src/plugin_comm.cpp
@@ -105,7 +105,7 @@ void SendMessageToAllPlugins(const wxString& message_id,
   LogMessage(msg);
   // LogMessage(std::string("internal ALL ") + msg->to_string());  FIXME/leamas
 
-  for (auto pic : *PluginLoader::getInstance()->GetPlugInArray()) {
+  for (auto pic : *PluginLoader::GetInstance()->GetPlugInArray()) {
     if (pic->m_enabled && pic->m_init_state) {
       if (pic->m_cap_flag & WANTS_PLUGIN_MESSAGING) {
         switch (pic->m_api_version) {
@@ -158,7 +158,7 @@ void SendJSONMessageToAllPlugins(const wxString& message_id, wxJSONValue v) {
 void SendAISSentenceToAllPlugIns(const wxString& sentence) {
   // decouple 'const wxString &' to keep interface.
   wxString decouple_sentence(sentence);
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state) {
@@ -182,7 +182,7 @@ void SendPositionFixToAllPlugIns(GenericPosDatEx* ppos) {
   pfix.FixTime = ppos->FixTime;
   pfix.nSats = ppos->nSats;
 
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state) {
@@ -242,7 +242,7 @@ void SendActiveLegInfoToAllPlugIns(const ActiveLegDat* leg_info) {
   leg.wp_name = leg_info->wp_name;
   leg.Xte = leg_info->Xte;
   leg.arrival = leg_info->arrival;
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state) {
@@ -275,7 +275,7 @@ void SendActiveLegInfoToAllPlugIns(const ActiveLegDat* leg_info) {
 
 bool SendMouseEventToPlugins(wxMouseEvent& event) {
   bool bret = false;
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state) {
@@ -304,7 +304,7 @@ bool SendMouseEventToPlugins(wxMouseEvent& event) {
 
 bool SendKeyEventToPlugins(wxKeyEvent& event) {
   bool bret = false;
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state) {
@@ -334,7 +334,7 @@ bool SendKeyEventToPlugins(wxKeyEvent& event) {
 }
 
 void SendPreShutdownHookToPlugins() {
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state) {
@@ -354,7 +354,7 @@ void SendPreShutdownHookToPlugins() {
 }
 
 void SendCursorLatLonToAllPlugIns(double lat, double lon) {
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state) {
@@ -387,7 +387,7 @@ void SendNMEASentenceToAllPlugIns(const wxString& sentence) {
 #endif
   auto msg = std::make_shared<PluginMsg>("NMEA-msg", sentence.ToStdString());
   LogMessage(msg, "internal ALL nmea-msg ");
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state) {
@@ -418,7 +418,7 @@ void SendNMEASentenceToAllPlugIns(const wxString& sentence) {
 
 int GetJSONMessageTargetCount() {
   int rv = 0;
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = plugin_array->Item(i);
     if (pic->m_enabled && pic->m_init_state &&
@@ -434,7 +434,7 @@ void SendVectorChartObjectInfo(const wxString& chart, const wxString& feature,
   wxString decouple_chart(chart);
   wxString decouple_feature(feature);
   wxString decouple_objname(objname);
-  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  auto plugin_array = PluginLoader::GetInstance()->GetPlugInArray();
   for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
     PlugInContainer* pic = (*plugin_array)[i];
     if (pic->m_enabled && pic->m_init_state) {

--- a/model/src/plugin_handler.cpp
+++ b/model/src/plugin_handler.cpp
@@ -523,6 +523,7 @@ static bool win_entry_set_install_path(struct archive_entry* entry,
   using namespace std;
 
   string path = archive_entry_pathname(entry);
+  bool is_library = false;
 
   // Check # components, drop the single top-level path
   int slashes = count(path.begin(), path.end(), '/');
@@ -549,6 +550,7 @@ static bool win_entry_set_install_path(struct archive_entry* entry,
     slashpos = path.find_first_of('/');
     path = path.substr(slashpos + 1);
     path = installPaths["bin"] + "\\" + path;
+    is_library = true;
   } else if (ocpn::startswith(path, "share")) {
     // The "share" directory should be a direct sibling of "plugins" directory
     wxFileName fn(installPaths["share"].c_str(),
@@ -568,6 +570,7 @@ static bool win_entry_set_install_path(struct archive_entry* entry,
     return false;
   }
   wxString s(path);
+  if (is_library) PluginLoader::MarkAsLoadable(path);
   s.Replace("/", "\\");  // std::regex_replace FTBS on gcc 4.8.4
   s.Replace("\\\\", "\\");
   archive_entry_set_pathname(entry, s.c_str());
@@ -602,6 +605,11 @@ static bool flatpak_entry_set_install_path(struct archive_entry* entry,
   }
   string dest = installPaths[location] + "/" + suffix;
   archive_entry_set_pathname(entry, dest.c_str());
+
+  PluginPaths* paths = PluginPaths::getInstance();
+  if (dest.find(paths->UserLibdir()) != std::string::npos) {
+    PluginLoader::MarkAsLoadable(dest);
+  }
 
   return true;
 }
@@ -640,6 +648,7 @@ static bool linux_entry_set_install_path(struct archive_entry* entry,
     return false;
   }
 
+  bool is_library = false;
   string dest = installPaths[location] + "/" + suffix;
 
   if (g_bportable) {
@@ -655,12 +664,16 @@ static bool linux_entry_set_install_path(struct archive_entry* entry,
     if (ocpn::startswith(location, "lib") &&
         ocpn::startswith(suffix, "opencpn/")) {
       suffix = suffix.substr(8);
-
       dest = g_BasePlatform->GetPrivateDataDir().ToStdString() +
              "/plugins/lib/" + suffix;
+      is_library = true;
     }
   }
 
+  PluginPaths* paths = PluginPaths::getInstance();
+  if (is_library || dest.find(paths->UserLibdir()) != std::string::npos) {
+    PluginLoader::MarkAsLoadable(dest);
+  }
   archive_entry_set_pathname(entry, dest.c_str());
   return true;
 }
@@ -674,6 +687,7 @@ static bool apple_entry_set_install_path(struct archive_entry* entry,
 
   string path = archive_entry_pathname(entry);
   if (ocpn::startswith(path, "./")) path = path.substr(2);
+  bool is_library = false;
 
   string dest("");
   size_t slashes = count(path.begin(), path.end(), '/');
@@ -695,6 +709,7 @@ static bool apple_entry_set_install_path(struct archive_entry* entry,
     parts = split(path, "Contents/PlugIns");
     if (parts.size() >= 2) {
       dest = base + "/Contents/PlugIns" + parts[1];
+      is_library = true;
     }
   }
   if (dest == "" && archive_entry_filetype(entry) == AE_IFREG) {
@@ -704,6 +719,7 @@ static bool apple_entry_set_install_path(struct archive_entry* entry,
     return false;
   }
   archive_entry_set_pathname(entry, dest.c_str());
+  if (is_library) PluginLoader::MarkAsLoadable(dest);
   return true;
 }
 
@@ -711,6 +727,7 @@ static bool android_entry_set_install_path(struct archive_entry* entry,
                                            pathmap_t installPaths) {
   using namespace std;
 
+  bool is_library = false;
   string path = archive_entry_pathname(entry);
   int slashes = count(path.begin(), path.end(), '/');
   if (slashes < 2) {
@@ -745,6 +762,7 @@ static bool android_entry_set_install_path(struct archive_entry* entry,
   if ((location == "lib") && ocpn::startswith(suffix, "opencpn")) {
     auto parts = split(suffix, "/");
     if (parts.size() == 2) suffix = parts[1];
+    is_library = true;
   }
 
   if ((location == "share") && ocpn::startswith(suffix, "opencpn")) {
@@ -756,6 +774,7 @@ static bool android_entry_set_install_path(struct archive_entry* entry,
   string dest = installPaths[location] + "/" + suffix;
 
   archive_entry_set_pathname(entry, dest.c_str());
+  if (is_library) PluginLoader::MarkAsLoadable(dest);
   return true;
 }
 

--- a/model/src/plugin_handler.cpp
+++ b/model/src/plugin_handler.cpp
@@ -939,7 +939,7 @@ bool PluginHandler::isPluginWritable(std::string name) {
   if (isRegularFile(PluginHandler::fileListPath(name).c_str())) {
     return true;
   }
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
   return PlugInIxByName(name, loader->GetPlugInArray()) == -1;
 }
 
@@ -1159,7 +1159,7 @@ const std::vector<PluginMetadata> PluginHandler::getInstalled() {
   using namespace std;
   vector<PluginMetadata> plugins;
 
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
   for (unsigned int i = 0; i < loader->GetPlugInArray()->GetCount(); i += 1) {
     const PlugInContainer* p = loader->GetPlugInArray()->Item(i);
     PluginMetadata plugin;
@@ -1182,7 +1182,7 @@ const std::vector<PluginMetadata> PluginHandler::getInstalled() {
 }
 
 void PluginHandler::SetInstalledMetadata(const PluginMetadata& pm) {
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
   ssize_t ix = PlugInIxByName(pm.name, loader->GetPlugInArray());
   if (ix == -1) return;  // no such plugin
 
@@ -1269,7 +1269,7 @@ bool PluginHandler::ExtractMetadata(const std::string& path,
 
 bool PluginHandler::ClearInstallData(const std::string plugin_name) {
   auto ix = PlugInIxByName(plugin_name,
-                           PluginLoader::getInstance()->GetPlugInArray());
+                           PluginLoader::GetInstance()->GetPlugInArray());
   if (ix != -1) {
     MESSAGE_LOG << "Attempt to remove installation data for loaded plugin";
     return false;
@@ -1308,7 +1308,7 @@ bool PluginHandler::DoClearInstallData(const std::string plugin_name) {
 bool PluginHandler::uninstall(const std::string plugin_name) {
   using namespace std;
 
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
   auto ix = PlugInIxByName(plugin_name, loader->GetPlugInArray());
   if (ix < 0) {
     MESSAGE_LOG << "trying to uninstall non-existing plugin " << plugin_name;

--- a/model/src/plugin_loader.cpp
+++ b/model/src/plugin_loader.cpp
@@ -166,7 +166,7 @@ static fs::path LoadStampPath(const std::string& file_path) {
   fs::path path(g_BasePlatform->DefaultPrivateDataDir().ToStdString());
   path = path / "load_stamps";
   if (!ocpn::exists(path.string())) {
-    mkdir(path.c_str(), 0755);
+    ocpn::mkdir(path.string());
   }
   path /= file_path;
   return path.parent_path() / path.stem();
@@ -177,16 +177,20 @@ static void CreateLoadStamp(const std::string& filename) {
 }
 
 static bool HasLoadStamp(const std::string& filename) {
-  return ocpn::exists(LoadStampPath(filename).c_str());
+  return exists(LoadStampPath(filename));
 }
 
 static void ClearLoadStamp(const std::string& filename) {
   auto path = LoadStampPath(filename);
-  if (ocpn::exists(path.string())) {
-    if (std::remove(path.c_str()) != 0) {
+  if (exists(path)) {
+    if (!remove(path)) {
       MESSAGE_LOG << " Cannot remove load stamp file: " << path;
     }
   }
+}
+
+void PluginLoader::MarkAsLoadable(const std::string& library_path) {
+  ClearLoadStamp(library_path);
 }
 
 std::string PluginLoader::GetPluginVersion(

--- a/model/src/plugin_loader.cpp
+++ b/model/src/plugin_loader.cpp
@@ -37,6 +37,17 @@
 #include <gelf.h>
 #endif
 
+#if (defined(OCPN_GHC_FILESYSTEM) || \
+     (defined(__clang_major__) && (__clang_major__ < 15)))
+#include <ghc/filesystem.hpp>
+namespace fs = ghc::filesystem;
+
+#else
+#include <filesystem>
+#include <utility>
+namespace fs = std::filesystem;
+#endif
+
 #if defined(__linux__) && !defined(__ANDROID__)
 #include <wordexp.h>
 #endif
@@ -149,6 +160,33 @@ static PluginMetadata CreateMetadata(const PlugInContainer* pic) {
   mdata.is_orphan = true;
 
   return mdata;
+}
+
+static fs::path LoadStampPath(const std::string& file_path) {
+  fs::path path(g_BasePlatform->DefaultPrivateDataDir().ToStdString());
+  path = path / "load_stamps";
+  if (!ocpn::exists(path.string())) {
+    mkdir(path.c_str(), 0755);
+  }
+  path /= file_path;
+  return path.parent_path() / path.stem();
+}
+
+static void CreateLoadStamp(const std::string& filename) {
+  std::ofstream(LoadStampPath(filename).string());
+}
+
+static bool HasLoadStamp(const std::string& filename) {
+  return ocpn::exists(LoadStampPath(filename).c_str());
+}
+
+static void ClearLoadStamp(const std::string& filename) {
+  auto path = LoadStampPath(filename);
+  if (ocpn::exists(path.string())) {
+    if (std::remove(path.c_str()) != 0) {
+      MESSAGE_LOG << " Cannot remove load stamp file: " << path;
+    }
+  }
 }
 
 std::string PluginLoader::GetPluginVersion(
@@ -454,6 +492,12 @@ bool PluginLoader::LoadPluginCandidate(const wxString& file_name,
                                        bool load_enabled) {
   wxString plugin_file = wxFileName(file_name).GetFullName();
   wxLogMessage("Checking plugin candidate: %s", file_name.mb_str().data());
+  if (HasLoadStamp(plugin_file.ToStdString())) {
+    MESSAGE_LOG << "Refusing to load " << file_name
+                << " failed at last attempt";
+    return false;
+  }
+  CreateLoadStamp(file_name.ToStdString());
   wxDateTime plugin_modification = wxFileName(file_name).GetModificationTime();
   wxLog::FlushActive();
 
@@ -645,6 +689,7 @@ bool PluginLoader::LoadPluginCandidate(const wxString& file_name,
   } else {  // pic == 0
     return false;
   }
+  ClearLoadStamp(file_name.ToStdString());
   return true;
 }
 

--- a/model/src/plugin_loader.cpp
+++ b/model/src/plugin_loader.cpp
@@ -1,4 +1,4 @@
- /**************************************************************************
+/**************************************************************************
  *   Copyright (C) 2010 by David S. Register                               *
  *   Copyright (C) 2022-2025 Alec Leamas                                   *
  *                                                                         *
@@ -19,9 +19,9 @@
  **************************************************************************/
 
 /**
-* \file
-* Implement config_loader.h
-*/
+ * \file
+ * Implement config_loader.h
+ */
 
 #include "config.h"
 
@@ -118,7 +118,7 @@ static bool IsSystemPluginName(const std::string& name) {
 static std::string GetInstalledVersion(const PlugInData& pd) {
   std::string path = PluginHandler::versionPath(pd.m_common_name.ToStdString());
   if (path == "" || !wxFileName::IsFileReadable(path)) {
-    auto loader = PluginLoader::getInstance();
+    auto loader = PluginLoader::GetInstance();
     auto pic = GetContainer(pd, *loader->GetPlugInArray());
     if (!pic || !pic->m_pplugin) {
       return SemanticVersion(0, 0, -1).to_string();
@@ -186,7 +186,7 @@ void PluginLoader::MarkAsLoadable(const std::string& library_path) {
 std::string PluginLoader::GetPluginVersion(
     const PlugInData pd,
     std::function<const PluginMetadata(const std::string&)> get_metadata) {
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
   auto pic = GetContainer(pd, *loader->GetPlugInArray());
   if (!pic) {
     return SemanticVersion(0, 0, -1).to_string();
@@ -324,7 +324,7 @@ static void ProcessLateInit(PlugInContainer* pic) {
   }
 }
 
-PluginLoader* PluginLoader::getInstance() {
+PluginLoader* PluginLoader::GetInstance() {
   static PluginLoader* instance = nullptr;
 
   if (!instance) instance = new PluginLoader();
@@ -351,7 +351,7 @@ bool PluginLoader::IsPlugInAvailable(const wxString& commonName) {
 
 void PluginLoader::ShowPreferencesDialog(const PlugInData& pd,
                                          wxWindow* parent) {
-  auto loader = PluginLoader::getInstance();
+  auto loader = PluginLoader::GetInstance();
   auto pic = GetContainer(pd, *loader->GetPlugInArray());
   if (pic) pic->m_pplugin->ShowPreferencesDialog(parent);
 }
@@ -378,7 +378,7 @@ void PluginLoader::NotifySetupOptionsPlugin(const PlugInData* pd) {
             auto ppi = dynamic_cast<opencpn_plugin_19*>(pic->m_pplugin);
             if (ppi) {
               ppi->OnSetupOptions();
-              auto loader = PluginLoader::getInstance();
+              auto loader = PluginLoader::GetInstance();
               loader->SetToolboxPanel(pic->m_common_name, true);
             }
             break;

--- a/model/src/plugin_loader.cpp
+++ b/model/src/plugin_loader.cpp
@@ -1,12 +1,6 @@
-/***************************************************************************
- *
- * Project:  OpenCPN
- * Purpose:  PlugIn Manager Object
- * Author:   David Register
- *
- ***************************************************************************
+ /**************************************************************************
  *   Copyright (C) 2010 by David S. Register                               *
- *   Copyright (C) 2022 Alec Leamas                                        *
+ *   Copyright (C) 2022-2025 Alec Leamas                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -24,6 +18,11 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 
+/**
+* \file
+* Implement config_loader.h
+*/
+
 #include "config.h"
 
 #include <algorithm>
@@ -35,17 +34,6 @@
 #include <elf.h>
 #include <libelf.h>
 #include <gelf.h>
-#endif
-
-#if (defined(OCPN_GHC_FILESYSTEM) || \
-     (defined(__clang_major__) && (__clang_major__ < 15)))
-#include <ghc/filesystem.hpp>
-namespace fs = ghc::filesystem;
-
-#else
-#include <filesystem>
-#include <utility>
-namespace fs = std::filesystem;
 #endif
 
 #if defined(__linux__) && !defined(__ANDROID__)
@@ -83,6 +71,7 @@ namespace fs = std::filesystem;
 #include "model/safe_mode.h"
 #include "model/semantic_vers.h"
 #include "observable_confvar.h"
+#include "std_filesystem.h"
 
 #ifdef __ANDROID__
 #include "androidUTIL.h"
@@ -100,8 +89,7 @@ static const std::vector<std::string> SYSTEM_PLUGINS = {
 /** Return complete PlugInContainer matching pic. */
 static PlugInContainer* GetContainer(const PlugInData& pd,
                                      const ArrayOfPlugIns& plugin_array) {
-  for (size_t i = 0; i < plugin_array.GetCount(); i++) {
-    const auto& p = plugin_array.Item(i);
+  for (const auto& p : plugin_array) {
     if (p->m_common_name == pd.m_common_name) return p;
   }
   return nullptr;
@@ -146,6 +134,7 @@ static std::string GetInstalledVersion(const PlugInData& pd) {
   return version;
 }
 
+/** Return metadata corresponding to a PlugInContainer. */
 static PluginMetadata CreateMetadata(const PlugInContainer* pic) {
   auto catalogHdlr = CatalogHandler::getInstance();
 
@@ -162,6 +151,7 @@ static PluginMetadata CreateMetadata(const PlugInContainer* pic) {
   return mdata;
 }
 
+/** Return path for loadstamp file created when loading. */
 static fs::path LoadStampPath(const std::string& file_path) {
   fs::path path(g_BasePlatform->DefaultPrivateDataDir().ToStdString());
   path = path / "load_stamps";


### PR DESCRIPTION
New shot on the implementation in ced2981c1. Use a loader stamp file which blocks further load attempts instead of removing files. Compared to the old approach:
  - This avoids pulling the rug out of under the installer
  - It should be faster, avoiding a full flush of the config file for each plugin load
  - It should behave better if there are multiple failing plugins for example after an opencpn ABI breaking update, current implementation will just work for one plugin at each opencnp restart.