### PR TITLE
N0183 net work driver cleanup.

### DIFF
--- a/model/include/model/comm_buffers.h
+++ b/model/include/model/comm_buffers.h
@@ -70,4 +70,27 @@ private:
   uint8_t m_last_ch;
 };
 
+/** Assemble characters to NMEA0183 sentences. */
+class N0183Buffer {
+public:
+  /** Add a single character, possibly making a sentence available */
+  void Put(uint8_t ch);
+
+  /** Return true if a sentence is available to be returned by GetSentence() */
+  bool HasSentence() const { return !m_lines.empty(); }
+
+  /**
+   * Retrieve a sentence from buffer
+   * @return Next available sentence in buffer or "" if none available
+   */
+  std::string GetSentence();
+
+  N0183Buffer() : m_state(State::PrefixWait) {}
+
+private:
+  std::deque<std::string> m_lines;
+  std::vector<uint8_t> m_line;
+  enum class State { PrefixWait, Data, CsDigit1, CsDigit2 } m_state;
+};
+
 #endif  // _COMM_BUFFERS_H__

--- a/model/include/model/comm_drv_n0183.h
+++ b/model/include/model/comm_drv_n0183.h
@@ -1,11 +1,6 @@
-/***************************************************************************
- *
- * Project:  OpenCPN
- * Purpose:
- * Author:   David Register, Alec Leamas
- *
- ***************************************************************************
- *   Copyright (C) 2022 by David Register, Alec Leamas                     *
+/**************************************************************************
+ *   Copyright (C) 2022 David Register                                     *
+ *   Copyright (C) 2022 Alec Leamas                                        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -22,6 +17,9 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
+
+/** \file comm_drv_n0183.h  NMEA0183 drivers common base. */
+
 #ifndef _COMMDRIVERN0183_H__
 #define _COMMDRIVERN0183_H__
 
@@ -30,6 +28,7 @@
 
 #include "model/comm_driver.h"
 
+/** NMEA0183 drivers common part. */
 class CommDriverN0183 : public AbstractCommDriver {
 public:
   CommDriverN0183();
@@ -49,4 +48,4 @@ public:
   void Activate() override;
 };
 
-#endif  // guarstring
+#endif  // guardstring

--- a/model/include/model/comm_drv_n0183_net.h
+++ b/model/include/model/comm_drv_n0183_net.h
@@ -115,8 +115,6 @@ private:
   bool m_ok;
 
   ObsListener resume_listener;
-
-  DECLARE_EVENT_TABLE()
 };
 
 #endif  // COMMDRIVERN0183NET_H_

--- a/model/include/model/comm_drv_n0183_net.h
+++ b/model/include/model/comm_drv_n0183_net.h
@@ -57,7 +57,6 @@
 #include "model/conn_params.h"
 #include "observable.h"
 
-class CommDriverN0183NetEvent;  // Internal
 class MrqContainer;
 
 class CommDriverN0183Net : public CommDriverN0183, public wxEvtHandler {
@@ -88,7 +87,7 @@ private:
   void OpenNetworkGpsd();
   void OpenNetworkTcp(unsigned int addr);
   void OpenNetworkUdp(unsigned int addr);
-  void HandleN0183Msg(CommDriverN0183NetEvent& event);
+  void HandleN0183Msg(const std::string& sentence);
   bool SendSentenceNetwork(const wxString& payload);
 
   wxString m_net_port;

--- a/model/include/model/comm_drv_n0183_net.h
+++ b/model/include/model/comm_drv_n0183_net.h
@@ -20,8 +20,8 @@
 
 /** \file comm_drv_n0183_net.h  NMEA0183 over IP driver. */
 
-#ifndef _COMMDRIVERN0183NET_H
-#define _COMMDRIVERN0183NET_H
+#ifndef COMMDRIVERN0183NET_H_
+#define COMMDRIVERN0183NET_H_
 
 #include <memory>
 #include <string>
@@ -64,7 +64,7 @@ class CommDriverN0183Net : public CommDriverN0183, public wxEvtHandler {
 public:
   CommDriverN0183Net(const ConnectionParams* params, DriverListener& listener);
 
-  virtual ~CommDriverN0183Net();
+  ~CommDriverN0183Net() override;
 
   void Open();
   void Close();
@@ -81,45 +81,17 @@ private:
 
   void HandleResume();
   void OnServerSocketEvent(wxSocketEvent& event);  // The listener
-  void OnTimerSocket(wxTimerEvent& event) { OnTimerSocket(); }
+  void OnTimerSocket(wxTimerEvent&) { OnTimerSocket(); }
   void OnTimerSocket();
   void OnSocketEvent(wxSocketEvent& event);
   void OnSocketReadWatchdogTimer(wxTimerEvent& event);
-  void OpenNetworkGPSD();
-  void OpenNetworkTCP(unsigned int addr);
-  void OpenNetworkUDP(unsigned int addr);
-  void handle_N0183_MSG(CommDriverN0183NetEvent& event);
+  void OpenNetworkGpsd();
+  void OpenNetworkTcp(unsigned int addr);
+  void OpenNetworkUdp(unsigned int addr);
+  void HandleN0183Msg(CommDriverN0183NetEvent& event);
   bool SendSentenceNetwork(const wxString& payload);
   bool SetOutputSocketOptions(wxSocketBase* tsock);
-
-  wxString GetNetPort() const { return m_net_port; }
-  wxIPV4address GetAddr() const { return m_addr; }
-  wxTimer* GetSocketThreadWatchdogTimer() {
-    return &m_socketread_watchdog_timer;
-  }
-  wxTimer* GetSocketTimer() { return &m_socket_timer; }
-  void SetSock(wxSocketBase* sock) { m_sock = sock; }
-  void SetTSock(wxSocketBase* sock) { m_tsock = sock; }
-  wxSocketBase* GetTSock() const { return m_tsock; }
-  void SetSockServer(wxSocketServer* sock) { m_socket_server = sock; }
-  wxSocketServer* GetSockServer() const { return m_socket_server; }
-  void SetMulticast(bool multicast) { m_is_multicast = multicast; }
-  bool GetMulticast() const { return m_is_multicast; }
-
-  NetworkProtocol GetProtocol() const { return m_net_protocol; }
-  void SetBrxConnectEvent(bool event) { m_brx_connect_event = event; }
-  bool GetBrxConnectEvent() const { return m_brx_connect_event; }
-
-  void SetConnectTime(wxDateTime time) { m_connect_time = time; }
-  wxDateTime GetConnectTime() const { return m_connect_time; }
-
-  dsPortType GetPortType() const { return m_io_select; }
-  wxString GetPort() const { return m_portstring; }
-
-  ConnectionType GetConnectionType() const { return m_connection_type; }
-
   bool ChecksumOK(const std::string& sentence);
-  void SetOk(bool ok) { m_bok = ok; };
 
   wxString m_net_port;
   NetworkProtocol m_net_protocol;
@@ -136,18 +108,17 @@ private:
   wxString m_portstring;
   dsPortType m_io_select;
   wxDateTime m_connect_time;
-  bool m_brx_connect_event;
-  bool m_bchecksumCheck;
-  ConnectionType m_connection_type;
+  bool m_rx_connect_event;
+  bool m_checksum_check;
 
   wxTimer m_socket_timer;
   wxTimer m_socketread_watchdog_timer;
 
-  bool m_bok;
+  bool m_ok;
 
   ObsListener resume_listener;
 
   DECLARE_EVENT_TABLE()
 };
 
-#endif  // guard
+#endif  // COMMDRIVERN0183NET_H_

--- a/model/include/model/comm_drv_n0183_net.h
+++ b/model/include/model/comm_drv_n0183_net.h
@@ -30,7 +30,7 @@
 
 #ifndef WX_PRECOMP
 #include <wx/wx.h>
-#endif  // precompiled header
+#endif
 
 #include <wx/datetime.h>
 #include <wx/string.h>
@@ -90,8 +90,6 @@ private:
   void OpenNetworkUdp(unsigned int addr);
   void HandleN0183Msg(CommDriverN0183NetEvent& event);
   bool SendSentenceNetwork(const wxString& payload);
-  bool SetOutputSocketOptions(wxSocketBase* tsock);
-  bool ChecksumOK(const std::string& sentence);
 
   wxString m_net_port;
   NetworkProtocol m_net_protocol;
@@ -109,7 +107,6 @@ private:
   dsPortType m_io_select;
   wxDateTime m_connect_time;
   bool m_rx_connect_event;
-  bool m_checksum_check;
 
   wxTimer m_socket_timer;
   wxTimer m_socketread_watchdog_timer;

--- a/model/include/model/comm_drv_n0183_net.h
+++ b/model/include/model/comm_drv_n0183_net.h
@@ -53,6 +53,7 @@
 #include <netinet/in.h>
 #endif
 
+#include "model/comm_buffers.h"
 #include "model/comm_drv_n0183.h"
 #include "model/conn_params.h"
 #include "observable.h"
@@ -90,6 +91,7 @@ private:
   void HandleN0183Msg(const std::string& sentence);
   bool SendSentenceNetwork(const wxString& payload);
 
+  N0183Buffer n0183_buffer;
   wxString m_net_port;
   NetworkProtocol m_net_protocol;
   wxIPV4address m_addr;

--- a/model/include/model/comm_drv_n0183_net.h
+++ b/model/include/model/comm_drv_n0183_net.h
@@ -62,7 +62,6 @@ class MrqContainer;
 
 class CommDriverN0183Net : public CommDriverN0183, public wxEvtHandler {
 public:
-  CommDriverN0183Net();
   CommDriverN0183Net(const ConnectionParams* params, DriverListener& listener);
 
   virtual ~CommDriverN0183Net();
@@ -71,27 +70,28 @@ public:
   void Close();
   ConnectionParams GetParams() const { return m_params; }
 
-  bool SetOutputSocketOptions(wxSocketBase* tsock);
-  bool SendSentenceNetwork(const wxString& payload);
-  void OnServerSocketEvent(wxSocketEvent& event);  // The listener
-  void OnTimerSocket(wxTimerEvent& event) { OnTimerSocket(); }
-  void OnTimerSocket();
-  void OnSocketEvent(wxSocketEvent& event);
-  void OpenNetworkGPSD();
-  void OpenNetworkTCP(unsigned int addr);
-  void OpenNetworkUDP(unsigned int addr);
-  void OnSocketReadWatchdogTimer(wxTimerEvent& event);
-  void HandleResume();
+  wxSocketBase* GetSock() const { return m_sock; }
 
   bool SendMessage(std::shared_ptr<const NavMsg> msg,
                    std::shared_ptr<const NavAddr> addr) override;
-  wxSocketBase* GetSock() const { return m_sock; }
 
 private:
   ConnectionParams m_params;
   DriverListener& m_listener;
 
+  void HandleResume();
+  void OnServerSocketEvent(wxSocketEvent& event);  // The listener
+  void OnTimerSocket(wxTimerEvent& event) { OnTimerSocket(); }
+  void OnTimerSocket();
+  void OnSocketEvent(wxSocketEvent& event);
+  void OnSocketReadWatchdogTimer(wxTimerEvent& event);
+  void OpenNetworkGPSD();
+  void OpenNetworkTCP(unsigned int addr);
+  void OpenNetworkUDP(unsigned int addr);
   void handle_N0183_MSG(CommDriverN0183NetEvent& event);
+  bool SendSentenceNetwork(const wxString& payload);
+  bool SetOutputSocketOptions(wxSocketBase* tsock);
+
   wxString GetNetPort() const { return m_net_port; }
   wxIPV4address GetAddr() const { return m_addr; }
   wxTimer* GetSocketThreadWatchdogTimer() {
@@ -106,12 +106,12 @@ private:
   void SetMulticast(bool multicast) { m_is_multicast = multicast; }
   bool GetMulticast() const { return m_is_multicast; }
 
-  NetworkProtocol GetProtocol() { return m_net_protocol; }
+  NetworkProtocol GetProtocol() const { return m_net_protocol; }
   void SetBrxConnectEvent(bool event) { m_brx_connect_event = event; }
-  bool GetBrxConnectEvent() { return m_brx_connect_event; }
+  bool GetBrxConnectEvent() const { return m_brx_connect_event; }
 
   void SetConnectTime(wxDateTime time) { m_connect_time = time; }
-  wxDateTime GetConnectTime() { return m_connect_time; }
+  wxDateTime GetConnectTime() const { return m_connect_time; }
 
   dsPortType GetPortType() const { return m_io_select; }
   wxString GetPort() const { return m_portstring; }

--- a/model/include/model/comm_drv_n0183_net.h
+++ b/model/include/model/comm_drv_n0183_net.h
@@ -99,7 +99,7 @@ private:
   wxSocketBase* m_tsock;
   wxSocketServer* m_socket_server;
   bool m_is_multicast;
-  MrqContainer* m_mrq_container;
+  std::unique_ptr<MrqContainer> m_mrq_container;
 
   int m_txenter;
   int m_dog_value;

--- a/model/include/model/comm_drv_n0183_net.h
+++ b/model/include/model/comm_drv_n0183_net.h
@@ -1,11 +1,6 @@
-/***************************************************************************
- *
- * Project:  OpenCPN
- * Purpose:
- * Author:   David Register, Alec Leamas
- *
- ***************************************************************************
- *   Copyright (C) 2022 by David Register, Alec Leamas                     *
+/**************************************************************************
+ *   Copyright (C) 2022  David Register                                    *
+ *   Copyright (C) 2022  Alec Leamas                                       *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -22,6 +17,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
+
+/** \file comm_drv_n0183_net.h  NMEA0183 over IP driver. */
 
 #ifndef _COMMDRIVERN0183NET_H
 #define _COMMDRIVERN0183NET_H

--- a/model/include/model/conn_params.h
+++ b/model/include/model/conn_params.h
@@ -122,8 +122,8 @@ public:
   NavAddr::Bus GetLastCommProtocol();
   wxString GetPortStr() const { return Port; }
   void SetPortStr(wxString str) { Port = str; }
-  std::string GetStrippedDSPort();
-  NavAddr::Bus GetCommProtocol();
+  std::string GetStrippedDSPort() const;
+  NavAddr::Bus GetCommProtocol() const;
 
   bool SentencePassesFilter(const wxString &sentence,
                             FilterDirection direction) const;

--- a/model/include/model/garmin_protocol_mgr.h
+++ b/model/include/model/garmin_protocol_mgr.h
@@ -74,8 +74,6 @@
 #define PI 3.1415926535897931160E0 /* pi */
 #endif
 
-#define TIMER_SOCKET 7006
-
 //----------------------------------------------------------------------------
 // Garmin Device Management
 // Handle USB and Serial Port Garmin PVT protocol data interface.

--- a/model/include/model/ocpn_utils.h
+++ b/model/include/model/ocpn_utils.h
@@ -58,6 +58,13 @@ bool replace(std::string& str, const std::string& from, const std::string& to);
 
 void copy_file(const std::string& src_path, const std::string& dest_path);
 
+/**
+ * Check if checksum in a NMEA0183 sentence is correct
+ * @param sentence complete NMEA01832 message
+ * @return true if checksum is OK, else false.
+ */
+bool N0183CheckSumOk(const std::string& sentence);
+
 }  // namespace ocpn
 
 #endif  //  _OCPN_UTILS_H__

--- a/model/src/comm_drv_n0183_android_bt.cpp
+++ b/model/src/comm_drv_n0183_android_bt.cpp
@@ -173,8 +173,7 @@ private:
 
 CommDriverN0183AndroidBT::CommDriverN0183AndroidBT(
     const ConnectionParams* params, DriverListener& listener)
-    : CommDriverN0183(NavAddr::Bus::N0183,
-                      ((ConnectionParams*)params)->GetStrippedDSPort()),
+    : CommDriverN0183(NavAddr::Bus::N0183, params->GetStrippedDSPort()),
       m_bok(false),
       m_portstring(params->GetDSPort()),
       m_params(*params),

--- a/model/src/comm_drv_n0183_android_int.cpp
+++ b/model/src/comm_drv_n0183_android_int.cpp
@@ -173,8 +173,7 @@ private:
 
 CommDriverN0183AndroidInt::CommDriverN0183AndroidInt(
     const ConnectionParams* params, DriverListener& listener)
-    : CommDriverN0183(NavAddr::Bus::N0183,
-                      ((ConnectionParams*)params)->GetStrippedDSPort()),
+    : CommDriverN0183(NavAddr::Bus::N0183, params->GetStrippedDSPort()),
       m_bok(false),
       m_portstring(params->GetDSPort()),
       m_params(*params),

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -89,17 +89,12 @@ static bool SetOutputSocketOptions(wxSocketBase* tsock) {
                            sizeof(outbuf_size)) &&
           ret);
 }
+
+
 //========================================================================
-/*    commdriverN0183Net implementation
- * */
-
-BEGIN_EVENT_TABLE(CommDriverN0183Net, wxEvtHandler)
-EVT_TIMER(TIMER_SOCKET, CommDriverN0183Net::OnTimerSocket)
-EVT_SOCKET(DS_SOCKET_ID, CommDriverN0183Net::OnSocketEvent)
-EVT_SOCKET(DS_SERVERSOCKET_ID, CommDriverN0183Net::OnServerSocketEvent)
-EVT_TIMER(TIMER_SOCKET + 1, CommDriverN0183Net::OnSocketReadWatchdogTimer)
-END_EVENT_TABLE()
-
+/*
+ * CommDriverN0183Net implementation
+ */
 CommDriverN0183Net::CommDriverN0183Net(const ConnectionParams* params,
                                        DriverListener& listener)
     : CommDriverN0183(NavAddr::Bus::N0183, params->GetStrippedDSPort()),
@@ -137,9 +132,16 @@ CommDriverN0183Net::CommDriverN0183Net(const ConnectionParams* params,
   this->attributes["ioDirection"] = s_iosel;
   m_mrq_container = new MrqContainer;
 
-  // Establish the power events response
+  // Establish event listeners
   resume_listener.Init(SystemEvents::GetInstance().evt_resume,
                        [&](ObservedEvt&) { HandleResume(); });
+  Bind(wxEVT_SOCKET, &CommDriverN0183Net::OnSocketEvent, this, DS_SOCKET_ID);
+  Bind(wxEVT_SOCKET, &CommDriverN0183Net::OnServerSocketEvent, this,
+       DS_SERVERSOCKET_ID );
+  Bind(wxEVT_TIMER, &CommDriverN0183Net::OnTimerSocket, this, TIMER_SOCKET);
+  Bind(wxEVT_TIMER, &CommDriverN0183Net::OnSocketReadWatchdogTimer, this,
+       TIMER_SOCKET + 1);
+
   Open();
 }
 

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -130,7 +130,7 @@ CommDriverN0183Net::CommDriverN0183Net(const ConnectionParams* params,
     s_iosel = "IN/OUT";
   }
   this->attributes["ioDirection"] = s_iosel;
-  m_mrq_container = new MrqContainer;
+  m_mrq_container = std::make_unique<MrqContainer>();
 
   // Establish event listeners
   resume_listener.Init(SystemEvents::GetInstance().evt_resume,
@@ -146,7 +146,6 @@ CommDriverN0183Net::CommDriverN0183Net(const ConnectionParams* params,
 }
 
 CommDriverN0183Net::~CommDriverN0183Net() {
-  delete m_mrq_container;
   Close();
 }
 

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -342,7 +342,9 @@ void CommDriverN0183Net::HandleResume() {
 bool CommDriverN0183Net::SendMessage(std::shared_ptr<const NavMsg> msg,
                                      std::shared_ptr<const NavAddr> addr) {
   auto msg_0183 = std::dynamic_pointer_cast<const Nmea0183Msg>(msg);
-  return SendSentenceNetwork(msg_0183->payload.c_str());
+  std::string payload(msg_0183->payload);
+  if (!ocpn::endswith(payload, "\r\n")) payload += "\r\n";
+  return SendSentenceNetwork(payload.c_str());
 }
 
 void CommDriverN0183Net::OnSocketEvent(wxSocketEvent& event) {

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -159,7 +159,7 @@ CommDriverN0183Net::CommDriverN0183Net(const ConnectionParams* params,
   this->attributes["userComment"] = params->UserComment.ToStdString();
   dsPortType iosel = params->IOSelect;
   std::string s_iosel = std::string("IN");
-  if (iosel == DS_TYPE_INPUT_OUTPUT) {
+  if (iosel == DS_TYPE_OUTPUT) {
     s_iosel = "OUT";
   } else if (iosel == DS_TYPE_INPUT_OUTPUT) {
     s_iosel = "IN/OUT";

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -294,7 +294,7 @@ void CommDriverN0183Net::OpenNetworkUDP(unsigned int addr) {
 
 void CommDriverN0183Net::OpenNetworkTCP(unsigned int addr) {
   int isServer = ((addr == INADDR_ANY) ? 1 : 0);
-  wxLogMessage(wxString::Format(_T("Opening TCP Server %d"), isServer));
+  wxLogMessage("Opening TCP Server %d", isServer);
 
   if (isServer) {
     SetSockServer(new wxSocketServer(GetAddr(), wxSOCKET_REUSEADDR));
@@ -348,8 +348,8 @@ void CommDriverN0183Net::OnSocketReadWatchdogTimer(wxTimerEvent& event) {
         if (tcp_socket) tcp_socket->Close();
 
         int n_reconnect_delay = wxMax(N_DOG_TIMEOUT - 2, 2);
-        wxLogMessage(wxString::Format(" Reconnection scheduled in %d seconds.",
-                                      n_reconnect_delay));
+        wxLogMessage("Reconnection scheduled in %d seconds.",
+                     n_reconnect_delay);
         GetSocketTimer()->Start(n_reconnect_delay * 1000, wxTIMER_ONE_SHOT);
 
         //  Stop DATA watchdog, will be restarted on successful connection.
@@ -364,7 +364,7 @@ void CommDriverN0183Net::OnTimerSocket() {
   wxSocketClient* tcp_socket = dynamic_cast<wxSocketClient*>(GetSock());
   if (tcp_socket) {
     if (tcp_socket->IsDisconnected()) {
-      wxLogDebug(" Attempting reconnection...");
+      wxLogDebug("Attempting reconnection...");
       SetBrxConnectEvent(false);
       //  Stop DATA watchdog, may be restarted on successful connection.
       GetSocketThreadWatchdogTimer()->Stop();
@@ -387,8 +387,7 @@ void CommDriverN0183Net::HandleResume() {
 
     // schedule reconnect attempt
     int n_reconnect_delay = wxMax(N_DOG_TIMEOUT - 2, 2);
-    wxLogMessage(wxString::Format(" Reconnection scheduled in %d seconds.",
-                                  n_reconnect_delay));
+    wxLogMessage("Reconnection scheduled in %d seconds.", n_reconnect_delay);
 
     GetSocketTimer()->Start(n_reconnect_delay * 1000, wxTIMER_ONE_SHOT);
   }
@@ -509,8 +508,8 @@ void CommDriverN0183Net::OnSocketEvent(wxSocketEvent& event) {
     case wxSOCKET_LOST: {
       if (GetProtocol() == TCP || GetProtocol() == GPSD) {
         if (GetBrxConnectEvent())
-          wxLogMessage(wxString::Format(
-              _T("NetworkDataStream connection lost: %s"), GetPort().c_str()));
+          wxLogMessage("NetworkDataStream connection lost: %s",
+                       GetPort().c_str());
         if (GetSockServer()) {
           GetSock()->Destroy();
           SetSock(NULL);
@@ -546,9 +545,8 @@ void CommDriverN0183Net::OnSocketEvent(wxSocketEvent& event) {
         char cmd[] = "?WATCH={\"class\":\"WATCH\", \"nmea\":true}";
         GetSock()->Write(cmd, strlen(cmd));
       } else if (GetProtocol() == TCP) {
-        wxLogMessage(wxString::Format(
-            _T("TCP NetworkDataStream connection established: %s"),
-            GetPort().c_str()));
+        wxLogMessage("TCP NetworkDataStream connection established: %s",
+                     GetPort().c_str());
 
         m_dog_value = N_DOG_TIMEOUT;  // feed the dog
         if (GetPortType() != DS_TYPE_OUTPUT) {
@@ -649,8 +647,7 @@ bool CommDriverN0183Net::SendSentenceNetwork(const wxString& payload) {
 }
 
 void CommDriverN0183Net::Close() {
-  wxLogMessage(wxString::Format(_T("Closing NMEA NetworkDataStream %s"),
-                                GetNetPort().c_str()));
+  wxLogMessage("Closing NMEA NetworkDataStream %s", GetNetPort().c_str());
   //    Kill off the TCP Socket if alive
   if (m_sock) {
     if (m_is_multicast)

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -141,8 +141,7 @@ END_EVENT_TABLE()
 
 CommDriverN0183Net::CommDriverN0183Net(const ConnectionParams* params,
                                        DriverListener& listener)
-    : CommDriverN0183(NavAddr::Bus::N0183,
-                      ((ConnectionParams*)params)->GetStrippedDSPort()),
+    : CommDriverN0183(NavAddr::Bus::N0183, params->GetStrippedDSPort()),
       m_params(*params),
       m_listener(listener),
       m_net_port(wxString::Format("%i", params->NetworkPort)),

--- a/model/src/comm_drv_n0183_serial.cpp
+++ b/model/src/comm_drv_n0183_serial.cpp
@@ -52,8 +52,7 @@ typedef enum DS_ENUM_BUFFER_STATE {
 
 CommDriverN0183Serial::CommDriverN0183Serial(const ConnectionParams* params,
                                              DriverListener& listener)
-    : CommDriverN0183(NavAddr::Bus::N0183,
-                      ((ConnectionParams*)params)->GetStrippedDSPort()),
+    : CommDriverN0183(NavAddr::Bus::N0183, params->GetStrippedDSPort()),
       m_portstring(params->GetDSPort()),
       m_baudrate(params->Baudrate),
       m_serial_io(SerialIo::Create(

--- a/model/src/comm_drv_n0183_serial.cpp
+++ b/model/src/comm_drv_n0183_serial.cpp
@@ -45,11 +45,6 @@
 
 using namespace std::literals::chrono_literals;
 
-typedef enum DS_ENUM_BUFFER_STATE {
-  DS_RX_BUFFER_EMPTY,
-  DS_RX_BUFFER_FULL
-} _DS_ENUM_BUFFER_STATE;
-
 CommDriverN0183Serial::CommDriverN0183Serial(const ConnectionParams* params,
                                              DriverListener& listener)
     : CommDriverN0183(NavAddr::Bus::N0183, params->GetStrippedDSPort()),

--- a/model/src/comm_drv_n2k_net.cpp
+++ b/model/src/comm_drv_n2k_net.cpp
@@ -184,7 +184,7 @@ END_EVENT_TABLE()
 
 CommDriverN2KNet::CommDriverN2KNet(const ConnectionParams* params,
                                    DriverListener& listener)
-    : CommDriverN2K(((ConnectionParams*)params)->GetStrippedDSPort()),
+    : CommDriverN2K(params->GetStrippedDSPort()),
       m_params(*params),
       m_listener(listener),
       m_net_port(wxString::Format("%i", params->NetworkPort)),

--- a/model/src/comm_drv_n2k_serial.cpp
+++ b/model/src/comm_drv_n2k_serial.cpp
@@ -207,7 +207,7 @@ wxDEFINE_EVENT(wxEVT_COMMDRIVER_N2K_SERIAL, CommDriverN2KSerialEvent);
 
 CommDriverN2KSerial::CommDriverN2KSerial(const ConnectionParams* params,
                                          DriverListener& listener)
-    : CommDriverN2K(((ConnectionParams*)params)->GetStrippedDSPort()),
+    : CommDriverN2K(params->GetStrippedDSPort()),
       m_Thread_run_flag(-1),
       m_bok(false),
       m_portstring(params->GetDSPort()),

--- a/model/src/comm_drv_n2k_socketcan.cpp
+++ b/model/src/comm_drv_n2k_socketcan.cpp
@@ -374,7 +374,7 @@ bool CommDriverN2KSocketCanImpl::SendMessage(
 
 CommDriverN2KSocketCAN::CommDriverN2KSocketCAN(const ConnectionParams* params,
                                                DriverListener& listener)
-    : CommDriverN2K(((ConnectionParams*)params)->GetStrippedDSPort()),
+    : CommDriverN2K(params->GetStrippedDSPort()),
       m_params(*params),
       m_listener(listener),
       m_ok(false),

--- a/model/src/comm_drv_signalk_net.cpp
+++ b/model/src/comm_drv_signalk_net.cpp
@@ -218,7 +218,7 @@ wxDEFINE_EVENT(wxEVT_COMMDRIVER_SIGNALK_NET, CommDriverSignalKNetEvent);
 
 CommDriverSignalKNet::CommDriverSignalKNet(const ConnectionParams* params,
                                            DriverListener& listener)
-    : CommDriverSignalK(((ConnectionParams*)params)->GetStrippedDSPort()),
+    : CommDriverSignalK(params->GetStrippedDSPort()),
       m_Thread_run_flag(-1),
       m_params(*params),
       m_listener(listener) {

--- a/model/src/conn_params.cpp
+++ b/model/src/conn_params.cpp
@@ -295,7 +295,7 @@ wxString ConnectionParams::GetDSPort() const {
     return _T("");
 }
 
-std::string ConnectionParams::GetStrippedDSPort() {
+std::string ConnectionParams::GetStrippedDSPort() const {
   if (Type == SERIAL) {
     wxString t = wxString::Format(_T("Serial:%s"), Port.c_str());
     wxString comx = t.AfterFirst(':').BeforeFirst(' ');
@@ -370,7 +370,7 @@ bool ConnectionParams::SentencePassesFilter(const wxString& sentence,
   return !listype;
 }
 
-NavAddr::Bus ConnectionParams::GetCommProtocol() {
+NavAddr::Bus ConnectionParams::GetCommProtocol() const {
   if (Type == NETWORK) {
     if (NetProtocol == SIGNALK)
       return NavAddr::Bus::Signalk;

--- a/model/src/ocpn_utils.cpp
+++ b/model/src/ocpn_utils.cpp
@@ -145,4 +145,21 @@ void copy_file(const std::string& src_path, const std::string& dest_path) {
   dest.close();
 }
 
+bool N0183CheckSumOk(const std::string& sentence) {
+  size_t check_start = sentence.find('*');
+  if (check_start == std::string::npos || check_start > sentence.size() - 3)
+    return false;  // * not found, or it didn't have 2 characters following it.
+
+  std::string check_str = sentence.substr(check_start + 1, 2);
+  unsigned long checksum = strtol(check_str.c_str(), 0, 16);
+  if (checksum == 0L && check_str != "00") return false;
+
+  unsigned char calculated_checksum = 0;
+  for (std::string::const_iterator i = sentence.begin() + 1;
+       i != sentence.end() && *i != '*'; ++i)
+    calculated_checksum ^= static_cast<unsigned char>(*i);
+
+  return calculated_checksum == checksum;
+}
+
 }  // namespace ocpn


### PR DESCRIPTION
General  cleanup of the 0183 network driver reflecting the serial driver update in #4160.

Here is:
  - Fix hacks caused by missing `const` in `GetStrippedDSPort()` declaration
  - Clean up of comments and logging.
  - Move checksum utility to ocpn_utils, clearing a FIXME
  - Clean up public interface making it  much smaller.
  - Clean up the resulting private interface by removing all private Get/Set accessors which just adds complexity.
  - Update some variable and function names to match Google GL.
  - Fix some clang-tidy diagnostics,  notably making sure that everything is initialized in the constructor.
  - Fix  a strange typo error in [fbb7558](https://github.com/OpenCPN/OpenCPN/pull/4189/commits/fbb7558e4d99de727b64292f135105c78d6495ee) (has this ever worked?)
  - Avoid an extra message passing and main loop iteration as of #3116.
  - Clean up the input data parsing using a FSM parser. Contrary to the serial driver this does not require any line feed separators, see #4191. The new parser should be more robust than current code.
  - Remove ancient EVENT_TABLE macros, use modern Bind() instead
  - Remove an evil raw pointer.
  - Remove the use of SOCKET_TIMER and SOCKET_TIMER+1 constants by using custom wxTimer objects which does not require to be bound to any handler. Hopefully, this should establish a alternative timer implementation pattern which could be used elsewhere over time.  It's some lines more to write, but  IMHO more straight forward to read.
  - A fix for #4191 


Closes: #4191