### PR TITLE
Lat/Lon coordinates at cursor are wrong when the scale factor != 1 and OpenGL is disabled

### DIFF
--- a/gui/include/gui/CanvasConfig.h
+++ b/gui/include/gui/CanvasConfig.h
@@ -48,29 +48,38 @@ public:
   canvasConfig(int index);
   ~canvasConfig();
 
+  /**
+   * Resets all configuration options to default values.
+   *
+   * Initializes follow mode, tides, currents, orientation modes, and AIS
+   * settings.
+   */
   void Reset();
   void LoadFromLegacyConfig(wxFileConfig *conf);
 
   int configIndex;
-  ChartCanvas *canvas;
-  double iLat, iLon, iScale, iRotation;
+  ChartCanvas *canvas;  //!< Pointer to associated chart canvas.
+  double iLat;          //!< Latitude of the center of the chart, in degrees.
+  double iLon;          //!< Longitude of the center of the chart, in degrees.
+  double iScale;        //!< Initial chart scale factor.
+  double iRotation;     //!< Initial rotation angle in radians.
   int DBindex;
   int GroupID;
-  bool bFollow;
-  bool bQuilt;
-  bool bShowTides;
-  bool bShowCurrents;
-  wxSize canvasSize;
-  bool bShowGrid;
-  bool bShowOutlines;
-  bool bShowDepthUnits;
-  bool bCourseUp;
-  bool bHeadUp;
-  bool bLookahead;
-  bool bShowAIS;
-  bool bAttenAIS;
+  bool bFollow;          //!< Enable vessel following mode.
+  bool bQuilt;           //!< Enable chart quilting.
+  bool bShowTides;       //!< Display tide information.
+  bool bShowCurrents;    //!< Display current information.
+  wxSize canvasSize;     //!< Canvas dimensions.
+  bool bShowGrid;        //!< Display coordinate grid.
+  bool bShowOutlines;    //!< Display chart outlines.
+  bool bShowDepthUnits;  //!< Display depth unit indicators.
+  bool bCourseUp;        //!< Orient display to course up.
+  bool bHeadUp;          //!< Orient display to heading up.
+  bool bLookahead;       //!< Enable lookahead mode.
+  bool bShowAIS;         //!< Display AIS targets.
+  bool bAttenAIS;        //!< Enable AIS target attenuation.
   // ENC options
-  bool bShowENCText;
+  bool bShowENCText;  //!< Display ENC text elements.
   int nENCDisplayCategory;
   bool bShowENCDepths;
   bool bShowENCBuoyLabels;

--- a/gui/include/gui/OCPNPlatform.h
+++ b/gui/include/gui/OCPNPlatform.h
@@ -115,11 +115,30 @@ public:
   virtual void ShowBusySpinner(void);
   virtual void HideBusySpinner(void);
   double getFontPointsperPixel(void);
+  /**
+   * Get the display size in logical pixels.
+   *
+   * Returns the display dimensions in logical pixels, which may differ from
+   * physical pixels on high-DPI displays. For example:
+   * - On a MacBook Pro 16" Retina: returns 1792x1120 (logical) rather than
+   * 4096x2560 (physical).
+   * - On standard displays: logical pixels equal physical pixels.
+   *
+   * @note On Retina/HiDPI displays, multiply by GetContentScaleFactor() to get
+   * physical pixels.
+   * @return wxSize containing the width and height in logical pixels.
+   */
   wxSize getDisplaySize();
+  /**
+   * Get the width of the screen in millimeters.
+   */
   double GetDisplaySizeMM();
   double GetDisplayAreaCM2();
   virtual double GetDisplayDPmm();
 
+  /**
+   * Set the width of the monitor in millimeters.
+   */
   void SetDisplaySizeMM(size_t monitor, double size);
   unsigned int GetSelectRadiusPix();
   double GetToolbarScaleFactor(int GUIScaleFactor);

--- a/gui/include/gui/chartimg.h
+++ b/gui/include/gui/chartimg.h
@@ -162,6 +162,16 @@ public:
                                     const LLRegion &Region);
 
   virtual bool AdjustVP(ViewPort &vp_last, ViewPort &vp_proposed);
+  /**
+   * Find the nearest preferred viewport scale (in pixels/meter) for this chart.
+   *
+   * The function aims to find a scale within 5% of the requested scale while
+   * staying between 1/0.01x and 64x of the chart's native scale.
+   *
+   * @param target_scale_ppm Desired viewport scale in physical pixels per
+   * meter.
+   * @return Closest preferred scale in physical pixels per meter
+   */
   virtual double GetNearestPreferredScalePPM(double target_scale_ppm);
 
   virtual void GetValidCanvasRegion(const ViewPort &VPoint,
@@ -208,6 +218,17 @@ protected:
   PaletteDir GetPaletteDir(void);
   int *GetPalettePtr(BSB_Color_Capability);
 
+  /**
+   * Find closest valid scale that's a power of 2 multiple of chart's native
+   * scale.
+   *
+   * @param target_scale Target scale in physical pixels per meter.
+   * @param scale_factor_min Minimum allowed scale multiplier (e.g., 0.01 allows
+   * zoom in to 100x).
+   * @param scale_factor_max Maximum allowed scale multiplier (e.g., 64 allows
+   * zoom out to 1/64x).
+   * @return Valid scale in physical pixels per meter.
+   */
   double GetClosestValidNaturalScalePPM(double target_scale,
                                         double scale_factor_min,
                                         double scale_factor_max);

--- a/gui/include/gui/chcanv.h
+++ b/gui/include/gui/chcanv.h
@@ -195,14 +195,48 @@ public:
   void LostMouseCapture(wxMouseCaptureLostEvent &event);
 
   void CancelMouseRoute();
+  /**
+   * Set the width of the screen in millimeters.
+   */
   void SetDisplaySizeMM(double size);
+  /**
+   * Get the width of the screen in millimeters.
+   */
   double GetDisplaySizeMM() { return m_display_size_mm; }
 
+  /**
+   * Sets the viewport scale while maintaining the center point.
+   *
+   * Changes the chart display scale while preserving the current view center,
+   * orientation, skew, and projection settings. This is typically used for zoom
+   * operations.
+   *
+   * @param scale The new viewport scale to set (pixels per meter)
+   * @param refresh Whether to refresh the display after changing the scale
+   * @return bool True if the scale change was successful
+   */
   bool SetVPScale(double sc, bool b_refresh = true);
   bool SetVPProjection(int projection);
+  /**
+   * Set the viewport center point.
+   */
   bool SetViewPoint(double lat, double lon);
   bool SetViewPointByCorners(double latSW, double lonSW, double latNE,
                              double lonNE);
+  /**
+   * Set the viewport center point, scale, skew, rotation and projection.
+   *
+   * @param lat Latitude of viewport center in degrees.
+   * @param lon Longitude of viewport center in degrees.
+   * @param scale_ppm Requested viewport scale in physical pixels per meter.
+   * This is the desired rendering scale before projection effects.
+   * @param skew Chart skew angle in radians.
+   * @param rotation Viewport rotation in radians.
+   * @param projection Projection type (default=0). If 0, maintains current
+   * projection.
+   * @param b_adjust Allow small viewport adjustments for performance.
+   * @param b_refresh Request screen refresh after change.
+   */
   bool SetViewPoint(double lat, double lon, double scale_ppm, double skew,
                     double rotation, int projection = 0, bool b_adjust = true,
                     bool b_refresh = true);
@@ -240,12 +274,84 @@ public:
   void JumpToPosition(double lat, double lon, double scale);
   void SetFirstAuto(bool b_auto) { m_bFirstAuto = b_auto; }
 
+  /**
+   * Convert latitude/longitude to canvas pixel coordinates (physical pixels)
+   * with double precision.
+   *
+   * Returns unrounded floating point pixel coordinates. When used with drawing
+   * functions that take integer coordinates, values will be truncated.
+   *
+   * @param rlat Latitude in degrees
+   * @param rlon Longitude in degrees
+   * @param r [out] Pointer to wxPoint2DDouble to receive the canvas pixel
+   * coordinates as unrounded floating point values
+   */
   void GetDoubleCanvasPointPix(double rlat, double rlon, wxPoint2DDouble *r);
+  /**
+   * Convert latitude/longitude to canvas pixel coordinates (physical pixels)
+   * with double precision, using specified viewport.
+   *
+   * Returns unrounded floating point pixel coordinates. When used with drawing
+   * functions that take integer coordinates, values will be truncated.
+   *
+   * @param vp ViewPort containing projection parameters and canvas settings
+   * @param rlat Latitude in degrees
+   * @param rlon Longitude in degrees
+   * @param r [out] Pointer to wxPoint2DDouble to receive the canvas pixel
+   * coordinates as unrounded floating point values
+   */
   void GetDoubleCanvasPointPixVP(ViewPort &vp, double rlat, double rlon,
                                  wxPoint2DDouble *r);
+
+  /**
+   * Convert latitude/longitude to canvas pixel coordinates (physical pixels)
+   * rounded to nearest integer.
+   *
+   * Uses GetDoubleCanvasPointPixVP internally and rounds results using wxRound
+   * (std::lround). This means 3.7 becomes 4, -3.7 becomes -4.
+   *
+   * @param rlat Latitude in degrees
+   * @param rlon Longitude in degrees
+   * @param r [out] Pointer to wxPoint to receive the canvas pixel coordinates
+   * in physical pixels, as rounded integer values.
+   * @return true if conversion successful, false if coordinates are invalid or
+   * out of bounds.
+   */
   bool GetCanvasPointPix(double rlat, double rlon, wxPoint *r);
+
+  /**
+   * Convert latitude/longitude to canvas pixel coordinates rounded to nearest
+   * integer using specified viewport.
+   *
+   * Uses GetDoubleCanvasPointPixVP internally and rounds results using wxRound
+   * (std::lround). This means 3.7 becomes 4, -3.7 becomes -4.
+   *
+   * @param vp ViewPort containing projection parameters and canvas settings
+   * @param rlat Latitude in degrees
+   * @param rlon Longitude in degrees
+   * @param r [out] Pointer to wxPoint to receive the canvas pixel coordinates
+   * in physical pixels, as rounded integer values.
+   * @return true if conversion successful, false if:
+   *         - Coordinates would be on other side of the world (resulting in
+   * NaN)
+   *         - Resulting pixel values would be too large (>1e6)
+   *         In these cases, r is set to INVALID_COORD
+   */
   bool GetCanvasPointPixVP(ViewPort &vp, double rlat, double rlon, wxPoint *r);
 
+  /**
+   * Convert canvas pixel coordinates (physical pixels) to latitude/longitude.
+   *
+   * Uses BSB chart geo-referencing for compatible raster charts when conditions
+   * permit, otherwise falls back to viewport projection estimation.
+   *
+   * @param x X-coordinate in physical pixels
+   * @param y Y-coordinate in physical pixels
+   * @param lat [out] Reference to receive the resulting latitude at the given
+   * (x, y) coordinates.
+   * @param lon [out] Reference to receive the resulting longitude at the given
+   * (x, y) coordinates.
+   */
   void GetCanvasPixPoint(double x, double y, double &lat, double &lon);
   void WarpPointerDeferred(int x, int y);
   void UpdateShips();
@@ -286,9 +392,23 @@ public:
   //    Accessors
   int GetCanvasWidth() { return m_canvas_width; }
   int GetCanvasHeight() { return m_canvas_height; }
+  /** Return the ViewPort scale factor, in physical pixels per meter. */
   float GetVPScale() { return GetVP().view_scale_ppm; }
+  /** Return the ViewPort chart scale denominator (e.g., 50000 for a 1:50000
+   * scale). */
   float GetVPChartScale() { return GetVP().chart_scale; }
+  /**
+   * Return the number of logical pixels per meter for the screen.
+   *
+   * @todo The name of this function is misleading. It should be renamed to
+   * GetCanvasLogicalPixelsPerMeter() or similar. It looks like some callers
+   * are expecting the physical pixels per meter, which is incorrect.
+   */
   double GetCanvasScaleFactor() { return m_canvas_scale_factor; }
+  /**
+   * Return the physical pixels per meter at chart center, accounting for
+   * latitude distortion.
+   */
   double GetCanvasTrueScale() { return m_true_scale_ppm; }
   double GetAbsoluteMinScalePpm() { return m_absolute_min_scale_ppm; }
   ViewPort &GetVP();
@@ -315,19 +435,64 @@ public:
   bool GetbShowTide() { return m_bShowTide; }
   void SetShowVisibleSectors(bool val) { m_bShowVisibleSectors = val; }
   bool GetShowVisibleSectors() { return m_bShowVisibleSectors; }
-
+  /** Get the number of logical pixels per millimeter on the screen. */
   double GetPixPerMM() { return m_pix_per_mm; }
 
   void SetOwnShipState(ownship_state_t state) { m_ownship_state = state; }
   void SetCursorStatus(double cursor_lat, double cursor_lon);
   void GetCursorLatLon(double *lat, double *lon);
-
+  /** Pans (moves) the canvas by the specified physical pixels in x and y
+   * directions. */
   bool PanCanvas(double dx, double dy);
   void StopAutoPan(void);
 
+  /**
+   * Perform a smooth zoom operation on the chart canvas by the specified
+   * factor.
+   *
+   * The zoom can either be centered on the cursor position or the center of the
+   * viewport.
+   *
+   * @param factor The zoom factor to apply:
+   *              - factor > 1: Zoom in, e.g. 2.0 makes objects twice as large
+   *              - factor < 1: Zoom out, e.g. 0.5 makes objects half as large
+   * @param can_zoom_to_cursor If true, zoom operation will be centered on
+   * current cursor position. If false, zoom operation centers on current
+   * viewport center.
+   * @param stoptimer If true, stops any ongoing movement/zoom operations before
+   * starting this zoom. If false, allows this zoom to blend with existing
+   * operations.
+   */
+
   void ZoomCanvas(double factor, bool can_zoom_to_cursor = true,
                   bool stoptimer = true);
+
+  /**
+   * Perform an immediate zoom operation without smooth transitions.
+   *
+   * This is a simplified version of ZoomCanvas that applies the zoom
+   * immediately without animation or cursor-centering logic. Typically used for
+   * programmatic zooming.
+   *
+   * @param factor The zoom factor to apply:
+   *              - factor > 1: Zoom in, e.g. 2.0 makes objects twice as large
+   *              - factor < 1: Zoom out, e.g. 0.5 makes objects half as large
+   */
   void ZoomCanvasSimple(double factor);
+
+  /**
+   * Internal function that implements the actual zoom operation.
+   *
+   * This function handles the core zoom functionality including scale
+   * calculations, chart selection and viewport updates.
+   *
+   * @param factor The zoom factor to apply:
+   *              - factor > 1: Zoom in, e.g. 2.0 makes objects twice as large
+   *              - factor < 1: Zoom out, e.g. 0.5 makes objects half as large
+   *
+   * @param can_zoom_to_cursor If true, zoom operation will be centered on
+   * cursor position. If false, zoom operation centers on viewport center.
+   */
   void DoZoomCanvas(double factor, bool can_zoom_to_cursor = true);
 
   void RotateCanvas(double dir);
@@ -422,7 +587,10 @@ public:
   TCWin *pCwin;
   wxBitmap *pscratch_bm;
   bool m_brepaint_piano;
-  double m_cursor_lon, m_cursor_lat;
+  double
+      m_cursor_lon;  //!< The longitude at the mouse cursor position in degrees.
+  double
+      m_cursor_lat;  //!< The latitude at the mouse cursor position in degrees.
   Undo *undo;
   wxPoint r_rband;
   double m_prev_rlat;
@@ -568,6 +736,15 @@ public:
   std::vector<int> GetQuiltNoshowIindexArray() {
     return m_quilt_noshow_index_array;
   }
+  /**
+   * Get the ratio of physical to logical pixel for the display.
+   *
+   * On standard displays, one logical pixel equals one physical pixel, so this
+   * value is 1.0. On high-DPI/Retina displays, one logical pixel may equal
+   * multiple physical pixels:
+   * - MacBook Pro Retina: 2.0 (2x2 physical pixels per logical pixel)
+   * - Other HiDPI displays: May be 1.5, 1.75, etc.
+   */
   double GetDisplayScale() { return m_displayScale; }
   void ResetOwnshipOffset() { m_OSoffsetx = m_OSoffsety = 0; }
 
@@ -645,14 +822,15 @@ private:
   bool bShowingCurrent;
   bool bShowingTide;
 
-  double
-      m_canvas_scale_factor;  // converter....
-                              // useage....
-                              // true_chart_scale_on_display =
-                              // m_canvas_scale_factor / pixels_per_meter of
-                              // displayed chart also may be considered as the
-                              // "pixels-per-meter" of the canvas on-screen
-  double m_pix_per_mm;        // pixels per millimeter on the screen
+  /**
+   * Display-specific scale factor in logical pixels per meter for the physical
+   * screen.
+   *
+   * @note This is the same as m_pix_per_mm / 1000.0
+   */
+  double m_canvas_scale_factor;
+  /** Number of logical pixels per millimeter on the screen. */
+  double m_pix_per_mm;
   double m_display_size_mm;
 
   double m_absolute_min_scale_ppm;
@@ -725,7 +903,10 @@ private:
   void ShowBrightnessLevelTimedPopup(int brightness, int min, int max);
 
   //    Data
-  int m_canvas_width, m_canvas_height;
+  /** The width of the canvas in physical pixels. */
+  int m_canvas_width;
+  /** The height of the canvas in physical pixels. */
+  int m_canvas_height;
 
   int xr_margin;  // chart scroll margins, control cursor, etc.
   int xl_margin;
@@ -783,6 +964,21 @@ private:
   emboss_data *m_pEM_OverZoom;
   //      emboss_data *m_pEM_CM93Offset;  // Flav
 
+  /**
+   * Physical pixels per meter at chart center, accounting for latitude
+   * distortion.
+   *
+   * This represents the true displayed scale at the chart center, calculated by
+   * measuring the screen distance in pixels between two points of known
+   * geographic distance. Unlike GetVPScale() which is the requested scale, this
+   * accounts for projection distortions, particularly in Mercator projection
+   * where scale varies with latitude.
+   *
+   * @note Key scale relationships:
+   * - GetVPScale() is the scale the user asks for.
+   * - m_true_scale_ppm is the actual scale after projection and latitude
+   * effects.
+   */
   double m_true_scale_ppm;
 
   ownship_state_t m_ownship_state;
@@ -937,6 +1133,7 @@ private:
   double m_sector_glat, m_sector_glon;
   std::vector<s57Sector_t> m_sectorlegsVisible;
   bool m_bShowVisibleSectors;
+  /** Physical to logical pixel ratio for the display. */
   double m_displayScale;
 
   DECLARE_EVENT_TABLE()

--- a/gui/include/gui/viewport.h
+++ b/gui/include/gui/viewport.h
@@ -86,42 +86,44 @@ public:
   ViewPort();
 
   /**
-   * Convert latitude and longitude to pixel coordinates.
+   * Convert latitude and longitude on the ViewPort to physical pixel
+   * coordinates.
    *
-   * @param lat Latitude in degrees
-   * @param lon Longitude in degrees
-   * @return wxPoint Pixel coordinates
+   * @param lat Latitude in degrees.
+   * @param lon Longitude in degrees.
+   * @return wxPoint Pixel coordinates.
    */
   wxPoint GetPixFromLL(double lat, double lon);
   /**
-   * @brief Convert pixel coordinates to latitude and longitude
-   * @param p Pixel coordinates
-   * @param lat Pointer to store resulting latitude
-   * @param lon Pointer to store resulting longitude
+   * Convert physical pixel coordinates on the ViewPort to latitude and
+   * longitude.
+   * @param p Physical pixel coordinates.
+   * @param lat Pointer to store resulting latitude.
+   * @param lon Pointer to store resulting longitude.
    */
   void GetLLFromPix(const wxPoint &p, double *lat, double *lon) {
     GetLLFromPix(wxPoint2DDouble(p), lat, lon);
   }
   /**
-   * @brief Convert pixel coordinates to latitude and longitude using double
-   * precision
-   * @param p Pixel coordinates as wxPoint2DDouble
-   * @param lat Pointer to store resulting latitude
-   * @param lon Pointer to store resulting longitude
+   * Convert physical pixel coordinates on the ViewPort to latitude and
+   * longitude using double precision.
+   * @param p Physical pixel coordinates as wxPoint2DDouble.
+   * @param lat Pointer to store resulting latitude.
+   * @param lon Pointer to store resulting longitude.
    */
   void GetLLFromPix(const wxPoint2DDouble &p, double *lat, double *lon);
   /**
-   * @brief Convert latitude and longitude to pixel coordinates with double
-   * precision
-   * @param lat Latitude in degrees
-   * @param lon Longitude in degrees
-   * @return wxPoint2DDouble Pixel coordinates
+   * Convert latitude and longitude on the ViewPort to physical pixel
+   * coordinates with double precision.
+   * @param lat Latitude in degrees.
+   * @param lon Longitude in degrees.
+   * @return wxPoint2DDouble Physical pixel coordinates.
    */
   wxPoint2DDouble GetDoublePixFromLL(double lat, double lon);
 
   LLRegion GetLLRegion(const OCPNRegion &region);
   /**
-   * @brief Get the intersection of the viewport with a given region
+   * Get the intersection of the viewport with a given region.
    * @param region OCPNRegion to intersect with
    * @param llregion LLRegion to use for the intersection
    * @param chart_native_scale Native scale of the chart
@@ -132,8 +134,8 @@ public:
                                   int chart_native_scale);
 
   /**
-   * @brief Get the intersection of the viewport with a polygon defined by
-   * lat/lon points
+   * Get the intersection of the viewport with a polygon defined by lat/lon
+   * points.
    * @param Region OCPNRegion to intersect with
    * @param nPoints Number of points in the polygon
    * @param llpoints Array of lat/lon points defining the polygon
@@ -145,7 +147,7 @@ public:
                                   float *llpoints, int chart_native_scale,
                                   wxPoint *ppoints);
   /**
-   * @brief Get the viewport rectangle intersecting with a set of lat/lon points
+   * Get the viewport rectangle intersecting with a set of lat/lon points.
    * @param n Number of points
    * @param llpoints Array of lat/lon points
    * @return wxRect Intersecting rectangle
@@ -154,7 +156,18 @@ public:
   ViewPort BuildExpandedVP(int width, int height);
 
   void SetBoxes(void);
-  void PixelScale(float factor);
+  /**
+   * Set the physical to logical pixel ratio for the display.
+   *
+   * On standard displays, one logical pixel equals one physical pixel, so this
+   * value is 1.0. On high-DPI/Retina displays, one logical pixel may equal
+   * multiple physical pixels:
+   * - MacBook Pro Retina: 2.0 (2x2 physical pixels per logical pixel)
+   * - Other HiDPI displays: May be 1.5, 1.75, etc.
+   *
+   * @param scale The ratio of physical pixels to logical pixels.
+   */
+  void SetPixelScale(double scale);
 
   //  Accessors
   void Invalidate() { bValid = false; }
@@ -175,18 +188,36 @@ public:
   void SetVPTransformMatrix();
 
   //  Generic
-  double clat;  // center point
+  /** Center latitude of the viewport in degrees. */
+  double clat;
+  /** Center longitude of the viewport in degrees. */
   double clon;
+  /**
+   * Requested view scale in physical pixels per meter (ppm), before applying
+   * projections.
+   */
   double view_scale_ppm;
+  /**
+   * Angular distortion (shear transform) applied to the viewport in radians.
+   *
+   * The skew parameter represents a shear transformation applied to the
+   * viewport, which maintains parallel lines while changing their angles
+   * relative to the axes.
+   */
   double skew;
+  /** Rotation angle of the viewport in radians. */
   double rotation;
-  double tilt;  // For perspective view
+  /** Tilt angle for perspective view in radians. */
+  double tilt;
 
-  double chart_scale;  // conventional chart displayed scale
-  double
-      ref_scale;  //  the nominal scale of the "reference chart" for this view
+  /** Chart scale denominator (e.g., 50000 for a 1:50000 scale). */
+  double chart_scale;
+  /** The nominal scale of the "reference chart" for this view. */
+  double ref_scale;
 
+  /** Width of the viewport in physical pixels. */
   int pix_width;
+  /** Height of the viewport in physical pixels. */
   int pix_height;
 
   bool b_quilt;
@@ -220,6 +251,9 @@ private:
   bool bValid;  // This VP is valid
 
   double lat0_cache, cache0, cache1;
+
+  /** The ratio of physical pixel to logical pixels. */
+  double m_displayScale;
 };
 
 #endif

--- a/gui/src/CanvasConfig.cpp
+++ b/gui/src/CanvasConfig.cpp
@@ -1,10 +1,4 @@
 /***************************************************************************
- *
- * Project:  OpenCPN
- * Purpose:  Canvas Configuration
- * Author:   David Register
- *
- ***************************************************************************
  *   Copyright (C) 2018 by David S. Register                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -292,7 +292,9 @@ extern bool g_boptionsactive;
 ShapeBaseChartSet gShapeBasemap;
 
 //  TODO why are these static?
+/** The current mouse X position in canvas coordinates (physical pixels). */
 static int mouse_x;
+/** The current mouse Y position in canvas coordinates (physical pixels). */
 static int mouse_y;
 static bool mouse_leftisdown;
 
@@ -756,6 +758,7 @@ ChartCanvas::ChartCanvas(wxFrame *frame, int canvasIndex)
   // Support scaled HDPI displays.
   m_displayScale = GetContentScaleFactor();
 #endif
+  VPoint.SetPixelScale(m_displayScale);
 
 #ifdef HAVE_WX_GESTURE_EVENTS
   // if (!m_glcc)
@@ -1630,6 +1633,10 @@ bool ChartCanvas::DoCanvasUpdate(void) {
       //  boolean...
       ChartData->CheckExclusiveTileGroup(m_canvasIndex);
 
+      // Calculate DPI compensation scale, i.e., the ratio of logical pixels to
+      // physical pixels. On standard DPI displays where logical = physical
+      // pixels, this ratio would be 1.0. On Retina displays where physical = 2x
+      // logical pixels, this ratio would be 0.5.
       double proposed_scale_onscreen =
           GetCanvasScaleFactor() / GetVPScale();  // as set from config load
 
@@ -1674,7 +1681,9 @@ bool ChartCanvas::DoCanvasUpdate(void) {
           m_pCurrentStack->SetCurrentEntryFromdbIndex(initial_db_index);
         }
       }
-
+      // TODO: GetCanvasScaleFactor() / proposed_scale_onscreen simplifies to
+      // just GetVPScale(), so I'm not sure why it's necessary to define the
+      // proposed_scale_onscreen variable.
       bNewView |= SetViewPoint(vpLat, vpLon,
                                GetCanvasScaleFactor() / proposed_scale_onscreen,
                                0, GetVPRotation());
@@ -2302,7 +2311,7 @@ void ChartCanvas::SetDisplaySizeMM(double size) {
   // int sx, sy;
   // wxDisplaySize( &sx, &sy );
 
-  // Calculate pixels per mm for later reference
+  // Calculate logical pixels per mm for later reference.
   wxSize sd = g_Platform->getDisplaySize();
   double horizontal = sd.x;
   // Set DPI (Win) scale factor
@@ -2557,7 +2566,10 @@ void ChartCanvas::CancelMeasureRoute() {
 
 ViewPort &ChartCanvas::GetVP() { return VPoint; }
 
-void ChartCanvas::SetVP(ViewPort &vp) { VPoint = vp; }
+void ChartCanvas::SetVP(ViewPort &vp) {
+  VPoint = vp;
+  VPoint.SetPixelScale(m_displayScale);
+}
 
 // void ChartCanvas::SetFocus()
 // {
@@ -4992,7 +5004,6 @@ bool ChartCanvas::SetViewPoint(double lat, double lon, double scale_ppm,
                                double skew, double rotation, int projection,
                                bool b_adjust, bool b_refresh) {
   bool b_ret = false;
-
   if (skew > PI) /* so our difference tests work, put in range of +-Pi */
     skew -= 2 * PI;
 
@@ -5351,7 +5362,7 @@ bool ChartCanvas::SetViewPoint(double lat, double lon, double scale_ppm,
     //    Calculate the on-screen displayed actual scale
     //    by a simple traverse northward from the center point
     //    of roughly one eighth of the canvas height
-    wxPoint2DDouble r, r1;
+    wxPoint2DDouble r, r1;  // Screen coordinates in physical pixels.
 
     double delta_check =
         (VPoint.pix_height / VPoint.view_scale_ppm) / (1852. * 60);
@@ -5367,6 +5378,7 @@ bool ChartCanvas::SetViewPoint(double lat, double lon, double scale_ppm,
 
     GetDoubleCanvasPointPix(check_point, VPoint.clon, &r1);
     GetDoubleCanvasPointPix(check_point + delta_check, VPoint.clon, &r);
+    // Calculate the distance between r1 and r in physical pixels.
     double delta_p = sqrt(((r1.m_y - r.m_y) * (r1.m_y - r.m_y)) +
                           ((r1.m_x - r.m_x) * (r1.m_x - r.m_x)));
 
@@ -5402,11 +5414,16 @@ bool ChartCanvas::SetViewPoint(double lat, double lon, double scale_ppm,
 #ifdef __WXOSX__
     if (g_bopengl) {
       retina_coef = GetContentScaleFactor();
-      ;
     }
 #endif
 #endif
 
+    // The chart scale denominator (e.g., 50000 if the scale is 1:50000),
+    // rounded to the nearest 10, 100 or 1000.
+    //
+    // @todo: on MacOS there is 2x ratio between VPoint.chart_scale and
+    // true_scale_display. That does not make sense. The chart scale should be
+    // the same as the true scale within the limits of the rounding factor.
     double true_scale_display =
         wxRound(VPoint.chart_scale / round_factor) * round_factor * retina_coef;
     wxString text;
@@ -6617,6 +6634,7 @@ void ChartCanvas::OnActivate(wxActivateEvent &event) { ReloadVP(); }
 
 void ChartCanvas::OnSize(wxSizeEvent &event) {
   if ((event.m_size.GetWidth() < 1) || (event.m_size.GetHeight() < 1)) return;
+  // GetClientSize returns the size of the canvas area in logical pixels.
   GetClientSize(&m_canvas_width, &m_canvas_height);
 
 #ifdef __WXOSX__
@@ -6624,12 +6642,14 @@ void ChartCanvas::OnSize(wxSizeEvent &event) {
   m_displayScale = GetContentScaleFactor();
 #endif
 
+  // Convert to physical pixels.
   m_canvas_width *= m_displayScale;
   m_canvas_height *= m_displayScale;
 
   //    Resize the current viewport
   VPoint.pix_width = m_canvas_width;
   VPoint.pix_height = m_canvas_height;
+  VPoint.SetPixelScale(m_displayScale);
 
   //    Get some canvas metrics
 

--- a/gui/src/glChartCanvas.cpp
+++ b/gui/src/glChartCanvas.cpp
@@ -462,6 +462,7 @@ void glChartCanvas::Init() {
   // Support scaled HDPI displays.
   m_displayScale = GetContentScaleFactor();
 #endif
+  m_pParentCanvas->VPoint.SetPixelScale(m_displayScale);
 
 #ifdef __ANDROID__
   //  Create/connect a dynamic event handler slot for gesture and some timer
@@ -593,6 +594,7 @@ void glChartCanvas::OnSize(wxSizeEvent &event) {
   SetCurrent(*m_pcontext);
 
   if (!g_bopengl) {
+    // Invoked immediately after user has disabled OpenGL.
     SetSize(GetSize().x, GetSize().y);
     event.Skip();
     return;
@@ -3924,6 +3926,7 @@ void glChartCanvas::Render() {
   // Support scaled HDPI displays.
   m_displayScale = GetContentScaleFactor();
 #endif
+  m_pParentCanvas->VPoint.SetPixelScale(m_displayScale);
 
   m_last_render_time = wxDateTime::Now().GetTicks();
 
@@ -3974,6 +3977,10 @@ void glChartCanvas::Render() {
                               -vp->pix_width / 2, -vp->pix_height / 2, 0);
   }
 
+  // @todo: If the intention was to work with the same ViewPort object, use a
+  // reference instead. Making a copy of VPoint here means that any changes to
+  // VPoint will not affect m_pParentCanvas->VPoint. It's not clear if this is
+  // the intended behavior.
   ViewPort VPoint = m_pParentCanvas->VPoint;
 
   OCPNRegion screen_region(wxRect(0, 0, gl_width, gl_height));

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -393,6 +393,9 @@ int g_lastClientRectx;
 int g_lastClientRecty;
 int g_lastClientRectw;
 int g_lastClientRecth;
+/**
+ * The width of the physical screen in millimeters.
+ */
 double g_display_size_mm;
 std::vector<size_t> g_config_display_size_mm;
 bool g_config_display_size_manual;

--- a/gui/src/viewport.cpp
+++ b/gui/src/viewport.cpp
@@ -127,13 +127,10 @@ ViewPort::ViewPort() {
   b_MercatorProjectionOverride = false;
   lat0_cache = NAN;
   m_projection_type = PROJECTION_MERCATOR;
+  m_displayScale = 1.0;
 }
 
-void ViewPort::PixelScale(float scale) {
-  pix_width *= scale;
-  pix_height *= scale;
-  view_scale_ppm *= scale;
-}
+void ViewPort::SetPixelScale(double scale) { m_displayScale = scale; }
 
 // TODO: eliminate the use of this function
 wxPoint ViewPort::GetPixFromLL(double lat, double lon) {
@@ -256,8 +253,16 @@ wxPoint2DDouble ViewPort::GetDoublePixFromLL(double lat, double lon) {
     dxr = epix * cos(angle) + npix * sin(angle);
     dyr = npix * cos(angle) - epix * sin(angle);
   }
-
-  return wxPoint2DDouble((pix_width / 2.0) + dxr, (pix_height / 2.0) - dyr);
+  double x = (pix_width / 2.0) + dxr;
+  double y = (pix_height / 2.0) - dyr;
+  if (!g_bopengl) {
+    // Convert from physical to logical pixels when not using OpenGL.
+    // This ensures that the viewport corner coordinates remain the
+    // same in OpenGL and no-OpenGL mode (especially in MacOS).
+    x /= m_displayScale;
+    y /= m_displayScale;
+  }
+  return wxPoint2DDouble(x, y);
 }
 
 void ViewPort::GetLLFromPix(const wxPoint2DDouble &p, double *lat,

--- a/libs/s52plib/src/s52plib.h
+++ b/libs/s52plib/src/s52plib.h
@@ -186,6 +186,10 @@ public:
   ~s52plib();
 
   // TODO: SetPPM, SetDisplayWidth etc. should be combined to be set together by pointing them to info about current monitor
+  /**
+   * Set pixels per millimeter for symbol rendering.
+   * @param ppmm Logical pixels per millimeter of display.
+   */
   void SetPPMM(float ppmm);
   void SetDisplayWidth(size_t pixels) { m_display_width = pixels; }
   float GetPPMM() { return canvas_pix_per_mm; }
@@ -529,8 +533,12 @@ private:
 
   wxString m_plib_file;
 
-  float
-      canvas_pix_per_mm;  // Set by parent, used to scale symbols/lines/patterns
+  /**
+   * The number of pixels per millimeter of the canvas.
+   *
+   * @note Set by parent, used to scale symbols/lines/patterns.
+   */
+  float canvas_pix_per_mm;
   double m_rv_scale_factor;
   float m_display_size_mm;
   size_t m_display_width;

--- a/model/include/model/base_platform.h
+++ b/model/include/model/base_platform.h
@@ -131,6 +131,13 @@ public:
   virtual double GetDisplaySizeMM() { return 1.0; }
   virtual double GetDisplayDPmm() { return 1.0; }
   virtual unsigned int GetSelectRadiusPix();
+
+  /**
+   * Get the display scaling factor for DPI-aware rendering.
+   *
+   * @note Only applies scaling on Windows. Other platforms return 1.0 as they
+   *       handle DPI scaling differently (e.g., macOS uses logical pixels).
+   */
   double GetDisplayDIPMult(wxWindow* win);
 
   static void ShowBusySpinner();


### PR DESCRIPTION
This is WIP

Fix for #4218 

Changes in this PR:
1. Add code comments to document whether some pixel coordinates are in physical pixels or logical pixels. It can be confusing when navigating through the code because physical pixels are used in the canvas, whereas WX widgets tend to use logical pixels.
1. I've documented a subtle difference between `GetDoubleCanvasPointPix` which truncates pixels, versus  `GetCanvasPointPix`, which rounds pixels. This can cause a one-pixel difference depending on which function is invoked.
   1. I found this while investigating another issue: https://github.com/OpenCPN/OpenCPN/issues/4229#issuecomment-2524578926
   2. I didn't change the logic: I've merely documented the differences, but it seems the code should be changed such that we can eliminate this one-pixel difference.
1. When OpenGL mode is disabled on macOS with retina display:
   1. The mouse pointer coordinates that are displayed in the status bar are correct (previously they were wrong).
   3. The center coordinates of the chart are now the same as in OpenGL mode.
   5. The coordinates of the chart corners are now the same as in OpenGL mode.
   6. The area covered by the chart is the same as in OpenGL mode.
   7. The chart scale does not change (i.e. the chart scale remains the same when switching between OpenGL and no-OpenGL mode).
   8. The physical length on the screen matches the displayed chart scale. For example, 1000 nautical miles at 1:13.2M scale should be 140.3 millimeters on the screen.