### PR TITLE
Fix crash with floating point exception when width attribute is not present in SVG image

### DIFF
--- a/gui/src/waypointman_gui.cpp
+++ b/gui/src/waypointman_gui.cpp
@@ -132,7 +132,11 @@ void WayPointmanGui::ProcessUserIcons(ocpnStyle::Style *style,
         bm_size_nom *= g_MarkScaleFactorExp;
 
         MarkIcon *pmi = NULL;
-        double aspect = h / w;
+        double aspect =
+            1.0;  // Use default aspect ratio of 1 if width/height are missing.
+        if (w != 0 && h != 0) {
+          aspect = h / w;
+        }
 
         // Make the rendered icon square, if necessary
         if (fabs(aspect - 1.0) > .05) {


### PR DESCRIPTION
Fix #4230 

Useful references:
1. https://www.izitru.com/image-file/svg/what-is-svg-width-and-height/
2. https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox
3. https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/width#svg
4. https://svgwg.org/specs/integration/#svg-css-sizing