### PR TITLE
Add Dashboard instrument Windlass rode count

### DIFF
--- a/libs/N2KParser/src/N2KParser.cpp
+++ b/libs/N2KParser/src/N2KParser.cpp
@@ -154,6 +154,22 @@ bool ParseN2kPGN128259(std::vector<unsigned char> &v, unsigned char &SID,
 
 }
 
+bool ParseN2kPGN128777(std::vector<unsigned char> &v, unsigned char &SID,
+                       unsigned char &WindlassIdentifier,
+                       double &RodeCounterValue, double &WindlassLineSpeed,
+                       tN2kWindlassMotionStates &WindlassMotionStatus,
+                       tN2kRodeTypeStates &RodeTypeStatus,
+                       tN2kAnchorDockingStates &AnchorDockingStatus,
+                       tN2kWindlassOperatingEvents &WindlassOperatingEvents) {
+  tN2kMsg msg;
+  MakeN2kMsg(v, msg);
+
+  return ParseN2kPGN128777(msg, SID, WindlassIdentifier, RodeCounterValue,
+                           WindlassLineSpeed, WindlassMotionStatus,
+                           RodeTypeStatus, AnchorDockingStatus,
+                           WindlassOperatingEvents);
+}
+
 bool ParseN2kPGN129540(std::vector<unsigned char> &v, unsigned char &SID,
                        tN2kRangeResidualMode &Mode, uint8_t &nSats) {
 

--- a/plugins/dashboard_pi/src/dashboard_pi.h
+++ b/plugins/dashboard_pi/src/dashboard_pi.h
@@ -264,6 +264,7 @@ private:
   void HandleN2K_128259(ObservedEvt ev);
   void HandleN2K_128267(ObservedEvt ev);
   void HandleN2K_128275(ObservedEvt ev);
+  void HandleN2K_128777(ObservedEvt ev);
   void HandleN2K_129029(ObservedEvt ev);
   void HandleN2K_129540(ObservedEvt ev);
   void HandleN2K_130306(ObservedEvt ev);
@@ -274,6 +275,7 @@ private:
   std::shared_ptr<ObservableListener> listener_128259;
   std::shared_ptr<ObservableListener> listener_128267;
   std::shared_ptr<ObservableListener> listener_128275;
+  std::shared_ptr<ObservableListener> listener_128777;
   std::shared_ptr<ObservableListener> listener_129029;
   std::shared_ptr<ObservableListener> listener_129540;
   std::shared_ptr<ObservableListener> listener_130306;
@@ -338,6 +340,7 @@ private:
   int mLOG_Watchdog;
   int mTrLOG_Watchdog;
   int mHUM_Watchdog;
+  int mWCC_Watchdog;
 
   iirfilter mSOGFilter;
   iirfilter mCOGFilter;

--- a/plugins/dashboard_pi/src/instrument.h
+++ b/plugins/dashboard_pi/src/instrument.h
@@ -112,93 +112,93 @@ enum DASH_CAP {
   OCPN_DBP_STC_HEEL,   // Heel
   OCPN_DBP_STC_ALTI,   // Altitude
   OCPN_DBP_STC_HUM,    // Humidity
-                      // Insert new instrument capability flags here
-  OCPN_DBP_STC_LAST   // This should always be the last enum in this list
+  OCPN_DBP_STC_WCC,    // Windlass
+                       // Insert new instrument capability flags here
+  OCPN_DBP_STC_LAST    // This should always be the last enum in this list
 };
 
 #define N_INSTRUMENTS \
   ((int)OCPN_DBP_STC_LAST)  // Number of instrument capability flags
 using CapType = std::bitset<N_INSTRUMENTS>;
 
-
 wxColour GetColourSchemeBackgroundColour(wxColour co);
 wxColour GetColourSchemeFont(wxColour co);
 
 class InstrumentProperties {
 public:
-    InstrumentProperties() { SetDefault(); }
-    InstrumentProperties(int aInstrument, int Listplace) {
-        m_aInstrument = aInstrument;
-        m_Listplace = Listplace;
-        m_ShowUnit = -1;
-        m_DataAlignment = wxALIGN_INVALID;
-        m_DataMargin = -1;
-        m_InstrumentSpacing = -1;
-        m_Format = "";
-        m_Title = "";
-        m_TitleFont = *(g_pFontTitle);
-        m_USTitleFont = *(g_pUSFontTitle);
-        m_DataFont = *(g_pFontData);
-        m_USDataFont = *(g_pUSFontData);
-        m_LabelFont = *(g_pFontLabel);
-        m_USLabelFont = *(g_pUSFontLabel);
-        m_SmallFont = *(g_pFontSmall);
-        m_USSmallFont = *(g_pUSFontSmall);
-        GetGlobalColor(_T("DASHL"), &m_TitleBackgroundColour);
-        GetGlobalColor(_T("DASHB"), &m_DataBackgroundColour);
-        GetGlobalColor(_T("DASHN"), &m_Arrow_First_Colour);
-        GetGlobalColor(_T("BLUE3"), &m_Arrow_Second_Colour);
-    }
-    ~InstrumentProperties() {}
-    void SetDefault()
-    {
-        m_aInstrument = -1;
-        m_Listplace = -1;
-        m_ShowUnit = -1;
-        m_DataAlignment = wxALIGN_INVALID;
-        m_DataMargin = -1;
-        m_InstrumentSpacing = -1;
-        m_Format = "";
-        m_Title = "";
-        m_TitleFont = *(g_pFontTitle);
-        m_USTitleFont = *(g_pUSFontTitle);
-        m_DataFont = *(g_pFontData);
-        m_USDataFont = *(g_pUSFontData);
-        m_LabelFont = *(g_pFontLabel);
-        m_USLabelFont = *(g_pUSFontLabel);
-        m_SmallFont = *(g_pFontSmall);
-        m_USSmallFont = *(g_pUSFontSmall);
-        GetGlobalColor(_T("DASHL"), &m_TitleBackgroundColour);
-        GetGlobalColor(_T("DASHB"), &m_DataBackgroundColour);
-        GetGlobalColor(_T("DASHN"), &m_Arrow_First_Colour);
-        GetGlobalColor(_T("BLUE3"), &m_Arrow_Second_Colour);
-    };
-    int m_aInstrument;
-    int m_Listplace;
-    int m_ShowUnit;
-    wxAlignment m_DataAlignment;
-    int m_DataMargin;
-    int m_InstrumentSpacing;
-    wxString m_Format;
-    wxString m_Title;
-    wxFontData m_TitleFont;
-    wxFontData m_USTitleFont;
-    wxColour m_TitleBackgroundColour;
-    wxFontData m_DataFont;
-    wxFontData m_USDataFont;
-    wxColour m_DataBackgroundColour;
-    wxFontData m_LabelFont;
-    wxFontData m_USLabelFont;
-    wxFontData m_SmallFont;
-    wxFontData m_USSmallFont;
-    wxColour m_Arrow_First_Colour;
-    wxColour m_Arrow_Second_Colour;
+  InstrumentProperties() { SetDefault(); }
+  InstrumentProperties(int aInstrument, int Listplace) {
+    m_aInstrument = aInstrument;
+    m_Listplace = Listplace;
+    m_ShowUnit = -1;
+    m_DataAlignment = wxALIGN_INVALID;
+    m_DataMargin = -1;
+    m_InstrumentSpacing = -1;
+    m_Format = "";
+    m_Title = "";
+    m_TitleFont = *(g_pFontTitle);
+    m_USTitleFont = *(g_pUSFontTitle);
+    m_DataFont = *(g_pFontData);
+    m_USDataFont = *(g_pUSFontData);
+    m_LabelFont = *(g_pFontLabel);
+    m_USLabelFont = *(g_pUSFontLabel);
+    m_SmallFont = *(g_pFontSmall);
+    m_USSmallFont = *(g_pUSFontSmall);
+    GetGlobalColor(_T("DASHL"), &m_TitleBackgroundColour);
+    GetGlobalColor(_T("DASHB"), &m_DataBackgroundColour);
+    GetGlobalColor(_T("DASHN"), &m_Arrow_First_Colour);
+    GetGlobalColor(_T("BLUE3"), &m_Arrow_Second_Colour);
+  }
+  ~InstrumentProperties() {}
+  void SetDefault() {
+    m_aInstrument = -1;
+    m_Listplace = -1;
+    m_ShowUnit = -1;
+    m_DataAlignment = wxALIGN_INVALID;
+    m_DataMargin = -1;
+    m_InstrumentSpacing = -1;
+    m_Format = "";
+    m_Title = "";
+    m_TitleFont = *(g_pFontTitle);
+    m_USTitleFont = *(g_pUSFontTitle);
+    m_DataFont = *(g_pFontData);
+    m_USDataFont = *(g_pUSFontData);
+    m_LabelFont = *(g_pFontLabel);
+    m_USLabelFont = *(g_pUSFontLabel);
+    m_SmallFont = *(g_pFontSmall);
+    m_USSmallFont = *(g_pUSFontSmall);
+    GetGlobalColor(_T("DASHL"), &m_TitleBackgroundColour);
+    GetGlobalColor(_T("DASHB"), &m_DataBackgroundColour);
+    GetGlobalColor(_T("DASHN"), &m_Arrow_First_Colour);
+    GetGlobalColor(_T("BLUE3"), &m_Arrow_Second_Colour);
+  };
+  int m_aInstrument;
+  int m_Listplace;
+  int m_ShowUnit;
+  wxAlignment m_DataAlignment;
+  int m_DataMargin;
+  int m_InstrumentSpacing;
+  wxString m_Format;
+  wxString m_Title;
+  wxFontData m_TitleFont;
+  wxFontData m_USTitleFont;
+  wxColour m_TitleBackgroundColour;
+  wxFontData m_DataFont;
+  wxFontData m_USDataFont;
+  wxColour m_DataBackgroundColour;
+  wxFontData m_LabelFont;
+  wxFontData m_USLabelFont;
+  wxFontData m_SmallFont;
+  wxFontData m_USSmallFont;
+  wxColour m_Arrow_First_Colour;
+  wxColour m_Arrow_Second_Colour;
 };
 
 class DashboardInstrument : public wxControl {
 public:
   DashboardInstrument(wxWindow *pparent, wxWindowID id, wxString title,
-                      DASH_CAP cap_flag, InstrumentProperties* Properties = NULL);
+                      DASH_CAP cap_flag,
+                      InstrumentProperties *Properties = NULL);
   ~DashboardInstrument() {}
 
   CapType GetCapacity();
@@ -235,18 +235,18 @@ protected:
   virtual void InitTitleAndDataPosition(int drawHeight);
   virtual int GetFullHeight(int drawHeight);
   virtual int GetDataBottom(int clientHeight);
-  virtual void SetDataFont(wxGCDC* dc);
+  virtual void SetDataFont(wxGCDC *dc);
 
 private:
   bool m_drawSoloInPane;
   bool m_popupWanted;
-
 };
 
 class DashboardInstrument_Single : public DashboardInstrument {
 public:
   DashboardInstrument_Single(wxWindow *pparent, wxWindowID id, wxString title,
-                             InstrumentProperties* Properties, DASH_CAP cap, wxString format);
+                             InstrumentProperties *Properties, DASH_CAP cap,
+                             wxString format);
   ~DashboardInstrument_Single() {}
 
   wxSize GetSize(int orient, wxSize hint);
@@ -255,8 +255,8 @@ public:
 protected:
   wxString m_data;
   wxString m_format;
-//  int m_DataHeight;
-//  InstrumentProperties* m_Properties;
+  //  int m_DataHeight;
+  //  InstrumentProperties* m_Properties;
 
   void Draw(wxGCDC *dc);
 };
@@ -264,7 +264,7 @@ protected:
 class DashboardInstrument_Position : public DashboardInstrument {
 public:
   DashboardInstrument_Position(wxWindow *pparent, wxWindowID id, wxString title,
-                               InstrumentProperties* Properties = NULL,
+                               InstrumentProperties *Properties = NULL,
                                DASH_CAP cap_flag1 = OCPN_DBP_STC_LAT,
                                DASH_CAP cap_flag2 = OCPN_DBP_STC_LON);
   ~DashboardInstrument_Position() {}
@@ -277,7 +277,7 @@ protected:
   wxString m_data2;
   DASH_CAP m_cap_flag1;
   DASH_CAP m_cap_flag2;
-//  int m_DataHeight;
+  //  int m_DataHeight;
 
   void Draw(wxGCDC *dc);
 };


### PR DESCRIPTION
This PR implements the instrument discussed here: #3427 
- NMEA0183 reads XDR type D name WINDLASS or WINDLASS#0. Tested
- N2k PGN 128777 reads "RodeCounterValue" . Not tested. We hope for testers during alpha.
- No Windlass rode count in SignalK. It has been discussed but not implemented.
