### PR TITLE
Fix OSX warnings in libs

### DIFF
--- a/libs/ShapefileCpp/lib/src/Point.cpp
+++ b/libs/ShapefileCpp/lib/src/Point.cpp
@@ -2,9 +2,9 @@
 
 namespace shp {
 
-    Point::Point(double xCoord, double yCoord) : x(xCoord), y(yCoord), z(NAN), m(NAN) {}
+    Point::Point(double xCoord, double yCoord) : x(xCoord), y(yCoord), m(NAN), z(NAN) {}
 
-    Point::Point(double xCoord, double yCoord, double zValue, double mValue) : x(xCoord), y(yCoord), z(zValue), m(mValue) {}
+    Point::Point(double xCoord, double yCoord, double zValue, double mValue) : x(xCoord), y(yCoord), m(mValue), z(zValue) {}
 
     std::unique_ptr<Geometry> Point::clone() const  {
         return std::make_unique<Point>(x,y);
@@ -33,11 +33,11 @@ namespace shp {
         } else {
             str << "POINT ";
             if (!isnan(z) && !isnan(m)) {
-                str << "ZM ";    
+                str << "ZM ";
             } else if (!isnan(z)) {
-                str << "Z ";    
+                str << "Z ";
             } else if (!isnan(m)) {
-                str << "M ";    
+                str << "M ";
             }
             str << "(";
             str << x << " ";
@@ -49,7 +49,7 @@ namespace shp {
                 str << " " << m;
             }
             str << ")";
-            
+
         }
         return str.str();
     }

--- a/libs/wxservdisc/1035.c
+++ b/libs/wxservdisc/1035.c
@@ -89,7 +89,7 @@ void _label(struct message *m, unsigned char **bufp, unsigned char **namep)
     *name = '\0';
     for(x = 0; x <= 19 && m->_labels[x]; x++)
     {
-        if(strcmp(*namep,m->_labels[x])) continue;
+        if(strcmp((const char *)*namep,(const char *)m->_labels[x])) continue;
         *namep = m->_labels[x];
         return;
     }
@@ -212,7 +212,7 @@ int _rrparse(struct message *m, struct resource *rr, int count, unsigned char **
         {
         case 1:
             if(m->_len + 16 > MAX_PACKET_LEN) return 0;
-            rr[i].known.a.name = m->_packet + m->_len;
+            rr[i].known.a.name = (char *)(m->_packet + m->_len);
             m->_len += 16;
             sprintf(rr[i].known.a.name,"%d.%d.%d.%d",(*bufp)[0],(*bufp)[1],(*bufp)[2],(*bufp)[3]);
             rr[i].known.a.ip = net2long(bufp);


### PR DESCRIPTION
Most of this is pointer casts. It doesn't look like this code is being updated regularly, so having it compile cleanly seems like a win.