### PR TITLE
undo: Plug memory leak (#4177)

### DIFF
--- a/gui/include/gui/undo.h
+++ b/gui/include/gui/undo.h
@@ -55,13 +55,13 @@ class Undo {
 public:
   Undo(ChartCanvas* parent);
   ~Undo();
-  bool AnythingToUndo();
-  bool AnythingToRedo();
+  bool AnythingToUndo() const;
+  bool AnythingToRedo() const;
   void InvalidateRedo();
   void InvalidateUndo();
-  bool InUndoableAction() { return m_is_inside_undoable_action; }
-  const UndoAction& GetNextUndoableAction();
-  const UndoAction& GetNextRedoableAction();
+  bool InUndoableAction() const { return m_is_inside_undoable_action; }
+  const UndoAction& GetNextUndoableAction() const;
+  const UndoAction& GetNextRedoableAction() const;
   bool UndoLastAction();
   bool RedoNextAction();
   bool BeforeUndoableAction(UndoType type, UndoItemPointer before,
@@ -76,7 +76,7 @@ private:
   UndoAction m_candidate;
   unsigned int m_stackpointer;
   unsigned int m_depth_setting;
-  std::deque<UndoAction> undoStack;
+  std::deque<UndoAction> m_undo_stack;
 };
 
 #endif

--- a/gui/include/gui/undo.h
+++ b/gui/include/gui/undo.h
@@ -48,7 +48,7 @@ typedef void* UndoItemPointer;
 class UndoAction {
 public:
   ~UndoAction();
-  wxString Description();
+  wxString Description() const;
 
   UndoType type;
   std::vector<UndoItemPointer> before;
@@ -65,10 +65,9 @@ public:
   bool AnythingToRedo();
   void InvalidateRedo();
   void InvalidateUndo();
-  void Invalidate();
-  bool InUndoableAction() { return isInsideUndoableAction; }
-  UndoAction* GetNextUndoableAction();
-  UndoAction* GetNextRedoableAction();
+  bool InUndoableAction() { return m_is_inside_undoable_action; }
+  const UndoAction& GetNextUndoableAction();
+  const UndoAction& GetNextRedoableAction();
   bool UndoLastAction();
   bool RedoNextAction();
   bool BeforeUndoableAction(UndoType type, UndoItemPointer before,
@@ -80,11 +79,11 @@ public:
 
 private:
   ChartCanvas* m_parent;
-  bool isInsideUndoableAction;
-  UndoAction* candidate;
-  unsigned int stackpointer;
-  unsigned int depthSetting;
-  std::deque<UndoAction*> undoStack;
+  bool m_is_inside_undoable_action;
+  UndoAction m_candidate;
+  unsigned int m_stackpointer;
+  unsigned int m_depth_setting;
+  std::deque<UndoAction> undoStack;
 };
 
 #endif

--- a/gui/include/gui/undo.h
+++ b/gui/include/gui/undo.h
@@ -1,11 +1,6 @@
-/******************************************************************************
- *
- * Project:  OpenCPN
- * Purpose:  Framework for Undo features
- * Author:   Jesper Weissglas
- *
- ***************************************************************************
+/**************************************************************************
  *   Copyright (C) 2012 by David S. Register                               *
+ *   Copyright (c) 2012 Jesper Weissglas                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -21,10 +16,9 @@
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
- ***************************************************************************
- *
- *
- */
+ ***************************************************************************/
+
+/** \file undo.h Framework for Undo features. */
 
 #ifndef UNDO_H
 #define UNDO_H

--- a/gui/include/gui/undo.h
+++ b/gui/include/gui/undo.h
@@ -75,7 +75,6 @@ public:
                             UndoItemPointer selectable);
   bool AfterUndoableAction(UndoItemPointer after);
   bool CancelUndoableAction(bool noDataDelete = false);
-  ChartCanvas* GetParent() { return m_parent; }
 
 private:
   ChartCanvas* m_parent;

--- a/gui/src/canvasMenu.cpp
+++ b/gui/src/canvasMenu.cpp
@@ -337,7 +337,7 @@ void CanvasMenuHandler::CanvasPopupMenu(int x, int y, int seltype) {
 
         wxString undoItem;
         undoItem << _("Undo") << _T(" ")
-                 << parent->undo->GetNextUndoableAction()->Description();
+                 << parent->undo->GetNextUndoableAction().Description();
         MenuAppend1(subMenuUndo, ID_UNDO, undoItem);
       }
       if (parent->undo->AnythingToRedo()) {
@@ -347,21 +347,21 @@ void CanvasMenuHandler::CanvasPopupMenu(int x, int y, int seltype) {
 
         wxString redoItem;
         redoItem << _("Redo") << _T(" ")
-                 << parent->undo->GetNextRedoableAction()->Description();
+                 << parent->undo->GetNextRedoableAction().Description();
         MenuAppend1(subMenuRedo, ID_REDO, redoItem);
       }
     } else {
       if (parent->undo->AnythingToUndo()) {
         wxString undoItem;
         undoItem << _("Undo") << _T(" ")
-                 << parent->undo->GetNextUndoableAction()->Description();
+                 << parent->undo->GetNextUndoableAction().Description();
         MenuAppend1(contextMenu, ID_UNDO, _menuText(undoItem, _T("Ctrl-Z")));
       }
 
       if (parent->undo->AnythingToRedo()) {
         wxString redoItem;
         redoItem << _("Redo") << _T(" ")
-                 << parent->undo->GetNextRedoableAction()->Description();
+                 << parent->undo->GetNextRedoableAction().Description();
 #ifdef __WXOSX__
         MenuAppend1(contextMenu, ID_REDO,
                     _menuText(redoItem, _T("Shift-Ctrl-Z")));

--- a/gui/src/undo.cpp
+++ b/gui/src/undo.cpp
@@ -1,11 +1,6 @@
-/******************************************************************************
- *
- * Project:  OpenCPN
- * Purpose:  Framework for Undo features
- * Author:   Jesper Weissglas
- *
- ***************************************************************************
- *   Copyright (C) 2012 by David S. Register                               *
+/**************************************************************************
+ *   Copyright (C) 2012 David S. Register                                  *
+ *   Copyright (c) 2012 Jesper  Weissglas                                  *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -21,10 +16,9 @@
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
- ***************************************************************************
- *
- *
- */
+ ***************************************************************************/
+
+/** \file undo.cpp Implement undo.h */
 
 #include "config.h"
 

--- a/gui/src/undo.cpp
+++ b/gui/src/undo.cpp
@@ -244,24 +244,24 @@ bool Undo::UndoLastAction() {
 
   switch (action.type) {
     case Undo_CreateWaypoint:
-      doRedoDeleteWaypoint(&action,
-                           GetParent());  // Same as delete but reversed.
+      // Same ss delete but reversed.
+      doRedoDeleteWaypoint(&action, m_parent);
       m_stackpointer++;
       break;
 
     case Undo_MoveWaypoint:
-      doUndoMoveWaypoint(&action, GetParent());
+      doUndoMoveWaypoint(&action, m_parent);
       m_stackpointer++;
       break;
 
     case Undo_DeleteWaypoint:
-      doUndoDeleteWaypoint(&action, GetParent());
+      doUndoDeleteWaypoint(&action, m_parent);
       m_stackpointer++;
       break;
 
     case Undo_AppendWaypoint:
       m_stackpointer++;
-      doUndoAppendWaypoint(&action, GetParent());
+      doUndoAppendWaypoint(&action, m_parent);
       break;
   }
   return true;
@@ -274,23 +274,23 @@ bool Undo::RedoNextAction() {
   switch (action.type) {
     case Undo_CreateWaypoint:
       // Same as delete but reversed.
-      doUndoDeleteWaypoint(&action, GetParent());
+      doUndoDeleteWaypoint(&action, m_parent);
       m_stackpointer--;
       break;
 
     case Undo_MoveWaypoint:
       // For Wpt move, redo is same as undo (swap lat/long);
-      doUndoMoveWaypoint(&action, GetParent());
+      doUndoMoveWaypoint(&action, m_parent);
       m_stackpointer--;
       break;
 
     case Undo_DeleteWaypoint:
-      doRedoDeleteWaypoint(&action, GetParent());
+      doRedoDeleteWaypoint(&action, m_parent);
       m_stackpointer--;
       break;
 
     case Undo_AppendWaypoint:
-      doRedoAppendWaypoint(&action, GetParent());
+      doRedoAppendWaypoint(&action, m_parent);
       m_stackpointer--;
       break;
   }


### PR DESCRIPTION
A more aggressive change than the one proposed in #4177, removing the raw pointers completely.

While on it, doing some cleanup