### PR TITLE
Serial logging update

### DIFF
--- a/model/include/model/logger.h
+++ b/model/include/model/logger.h
@@ -1,9 +1,7 @@
-/******************************************************************************
- *
- * Project:  OpenCPN
- *
- ***************************************************************************
- *   Copyright (C) 2013 by David S. Register                               *
+
+/**************************************************************************
+ *   Copyright (C) 2013 David S. Register                                  *
+ *   Copyright (C) 2022 - 2024 Alec Leamas                                 *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -19,21 +17,10 @@
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
- ***************************************************************************
- */
-
-#ifndef LOGGER_H
-#define LOGGER_H
-
-#include <fstream>
-#include <ostream>
-#include <sstream>
-#include <string>
-
-#include <wx/log.h>
+ ***************************************************************************/
 
 /**
- * Logging interface.
+ * \file logger.h Enhanced logging interface on top of wx/log.h.
  *
  * The OcpnLog acts as the active wxLog target: it formats and prints
  * log messages, overriding the default setup.
@@ -52,6 +39,43 @@
  * wxLog's component levels and trace masks, logging anything with a
  * level <= wxLog::GetLogLevel().
  */
+
+#ifndef LOGGER_H
+#define LOGGER_H
+
+#include <fstream>
+#include <ostream>
+#include <sstream>
+#include <string>
+
+#include <wx/log.h>
+
+#define DO_LOG_MESSAGE(level, fmt, ...)                                  \
+  {                                                                      \
+    if (level <= wxLog::GetLogLevel()) {                                 \
+      Logger::logMessage(level, __FILE__, __LINE__, fmt, ##__VA_ARGS__); \
+    }                                                                    \
+  }
+
+#define _LOG(level)                 \
+  if (level > wxLog::GetLogLevel()) \
+    ;                               \
+  else                              \
+    Logger().get(level, __FILE__, __LINE__)
+
+#define TRACE_LOG _LOG(wxLOG_Trace)
+#define DEBUG_LOG _LOG(wxLOG_Debug)
+#define INFO_LOG _LOG(wxLOG_Info)
+#define MESSAGE_LOG _LOG(wxLOG_Message)
+#define WARNING_LOG _LOG(wxLOG_Warning)
+#define ERROR_LOG _LOG(wxLOG_Error)
+
+#define LOG_TRACE(fmt, ...) DO_LOG_MESSAGE(wxLOG_Trace, fmt, ##__VA_ARGS__);
+#define LOG_DEBUG(fmt, ...) DO_LOG_MESSAGE(wxLOG_Debug, fmt, ##__VA_ARGS__);
+#define LOG_INFO(fmt, ...) DO_LOG_MESSAGE(wxLOG_Info, fmt, ##__VA_ARGS__);
+#define LOG_MESSAGE(fmt, ...) DO_LOG_MESSAGE(wxLOG_Message, fmt, ##__VA_ARGS__);
+#define LOG_WARNING(fmt, ...) DO_LOG_MESSAGE(wxLOG_Warning, fmt, ##__VA_ARGS__);
+#define LOG_ERROR(fmt, ...) DO_LOG_MESSAGE(wxLOG_Error, fmt, ##__VA_ARGS__);
 
 /**
  * Customized logger class appending to a file providing:
@@ -99,32 +123,5 @@ protected:
   wxLogRecordInfo info;
   wxLogLevel level;
 };
-
-#define DO_LOG_MESSAGE(level, fmt, ...)                                  \
-  {                                                                      \
-    if (level <= wxLog::GetLogLevel()) {                                 \
-      Logger::logMessage(level, __FILE__, __LINE__, fmt, ##__VA_ARGS__); \
-    }                                                                    \
-  }
-
-#define _LOG(level)                 \
-  if (level > wxLog::GetLogLevel()) \
-    ;                               \
-  else                              \
-    Logger().get(level, __FILE__, __LINE__)
-
-#define TRACE_LOG _LOG(wxLOG_Trace)
-#define DEBUG_LOG _LOG(wxLOG_Debug)
-#define INFO_LOG _LOG(wxLOG_Info)
-#define MESSAGE_LOG _LOG(wxLOG_Message)
-#define WARNING_LOG _LOG(wxLOG_Warning)
-#define ERROR_LOG _LOG(wxLOG_Error)
-
-#define LOG_TRACE(fmt, ...) DO_LOG_MESSAGE(wxLOG_Trace, fmt, ##__VA_ARGS__);
-#define LOG_DEBUG(fmt, ...) DO_LOG_MESSAGE(wxLOG_Debug, fmt, ##__VA_ARGS__);
-#define LOG_INFO(fmt, ...) DO_LOG_MESSAGE(wxLOG_Info, fmt, ##__VA_ARGS__);
-#define LOG_MESSAGE(fmt, ...) DO_LOG_MESSAGE(wxLOG_Message, fmt, ##__VA_ARGS__);
-#define LOG_WARNING(fmt, ...) DO_LOG_MESSAGE(wxLOG_Warning, fmt, ##__VA_ARGS__);
-#define LOG_ERROR(fmt, ...) DO_LOG_MESSAGE(wxLOG_Error, fmt, ##__VA_ARGS__);
 
 #endif  // LOGGER_H

--- a/model/include/model/logger.h
+++ b/model/include/model/logger.h
@@ -43,6 +43,7 @@
 #ifndef LOGGER_H
 #define LOGGER_H
 
+#include <chrono>
 #include <fstream>
 #include <ostream>
 #include <sstream>
@@ -122,6 +123,38 @@ protected:
   std::stringstream os;
   wxLogRecordInfo info;
   wxLogLevel level;
+};
+
+/** Filter logging every nth message */
+class CountedLogFilter {
+public:
+  CountedLogFilter(unsigned n, wxLogLevel level = wxLOG_Message)
+      : m_count(n), m_level(level), m_not_logged(0) {}
+
+  /** Log a repeated message after suppressing n ones. */
+  void Log(const std::string& message);
+
+private:
+  const unsigned m_count;
+  const wxLogLevel m_level;
+  unsigned m_not_logged;
+};
+
+/** Filter logging repeated message with specified interval. */
+class TimedLogFilter {
+public:
+  TimedLogFilter(const std::chrono::seconds& interval,
+                 wxLogLevel level = wxLOG_Message)
+      : m_interval(interval), m_level(level), m_not_logged(0) {}
+
+  /** Log a repeated message after interval seconds. */
+  void Log(const std::string& message);
+
+private:
+  const std::chrono::seconds m_interval;
+  const wxLogLevel m_level;
+  std::chrono::time_point<std::chrono::steady_clock> m_last_logged;
+  unsigned m_not_logged;
 };
 
 #endif  // LOGGER_H

--- a/model/include/model/serial_io.h
+++ b/model/include/model/serial_io.h
@@ -32,8 +32,11 @@
 #include <wx/string.h>
 
 #include "comm_buffers.h"
+#include "model/logger.h"
 #include "model/thread_ctrl.h"
 #include "model/ocpn_utils.h"
+
+using namespace std::literals::chrono_literals;
 
 /** Remove possible Serial: prefix. */
 static std::string NormalizePort(const std::string& port) {
@@ -65,11 +68,13 @@ protected:
   const wxString m_portname;
   const unsigned m_baud;
   const SendMsgFunc m_send_msg_func;
+  TimedLogFilter m_open_log_filter;
 
   SerialIo(SendMsgFunc send_msg_func, const std::string& port, unsigned baud)
       : m_portname(NormalizePort(port)),
         m_baud(baud),
-        m_send_msg_func(send_msg_func) {}
+        m_send_msg_func(send_msg_func),
+        m_open_log_filter(5min) {}
 };
 
 #ifdef __clang__

--- a/model/src/logger.cpp
+++ b/model/src/logger.cpp
@@ -1,9 +1,6 @@
-/******************************************************************************
- *
- * Project:  OpenCPN
- *
- ***************************************************************************
+/***************************************************************************
  *   Copyright (C) 2013 by David S. Register                               *
+ *   Copyright (C) 2022 Alec Leamas                                        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -19,8 +16,9 @@
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
- ***************************************************************************
- */
+ ***************************************************************************/
+
+/** \file logger.cpp Implement logger.h */
 
 #include <algorithm>
 #include <iomanip>

--- a/model/src/logger.cpp
+++ b/model/src/logger.cpp
@@ -136,3 +136,23 @@ void Logger::logMessage(wxLogLevel level, const char* path, int line,
     log->LogRecord(level, buf, info);
   }
 }
+
+void CountedLogFilter::Log(const std::string& message) {
+  m_not_logged += 1;
+  if (m_not_logged < m_count) return;
+
+  wxLogGeneric(m_level, message.c_str());
+  wxLogGeneric(m_level, "Previous message suppressed %d times", m_count);
+  m_not_logged = 0;
+}
+
+void TimedLogFilter::Log(const std::string& message) {
+  auto now = std::chrono::steady_clock::now();
+  m_not_logged += 1;
+  if (now - m_last_logged < m_interval) return;
+
+  wxLogGeneric(m_level, message.c_str());
+  wxLogGeneric(m_level, "Previous message suppressed %d times", m_not_logged);
+  m_not_logged = 0;
+  m_last_logged = now;
+}

--- a/model/src/std_serial_io.cpp
+++ b/model/src/std_serial_io.cpp
@@ -159,8 +159,8 @@ bool StdSerialIo::OpenComPortPhysical(const wxString& com_name,
     m_serial.open();
     m_serial.setTimeout(250, 250, 0, 250, 0);
   } catch (std::exception& e) {
-    MESSAGE_LOG << "Unhandled Exception while opening serial port: "
-                << e.what();
+    auto msg = std::string("Unhandled Exception while opening serial port: ");
+    m_open_log_filter.Log(msg + e.what());
   }
   return m_serial.isOpen();
 }

--- a/plugins/demo_pi_sample/CMakeLists.txt
+++ b/plugins/demo_pi_sample/CMakeLists.txt
@@ -78,7 +78,7 @@ endif ()
 
 set(BUILD_SHARED_LIBS TRUE)
 
-if ($ENV{CI} STREQUAL "")
+if ("$ENV{CI}" STREQUAL "")
   set(wxWidgets_USE_LIBS base core net xml html adv)
   find_package(wxWidgets REQUIRED)
   include(${wxWidgets_USE_FILE})


### PR DESCRIPTION
Stop serial io from flooding log when the port is not available.

Add new infrastructure to logger.h  with filters which only logs every n message or only once in a time interval. Should be generally useful.