### PR TITLE
Improve logging of NMEA0183 messages in debug window

### DIFF
--- a/gui/include/gui/ocpndc.h
+++ b/gui/include/gui/ocpndc.h
@@ -87,6 +87,22 @@ public:
 
   void GetSize(wxCoord *width, wxCoord *height) const;
 
+  /**
+   * Draw a line between two points using either wxDC or OpenGL.
+   *
+   * When using OpenGL, this function supports different line qualities and
+   * widths. For high quality lines (b_hiqual=true), it enables anti-aliasing
+   * and line smoothing. The function also handles dashed lines via line
+   * stippling in OpenGL mode.
+   *
+   * @param x1 The x-coordinate of the starting point, in physical pixels.
+   * @param y1 The y-coordinate of the starting point, in physical pixels.
+   * @param x2 The x-coordinate of the ending point, in physical pixels.
+   * @param y2 The y-coordinate of the ending point, in physical pixels.
+   * @param b_hiqual If true, enables high quality rendering with anti-aliasing
+   *                 and line smoothing in OpenGL mode. Has no effect in wxDC
+   * mode.
+   */
   void DrawLine(wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2,
                 bool b_hiqual = true);
   void DrawLines(int n, wxPoint points[], wxCoord xoffset = 0,

--- a/gui/src/TTYWindow.cpp
+++ b/gui/src/TTYWindow.cpp
@@ -148,6 +148,9 @@ void TTYWindow::CreateLegendBitmap() {
     dc.SetBrush(b2);
     dc.DrawRectangle(boff, y, bsize, bsize);
     dc.SetTextForeground(wxColour(_T("CORAL")));
+    // Indicate message has been filtered and dropped.
+    // This could be an input or output message.
+    // For input messages, only used if m_legacy_input_filter_behaviour is true.
     dc.DrawText(
         _("Input message filtered, output message filtered and dropped"),
         text_x, y);
@@ -163,6 +166,7 @@ void TTYWindow::CreateLegendBitmap() {
     wxBrush b4(wxColour(_T("BLUE")));
     dc.SetBrush(b4);
     dc.DrawRectangle(boff, y, bsize, bsize);
+    // Indicate message has been sent successfully.
     dc.SetTextForeground(wxColour(_T("BLUE")));
     dc.DrawText(_("Output Message"), text_x, y);
 
@@ -171,7 +175,9 @@ void TTYWindow::CreateLegendBitmap() {
     dc.SetBrush(b5);
     dc.DrawRectangle(boff, y, bsize, bsize);
     dc.SetTextForeground(wxColour(_T("RED")));
-    dc.DrawText(_("Information Message or Message with errors"), text_x, y);
+    // Indicate message has error (parse error, wrong checksum, cannot be sent,
+    // etc). This could be an input or output message.
+    dc.DrawText(_("Message with errors"), text_x, y);
   }
   dc.SelectObject(wxNullBitmap);
 }

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -714,7 +714,7 @@ MyFrame::MyFrame(wxFrame *frame, const wxString &title, const wxPoint &pos,
   log_callbacks.log_is_active = []() {
     return NMEALogWindow::GetInstance().Active();
   };
-  log_callbacks.log_message = [](const std::string &s) {
+  log_callbacks.log_message = [](const wxString &s) {
     NMEALogWindow::GetInstance().Add(s);
   };
   g_pMUX = new Multiplexer(log_callbacks, g_b_legacy_input_filter_behaviour);

--- a/libs/nmea0183/src/nmea0183.cpp
+++ b/libs/nmea0183/src/nmea0183.cpp
@@ -366,7 +366,7 @@ wxArrayString NMEA0183::GetRecognizedArray(void)
 
 
 
-NMEA0183& NMEA0183::operator << ( wxString & source )
+NMEA0183& NMEA0183::operator << ( const wxString & source )
 {
 //   ASSERT_VALID( this );
 

--- a/libs/nmea0183/src/nmea0183.hpp
+++ b/libs/nmea0183/src/nmea0183.hpp
@@ -240,11 +240,47 @@ class NMEA0183
 
 //      MANUFACTURER_LIST Manufacturers;
 
+      /**
+       * Performs basic validation of NMEA sentence structure.
+       *
+       * Currently only checks if the sentence starts with '$' character.
+       */
       virtual bool IsGood( void ) const;
+
+      /**
+       * Parse - Full parsing of NMEA sentence including message-specific interpretation.
+       *
+       * This function builds on PreParse by:
+       * 1. First calling PreParse for basic validation
+       * 2. Re-extracting the mnemonic (duplicates PreParse logic)
+       * 3. Setting up error handling infrastructure
+       * 4. Looking up the appropriate parser for this message type in response_table
+       * 5. If found, calls the message-specific parser
+       * 6. Updates parsing status (ErrorMessage, LastSentenceIDParsed, TalkerID)
+       *
+       * The key difference from PreParse is that this function:
+       * - Actually interprets the message contents using type-specific parsers
+       * - Maintains more detailed error state
+       * - Updates additional metadata about the parsed message
+       *
+       * @return bool - Returns true if message was successfully parsed by its handler,
+       *               false if validation failed or no parser was found.
+       */
       virtual bool Parse( void );
+      /**
+       * PreParse - Performs initial validation and basic extraction of NMEA sentence.
+       *
+       * This function:
+       * 1. Validates that the sentence can be converted to UTF-8
+       * 2. Checks if the sentence passes basic NMEA validation (via IsGood())
+       * 3. Extracts the sentence mnemonic (message type identifier)
+       * 4. Handles proprietary messages starting with 'P'
+       *
+       * @return bool - Returns true if basic sentence validation passes, false otherwise
+       */
       virtual bool PreParse( void );
 
-      NMEA0183& operator << ( wxString& source );
+      NMEA0183& operator << ( const wxString& source );
       NMEA0183& operator >> ( wxString& destination );
 };
 

--- a/model/include/model/comm_util.h
+++ b/model/include/model/comm_util.h
@@ -31,6 +31,6 @@
 bool StopAndRemoveCommDriver(std::string ident,
                              NavAddr::Bus = NavAddr::Bus::Undef);
 
-wxString ProcessNMEA4Tags(wxString& msg);
+wxString ProcessNMEA4Tags(const wxString& msg);
 
 #endif  // _COMM_UTIL_H

--- a/model/include/model/multiplexer.h
+++ b/model/include/model/multiplexer.h
@@ -41,10 +41,10 @@ extern Multiplexer *g_pMUX;
 
 struct MuxLogCallbacks {
   std::function<bool()> log_is_active;
-  std::function<void(const std::string &)> log_message;
+  std::function<void(const wxString &)> log_message;
   MuxLogCallbacks()
       : log_is_active([]() { return false; }),
-        log_message([](const std::string &s) {}) {}
+        log_message([](const wxString &s) {}) {}
 };
 
 class Multiplexer : public wxEvtHandler {
@@ -57,8 +57,19 @@ public:
                         bool b_filter);
   void LogOutputMessageColor(const wxString &msg, const wxString &stream_name,
                              const wxString &color);
+  /**
+   * Logs an input message with context information.
+   *
+   * @param msg The message to be logged.
+   * @param stream_name The name of the stream from which the message
+   * originated.
+   * @param b_filter Indicates whether the message was filtered.
+   * @param b_error Indicates whether the message has an error such as bad CRC.
+   * @param error_msg The error message to be logged.
+   */
   void LogInputMessage(const wxString &msg, const wxString &stream_name,
-                       bool b_filter, bool b_error = false);
+                       bool b_filter, bool b_error = false,
+                       const wxString error_msg = wxEmptyString);
 
   bool IsLogActive() { return m_log_callbacks.log_is_active(); }
 

--- a/model/src/comm_util.cpp
+++ b/model/src/comm_util.cpp
@@ -50,10 +50,15 @@ bool StopAndRemoveCommDriver(std::string ident, NavAddr::Bus _bus) {
   return true;
 }
 
-//----------------------------------------------------------------------------------
-//     Strip NMEA V4 tags from NMEA0183 message
-//----------------------------------------------------------------------------------
-wxString ProcessNMEA4Tags(wxString& msg) {
+/**
+ * Strip NMEA V4 tag blocks from NMEA0183 message.
+ *
+ * Tag blocks are enclosed in '\' characters and appear before the
+ * traditional NMEA sentence (which starts with $ or !).
+ * The format is:
+ * \tag:value,tag:value*checksum\actual NMEA message
+ */
+wxString ProcessNMEA4Tags(const wxString& msg) {
   int idxFirst = msg.Find('\\');
 
   if (wxNOT_FOUND == idxFirst) return msg;


### PR DESCRIPTION
Partial fix for https://github.com/OpenCPN/OpenCPN/issues/3882

1. Add arrow character to show direction of NMEA message (input vs output).
1. Add character to show accepted vs error vs filtered vs dropped.
1. Changed "Information Message or Message with errors" to "Message with error". I don't see an actual use case where red is used to represent "information".
1. Add code comments.
