### PR TITLE
Fix bad ioDirection driver attribute (#4192)

### DIFF
--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -166,6 +166,7 @@ set(SRC
   ${MODEL_SRC_DIR}/conn_params.cpp
   ${MODEL_SRC_DIR}/cutil.cpp
   ${MODEL_SRC_DIR}/downloader.cpp
+  ${MODEL_SRC_DIR}/ds_porttype.cpp
   ${MODEL_SRC_DIR}/garmin_protocol_mgr.cpp
   ${MODEL_SRC_DIR}/geodesic.cpp
   ${MODEL_SRC_DIR}/georef.cpp

--- a/model/src/comm_drv_n0183_android_bt.cpp
+++ b/model/src/comm_drv_n0183_android_bt.cpp
@@ -182,14 +182,7 @@ CommDriverN0183AndroidBT::CommDriverN0183AndroidBT(
   // SetSecThreadInActive();
   this->attributes["commPort"] = params->Port.ToStdString();
   this->attributes["userComment"] = params->UserComment.ToStdString();
-  dsPortType iosel = params->IOSelect;
-  std::string s_iosel = std::string("IN");
-  if (iosel == DS_TYPE_OUTPUT) {
-    s_iosel = "OUT";
-  } else if (iosel == DS_TYPE_INPUT_OUTPUT) {
-    s_iosel = "IN/OUT";
-  }
-  this->attributes["ioDirection"] = s_iosel;
+  this->attributes["ioDirection"] = DsPortTypeToString(params->IOSelect);
 
   // Prepare the wxEventHandler to accept events from the actual hardware thread
   Bind(wxEVT_COMMDRIVER_N0183_ANDROID_BT,

--- a/model/src/comm_drv_n0183_android_bt.cpp
+++ b/model/src/comm_drv_n0183_android_bt.cpp
@@ -184,7 +184,7 @@ CommDriverN0183AndroidBT::CommDriverN0183AndroidBT(
   this->attributes["userComment"] = params->UserComment.ToStdString();
   dsPortType iosel = params->IOSelect;
   std::string s_iosel = std::string("IN");
-  if (iosel == DS_TYPE_INPUT_OUTPUT) {
+  if (iosel == DS_TYPE_OUTPUT) {
     s_iosel = "OUT";
   } else if (iosel == DS_TYPE_INPUT_OUTPUT) {
     s_iosel = "IN/OUT";

--- a/model/src/comm_drv_n0183_android_int.cpp
+++ b/model/src/comm_drv_n0183_android_int.cpp
@@ -182,7 +182,7 @@ CommDriverN0183AndroidInt::CommDriverN0183AndroidInt(
   this->attributes["userComment"] = params->UserComment.ToStdString();
   dsPortType iosel = params->IOSelect;
   std::string s_iosel = std::string("IN");
-  if (iosel == DS_TYPE_INPUT_OUTPUT) {
+  if (iosel == DS_TYPE_OUTPUT) {
     s_iosel = "OUT";
   } else if (iosel == DS_TYPE_INPUT_OUTPUT) {
     s_iosel = "IN/OUT";

--- a/model/src/comm_drv_n0183_android_int.cpp
+++ b/model/src/comm_drv_n0183_android_int.cpp
@@ -180,14 +180,7 @@ CommDriverN0183AndroidInt::CommDriverN0183AndroidInt(
       m_listener(listener) {
   this->attributes["commPort"] = params->Port.ToStdString();
   this->attributes["userComment"] = params->UserComment.ToStdString();
-  dsPortType iosel = params->IOSelect;
-  std::string s_iosel = std::string("IN");
-  if (iosel == DS_TYPE_OUTPUT) {
-    s_iosel = "OUT";
-  } else if (iosel == DS_TYPE_INPUT_OUTPUT) {
-    s_iosel = "IN/OUT";
-  }
-  this->attributes["ioDirection"] = s_iosel;
+  this->attributes["ioDirection"] = DsPortTypeToString(params->IOSelect);
 
   // Prepare the wxEventHandler to accept events from the actual hardware thread
   Bind(wxEVT_COMMDRIVER_N0183_ANDROID_INT,

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -121,14 +121,8 @@ CommDriverN0183Net::CommDriverN0183Net(const ConnectionParams* params,
   sprintf(port_char, "%d", params->NetworkPort);
   this->attributes["netPort"] = std::string(port_char);
   this->attributes["userComment"] = params->UserComment.ToStdString();
-  dsPortType iosel = params->IOSelect;
-  std::string s_iosel = std::string("IN");
-  if (iosel == DS_TYPE_OUTPUT) {
-    s_iosel = "OUT";
-  } else if (iosel == DS_TYPE_INPUT_OUTPUT) {
-    s_iosel = "IN/OUT";
-  }
-  this->attributes["ioDirection"] = s_iosel;
+  this->attributes["ioDirection"] = DsPortTypeToString(params->IOSelect);
+
   m_mrq_container = std::make_unique<MrqContainer>();
 
   // Establish event listeners

--- a/model/src/comm_drv_n0183_serial.cpp
+++ b/model/src/comm_drv_n0183_serial.cpp
@@ -60,7 +60,7 @@ CommDriverN0183Serial::CommDriverN0183Serial(const ConnectionParams* params,
   this->attributes["userComment"] = params->UserComment.ToStdString();
   dsPortType iosel = params->IOSelect;
   std::string s_iosel = std::string("IN");
-  if (iosel == DS_TYPE_INPUT_OUTPUT) {
+  if (iosel == DS_TYPE_OUTPUT) {
     s_iosel = "OUT";
   } else if (iosel == DS_TYPE_INPUT_OUTPUT) {
     s_iosel = "IN/OUT";

--- a/model/src/comm_drv_n0183_serial.cpp
+++ b/model/src/comm_drv_n0183_serial.cpp
@@ -58,14 +58,8 @@ CommDriverN0183Serial::CommDriverN0183Serial(const ConnectionParams* params,
   m_garmin_handler = nullptr;
   this->attributes["commPort"] = params->Port.ToStdString();
   this->attributes["userComment"] = params->UserComment.ToStdString();
-  dsPortType iosel = params->IOSelect;
-  std::string s_iosel = std::string("IN");
-  if (iosel == DS_TYPE_OUTPUT) {
-    s_iosel = "OUT";
-  } else if (iosel == DS_TYPE_INPUT_OUTPUT) {
-    s_iosel = "IN/OUT";
-  }
-  this->attributes["ioDirection"] = s_iosel;
+  this->attributes["ioDirection"] = DsPortTypeToString(params->IOSelect);
+
   Open();
 }
 

--- a/model/src/ds_porttype.cpp
+++ b/model/src/ds_porttype.cpp
@@ -1,5 +1,5 @@
-/**************************************************************************
- *   Copyright (C) 2013 by David S. Register                               *
+/***************************************************************************
+ *   Copyright (C) 2014  ALec Leamas                                       *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -16,16 +16,22 @@
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  ***************************************************************************/
+#include <cassert>
 
-#ifndef __DSPORTTYPE_H__
-#define __DSPORTTYPE_H__
+#include "model/ds_porttype.h"
 
-#include <string>
-
-//      Port I/O type
-typedef enum { DS_TYPE_INPUT, DS_TYPE_INPUT_OUTPUT, DS_TYPE_OUTPUT } dsPortType;
-
-/** Return textual representation for use in driver ioDirection attribute. */
-std::string DsPortTypeToString(dsPortType type);
-
-#endif
+std::string DsPortTypeToString(dsPortType type) {
+  switch (type) {
+    case DS_TYPE_INPUT_OUTPUT:
+      return "IN/OUT";
+      break;
+    case DS_TYPE_OUTPUT:
+      return "OUT";
+      break;
+    case DS_TYPE_INPUT:
+      return "IN";
+      break;
+  };
+  assert(false && "Compiler error (undefined dsPortType)");
+  return "";  // for the compiler
+}


### PR DESCRIPTION
Make sure the ioDirection attribute  is correct. While on it, centralize the textual dsPortType representation to make things more robust.

Closes: #4192