### PR TITLE
Fix build failure when executing `make pot-udpate`

### DIFF
--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -194,7 +194,7 @@ void RedirectIOToConsole();
 #include "wiz_ui.h"
 
 const char *const kUsage =
-    R"""(Usage:
+    R"(Usage:
   opencpn -h | --help
   opencpn [-p] [-f] [-G] [-g] [-P] [-l <str>] [-u <num>] [-U] [-s] [GPX file ...]
   opencpn --remote [-R] | -q] | -e] |-o <str>]
@@ -225,7 +225,7 @@ Options manipulating already started opencpn
 
 Arguments:
   GPX  file                     GPX-formatted file with waypoints or routes.
-)""";
+)";
 
 //  comm event definitions
 wxDEFINE_EVENT(EVT_N2K_129029, wxCommandEvent);

--- a/manual/modules/ROOT/pages/coding-guidelines.adoc
+++ b/manual/modules/ROOT/pages/coding-guidelines.adoc
@@ -77,6 +77,23 @@ results in the http://opencpn.github.io/OpenCPN/api-docs/classAbstractRestServer
 . When working with existing code, gradually refactor to comply with coding guidelines.
 . Do not submit large PRs that refactor a lot of code changes.
 
+=== Localization and Internationalization
+
+. Use the gettext macro `_()` for user-visible strings that need translation.
+.. Do not use `_()` for log file messages and internal strings.
+. Add new source files containing translatable strings in `po/POTFILES.in`.
+. Maintainers run the following commands before each release. Do not run them in your pull requests.
+.. `make pot-update` - Scans source files and updates the template (`.pot`) file.
+.. `make po-update` - Updates all language files (`.po`) with new strings from template, to merge new strings into existing language files.
+
+[options="header", cols="50,50"]
+|===
+| Avoid | Use Instead
+| `mode = "Auto";` | `mode = _("Auto");`
+| `msg = _("File") + " " + _("not found");` | `msg = _("File not found");`
+| `msg = _("Found") + wxString::Format(" %d ", count) + _("errors");` | `msg = wxString::Format(_("Found %d errors"), count);`
+|===
+
 == Code Formatting
 
 === C/C++

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -411,9 +411,5 @@ gui/src/update_mgr.cpp
 gui/src/viewport.cpp
 gui/src/waypointman_gui.cpp
 gui/src/mbtiles/mbtiles.cpp
-gui/src/mbtiles/TileCache.hpp
-gui/src/mbtiles/TileDescriptor.hpp
-gui/src/mbtiles/TileQueue.hpp
-gui/src/mbtiles/WorkerThread.hpp
 gui/src/initwiz/wiz_ui.cpp
 gui/src/initwiz/wiz_ui_proto.cpp


### PR DESCRIPTION
Fix two build failures when invoking `make pot-update`.

1. These files do not exist:

```
gui/src/mbtiles/TileCache.hpp
gui/src/mbtiles/TileDescriptor.hpp
gui/src/mbtiles/TileQueue.hpp
gui/src/mbtiles/WorkerThread.hpp
```

2. The `kUsage` variable value was causing a `xgettext` failure.

In addition:
1. Change `BUOY` label to 'Buoy' such that label is the same for short and long labels. Previously the short label was 'Buoy' and the long label was 'BUOY' all uppercase. This caused one more i18n message to be created in the `.pot` file and was inconsistent with the labeling conventions for the other labels.
2. Add coding instructions for localization.