### PR TITLE
Get rid of *_DYNAMIC_CLASS, wxDynamicCast, CLASSINFO et. al.

### DIFF
--- a/android/androidUTIL.cpp
+++ b/android/androidUTIL.cpp
@@ -1710,7 +1710,7 @@ JNIEXPORT int JNICALL Java_org_opencpn_OCPNNativeLib_getTLWCount(JNIEnv *env,
   wxWindowList::compatibility_iterator node = wxTopLevelWindows.GetFirst();
   while (node) {
     wxWindow *win = node->GetData();
-    if (win->IsShown() && !win->IsKindOf(CLASSINFO(CanvasOptions))) ret++;
+    if (win->IsShown() && !dynamic_cast<CanvasOptions>(win) ret++;
 
     node = node->GetNext();
   }

--- a/gui/include/gui/GoToPositionDialog.h
+++ b/gui/include/gui/GoToPositionDialog.h
@@ -54,7 +54,6 @@ class ChartCanvas;
  * GoToPositionDialog class declaration
  */
 class GoToPositionDialog : public wxDialog {
-  DECLARE_DYNAMIC_CLASS(GoToPositionDialog)
   DECLARE_EVENT_TABLE()
 
 public:

--- a/gui/include/gui/MarkInfo.h
+++ b/gui/include/gui/MarkInfo.h
@@ -146,8 +146,9 @@ WX_DECLARE_OBJARRAY(wxBitmap, ArrayOfBitmaps);
 class SaveDefaultsDialog;
 
 /**
- * Custom combobox for selecting waypoint icons. Extends wxOwnerDrawnComboBox to provide
- * a combobox with custom-drawn items, specifically for selecting waypoint icons.
+ * Custom combobox for selecting waypoint icons. Extends wxOwnerDrawnComboBox to
+ * provide a combobox with custom-drawn items, specifically for selecting
+ * waypoint icons.
  */
 class OCPNIconCombo : public wxOwnerDrawnComboBox {
 public:
@@ -382,7 +383,7 @@ public:
   void OnActivate(wxActivateEvent& event);
 
   wxSimpleHtmlListBox* GetSimpleBox() {
-    return wxDynamicCast(m_htmlList, wxSimpleHtmlListBox);
+    return dynamic_cast<wxSimpleHtmlListBox*>(m_htmlList);
   }
   void OnHtmlCellClicked(wxHtmlCellEvent& event);
 
@@ -391,7 +392,8 @@ public:
 
 /**
  * Dialog for saving default waypoint properties. Allows users to select
- * which properties of the current waypoint should be saved as defaults for future waypoints.
+ * which properties of the current waypoint should be saved as defaults for
+ * future waypoints.
  */
 class SaveDefaultsDialog : public wxDialog {
   friend class MarkInfoDlg;

--- a/gui/include/gui/MarkInfo.h
+++ b/gui/include/gui/MarkInfo.h
@@ -182,7 +182,6 @@ private:
 extern /*expdecl*/ const wxEventType EVT_LLCHANGE;
 
 class LatLonTextCtrl : public wxTextCtrl {
-  //    DECLARE_DYNAMIC_CLASS( LatLonTextCtrl )
   DECLARE_EVENT_TABLE()
 
 public:

--- a/gui/include/gui/OCPNRegion.h
+++ b/gui/include/gui/OCPNRegion.h
@@ -145,9 +145,6 @@ protected:
   //    virtual bool DoXor(const OCPNRegion& region);
 
 #endif
-
-private:
-  DECLARE_DYNAMIC_CLASS(OCPNRegion)
 };
 
 /**

--- a/gui/include/gui/SendToGpsDlg.h
+++ b/gui/include/gui/SendToGpsDlg.h
@@ -46,11 +46,11 @@ class Route;
 class RoutePoint;
 
 /**
- * Dialog for sending routes/waypoints to a GPS device. Allows users to send route and waypoint data to a connected GPS device.
- * It provides options to select the GPS device and displays a progress gauge during transfer.
+ * Dialog for sending routes/waypoints to a GPS device. Allows users to send
+ * route and waypoint data to a connected GPS device. It provides options to
+ * select the GPS device and displays a progress gauge during transfer.
  */
 class SendToGpsDlg : public wxDialog {
-  DECLARE_DYNAMIC_CLASS(SendToGpsDlg)
   DECLARE_EVENT_TABLE()
 
 public:

--- a/gui/include/gui/SendToPeerDlg.h
+++ b/gui/include/gui/SendToPeerDlg.h
@@ -65,11 +65,12 @@
 enum { ID_STP_CANCEL = 10000, ID_STP_OK, ID_STP_CHOICE_PEER, ID_STP_SCAN };
 
 /**
- * Dialog for sending navigation objects to peer devices. Enables sending routes, waypoints, and tracks to peer devices over a network.
- * It allows selecting the peer device and provides options for scanning for available peers.
+ * Dialog for sending navigation objects to peer devices. Enables sending
+ * routes, waypoints, and tracks to peer devices over a network. It allows
+ * selecting the peer device and provides options for scanning for available
+ * peers.
  */
 class SendToPeerDlg : public wxDialog {
-  DECLARE_DYNAMIC_CLASS(SendToPeerDlg)
   DECLARE_EVENT_TABLE()
 
 public:

--- a/gui/include/gui/TTYWindow.h
+++ b/gui/include/gui/TTYWindow.h
@@ -34,7 +34,6 @@ class TTYScroll;
 class WindowDestroyListener;
 
 class TTYWindow : public wxFrame {
-  DECLARE_DYNAMIC_CLASS(TTYWindow)
   DECLARE_EVENT_TABLE()
 
 public:

--- a/gui/include/gui/about.h
+++ b/gui/include/gui/about.h
@@ -46,11 +46,10 @@
 class wxHtmlWindow;
 
 /**
- * Represents the About dialog for OpenCPN. Implements a dialog that displays information about OpenCPN,
- * including version, authors, license, and tips.
+ * Represents the About dialog for OpenCPN. Implements a dialog that displays
+ * information about OpenCPN, including version, authors, license, and tips.
  */
 class about : public wxDialog {
-  DECLARE_DYNAMIC_CLASS(about)
   DECLARE_EVENT_TABLE()
 
 public:

--- a/gui/include/gui/ocpn_fontdlg.h
+++ b/gui/include/gui/ocpn_fontdlg.h
@@ -85,7 +85,6 @@ private:
 
   //  static bool fontDialogCancelled;
   wxDECLARE_EVENT_TABLE();
-  wxDECLARE_DYNAMIC_CLASS(ocpnGenericFontDialog);
 };
 
 #endif  // _OCPN_GENERIC_FONTDLGG_H

--- a/gui/include/gui/ocpn_pixel.h
+++ b/gui/include/gui/ocpn_pixel.h
@@ -286,9 +286,6 @@ protected:
 #ifdef __WXX11__
   bool CreateFromocpnXImage(ocpnXImage *poXI, int width, int height, int depth);
 #endif
-
-private:
-  DECLARE_DYNAMIC_CLASS(ocpnBitmap)
 };
 
 #endif  // ocpnUSE_ocpnBitmap
@@ -317,8 +314,6 @@ private:
 #ifdef ocpnUSE_DIBSECTION
   wxDIB *m_pselectedDIB;
 #endif
-
-  DECLARE_DYNAMIC_CLASS(ocpnMemDC)
 };
 
 #endif  // _OCPN_PIXEL_H_

--- a/gui/include/gui/rest_server_gui.h
+++ b/gui/include/gui/rest_server_gui.h
@@ -50,7 +50,6 @@
  * "Accept Object" Dialog Definition
  */
 class AcceptObjectDialog : public wxDialog {
-  DECLARE_DYNAMIC_CLASS(AcceptObjectDialog)
   DECLARE_EVENT_TABLE()
 
 public:
@@ -87,7 +86,6 @@ private:
 };
 
 class PINCreateDialog : public wxDialog {
-  DECLARE_DYNAMIC_CLASS(PINCreateDialog)
   DECLARE_EVENT_TABLE()
 
 public:

--- a/gui/include/gui/routeprintout.h
+++ b/gui/include/gui/routeprintout.h
@@ -83,7 +83,6 @@ protected:
 #define ID_ROUTEPRINT_SELECTION_CANCEL 9002
 
 class RoutePrintSelection : public wxDialog {
-  DECLARE_DYNAMIC_CLASS(RoutePrintSelection)
   DECLARE_EVENT_TABLE()
 
 public:

--- a/gui/include/gui/toolbar.h
+++ b/gui/include/gui/toolbar.h
@@ -97,7 +97,8 @@ class ToolTipWin;
 class ocpnToolBarTool;
 
 /**
- * Generic toolbar implementation in pure wxWidgets adapted from wxToolBarSimple (deprecated).
+ * Generic toolbar implementation in pure wxWidgets adapted from wxToolBarSimple
+ * (deprecated).
  */
 class ocpnToolBarSimple : public wxEvtHandler {
 public:
@@ -556,7 +557,6 @@ public:
   wxCAPTION | wxRESIZE_BORDER | wxSYSTEM_MENU | wxCLOSE_BOX
 
 class ToolbarChoicesDialog : public wxDialog {
-  DECLARE_DYNAMIC_CLASS(ToolbarChoicesDialog)
   DECLARE_EVENT_TABLE()
 
 public:

--- a/gui/include/gui/trackprintout.h
+++ b/gui/include/gui/trackprintout.h
@@ -84,7 +84,6 @@ protected:
 #define ID_TRACKPRINT_SELECTION_CANCEL 9002
 
 class TrackPrintSelection : public wxDialog {
-  DECLARE_DYNAMIC_CLASS(TrackPrintSelection)
   DECLARE_EVENT_TABLE()
 
 public:

--- a/gui/src/CanvasOptions.cpp
+++ b/gui/src/CanvasOptions.cpp
@@ -355,7 +355,8 @@ void CanvasOptions::OnOptionChange(wxCommandEvent& event) {
 }
 
 void CanvasOptions::RefreshControlValues(void) {
-  ChartCanvas* parentCanvas = wxDynamicCast(m_parent, ChartCanvas);
+  auto parentCanvas = dynamic_cast<ChartCanvas*>(m_parent);
+  ;
   if (!parentCanvas) return;
 
   m_bmode_change_while_hidden = !wxWindow::IsShown();
@@ -460,7 +461,7 @@ void CanvasOptions::SetENCAvailable(bool avail) {
 }
 
 void CanvasOptions::UpdateCanvasOptions(void) {
-  ChartCanvas* parentCanvas = wxDynamicCast(m_parent, ChartCanvas);
+  auto parentCanvas = dynamic_cast<ChartCanvas*>(m_parent);
   if (!parentCanvas) return;
 
   bool b_needRefresh = false;

--- a/gui/src/GoToPositionDialog.cpp
+++ b/gui/src/GoToPositionDialog.cpp
@@ -42,7 +42,6 @@ extern MyFrame* gFrame;
  * GoToPositionDialog type definition
  */
 
-IMPLEMENT_DYNAMIC_CLASS(GoToPositionDialog, wxDialog)
 /*!
  * GoToPositionDialog event table definition
  */

--- a/gui/src/MUIBar.cpp
+++ b/gui/src/MUIBar.cpp
@@ -866,7 +866,7 @@ bool MUIBar::MouseEvent(wxMouseEvent& event) {
 }
 
 void MUIBar::OnScaleSelected(wxMouseEvent& event) {
-  ChartCanvas* pcc = wxDynamicCast(m_parentCanvas, ChartCanvas);
+  auto pcc = dynamic_cast<ChartCanvas*>(m_parentCanvas);
   if (!pcc) return;
 
   SetScaleDialog dlg(pcc);
@@ -1357,7 +1357,7 @@ void MUIBar::PullCanvasOptions() {
   m_animationTotalTime = 200;  // msec
 
   m_pushPull = CO_PULL;
-  ChartCanvas* pcc = wxDynamicCast(m_parentCanvas, ChartCanvas);
+  auto pcc = dynamic_cast<ChartCanvas*>(m_parentCanvas);
   pcc->m_b_paint_enable = false;
 
   // Start the animation....
@@ -1395,7 +1395,7 @@ void MUIBar::PushCanvasOptions() {
   m_animateSteps = 5;
   m_animationTotalTime = 100;  // msec
   m_pushPull = CO_PUSH;
-  ChartCanvas* pcc = wxDynamicCast(m_parentCanvas, ChartCanvas);
+  auto pcc = dynamic_cast<ChartCanvas*>(m_parentCanvas);
 
   // Start the animation....
   m_animateStep = 0;
@@ -1452,7 +1452,7 @@ void MUIBar::onCanvasOptionsAnimationTimerEvent(wxTimerEvent& event) {
     m_currentCOPos = m_targetCOPos;
     m_canvasOptions->Show(m_pushPull == CO_PULL);
 
-    ChartCanvas* pcc = wxDynamicCast(m_parentCanvas, ChartCanvas);
+    auto pcc = dynamic_cast<ChartCanvas*>(m_parentCanvas);
     if (pcc) {
       pcc->m_b_paint_enable = true;
 

--- a/gui/src/MarkInfo.cpp
+++ b/gui/src/MarkInfo.cpp
@@ -250,7 +250,7 @@ MarkInfoDlg::MarkInfoDlg(wxWindow* parent, wxWindowID id, const wxString& title,
 }
 
 void MarkInfoDlg::OnActivate(wxActivateEvent& event) {
-  DIALOG_PARENT* pWin = wxDynamicCast(event.GetEventObject(), DIALOG_PARENT);
+  auto pWin = dynamic_cast<DIALOG_PARENT*>(event.GetEventObject());
   long int style = pWin->GetWindowStyle();
   if (event.GetActive())
     pWin->SetWindowStyle(style | wxSTAY_ON_TOP);
@@ -1177,7 +1177,7 @@ void MarkInfoDlg::m_htmlListContextMenu(wxMouseEvent& event) {
   delete popup;
 #else
 
-  m_pEditedLink = wxDynamicCast(event.GetEventObject(), wxHyperlinkCtrl);
+  m_pEditedLink = dynamic_cast<wxHyperlinkCtrl*>(event.GetEventObject());
 
   if (m_pEditedLink) {
     wxString url = m_pEditedLink->GetURL();

--- a/gui/src/MarkInfo.cpp
+++ b/gui/src/MarkInfo.cpp
@@ -989,13 +989,14 @@ void MarkInfoDlg::UpdateHtmlList() {
     wxWindowListNode* node = kids.Item(i);
     wxWindow* win = node->GetData();
 
-    if (win->IsKindOf(CLASSINFO(wxHyperlinkCtrl))) {
-      ((wxHyperlinkCtrl*)win)
-          ->Disconnect(wxEVT_COMMAND_HYPERLINK,
-                       wxHyperlinkEventHandler(MarkInfoDlg::OnHyperLinkClick));
-      ((wxHyperlinkCtrl*)win)
-          ->Disconnect(wxEVT_RIGHT_DOWN,
-                       wxMouseEventHandler(MarkInfoDlg::m_htmlListContextMenu));
+    auto link_win = dynamic_cast<wxHyperlinkCtrl*>(win);
+    if (link_win) {
+      link_win->Disconnect(
+          wxEVT_COMMAND_HYPERLINK,
+          wxHyperlinkEventHandler(MarkInfoDlg::OnHyperLinkClick));
+      link_win->Disconnect(
+          wxEVT_RIGHT_DOWN,
+          wxMouseEventHandler(MarkInfoDlg::m_htmlListContextMenu));
       win->Destroy();
     }
   }

--- a/gui/src/OCPNRegion.cpp
+++ b/gui/src/OCPNRegion.cpp
@@ -391,8 +391,6 @@ public:
 #define M_REGIONDATA ((OCPNRegionRefData *)m_refData)
 #define M_REGIONDATA_OF(rgn) ((OCPNRegionRefData *)(rgn.m_refData))
 
-IMPLEMENT_DYNAMIC_CLASS(OCPNRegion, wxGDIObject)
-
 // ----------------------------------------------------------------------------
 // OCPNRegion construction
 // ----------------------------------------------------------------------------

--- a/gui/src/OCPN_AUIManager.cpp
+++ b/gui/src/OCPN_AUIManager.cpp
@@ -158,7 +158,7 @@ void OCPN_AUIManager::OnMotionx(wxMouseEvent& event) {
 
         //  Tell MyFrame that the sash is moving, so that he
         //  may disable any top-level windows and so avoid mouse focus problems.
-        MyFrame* pmf = wxDynamicCast(m_frame, MyFrame);
+        auto pmf = dynamic_cast<MyFrame*>(m_frame);
         if (pmf) pmf->NotifyChildrenResize();
 
         wxRect rect(m_frame->ClientToScreen(pos), m_actionPart->rect.GetSize());
@@ -221,7 +221,7 @@ bool OCPN_AUIManager::DoEndResizeAction(wxMouseEvent& event) {
 #if wxUSE_STATUSBAR
     // if there's a status control, the available
     // height decreases accordingly
-    if (wxDynamicCast(m_frame, wxFrame)) {
+    if (dynamic_cast<wxFrame*>(m_frame)) {
       wxFrame* frame = static_cast<wxFrame*>(m_frame);
       wxStatusBar* status = frame->GetStatusBar();
       if (status) {

--- a/gui/src/RolloverWin.cpp
+++ b/gui/src/RolloverWin.cpp
@@ -61,12 +61,12 @@ extern BasePlatform *g_BasePlatform;
 BEGIN_EVENT_TABLE(RolloverWin, wxWindow)
 EVT_PAINT(RolloverWin::OnPaint)
 EVT_TIMER(ROLLOVER_TIMER, RolloverWin::OnTimer)
-    EVT_MOUSE_EVENTS(RolloverWin::OnMouseEvent)
+EVT_MOUSE_EVENTS(RolloverWin::OnMouseEvent)
 
-        END_EVENT_TABLE()
+END_EVENT_TABLE()
 
-    // Define a constructor
-    RolloverWin::RolloverWin(wxWindow *parent, int timeout, bool maincanvas)
+// Define a constructor
+RolloverWin::RolloverWin(wxWindow *parent, int timeout, bool maincanvas)
     : wxWindow(parent, wxID_ANY, wxPoint(0, 0), wxSize(1, 1), wxNO_BORDER),
       m_bmaincanvas(maincanvas) {
   m_pbm = NULL;
@@ -261,7 +261,7 @@ void RolloverWin::Draw(ocpnDC &dc) {
     coords[6] = x0;
     coords[7] = y1;
 
-    ChartCanvas *pCanvas = wxDynamicCast(GetParent(), ChartCanvas);
+    auto pCanvas = dynamic_cast<ChartCanvas *>(GetParent());
     if (pCanvas)
       pCanvas->GetglCanvas()->RenderTextures(dc, coords, uv, 4,
                                              pCanvas->GetpVP());

--- a/gui/src/RoutePropDlgImpl.cpp
+++ b/gui/src/RoutePropDlgImpl.cpp
@@ -544,15 +544,14 @@ void RoutePropDlgImpl::SetRouteAndUpdate(Route* pR, bool only_points) {
       for (unsigned int i = 0; i < kids.GetCount(); i++) {
         wxWindowListNode* node = kids.Item(i);
         wxWindow* win = node->GetData();
-        if (win->IsKindOf(CLASSINFO(wxHyperlinkCtrl))) {
-          ((wxHyperlinkCtrl*)win)
-              ->Disconnect(
-                  wxEVT_COMMAND_HYPERLINK,
-                  wxHyperlinkEventHandler(RoutePropDlgImpl::OnHyperlinkClick));
-          ((wxHyperlinkCtrl*)win)
-              ->Disconnect(
-                  wxEVT_RIGHT_DOWN,
-                  wxMouseEventHandler(RoutePropDlgImpl::HyperlinkContextMenu));
+        auto link_win = dynamic_cast<wxHyperlinkCtrl*>(win);
+        if (link_win) {
+          link_win->Disconnect(
+              wxEVT_COMMAND_HYPERLINK,
+              wxHyperlinkEventHandler(RoutePropDlgImpl::OnHyperlinkClick));
+          link_win->Disconnect(
+              wxEVT_RIGHT_DOWN,
+              wxMouseEventHandler(RoutePropDlgImpl::HyperlinkContextMenu));
           win->Destroy();
         }
       }
@@ -1260,15 +1259,14 @@ void RoutePropDlgImpl::ItemDeleteOnMenuSelection(wxCommandEvent& event) {
     wxWindowListNode* node = kids.Item(i);
     wxWindow* win = node->GetData();
 
-    if (win->IsKindOf(CLASSINFO(wxHyperlinkCtrl))) {
-      ((wxHyperlinkCtrl*)win)
-          ->Disconnect(
-              wxEVT_COMMAND_HYPERLINK,
-              wxHyperlinkEventHandler(RoutePropDlgImpl::OnHyperlinkClick));
-      ((wxHyperlinkCtrl*)win)
-          ->Disconnect(
-              wxEVT_RIGHT_DOWN,
-              wxMouseEventHandler(RoutePropDlgImpl::HyperlinkContextMenu));
+    auto link_win = dynamic_cast<wxHyperlinkCtrl*>(win);
+    if (link_win) {
+      link_win->Disconnect(
+          wxEVT_COMMAND_HYPERLINK,
+          wxHyperlinkEventHandler(RoutePropDlgImpl::OnHyperlinkClick));
+      link_win->Disconnect(
+          wxEVT_RIGHT_DOWN,
+          wxMouseEventHandler(RoutePropDlgImpl::HyperlinkContextMenu));
       win->Destroy();
     }
   }

--- a/gui/src/RoutePropDlgImpl.cpp
+++ b/gui/src/RoutePropDlgImpl.cpp
@@ -281,7 +281,7 @@ RoutePropDlgImpl* RoutePropDlgImpl::getInstance(wxWindow* parent) {
 }
 
 void RoutePropDlgImpl::OnActivate(wxActivateEvent& event) {
-  wxFrame* pWin = wxDynamicCast(event.GetEventObject(), wxFrame);
+  auto pWin = dynamic_cast<wxFrame*>(event.GetEventObject());
   long int style = pWin->GetWindowStyle();
   if (event.GetActive())
     pWin->SetWindowStyle(style | wxSTAY_ON_TOP);

--- a/gui/src/SendToGpsDlg.cpp
+++ b/gui/src/SendToGpsDlg.cpp
@@ -47,14 +47,12 @@
 extern OCPNPlatform* g_Platform;
 extern wxString g_uploadConnection;
 
-IMPLEMENT_DYNAMIC_CLASS(SendToGpsDlg, wxDialog)
-
 BEGIN_EVENT_TABLE(SendToGpsDlg, wxDialog)
 EVT_BUTTON(ID_STG_CANCEL, SendToGpsDlg::OnCancelClick)
 EVT_BUTTON(ID_STG_OK, SendToGpsDlg::OnSendClick)
 END_EVENT_TABLE()
 
-    SendToGpsDlg::SendToGpsDlg() {
+SendToGpsDlg::SendToGpsDlg() {
   m_itemCommListBox = NULL;
   m_pgauge = NULL;
   m_SendButton = NULL;

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -153,8 +153,6 @@ static void ParsePeer(const wxString& ui_value, PeerData& peer_data) {
   peer_data.dest_ip_address = peer_ip.ToStdString();
 }
 
-IMPLEMENT_DYNAMIC_CLASS(SendToPeerDlg, wxDialog)
-
 BEGIN_EVENT_TABLE(SendToPeerDlg, wxDialog)
 EVT_BUTTON(ID_STP_CANCEL, SendToPeerDlg::OnCancelClick)
 EVT_BUTTON(ID_STP_OK, SendToPeerDlg::OnSendClick)

--- a/gui/src/TTYWindow.cpp
+++ b/gui/src/TTYWindow.cpp
@@ -37,8 +37,6 @@
 #include "ocpn_plugin.h"
 #include "FontMgr.h"
 
-IMPLEMENT_DYNAMIC_CLASS(TTYWindow, wxFrame)
-
 BEGIN_EVENT_TABLE(TTYWindow, wxFrame)
 EVT_CLOSE(TTYWindow::OnCloseWindow)
 END_EVENT_TABLE()

--- a/gui/src/TrackPropDlg.cpp
+++ b/gui/src/TrackPropDlg.cpp
@@ -1088,15 +1088,14 @@ bool TrackPropDlg::UpdateProperties() {
       wxWindowListNode* node = kids.Item(i);
       wxWindow* win = node->GetData();
 
-      if (win->IsKindOf(CLASSINFO(wxHyperlinkCtrl))) {
-        ((wxHyperlinkCtrl*)win)
-            ->Disconnect(
-                wxEVT_COMMAND_HYPERLINK,
-                wxHyperlinkEventHandler(TrackPropDlg::OnHyperLinkClick));
-        ((wxHyperlinkCtrl*)win)
-            ->Disconnect(
-                wxEVT_RIGHT_DOWN,
-                wxMouseEventHandler(TrackPropDlg::m_hyperlinkContextMenu));
+      auto link_win = dynamic_cast<wxHyperlinkCtrl*>(win);
+      if (link_win) {
+        link_win->Disconnect(
+            wxEVT_COMMAND_HYPERLINK,
+            wxHyperlinkEventHandler(TrackPropDlg::OnHyperLinkClick));
+        link_win->Disconnect(
+            wxEVT_RIGHT_DOWN,
+            wxMouseEventHandler(TrackPropDlg::m_hyperlinkContextMenu));
         win->Destroy();
       }
     }
@@ -1499,14 +1498,14 @@ void TrackPropDlg::OnDeleteLink(wxCommandEvent& event) {
     wxWindowListNode* node = kids.Item(i);
     wxWindow* win = node->GetData();
 
-    if (win->IsKindOf(CLASSINFO(wxHyperlinkCtrl))) {
-      ((wxHyperlinkCtrl*)win)
-          ->Disconnect(wxEVT_COMMAND_HYPERLINK,
-                       wxHyperlinkEventHandler(TrackPropDlg::OnHyperLinkClick));
-      ((wxHyperlinkCtrl*)win)
-          ->Disconnect(
-              wxEVT_RIGHT_DOWN,
-              wxMouseEventHandler(TrackPropDlg::m_hyperlinkContextMenu));
+    auto link_win = dynamic_cast<wxHyperlinkCtrl*>(win);
+    if (link_win) {
+      link_win->Disconnect(
+          wxEVT_COMMAND_HYPERLINK,
+          wxHyperlinkEventHandler(TrackPropDlg::OnHyperLinkClick));
+      link_win->Disconnect(
+          wxEVT_RIGHT_DOWN,
+          wxMouseEventHandler(TrackPropDlg::m_hyperlinkContextMenu));
       win->Destroy();
     }
   }

--- a/gui/src/TrackPropDlg.cpp
+++ b/gui/src/TrackPropDlg.cpp
@@ -261,7 +261,7 @@ TrackPropDlg::~TrackPropDlg() {
 }
 
 void TrackPropDlg::OnActivate(wxActivateEvent& event) {
-  DIALOG_PARENT* pWin = wxDynamicCast(event.GetEventObject(), DIALOG_PARENT);
+  auto pWin = dynamic_cast<DIALOG_PARENT*>(event.GetEventObject());
   long int style = pWin->GetWindowStyle();
   if (event.GetActive())
     pWin->SetWindowStyle(style | wxSTAY_ON_TOP);

--- a/gui/src/about.cpp
+++ b/gui/src/about.cpp
@@ -177,8 +177,6 @@ const wxString AuthorText =
 
 // clang-format on
 
-IMPLEMENT_DYNAMIC_CLASS(about, wxDialog)
-
 BEGIN_EVENT_TABLE(about, wxDialog)
 EVT_BUTTON(xID_OK, about::OnXidOkClick)
 EVT_BUTTON(ID_DONATE, about::OnDonateClick)

--- a/gui/src/canvasMenu.cpp
+++ b/gui/src/canvasMenu.cpp
@@ -1438,8 +1438,7 @@ void CanvasMenuHandler::PopupMenuHandler(wxCommandEvent &event) {
       break;
     }
     case ID_DEF_MENU_AIS_QUERY: {
-      wxWindow *pwin = wxDynamicCast(parent, wxWindow);
-      ShowAISTargetQueryDialog(pwin, m_FoundAIS_MMSI);
+      ShowAISTargetQueryDialog(parent, m_FoundAIS_MMSI);
       break;
     }
 

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -7677,8 +7677,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
       if (pFindAIS) {
         m_FoundAIS_MMSI = pFindAIS->GetUserData();
         if (g_pAIS->Get_Target_Data_From_MMSI(m_FoundAIS_MMSI)) {
-          wxWindow *pwin = wxDynamicCast(this, wxWindow);
-          ShowAISTargetQueryDialog(pwin, m_FoundAIS_MMSI);
+          ShowAISTargetQueryDialog(this, m_FoundAIS_MMSI);
         }
         return true;
       }

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -3650,14 +3650,13 @@ void DimeControl(wxWindow *ctrl, wxColour col, wxColour window_back_color,
     wxWindowListNode *node = kids.Item(i);
     wxWindow *win = node->GetData();
 
-    if (win->IsKindOf(CLASSINFO(wxListBox)) ||
-        win->IsKindOf(CLASSINFO(wxListCtrl)) ||
-        win->IsKindOf(CLASSINFO(wxTextCtrl)) ||
-        win->IsKindOf(CLASSINFO(wxTimePickerCtrl))) {
+    if (dynamic_cast<wxListBox *>(win) || dynamic_cast<wxListCtrl *>(win) ||
+        dynamic_cast<wxTextCtrl *>(win) ||
+        dynamic_cast<wxTimePickerCtrl *>(win)) {
       win->SetBackgroundColour(col);
-    } else if (win->IsKindOf(CLASSINFO(wxStaticText)) ||
-               win->IsKindOf(CLASSINFO(wxCheckBox)) ||
-               win->IsKindOf(CLASSINFO(wxRadioButton))) {
+    } else if (dynamic_cast<wxStaticText *>(win) ||
+               dynamic_cast<wxCheckBox *>(win) ||
+               dynamic_cast<wxRadioButton *>(win)) {
       win->SetForegroundColour(uitext);
     }
 #ifndef __WXOSX__
@@ -3665,43 +3664,39 @@ void DimeControl(wxWindow *ctrl, wxColour col, wxColour window_back_color,
     // weird coloured boxes around them. Fortunately, however, many of them
     // inherit a colour or tint from the background of their parent.
 
-    else if (win->IsKindOf(CLASSINFO(wxBitmapComboBox)) ||
-             win->IsKindOf(CLASSINFO(wxChoice)) ||
-             win->IsKindOf(CLASSINFO(wxComboBox)) ||
-             win->IsKindOf(CLASSINFO(wxTreeCtrl))) {
+    else if (dynamic_cast<wxBitmapComboBox *>(win) ||
+             dynamic_cast<wxChoice *>(win) || dynamic_cast<wxComboBox *>(win) ||
+             dynamic_cast<wxTreeCtrl *>(win)) {
       win->SetBackgroundColour(col);
     }
 
-    else if (win->IsKindOf(CLASSINFO(wxScrolledWindow)) ||
-             win->IsKindOf(CLASSINFO(wxGenericDirCtrl)) ||
-             win->IsKindOf(CLASSINFO(wxListbook)) ||
-             win->IsKindOf(CLASSINFO(wxButton)) ||
-             win->IsKindOf(CLASSINFO(wxToggleButton))) {
+    else if (dynamic_cast<wxScrolledWindow *>(win) ||
+             dynamic_cast<wxGenericDirCtrl *>(win) ||
+             dynamic_cast<wxListbook *>(win) || dynamic_cast<wxButton *>(win) ||
+             dynamic_cast<wxToggleButton *>(win)) {
       win->SetBackgroundColour(window_back_color);
     }
 
-    else if (win->IsKindOf(CLASSINFO(wxNotebook))) {
-      ((wxNotebook *)win)->SetBackgroundColour(window_back_color);
-      ((wxNotebook *)win)->SetForegroundColour(text_color);
+    else if (dynamic_cast<wxNotebook *>(win)) {
+      win->SetBackgroundColour(window_back_color);
+      win->SetForegroundColour(text_color);
     }
 #endif
 
-    else if (win->IsKindOf(CLASSINFO(wxHtmlWindow))) {
+    else if (dynamic_cast<wxHtmlWindow *>(win)) {
       if (cs != GLOBAL_COLOR_SCHEME_DAY && cs != GLOBAL_COLOR_SCHEME_RGB)
-        ((wxPanel *)win)->SetBackgroundColour(ctrl_back_color);
+        win->SetBackgroundColour(ctrl_back_color);
       else
-        ((wxPanel *)win)->SetBackgroundColour(wxNullColour);
+        win->SetBackgroundColour(wxNullColour);
     }
 
-    else if (win->IsKindOf(CLASSINFO(wxGrid))) {
-      ((wxGrid *)win)->SetDefaultCellBackgroundColour(window_back_color);
-      ((wxGrid *)win)->SetDefaultCellTextColour(uitext);
-      ((wxGrid *)win)->SetLabelBackgroundColour(col);
-      ((wxGrid *)win)->SetLabelTextColour(uitext);
-#if !wxCHECK_VERSION(3, 0, 0)
-      ((wxGrid *)win)->SetDividerPen(wxPen(col));
-#endif
-      ((wxGrid *)win)->SetGridLineColour(gridline);
+    else if (dynamic_cast<wxGrid *>(win)) {
+      dynamic_cast<wxGrid *>(win)->SetDefaultCellBackgroundColour(
+          window_back_color);
+      dynamic_cast<wxGrid *>(win)->SetDefaultCellTextColour(uitext);
+      dynamic_cast<wxGrid *>(win)->SetLabelBackgroundColour(col);
+      dynamic_cast<wxGrid *>(win)->SetLabelTextColour(uitext);
+      dynamic_cast<wxGrid *>(win)->SetGridLineColour(gridline);
     }
 
     if (win->GetChildren().GetCount() > 0) {

--- a/gui/src/ocpn_fontdlg.cpp
+++ b/gui/src/ocpn_fontdlg.cpp
@@ -165,8 +165,6 @@ static wxFontWeight ocpnFontWeightStringToInt(const wxString& weight) {
 // ocpnGenericFontDialog
 //-----------------------------------------------------------------------------
 
-wxIMPLEMENT_DYNAMIC_CLASS(ocpnGenericFontDialog, wxDialog);
-
 wxBEGIN_EVENT_TABLE(ocpnGenericFontDialog, wxDialog)
     EVT_CHECKBOX(wxID_FONT_UNDERLINE, ocpnGenericFontDialog::OnChangeFont)
         EVT_CHOICE(wxID_FONT_STYLE, ocpnGenericFontDialog::OnChangeFont)

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -1452,7 +1452,7 @@ void MyFrame::SwitchKBFocus(ChartCanvas *pCanvas) {
     int nTargetGTK = -1;
     ChartCanvas *target;
     wxWindow *source = FindFocus();
-    ChartCanvas *test = wxDynamicCast(source, ChartCanvas);
+    auto test = dynamic_cast<ChartCanvas *>(source);
     if (!test) return;
 
     // On linux(GTK), the TAB key causes a loss of focus immediately
@@ -1487,8 +1487,7 @@ void MyFrame::SwitchKBFocus(ChartCanvas *pCanvas) {
                        .Item(nfinalTarget)
                        ->canvas;
           if (target) {
-            wxWindow *win = wxDynamicCast(target, wxWindow);
-            win->SetFocus();
+            target->SetFocus();
             target->Refresh(true);
           }
         }

--- a/gui/src/ocpn_pixel.cpp
+++ b/gui/src/ocpn_pixel.cpp
@@ -448,8 +448,6 @@ unsigned char *PixelCache::GetpData(void) const { return pData; }
 // ----------------------------------------------------------------------------
 #define M_BMPDATA wx_static_cast(wxBitmapRefData *, m_refData)
 
-IMPLEMENT_DYNAMIC_CLASS(ocpnBitmap, wxBitmap /*wxGDIObject*/)
-
 // class wxBitmapRefData;
 
 // ============================================================================
@@ -1062,8 +1060,6 @@ bool ocpnBitmap::CreateFromImage(const wxImage &image, int depth) {
 // ============================================================================
 // ocpnMemDC implementation
 // ============================================================================
-
-IMPLEMENT_DYNAMIC_CLASS(ocpnMemDC, wxMemoryDC)
 
 ocpnMemDC::ocpnMemDC() {}
 

--- a/gui/src/ocpndc.cpp
+++ b/gui/src/ocpndc.cpp
@@ -112,11 +112,11 @@ ocpnDC::ocpnDC(wxDC &pdc)
       m_brush(wxNullBrush) {
 #if wxUSE_GRAPHICS_CONTEXT
   pgc = NULL;
-  wxMemoryDC *pmdc = wxDynamicCast(dc, wxMemoryDC);
+  auto pmdc = dynamic_cast<wxMemoryDC *>(dc);
   if (pmdc)
     pgc = wxGraphicsContext::Create(*pmdc);
   else {
-    wxClientDC *pcdc = wxDynamicCast(dc, wxClientDC);
+    auto pcdc = dynamic_cast<wxClientDC *>(dc);
     if (pcdc) pgc = wxGraphicsContext::Create(*pcdc);
   }
 #endif

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -1828,7 +1828,7 @@ wxScrolledWindow* options::AddPage(size_t parent, const wxString& title) {
 bool options::DeletePluginPage(wxScrolledWindow* page) {
   for (size_t i = 0; i < m_pListbook->GetPageCount(); i++) {
     wxNotebookPage* pg = m_pListbook->GetPage(i);
-    wxNotebook* nb = dynamic_cast<wxNotebook*>(pg);
+    auto nb = dynamic_cast<wxNotebook*>(pg);
 
     if (nb) {
       for (size_t j = 0; j < nb->GetPageCount(); j++) {
@@ -2706,9 +2706,9 @@ void options::ClearConfigList() {
     for (unsigned int i = 0; i < kids.GetCount(); i++) {
       wxWindowListNode* node = kids.Item(i);
       wxWindow* win = node->GetData();
-      wxPanel* pcp = wxDynamicCast(win, wxPanel);
+      auto pcp = dynamic_cast<wxPanel*>(win);
       if (pcp) {
-        ConfigPanel* cPanel = wxDynamicCast(pcp, ConfigPanel);
+        auto cPanel = dynamic_cast<ConfigPanel*>(pcp);
         if (cPanel) {
           cPanel->Destroy();
         }
@@ -2822,9 +2822,9 @@ void options::OnApplyConfig(wxCommandEvent& event) {
     for (unsigned int i = 0; i < kids.GetCount(); i++) {
       wxWindowListNode* node = kids.Item(i);
       wxWindow* win = node->GetData();
-      wxPanel* pcp = wxDynamicCast(win, wxPanel);
+      auto pcp = dynamic_cast<wxPanel*>(win);
       if (pcp) {
-        ConfigPanel* cPanel = wxDynamicCast(pcp, ConfigPanel);
+        auto cPanel = dynamic_cast<ConfigPanel*>(pcp);
         if (cPanel) {
           cPanel->SetBackgroundColour(m_panelBackgroundUnselected);
         }
@@ -2844,15 +2844,15 @@ void options::OnConfigMouseSelected(wxMouseEvent& event) {
   wxPanel* selectedPanel = NULL;
   wxObject* obj = event.GetEventObject();
   if (obj) {
-    wxPanel* panel = wxDynamicCast(obj, wxPanel);
+    auto panel = dynamic_cast<wxPanel*>(obj);
     if (panel) {
       selectedPanel = panel;
     }
     // Clicked on child?
     else {
-      wxWindow* win = wxDynamicCast(obj, wxWindow);
+      auto win = dynamic_cast<wxWindow*>(obj);
       if (win) {
-        wxPanel* parentpanel = wxDynamicCast(win->GetParent(), wxPanel);
+        auto parentpanel = dynamic_cast<wxPanel*>(win->GetParent());
         if (parentpanel) {
           selectedPanel = parentpanel;
         }
@@ -2864,12 +2864,12 @@ void options::OnConfigMouseSelected(wxMouseEvent& event) {
       for (unsigned int i = 0; i < kids.GetCount(); i++) {
         wxWindowListNode* node = kids.Item(i);
         wxWindow* win = node->GetData();
-        wxPanel* panel = wxDynamicCast(win, wxPanel);
+        auto panel = dynamic_cast<wxPanel*>(win);
         if (panel) {
           if (panel == selectedPanel) {
             panel->SetBackgroundColour(wxSystemSettings::GetColour(
                 wxSystemColour::wxSYS_COLOUR_HIGHLIGHT));
-            ConfigPanel* cPanel = wxDynamicCast(panel, ConfigPanel);
+            auto cPanel = dynamic_cast<ConfigPanel*>(panel);
             if (cPanel) m_selectedConfigPanelGUID = cPanel->GetConfigGUID();
           } else
             panel->SetBackgroundColour(m_panelBackgroundUnselected);
@@ -4256,8 +4256,9 @@ void options::CreatePanel_Display(size_t parent, int border_size,
     // (for calculation, in case GPS speed is null)
     wxBoxSizer* defaultBoatSpeedSizer = new wxBoxSizer(wxHORIZONTAL);
     boxDispStatusBar->Add(defaultBoatSpeedSizer, wxALL, group_item_spacing);
-    m_Text_def_boat_speed = new wxStaticText( pDisplayPanel, wxID_ANY,
-               _("Default Boat Speed ") + "(" + getUsrSpeedUnit() + ")    ");
+    m_Text_def_boat_speed = new wxStaticText(
+        pDisplayPanel, wxID_ANY,
+        _("Default Boat Speed ") + "(" + getUsrSpeedUnit() + ")    ");
     defaultBoatSpeedSizer->Add(m_Text_def_boat_speed, groupLabelFlagsHoriz);
     pSDefaultBoatSpeed =
         new wxTextCtrl(pDisplayPanel, ID_DEFAULT_BOAT_SPEED, _T(""),

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -5190,7 +5190,7 @@ ChartPlugInWrapper::ChartPlugInWrapper() {}
 
 ChartPlugInWrapper::ChartPlugInWrapper(const wxString& chart_class) {
   m_ppo = ::wxCreateDynamicObject(chart_class);
-  m_ppicb = wxDynamicCast(m_ppo, PlugInChartBase);
+  m_ppicb = dynamic_cast<PlugInChartBase*>(m_ppo);
 }
 
 ChartPlugInWrapper::~ChartPlugInWrapper() {
@@ -5264,7 +5264,7 @@ InitReturn ChartPlugInWrapper::Init(const wxString& name,
 
     //  PlugIn may invoke wxExecute(), which steals the keyboard focus
     //  So take it back
-    ChartCanvas* pc = wxDynamicCast(pa, ChartCanvas);
+    auto pc = dynamic_cast<ChartCanvas*>(pa);
     if (pc) pc->SetFocus();
 
     return ret_val;
@@ -7346,7 +7346,7 @@ wxWindow* PluginGetOverlayRenderCanvas() {
 
 void CanvasJumpToPosition(wxWindow* canvas, double lat, double lon,
                           double scale) {
-  ChartCanvas* oCanvas = wxDynamicCast(canvas, ChartCanvas);
+  auto oCanvas = dynamic_cast<ChartCanvas*>(canvas);
   if (oCanvas) gFrame->JumpToPosition(oCanvas, lat, lon, scale);
 }
 

--- a/gui/src/rest_server_gui.cpp
+++ b/gui/src/rest_server_gui.cpp
@@ -85,8 +85,6 @@ RestServerDlgCtx PINCreateDialog::GetDlgCtx() {
   return ctx;
 }
 
-IMPLEMENT_DYNAMIC_CLASS(AcceptObjectDialog, wxDialog)
-
 BEGIN_EVENT_TABLE(AcceptObjectDialog, wxDialog)
 EVT_BUTTON(ID_STG_CANCEL, AcceptObjectDialog::OnCancelClick)
 EVT_BUTTON(ID_STG_OK, AcceptObjectDialog::OnOKClick)
@@ -202,8 +200,6 @@ void AcceptObjectDialog::OnCancelClick(wxCommandEvent& event) {
   androidDisableRotation();
 #endif
 }
-
-IMPLEMENT_DYNAMIC_CLASS(PINCreateDialog, wxDialog)
 
 BEGIN_EVENT_TABLE(PINCreateDialog, wxDialog)
 EVT_BUTTON(ID_STG_CANCEL, PINCreateDialog::OnCancelClick)

--- a/gui/src/routeprintout.cpp
+++ b/gui/src/routeprintout.cpp
@@ -293,7 +293,6 @@ void MyRoutePrintout::DrawPage(wxDC* dc) {
  * RoutePrintSelection type definition
  */
 
-IMPLEMENT_DYNAMIC_CLASS(RoutePrintSelection, wxDialog)
 /*!
  * RouteProp event table definition
  */

--- a/gui/src/toolbar.cpp
+++ b/gui/src/toolbar.cpp
@@ -1508,8 +1508,6 @@ bool ocpnToolBarSimple::OnMouseEvent(wxMouseEvent &event, wxPoint &position) {
     OnRightClick(tool->GetId(), x, y);
   }
 
-
-
   // Left Button Released.  Only this action confirms selection.
   // If the button is enabled and it is not a toggle tool and it is
   // in the pressed state, then raise the button and call OnLeftClick.
@@ -2312,7 +2310,6 @@ int ToolbarMOBDialog::GetSelection() {
   return 0;
 }
 
-IMPLEMENT_DYNAMIC_CLASS(ToolbarChoicesDialog, wxDialog)
 /*!
  * ToolbarChoicesDialog event table definition
  */

--- a/gui/src/trackprintout.cpp
+++ b/gui/src/trackprintout.cpp
@@ -235,7 +235,6 @@ void MyTrackPrintout::DrawPage(wxDC* dc) {
 
 // ---------- TrackPrintSelection dialof implementation
 
-IMPLEMENT_DYNAMIC_CLASS(TrackPrintSelection, wxDialog)
 BEGIN_EVENT_TABLE(TrackPrintSelection, wxDialog)
 EVT_BUTTON(ID_TRACKPRINT_SELECTION_CANCEL,
            TrackPrintSelection::OnTrackpropCancelClick)

--- a/gui/src/update_mgr.cpp
+++ b/gui/src/update_mgr.cpp
@@ -496,8 +496,8 @@ void UpdateDialog::RecalculateSize() {
     wxWindowListNode* node = kids.Item(i);
     wxWindow* win = node->GetData();
 
-    if (win && win->IsKindOf(CLASSINFO(PluginTextPanel))) {
-      PluginTextPanel* panel = (PluginTextPanel*)win;
+    auto panel = dynamic_cast<PluginTextPanel*>(win);
+    if (panel) {
       if (panel->m_isDesc) {
         wxSize tsize = win->GetEffectiveMinSize();
         calcHeight += tsize.y + GetCharHeight();

--- a/gui/src/update_mgr.cpp
+++ b/gui/src/update_mgr.cpp
@@ -376,7 +376,7 @@ public:
     m_more->SetLabelMarkup(m_descr->IsShown() ? LESS : MORE);
     m_buttons->HideDetails(!m_descr->IsShown());
 
-    UpdateDialog* swin = wxDynamicCast(GetGrandParent(), UpdateDialog);
+    auto swin = dynamic_cast<UpdateDialog*>(GetGrandParent());
     if (swin) {
       swin->RecalculateSize();
     }

--- a/libs/wxcurl/include/wx/curl/base.h
+++ b/libs/wxcurl/include/wx/curl/base.h
@@ -191,9 +191,6 @@ public:
 
 protected:
     double m_rDownloadTotal, m_rDownloadNow;
-
-private:
-    DECLARE_DYNAMIC_CLASS(wxCurlDownloadEvent);
 };
 
 typedef void (wxEvtHandler::*wxCurlDownloadEventFunction)(wxCurlDownloadEvent&);
@@ -238,9 +235,6 @@ public:
 
 protected:
     double m_rUploadTotal, m_rUploadNow;
-
-private:
-    DECLARE_DYNAMIC_CLASS(wxCurlUploadEvent);
 };
 
 typedef void (wxEvtHandler::*wxCurlUploadEventFunction)(wxCurlUploadEvent&);
@@ -273,9 +267,6 @@ public:
 
 protected:
     std::string m_szURL;
-
-private:
-    DECLARE_DYNAMIC_CLASS(wxCurlBeginPerformEvent);
 };
 
 typedef void (wxEvtHandler::*wxCurlBeginPerformEventFunction)(wxCurlBeginPerformEvent&);
@@ -315,9 +306,6 @@ public:
 protected:
     std::string	m_szURL;
     long		m_iResponseCode;
-
-private:
-    DECLARE_DYNAMIC_CLASS(wxCurlEndPerformEvent);
 };
 
 typedef void (wxEvtHandler::*wxCurlEndPerformEventFunction)(wxCurlEndPerformEvent&);

--- a/libs/wxcurl/include/wx/curl/dialog.h
+++ b/libs/wxcurl/include/wx/curl/dialog.h
@@ -240,7 +240,6 @@ public:     // event handlers
 
 private:
     DECLARE_EVENT_TABLE()
-    DECLARE_DYNAMIC_CLASS(wxCurlDownloadDialog)
 };
 
 
@@ -278,7 +277,6 @@ public:     // event handlers
 
 private:
     DECLARE_EVENT_TABLE()
-    DECLARE_DYNAMIC_CLASS(wxCurlUploadDialog)
 };
 
 
@@ -318,11 +316,7 @@ protected:
 
     virtual int ShowModal()
         { return wxDialog::ShowModal(); }
-
-private:
-    DECLARE_DYNAMIC_CLASS(wxCurlConnectionSettingsDialog)
 };
 
 
 #endif // _WXCURL_DIALOG_H_
-

--- a/libs/wxcurl/include/wx/curl/panel.h
+++ b/libs/wxcurl/include/wx/curl/panel.h
@@ -93,9 +93,7 @@ protected:      // controls
 
 private:
     DECLARE_EVENT_TABLE()
-    DECLARE_DYNAMIC_CLASS(wxCurlConnectionSettingsPanel)
 };
 
 
 #endif // _WXCURL_PANEL_H_
-

--- a/libs/wxcurl/src/base.cpp
+++ b/libs/wxcurl/src/base.cpp
@@ -273,8 +273,6 @@ std::string wxCurlProgressBaseEvent::GetHumanReadableSpeed(const std::string &in
 
 DEFINE_EVENT_TYPE(wxCURL_DOWNLOAD_EVENT);
 
-IMPLEMENT_DYNAMIC_CLASS(wxCurlDownloadEvent, wxEvent);
-
 wxCurlDownloadEvent::wxCurlDownloadEvent()
 : wxCurlProgressBaseEvent(-1, wxCURL_DOWNLOAD_EVENT),
   m_rDownloadTotal(0.0), m_rDownloadNow(0.0)
@@ -307,8 +305,6 @@ wxCurlDownloadEvent::wxCurlDownloadEvent(const wxCurlDownloadEvent& event)
 //////////////////////////////////////////////////////////////////////
 
 DEFINE_EVENT_TYPE(wxCURL_UPLOAD_EVENT);
-
-IMPLEMENT_DYNAMIC_CLASS(wxCurlUploadEvent, wxEvent);
 
 wxCurlUploadEvent::wxCurlUploadEvent()
 : wxCurlProgressBaseEvent(-1, wxCURL_UPLOAD_EVENT),
@@ -343,8 +339,6 @@ wxCurlUploadEvent::wxCurlUploadEvent(const wxCurlUploadEvent& event)
 
 DEFINE_EVENT_TYPE(wxCURL_BEGIN_PERFORM_EVENT);
 
-IMPLEMENT_DYNAMIC_CLASS(wxCurlBeginPerformEvent, wxEvent);
-
 wxCurlBeginPerformEvent::wxCurlBeginPerformEvent()
 : wxEvent(-1, wxCURL_BEGIN_PERFORM_EVENT)
 {
@@ -371,8 +365,6 @@ wxCurlBeginPerformEvent::wxCurlBeginPerformEvent(const wxCurlBeginPerformEvent& 
 //////////////////////////////////////////////////////////////////////
 
 DEFINE_EVENT_TYPE(wxCURL_END_PERFORM_EVENT);
-
-IMPLEMENT_DYNAMIC_CLASS(wxCurlEndPerformEvent, wxEvent);
 
 wxCurlEndPerformEvent::wxCurlEndPerformEvent()
 : wxEvent(-1, wxCURL_END_PERFORM_EVENT),

--- a/libs/wxcurl/src/dialog.cpp
+++ b/libs/wxcurl/src/dialog.cpp
@@ -524,7 +524,6 @@ void wxCurlTransferDialog::OnEndPerform(wxCurlEndPerformEvent &ev)
 // wxCurlDownloadDialog
 // ----------------------------------------------------------------------------
 
-IMPLEMENT_DYNAMIC_CLASS( wxCurlDownloadDialog, wxCurlTransferDialog )
 BEGIN_EVENT_TABLE( wxCurlDownloadDialog, wxCurlTransferDialog )
     EVT_CURL_DOWNLOAD( ThreadId, wxCurlDownloadDialog::OnDownload )
 END_EVENT_TABLE()
@@ -572,7 +571,6 @@ void wxCurlDownloadDialog::OnDownload(wxCurlDownloadEvent &ev)
 // wxCurlUploadDialog
 // ----------------------------------------------------------------------------
 
-IMPLEMENT_DYNAMIC_CLASS( wxCurlUploadDialog, wxCurlTransferDialog )
 BEGIN_EVENT_TABLE( wxCurlUploadDialog, wxCurlTransferDialog )
     EVT_CURL_UPLOAD( ThreadId, wxCurlUploadDialog::OnUpload )
 END_EVENT_TABLE()
@@ -620,8 +618,6 @@ void wxCurlUploadDialog::OnUpload(wxCurlUploadEvent &ev)
 // wxCurlConnectionSettingsDialog
 // ----------------------------------------------------------------------------
 
-IMPLEMENT_DYNAMIC_CLASS( wxCurlConnectionSettingsDialog, wxDialog )
-
 bool wxCurlConnectionSettingsDialog::Create(const wxString& title,
                                             const wxString& message,
                                             wxWindow *parent,
@@ -650,4 +646,3 @@ void wxCurlConnectionSettingsDialog::RunModal(wxCurlBase *pCURL)
     if (ShowModal() == wxID_OK)
         m_pPanel->SetCURLOptions(pCURL);
 }
-

--- a/libs/wxcurl/src/panel.cpp
+++ b/libs/wxcurl/src/panel.cpp
@@ -53,7 +53,6 @@ enum
     UseProxy = wxID_HIGHEST+1
 };
 
-IMPLEMENT_DYNAMIC_CLASS( wxCurlConnectionSettingsPanel, wxPanel )
 BEGIN_EVENT_TABLE( wxCurlConnectionSettingsPanel, wxPanel )
     EVT_CHECKBOX( UseProxy, wxCurlConnectionSettingsPanel::OnUseProxy )
 END_EVENT_TABLE()
@@ -207,5 +206,3 @@ void wxCurlConnectionSettingsPanel::OnUseProxy(wxCommandEvent &ev)
     m_pProxyPassword->Enable(ev.IsChecked());
     m_pProxyPort->Enable(ev.IsChecked());
 }
-
-

--- a/libs/wxsvg/include/wxSVG/SVGDocument.h
+++ b/libs/wxsvg/include/wxSVG/SVGDocument.h
@@ -92,8 +92,6 @@ class wxSVGDocument:
 		bool alpha = false, wxProgressDialog* progressDlg = NULL);
 
     static void ApplyAnimation(wxSVGElement* parent, wxSVGSVGElement* ownerSVGElement);
-  private:
-      DECLARE_DYNAMIC_CLASS(wxSVGDocument)
 };
 
 #endif // WX_SVG_DOCUMENT_H

--- a/libs/wxsvg/include/wxSVG/imagsvg.h
+++ b/libs/wxsvg/include/wxSVG/imagsvg.h
@@ -26,9 +26,6 @@ public:
 protected:
 	virtual bool DoCanRead(wxInputStream& stream);
 #endif
-
-private:
-    DECLARE_DYNAMIC_CLASS(wxImageHandler)
 };
 
 #endif // IMAGE_SVG_H

--- a/libs/wxsvg/include/wxSVG/svgctrl.h
+++ b/libs/wxsvg/include/wxSVG/svgctrl.h
@@ -72,8 +72,6 @@ public:
     wxSVGCtrl();
     wxSVGCtrl(wxWindow* parent, wxWindowID id = wxID_ANY, const wxPoint& pos = wxDefaultPosition,
     		const wxSize& size = wxDefaultSize, long style = 0, const wxString& name = wxPanelNameStr);
-private:
-    DECLARE_DYNAMIC_CLASS(wxSVGCtrl)
 };
 
 

--- a/libs/wxsvg/src/imagsvg.cpp
+++ b/libs/wxsvg/src/imagsvg.cpp
@@ -11,8 +11,6 @@
 #include "imagsvg.h"
 #include "SVGDocument.h"
 
-IMPLEMENT_DYNAMIC_CLASS(wxSVGHandler, wxImageHandler)
-
 wxSVGHandler::wxSVGHandler() {
 	m_name = wxT("SVG file");
 	m_extension = wxT("svg");

--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -359,30 +359,30 @@ void SetBackColor(wxWindow *ctrl, wxColour col) {
     wxWindowListNode *node = kids.Item(i);
     wxWindow *win = node->GetData();
 
-    if (win->IsKindOf(CLASSINFO(wxListBox)))
-      ((wxListBox *)win)->SetBackgroundColour(col);
+    if (dynamic_cast<wxListBox *>(win))
+      dynamic_cast<wxListBox *>(win)->SetBackgroundColour(col);
 
-    else if (win->IsKindOf(CLASSINFO(wxTextCtrl)))
-      ((wxTextCtrl *)win)->SetBackgroundColour(col);
+    else if (dynamic_cast<wxTextCtrl *>(win))
+      dynamic_cast<wxTextCtrl *>(win)->SetBackgroundColour(col);
 
     //        else if( win->IsKindOf( CLASSINFO(wxStaticText) ) )
     //            ( (wxStaticText*) win )->SetForegroundColour( uitext );
 
-    else if (win->IsKindOf(CLASSINFO(wxChoice)))
-      ((wxChoice *)win)->SetBackgroundColour(col);
+    else if (dynamic_cast<wxChoice *>(win))
+      dynamic_cast<wxChoice *>(win)->SetBackgroundColour(col);
 
-    else if (win->IsKindOf(CLASSINFO(wxComboBox)))
-      ((wxComboBox *)win)->SetBackgroundColour(col);
+    else if (dynamic_cast<wxComboBox *>(win))
+      dynamic_cast<wxComboBox *>(win)->SetBackgroundColour(col);
 
-    else if (win->IsKindOf(CLASSINFO(wxRadioButton)))
-      ((wxRadioButton *)win)->SetBackgroundColour(col);
+    else if (dynamic_cast<wxRadioButton *>(win))
+      dynamic_cast<wxRadioButton *>(win)->SetBackgroundColour(col);
 
-    else if (win->IsKindOf(CLASSINFO(wxScrolledWindow))) {
-      ((wxScrolledWindow *)win)->SetBackgroundColour(col);
+    else if (dynamic_cast<wxScrolledWindow *>(win)) {
+      dynamic_cast<wxScrolledWindow *>(win)->SetBackgroundColour(col);
     }
 
-    else if (win->IsKindOf(CLASSINFO(wxButton))) {
-      ((wxButton *)win)->SetBackgroundColour(col);
+    else if (dynamic_cast<wxButton *>(win)) {
+      dynamic_cast<wxButton *>(win)->SetBackgroundColour(col);
     }
 
     else {

--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -539,7 +539,6 @@ ChartSource::~ChartSource() { m_update_data.clear(); }
 
 enum { ThreadId = wxID_HIGHEST + 1 };
 
-IMPLEMENT_DYNAMIC_CLASS(ChartDldrPanelImpl, ChartDldrPanel)
 BEGIN_EVENT_TABLE(ChartDldrPanelImpl, ChartDldrPanel)
 END_EVENT_TABLE()
 

--- a/plugins/chartdldr_pi/src/chartdldr_pi.h
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.h
@@ -270,7 +270,6 @@ public:
   }
 
 private:
-  DECLARE_DYNAMIC_CLASS(ChartDldrPanelImpl)
   DECLARE_EVENT_TABLE()
 };
 

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -6075,8 +6075,6 @@ void DashboardWindow::SendUtcTimeToAllInstruments(wxDateTime value) {
 // implementation
 // ============================================================================
 
-IMPLEMENT_DYNAMIC_CLASS(OCPNFontButton, wxButton)
-
 // ----------------------------------------------------------------------------
 // OCPNFontButton
 // ----------------------------------------------------------------------------

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -6044,8 +6044,8 @@ void DashboardWindow::SendSatInfoToAllInstruments(int cnt, int seq,
                                                   SAT_INFO sats[4]) {
   for (size_t i = 0; i < m_ArrayOfInstrument.GetCount(); i++) {
     if ((m_ArrayOfInstrument.Item(i)->m_cap_flag.test(OCPN_DBP_STC_GPS)) &&
-        m_ArrayOfInstrument.Item(i)->m_pInstrument->IsKindOf(
-            CLASSINFO(DashboardInstrument_GPS)))
+        dynamic_cast<DashboardInstrument_GPS *>(
+            m_ArrayOfInstrument.Item(i)->m_pInstrument))
       ((DashboardInstrument_GPS *)m_ArrayOfInstrument.Item(i)->m_pInstrument)
           ->SetSatInfo(cnt, seq, talk, sats);
   }
@@ -6054,8 +6054,8 @@ void DashboardWindow::SendSatInfoToAllInstruments(int cnt, int seq,
 void DashboardWindow::SendUtcTimeToAllInstruments(wxDateTime value) {
   for (size_t i = 0; i < m_ArrayOfInstrument.GetCount(); i++) {
     if ((m_ArrayOfInstrument.Item(i)->m_cap_flag.test(OCPN_DBP_STC_CLK)) &&
-        m_ArrayOfInstrument.Item(i)->m_pInstrument->IsKindOf(
-            CLASSINFO(DashboardInstrument_Clock)))
+        dynamic_cast<DashboardInstrument_Clock *>(
+            m_ArrayOfInstrument.Item(i)->m_pInstrument))
       //                  || m_ArrayOfInstrument.Item( i
       //                  )->m_pInstrument->IsKindOf( CLASSINFO(
       //                  DashboardInstrument_Sun ) )

--- a/plugins/dashboard_pi/src/dashboard_pi.h
+++ b/plugins/dashboard_pi/src/dashboard_pi.h
@@ -533,9 +533,6 @@ protected:
   wxFontData m_data;
 
   wxFont m_selectedFont;
-
-private:
-  DECLARE_DYNAMIC_CLASS(OCPNFontButton)
 };
 
 #endif

--- a/plugins/grib_pi/src/CursorData.cpp
+++ b/plugins/grib_pi/src/CursorData.cpp
@@ -44,11 +44,11 @@ CursorData::CursorData(wxWindow *window, GRIBUICtrlBar &parent)
   wxWindowListNode *node = this->GetChildren().GetFirst();
   while (node) {
     wxWindow *win = node->GetData();
-    if (win->IsKindOf(CLASSINFO(wxCheckBox))) {
-      int winId = ((wxCheckBox *)win)->GetId() - ID_CB_WIND;
+    if (dynamic_cast<wxCheckBox *>(win)) {
+      int winId = dynamic_cast<wxCheckBox *>(win)->GetId() - ID_CB_WIND;
       if (m_gparent.InDataPlot(winId)) {
-        ((wxCheckBox *)win)->SetId(winId);
-        ((wxCheckBox *)win)->SetValue(m_gparent.m_bDataPlot[winId]);
+        dynamic_cast<wxCheckBox *>(win)->SetId(winId);
+        dynamic_cast<wxCheckBox *>(win)->SetValue(m_gparent.m_bDataPlot[winId]);
       }
     }
     node = node->GetNext();

--- a/plugins/grib_pi/src/CustomGrid.cpp
+++ b/plugins/grib_pi/src/CustomGrid.cpp
@@ -408,8 +408,8 @@ void CustomRenderer::Draw(wxGrid& grid, wxGridCellAttr& attr, wxDC& dc,
 
 #if wxUSE_GRAPHICS_CONTEXT
     wxGraphicsContext* gdc;
-    wxClientDC* cdc = new wxClientDC(wxDynamicCast(&grid, wxWindow));
-    cdc = wxDynamicCast(&dc, wxClientDC);
+    wxClientDC* cdc = new wxClientDC(dynamic_cast<wxWindow*>(&grid));
+    cdc = dynamic_cast<wxClientDC*>(&dc);
     if (cdc) {
       gdc = wxGraphicsContext::Create(*cdc);
 #ifdef __WXGTK__

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -472,7 +472,7 @@ bool GRIBOverlayFactory::RenderGribOverlay(wxDC &dc, PlugIn_ViewPort *vp) {
 #if 0
 #if wxUSE_GRAPHICS_CONTEXT
     wxMemoryDC *pmdc;
-    pmdc = wxDynamicCast(&dc, wxMemoryDC);
+    pmdc = dynamic_cast<wxMemoryDC*>(&dc);
     wxGraphicsContext *pgc = wxGraphicsContext::Create( *pmdc );
     m_gdc = pgc;
 #endif

--- a/plugins/grib_pi/src/GribRequestDialog.cpp
+++ b/plugins/grib_pi/src/GribRequestDialog.cpp
@@ -395,7 +395,7 @@ bool GribRequestSetting::MouseEventHook(wxMouseEvent &event) {
 
   // This does not work, but something like it should
   //     wxObject *obj = event.GetEventObject();
-  //     wxWindow *win = wxDynamicCast(obj, wxWindow);
+  //     wxWindow *win = dynamic_cast<wxWindow*>(obj);
   //     if( win && (win != PluginGetFocusCanvas()))
   //         return false;
 

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -1119,12 +1119,9 @@ void GRIBUICtrlBar::OnPaint(wxPaintEvent &event) {
   wxPaintDC dc(this);
   while (node) {
     wxWindow *win = node->GetData();
-    if (win->IsKindOf(CLASSINFO(wxBitmapButton)))
-#if wxCHECK_VERSION(3, 0, 0)
-      dc.DrawBitmap(((wxBitmapButton *)win)->GetBitmap(), 5, 5, false);
-#else
-      dc.DrawBitmap(((wxBitmapButton *)win)->GetBitmapSelected(), 5, 5, false);
-#endif
+    if (dynamic_cast<wxBitmapButton *>(win))
+      dc.DrawBitmap(dynamic_cast<wxBitmapButton *>(win)->GetBitmap(), 5, 5,
+                    false);
     node = node->GetNext();
   }
 }

--- a/plugins/grib_pi/src/IsoLine.cpp
+++ b/plugins/grib_pi/src/IsoLine.cpp
@@ -382,7 +382,7 @@ void IsoLine::drawIsoLine(GRIBOverlayFactory *pof, wxDC *dc,
 
 #if wxUSE_GRAPHICS_CONTEXT
     wxMemoryDC *pmdc;
-    pmdc = wxDynamicCast(dc, wxMemoryDC);
+    pmdc = dynamic_cast<wxMemoryDC *>(dc);
     pgc = wxGraphicsContext::Create(*pmdc);
     pgc->SetPen(ppISO);
 #endif

--- a/plugins/grib_pi/src/pi_ocpndc.cpp
+++ b/plugins/grib_pi/src/pi_ocpndc.cpp
@@ -127,11 +127,11 @@ pi_ocpnDC::pi_ocpnDC(wxDC &pdc)
       m_buseGL(false) {
 #if wxUSE_GRAPHICS_CONTEXT
   pgc = NULL;
-  wxMemoryDC *pmdc = wxDynamicCast(dc, wxMemoryDC);
+  auto pmdc = dynamic_cast<wxMemoryDC *>(dc);
   if (pmdc)
     pgc = wxGraphicsContext::Create(*pmdc);
   else {
-    wxClientDC *pcdc = wxDynamicCast(dc, wxClientDC);
+    auto pcdc = dynamic_cast<wxClientDC *>(dc);
     if (pcdc) pgc = wxGraphicsContext::Create(*pcdc);
   }
 #endif

--- a/plugins/wmm_pi/src/pi_ocpndc.cpp
+++ b/plugins/wmm_pi/src/pi_ocpndc.cpp
@@ -117,11 +117,11 @@ pi_ocpnDC::pi_ocpnDC(wxDC &pdc)
     : glcanvas(NULL), dc(&pdc), m_pen(wxNullPen), m_brush(wxNullBrush) {
 #if wxUSE_GRAPHICS_CONTEXT
   pgc = NULL;
-  wxMemoryDC *pmdc = wxDynamicCast(dc, wxMemoryDC);
+  auto pmdc = dynamic_cast<wxMemoryDC *>(dc);
   if (pmdc)
     pgc = wxGraphicsContext::Create(*pmdc);
   else {
-    wxClientDC *pcdc = wxDynamicCast(dc, wxClientDC);
+    auto pcdc = dynamic_cast<wxClientDC *>(dc);
     if (pcdc) pgc = wxGraphicsContext::Create(*pcdc);
   }
 #endif
@@ -1644,7 +1644,7 @@ void pi_odc_endCallbackD_GLSL(void *data) {
 }
 #endif
 
-#endif  //#ifdef ocpnUSE_GL
+#endif  // #ifdef ocpnUSE_GL
 
 void pi_ocpnDC::DrawPolygonTessellated(int n, wxPoint points[], wxCoord xoffset,
                                        wxCoord yoffset) {
@@ -1828,7 +1828,7 @@ void pi_ocpnDC::DrawBitmap(const wxBitmap &bitmap, wxCoord x, wxCoord y,
 
       glColor4f(1, 1, 1, 1);
       GLDrawBlendData(x, y, w, h, GL_RGBA, e);
-      delete[](e);
+      delete[] (e);
     } else {
       glRasterPos2i(x, y);
       glPixelZoom(1, -1); /* draw data from top to bottom */


### PR DESCRIPTION
As discussed in [zulip](https://leamas.github.io/zulip-archive/stream/332168-Master/topic/Should.20we.20get.20rid.20of.20wxwidgets.20DYNAMIC_CLASS.20macros.3F.html)

Remove the now obsolete wxWidgets RTTI implementation usage. Use the standard C++ stuff which has been available since C++11 instead. 

@bdbcat  @nohal :  Did I miss anything?