### PR TITLE
Latitude/Longitude is slightly off

### DIFF
--- a/gui/include/gui/ocpndc.h
+++ b/gui/include/gui/ocpndc.h
@@ -87,6 +87,22 @@ public:
 
   void GetSize(wxCoord *width, wxCoord *height) const;
 
+  /**
+   * Draw a line between two points using either wxDC or OpenGL.
+   *
+   * When using OpenGL, this function supports different line qualities and
+   * widths. For high quality lines (b_hiqual=true), it enables anti-aliasing
+   * and line smoothing. The function also handles dashed lines via line
+   * stippling in OpenGL mode.
+   *
+   * @param x1 The x-coordinate of the starting point, in physical pixels.
+   * @param y1 The y-coordinate of the starting point, in physical pixels.
+   * @param x2 The x-coordinate of the ending point, in physical pixels.
+   * @param y2 The y-coordinate of the ending point, in physical pixels.
+   * @param b_hiqual If true, enables high quality rendering with anti-aliasing
+   *                 and line smoothing in OpenGL mode. Has no effect in wxDC
+   * mode.
+   */
   void DrawLine(wxCoord x1, wxCoord y1, wxCoord x2, wxCoord y2,
                 bool b_hiqual = true);
   void DrawLines(int n, wxPoint points[], wxCoord xoffset = 0,

--- a/gui/src/glChartCanvas.cpp
+++ b/gui/src/glChartCanvas.cpp
@@ -2020,13 +2020,13 @@ void glChartCanvas::GridDraw() {
   if (!straight_latitudes) lon_step /= ceil(lon_step / curved_step);
 
   for (lat = startlat; lat < nlat; lat += gridlatMajor) {
-    wxPoint2DDouble r, s;
-    s.m_x = NAN;
-
+    wxPoint r, s;
+    s.x = INVALID_COORD;
+    s.y = INVALID_COORD;
     for (lon = wlon; lon < elon + lon_step / 2; lon += lon_step) {
-      m_pParentCanvas->GetDoubleCanvasPointPix(lat, lon, &r);
-      if (!std::isnan(s.m_x) && !std::isnan(r.m_x)) {
-        gldc.DrawLine(s.m_x, s.m_y, r.m_x, r.m_y, false);
+      m_pParentCanvas->GetCanvasPointPix(lat, lon, &r);
+      if (s.x != INVALID_COORD && s.y != INVALID_COORD) {
+        gldc.DrawLine(s.x, s.y, r.x, r.y, false);
       }
       s = r;
     }
@@ -2040,8 +2040,6 @@ void glChartCanvas::GridDraw() {
       m_pParentCanvas->GetCanvasPointPix(lat, (elon + wlon) / 2, &r);
       gldc.DrawLine(0, r.y, 10, r.y, true);
       gldc.DrawLine(w - 10, r.y, w, r.y, false);
-
-      lat = lat + gridlatMinor;
     }
   }
 
@@ -2050,13 +2048,13 @@ void glChartCanvas::GridDraw() {
   if (!straight_longitudes) lat_step /= ceil(lat_step / curved_step);
 
   for (lon = startlon; lon < elon; lon += gridlonMajor) {
-    wxPoint2DDouble r, s;
-    s.m_x = NAN;
+    wxPoint r, s;
+    s.x = INVALID_COORD;
+    s.y = INVALID_COORD;
     for (lat = slat; lat < nlat + lat_step / 2; lat += lat_step) {
-      m_pParentCanvas->GetDoubleCanvasPointPix(lat, lon, &r);
-
-      if (!std::isnan(s.m_x) && !std::isnan(r.m_x)) {
-        gldc.DrawLine(s.m_x, s.m_y, r.m_x, r.m_y, false);
+      m_pParentCanvas->GetCanvasPointPix(lat, lon, &r);
+      if (s.x != INVALID_COORD && s.y != INVALID_COORD) {
+        gldc.DrawLine(s.x, s.y, r.x, r.y, false);
       }
       s = r;
     }


### PR DESCRIPTION
# Changes in this PR

Fix for #4229 

1. Fix up to one pixel offset by using `GetCanvasPointPix` consistently when drawing the latitude/longitude grid. Previously the code was using both `GetCanvasPointPix` and `GetDoubleCanvasPointPix`.
2. Fix double-increment of minor latitude grid.

When converting lat/lon to pixels:
1. `GetDoubleCanvasPointPix`truncates `double` values to an integer.
3. `GetCanvasPointPix` rounds `double` values to the nearest integer.
 
This can cause a one-pixel difference depending on which function is invoked.

# Suggestion for follow-up PRs

IMO, the `GetDoubleCanvasPointPix` function should be deprecated, because it can cause up to a one-pixel error compared to the code that uses `GetCanvasPointPix`. That's because `GetCanvasPointPix` uses rounding before invoking drawing functions, whereas `GetDoubleCanvasPointPix` returns a double, which is then truncated when invoking drawing functions.
