### PR TITLE
S57 Objectquery, check and correct for wrong filename upper/lower case.

### DIFF
--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -645,7 +645,7 @@ int MyConfig::LoadMyConfig() {
 
   g_nAWDefault = 50;
   g_nAWMax = 1852;
-  g_ObjQFileExt = _T("txt,rtf,png,html,gif,tif");
+  g_ObjQFileExt = _T("txt,rtf,png,html,gif,tif,jpg");
 
   // Load the raw value, with no defaults, and no processing
   int ret_Val = LoadMyConfigRaw();

--- a/gui/src/s57chart.cpp
+++ b/gui/src/s57chart.cpp
@@ -5772,6 +5772,22 @@ wxString s57chart::CreateObjDescriptions(ListOfObjRazRules *rule_list) {
             file.Assign(GetFullPath());
             file.Assign(file.GetPath(), value);
             file.Normalize();
+            // Make the filecheck case-unsensitive (linux)
+            if(file.IsCaseSensitive()){
+              wxDir dir(file.GetPath());
+              wxString filename;
+              bool cont = dir.GetFirst(&filename, "", wxDIR_FILES);
+              while ( cont )
+              {
+                if(filename.IsSameAs( value, false)) {
+                  value = filename;
+                  file.Assign(file.GetPath(), value);
+                  break;
+                }
+                cont = dir.GetNext(&filename);
+              }
+            }
+
             if (file.IsOk()) {
               if (file.Exists())
                 value =


### PR DESCRIPTION
Some ENC charts have a discrepancy between filenames used in the chartdata, and the attached files. Window is not case-sensitive with filenames but linux does care. 
This will check if an attached file is available using case on-sensitve compare with chart data. If found then the filename as attached is used for the link in the object-query.

I did use the i_f(file.IsCaseSensitive())_ function from wxFilname, but might be as well a #ifndef __MSVC__  .
Attached a Belgium inland chart for testing.
[Archive.zip](https://github.com/user-attachments/files/17980821/Archive.zip)
