### PR TITLE
Fix memory leak in InvalidateUndo()

### DIFF
--- a/gui/src/undo.cpp
+++ b/gui/src/undo.cpp
@@ -243,6 +243,11 @@ void Undo::InvalidateRedo() {
 }
 
 void Undo::InvalidateUndo() {
+  for (auto* undoItem : undoStack)
+  {
+    delete undoItem;
+  }
+
   undoStack.clear();
   stackpointer = 0;
 }


### PR DESCRIPTION
calling clear() won't delete underlying objects, so delete them manually before