### PR TITLE
Update to allow '-p' flag to apply for language file locations.

### DIFF
--- a/gui/src/OCPNPlatform.cpp
+++ b/gui/src/OCPNPlatform.cpp
@@ -994,6 +994,12 @@ void OCPNPlatform::SetLocaleSearchPrefixes(void) {
   if (!wxGetEnv(_T("OPENCPN_PREFIX"), &locale_location)) {
     locale_location = _T("/usr/local");
   }
+
+  if(g_bportable) {
+    locale_location = g_Platform->GetHomeDir();
+  }
+
+
   wxFileName location;
   location.AssignDir(locale_location);
   location.AppendDir(_T("share"));


### PR DESCRIPTION
When debugging under linux it can be useful to have the language files in the same location as all the other runtime files, i.e. a build directory. This change uses the '-p' flag to change the language base directory from '/usr/local' to '{build/runtime directory}' 