### PR TITLE
Remove unused colors in NMEA0183 debug window

### DIFF
--- a/gui/src/TTYScroll.cpp
+++ b/gui/src/TTYScroll.cpp
@@ -81,21 +81,12 @@ void TTYScroll::OnDraw(wxDC &dc) {
     if (ls.Mid(0, 7) == _T("<GREEN>")) {
       dc.SetTextForeground(wxColour(_T("DARK GREEN")));
       lss = ls.Mid(7);
-    } else if (ls.Mid(0, 7) == _T("<GOLD>")) {
-      dc.SetTextForeground(wxColour(_T("GOLD")));
-      lss = ls.Mid(7);
     } else if (ls.Mid(0, 6) == _T("<BLUE>")) {
       dc.SetTextForeground(wxColour(_T("BLUE")));
       lss = ls.Mid(6);
     } else if (ls.Mid(0, 5) == _T("<RED>")) {
       dc.SetTextForeground(wxColour(_T("RED")));
       lss = ls.Mid(5);
-    } else if (ls.Mid(0, 7) == _T("<BROWN>")) {
-      dc.SetTextForeground(wxColour(_T("BROWN")));
-      lss = ls.Mid(7);
-    } else if (ls.Mid(0, 8) == _T("<SIENNA>")) {
-      dc.SetTextForeground(wxColour(_T("SIENNA")));
-      lss = ls.Mid(8);
     } else if (ls.Mid(0, 8) == _T("<MAROON>")) {
       dc.SetTextForeground(wxColour(_T("MAROON")));
       lss = ls.Mid(8);


### PR DESCRIPTION
Remove unused colors in the NMEA debug window (GOLD, BROWN, SIENNA).