### PR TITLE
Add tool Copy N0183 to NMEA Debug Window

### DIFF
--- a/gui/include/gui/TTYScroll.h
+++ b/gui/include/gui/TTYScroll.h
@@ -37,7 +37,7 @@ public:
   virtual void Add(const wxString &line);
   void OnSize(wxSizeEvent &event);
   void Pause(bool pause) { bpause = pause; }
-  void Copy();
+  void Copy(bool);
 
 protected:
   wxCoord m_hLine;  // the height of one line on screen

--- a/gui/include/gui/TTYWindow.h
+++ b/gui/include/gui/TTYWindow.h
@@ -47,6 +47,7 @@ public:
   void Close();
   void OnPauseClick(wxCommandEvent &event);
   void OnCopyClick(wxCommandEvent &event);
+  void OnCopyN0183Click(wxCommandEvent &event);
 
 protected:
   void CreateLegendBitmap();
@@ -54,6 +55,7 @@ protected:
   TTYScroll *m_tty_scroll;
   wxButton *m_btn_pause;
   wxButton *m_btn_copy;
+  wxButton *m_btn_copy_N0183;
   bool m_is_paused;
   wxBitmap m_bm_legend;
   wxTextCtrl *m_filter;

--- a/gui/src/TTYScroll.cpp
+++ b/gui/src/TTYScroll.cpp
@@ -99,11 +99,21 @@ void TTYScroll::OnDraw(wxDC &dc) {
   }
 }
 
-void TTYScroll::Copy() {
+void TTYScroll::Copy(bool n0183) {
   wxString theText;
   for (unsigned int i = 0; i < m_plineArray->GetCount(); i++) {
-    theText.append(m_plineArray->Item(i));
-    theText.append("\n");
+    wxString s = m_plineArray->Item(i);
+    if (n0183) {
+      int pos = 0;
+      if ((pos = s.Find("$")) != wxNOT_FOUND) {
+        theText.append(s.Mid(pos) + "\n");
+      } else if ((pos = s.Find("!")) != wxNOT_FOUND) {
+        theText.append(s.Mid(pos) + "\n");
+      }
+    } else {
+      theText.append(s);
+      theText.append("\n");
+    }
   }
   // Write scrolled text to the clipboard
   if (wxTheClipboard->Open()) {

--- a/gui/src/TTYWindow.cpp
+++ b/gui/src/TTYWindow.cpp
@@ -76,22 +76,30 @@ TTYWindow::TTYWindow(wxWindow* parent, int n_lines,
   wxBitmapButton* bb = new wxBitmapButton(this, wxID_ANY, m_bm_legend);
   sbSizer1->Add(bb, 1, wxALL | wxEXPAND, 5);
 
-  wxStaticBox* buttonBox = new wxStaticBox(this, wxID_ANY, wxEmptyString);
+  wxStaticBox* buttonBox = new wxStaticBox(this, wxID_ANY, "Tools");
   wxStaticBoxSizer* bbSizer1 = new wxStaticBoxSizer(buttonBox, wxVERTICAL);
 
   m_btn_pause = new wxButton(this, wxID_ANY, _("Pause"), wxDefaultPosition,
                              wxDefaultSize, 0);
-  m_btn_copy = new wxButton(this, wxID_ANY, _("Copy"), wxDefaultPosition,
+  m_btn_copy = new wxButton(this, wxID_ANY, _("Copy all"), wxDefaultPosition,
                             wxDefaultSize, 0);
-  m_btn_copy->SetToolTip(_("Copy NMEA Debug window to clipboard."));
+  m_btn_copy->SetToolTip(_("Copy all NMEA Debug window to clipboard."));
+  m_btn_copy_N0183 = new wxButton(this, wxID_ANY, _("Copy NMEA 0183"),
+                                  wxDefaultPosition, wxDefaultSize, 0);
+  m_btn_copy_N0183->SetToolTip(
+      _("Copy only pure NMEA 0183 sentences to clipboard."));
 
   bbSizer1->Add(m_btn_pause, 0, wxALL, 5);
   bbSizer1->Add(m_btn_copy, 0, wxALL, 5);
+  bbSizer1->Add(m_btn_copy_N0183, 0, wxALL, 5);
   bSizerBottomContainer->Add(bbSizer1, 1, wxALL | wxEXPAND, 5);
 
   m_btn_copy->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
                       wxCommandEventHandler(TTYWindow::OnCopyClick), NULL,
                       this);
+  m_btn_copy_N0183->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
+                            wxCommandEventHandler(TTYWindow::OnCopyN0183Click),
+                            NULL, this);
   m_btn_pause->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
                        wxCommandEventHandler(TTYWindow::OnPauseClick), NULL,
                        this);
@@ -181,7 +189,9 @@ void TTYWindow::OnPauseClick(wxCommandEvent&) {
   }
 }
 
-void TTYWindow::OnCopyClick(wxCommandEvent&) { m_tty_scroll->Copy(); }
+void TTYWindow::OnCopyClick(wxCommandEvent&) { m_tty_scroll->Copy(false); }
+
+void TTYWindow::OnCopyN0183Click(wxCommandEvent&) { m_tty_scroll->Copy(true); }
 
 void TTYWindow::OnCloseWindow(wxCloseEvent&) {
   if (m_window_destroy_listener) {


### PR DESCRIPTION
Closes #4243
Insert a new function in NMEA Debug Window to copy only N0183 sentences without date and source info as discussed [here](https://github.com/OpenCPN/OpenCPN/discussions/4243).