### PR TITLE
Change translatable strings to use US English instead of British English

### DIFF
--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -1990,7 +1990,7 @@ void options::CreatePanel_Ownship(size_t parent, int border_size,
   radarGrid->Add(m_itemRadarRingsUnits, 0, wxALIGN_RIGHT | wxALL, border_size);
 
   wxStaticText* colourText =
-      new wxStaticText(itemPanelShip, wxID_STATIC, _("Range Ring Colour"));
+      new wxStaticText(itemPanelShip, wxID_STATIC, _("Range Ring Color"));
   radarGrid->Add(colourText, 1, wxEXPAND | wxALL, group_item_spacing);
 
   m_colourOwnshipRangeRingColour = new OCPNColourPickerCtrl(
@@ -2103,7 +2103,7 @@ void options::CreatePanel_Ownship(size_t parent, int border_size,
   hTrackGrid->Add(pTrackHighlite, 1, wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL,
                   border_size);
   wxStaticText* trackColourText =
-      new wxStaticText(itemPanelShip, wxID_STATIC, _("Highlight Colour"));
+      new wxStaticText(itemPanelShip, wxID_STATIC, _("Highlight Color"));
   hTrackGrid->Add(trackColourText, 1, wxALIGN_RIGHT | wxALIGN_CENTER_VERTICAL,
                   border_size);
   m_colourTrackLineColour = new OCPNColourPickerCtrl(
@@ -2350,7 +2350,7 @@ void options::CreatePanel_Routes(size_t parent, int border_size,
                          wxALIGN_RIGHT | wxALL, border_size);
 
   wxStaticText* waypointrangeringsColour = new wxStaticText(
-      itemPanelRoutes, wxID_STATIC, _("Waypoint Range Ring Colours"));
+      itemPanelRoutes, wxID_STATIC, _("Waypoint Range Ring Colors"));
   waypointradarGrid->Add(waypointrangeringsColour, 1, wxEXPAND | wxALL, 1);
 
   m_colourWaypointRangeRingsColour = new OCPNColourPickerCtrl(

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -6345,7 +6345,7 @@ EditDialog::EditDialog(wxWindow *parent, InstrumentProperties &Properties,
                                        wxDefaultPosition, wxDefaultSize);
   fgSizer2->Add(m_fontPicker6, 0, wxALL, 5);
 
-  m_staticText9 = new wxStaticText(this, wxID_ANY, _("Arrow 1 Colour :"),
+  m_staticText9 = new wxStaticText(this, wxID_ANY, _("Arrow 1 Color :"),
                                    wxDefaultPosition, wxDefaultSize, 0);
   m_staticText9->Wrap(-1);
   fgSizer2->Add(m_staticText9, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
@@ -6355,7 +6355,7 @@ EditDialog::EditDialog(wxWindow *parent, InstrumentProperties &Properties,
       wxDefaultSize, wxCLRP_DEFAULT_STYLE);
   fgSizer2->Add(m_colourPicker3, 0, wxALL, 5);
 
-  m_staticText10 = new wxStaticText(this, wxID_ANY, _("Arrow 2 Colour :"),
+  m_staticText10 = new wxStaticText(this, wxID_ANY, _("Arrow 2 Color :"),
                                     wxDefaultPosition, wxDefaultSize, 0);
   m_staticText10->Wrap(-1);
   fgSizer2->Add(m_staticText10, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);

--- a/plugins/grib_pi/src/GribRequestDialog.cpp
+++ b/plugins/grib_pi/src/GribRequestDialog.cpp
@@ -94,7 +94,7 @@ GribRequestSetting::GribRequestSetting(GRIBUICtrlBar &parent)
       ">" +
       _("<h1>OpenCPN ECMWF forecast</h1>"
         "<p>Free service based on ECMWF Open Data published under the terms of "
-        "Creative Commons CC-4.0-BY licence</p>"
+        "Creative Commons CC-4.0-BY license</p>"
         "<p>The IFS model GRIB files include information about surface "
         "temperature, "
         "atmospheric pressure, wind strength, wind direction, wave height and "

--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -1168,8 +1168,8 @@ GribSettingsDialogBase::GribSettingsDialogBase(wxWindow* parent, wxWindowID id,
   m_fgBarbedData1->SetFlexibleDirection(wxBOTH);
   m_fgBarbedData1->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
 
-  wxString m_cBarbedColoursChoices[] = {_("Default Colour"),
-                                        _("Controlled Colours")};
+  wxString m_cBarbedColoursChoices[] = {_("Default Color"),
+                                        _("Controlled Colors")};
   int m_cBarbedColoursNChoices =
       sizeof(m_cBarbedColoursChoices) / sizeof(wxString);
   m_cBarbedColours =


### PR DESCRIPTION
Standardize the spelling of British English words ("color" and "licence") to US English for translatable strings in the source code.

Fix #4213
