### PR TITLE
Open Properties dialog on Drop Mark

### DIFF
--- a/gui/include/gui/MarkInfo.h
+++ b/gui/include/gui/MarkInfo.h
@@ -212,6 +212,7 @@ private:
   std::vector<RoutePoint*> m_pRoutePoints;
   static bool instanceFlag;
   int i_htmlList_item;
+  bool m_deleteOnCancel;
 
   bool m_bShowName_save;
   wxString m_Name_save;
@@ -380,6 +381,9 @@ public:
   void ValidateMark(void);
   bool SaveChanges();
   void OnActivate(wxActivateEvent& event);
+  void SetDeleteOnCancel(bool deleteOnCancel) {
+    m_deleteOnCancel = deleteOnCancel;
+  }
 
   wxSimpleHtmlListBox* GetSimpleBox() {
     return dynamic_cast<wxSimpleHtmlListBox*>(m_htmlList);

--- a/gui/include/gui/chcanv.h
+++ b/gui/include/gui/chcanv.h
@@ -360,7 +360,8 @@ public:
   void SetShowGPS(bool show);
 
   void ShowObjectQueryWindow(int x, int y, float zlat, float zlon);
-  void ShowMarkPropertiesDialog(RoutePoint *markPoint);
+  void ShowMarkPropertiesDialog(RoutePoint *markPoint,
+                                bool deleteMarkOnCancelClick = false);
   void ShowRoutePropertiesDialog(wxString title, Route *selected);
   void ShowTrackPropertiesDialog(Track *selected);
   void DrawTCWindow(int x, int y, void *pIDX);

--- a/gui/include/gui/undo.h
+++ b/gui/include/gui/undo.h
@@ -65,7 +65,7 @@ public:
   bool AnythingToRedo();
   void InvalidateRedo();
   void InvalidateUndo();
-  void Invalidate();
+  void InvalidateLastAddedUndoableAction();
   bool InUndoableAction() { return isInsideUndoableAction; }
   UndoAction* GetNextUndoableAction();
   UndoAction* GetNextRedoableAction();

--- a/gui/src/canvasMenu.cpp
+++ b/gui/src/canvasMenu.cpp
@@ -1227,6 +1227,9 @@ void CanvasMenuHandler::PopupMenuHandler(wxCommandEvent &event) {
       gFrame->RefreshAllCanvas(false);
       gFrame->InvalidateAllGL();
       g_FlushNavobjChanges = true;
+
+      parent->ShowMarkPropertiesDialog(pWP, true);
+
       break;
     }
 

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -9891,13 +9891,16 @@ void ChartCanvas::ShowObjectQueryWindow(int x, int y, float zlat, float zlon) {
   }
 }
 
-void ChartCanvas::ShowMarkPropertiesDialog(RoutePoint *markPoint) {
+void ChartCanvas::ShowMarkPropertiesDialog(RoutePoint *markPoint,
+                                           bool deleteMarkOnCancelClick) {
   bool bNew = false;
   if (!g_pMarkInfoDialog) {  // There is one global instance of the MarkProp
                              // Dialog
     g_pMarkInfoDialog = new MarkInfoDlg(this);
     bNew = true;
   }
+
+  g_pMarkInfoDialog->SetDeleteOnCancel(deleteMarkOnCancelClick);
 
   if (1 /*g_bresponsive*/) {
     wxSize canvas_size = GetSize();

--- a/gui/src/undo.cpp
+++ b/gui/src/undo.cpp
@@ -247,6 +247,11 @@ void Undo::InvalidateUndo() {
   stackpointer = 0;
 }
 
+void Undo::InvalidateLastAddedUndoableAction() {
+  delete undoStack.front();
+  undoStack.pop_front();
+}
+
 bool Undo::UndoLastAction() {
   if (!AnythingToUndo()) return false;
   UndoAction* action = GetNextUndoableAction();


### PR DESCRIPTION
In addition to dropping the mark on right-click->Drop Mark context menu item selection, open mark Properties dialog right away to be able to modify the mark. Ok dialog button saves changes. Cancel dialog button discards the mark fully.