### PR TITLE
Zoom chart with '=' key only

### DIFF
--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -2598,6 +2598,7 @@ void ChartCanvas::OnKeyChar(wxKeyEvent &event) {
     case '?':
       HotkeysDlg(wxWindow::FindWindowByName("MainWindow")).ShowModal();
       break;
+    case '=':
     case '+':
       ZoomCanvas(g_plus_minus_zoom_factor, false);
       break;


### PR DESCRIPTION
Accept '=' key so user can zoom in with single key press. 
Simplifies key presses zooming in/out (no need for modifier, eg.  shift =).