### PR TITLE
Handle also internal messages in new API (#4255)

### DIFF
--- a/gui/include/gui/pluginmanager.h
+++ b/gui/include/gui/pluginmanager.h
@@ -27,32 +27,21 @@
 #ifndef _PLUGINMGR_H_
 #define _PLUGINMGR_H_
 
-#include <wx/wx.h>
-#include <wx/dynarray.h>
-#include <wx/dynlib.h>
-
-#include <memory>
 #include <atomic>
+#include <memory>
+#include <string>
+
 #include "config.h"
 
-#include "ocpn_plugin.h"
-#include "OCPN_Sound.h"
-#include "chartimg.h"
-#include "model/catalog_parser.h"
-#include "model/plugin_blacklist.h"
-#include "observable.h"
-#include "ocpndc.h"
-#include "model/ais_target_data.h"
-#include "model/comm_navmsg.h"
-#include "model/comm_vars.h"
-#include "s57chart.h"  // for Object list
-#include "model/semantic_vers.h"
-
-// For widgets...
-#include <wx/hyperlink.h>
-#include <wx/choice.h>
-#include <wx/tglbtn.h>
+#include <wx/wx.h>
 #include <wx/bmpcbox.h>
+#include <wx/choice.h>
+#include <wx/dynarray.h>
+#include <wx/dynlib.h>
+#include <wx/hyperlink.h>
+#include <wx/json_defs.h>
+#include <wx/jsonwriter.h>
+#include <wx/tglbtn.h>
 
 #ifndef __OCPN__ANDROID__
 #ifdef OCPN_USE_CURL
@@ -61,21 +50,18 @@
 #endif
 #endif
 
-//    Include wxJSON headers
-//    We undefine MIN/MAX so avoid warning of redefinition coming from
-//    json_defs.h
-//    Definitions checked manually, and are identical
-#ifdef MIN
-#undef MIN
-#endif
-
-#ifdef MAX
-#undef MAX
-#endif
-
-#include <wx/json_defs.h>
-#include <wx/jsonwriter.h>
+#include "model/ais_target_data.h"
+#include "model/catalog_parser.h"
+#include "model/comm_navmsg.h"
+#include "model/plugin_blacklist.h"
 #include "model/plugin_loader.h"
+#include "model/semantic_vers.h"
+#include "chartimg.h"
+#include "observable.h"
+#include "ocpndc.h"
+#include "ocpn_plugin.h"
+#include "OCPN_Sound.h"
+#include "s57chart.h"  // for Object list
 
 //    Assorted static helper routines
 

--- a/gui/include/gui/pluginmanager.h
+++ b/gui/include/gui/pluginmanager.h
@@ -44,6 +44,7 @@
 #include "ocpndc.h"
 #include "model/ais_target_data.h"
 #include "model/comm_navmsg.h"
+#include "model/comm_vars.h"
 #include "s57chart.h"  // for Object list
 #include "model/semantic_vers.h"
 

--- a/gui/include/gui/pluginmanager.h
+++ b/gui/include/gui/pluginmanager.h
@@ -191,7 +191,7 @@ public:
   bool RenderAllGLCanvasOverlayPlugIns(wxGLContext* pcontext,
                                        const ViewPort& vp, int canvasIndex,
                                        int priority);
-  void SendCursorLatLonToAllPlugIns(double lat, double lon);
+  // void SendCursorLatLonToAllPlugIns(double lat, double lon);
   void SendViewPortToRequestingPlugIns(ViewPort& vp);
   void PrepareAllPluginContextMenus();
 
@@ -234,17 +234,9 @@ public:
   void SetCanvasContextMenuItemViz(int item, bool viz, const char* name = "");
   void SetCanvasContextMenuItemGrey(int item, bool grey, const char* name = "");
 
-  static void SendNMEASentenceToAllPlugIns(const wxString& sentence);
-  void SendPositionFixToAllPlugIns(GenericPosDatEx* ppos);
-  void SendActiveLegInfoToAllPlugIns(const ActiveLegDat* infos);
-  void SendAISSentenceToAllPlugIns(const wxString& sentence);
-  void SendJSONMessageToAllPlugins(const wxString& message_id, wxJSONValue v);
-  void SendMessageToAllPlugins(const wxString& message_id,
-                               const wxString& message_body);
   bool UpDateChartDataTypes();
   void FinalizePluginLoadall();
 
-  int GetJSONMessageTargetCount();
   bool UpdateConfig();
   void SendResizeEventToAllPlugIns(int x, int y);
   void SetColorSchemeForAllPlugIns(ColorScheme cs);
@@ -252,14 +244,6 @@ public:
   bool CallLateInit(void);
 
   bool IsAnyPlugInChartEnabled();
-
-  void SendVectorChartObjectInfo(const wxString& chart, const wxString& feature,
-                                 const wxString& objname, double& lat,
-                                 double& lon, double& scale, int& nativescale);
-
-  bool SendMouseEventToPlugins(wxMouseEvent& event);
-  bool SendKeyEventToPlugins(wxKeyEvent& event);
-  void SendPreShutdownHookToPlugins();
 
   void SendBaseConfigToAllPlugIns();
   void SendS52ConfigToAllPlugIns(bool bReconfig = false);

--- a/gui/src/TrackPropDlg.cpp
+++ b/gui/src/TrackPropDlg.cpp
@@ -27,6 +27,7 @@
 #include "model/georef.h"
 #include "model/navutil_base.h"
 #include "model/own_ship.h"
+#include "model/plugin_comm.h"
 #include "model/route.h"
 #include "model/routeman.h"
 #include "model/select.h"
@@ -61,7 +62,6 @@ extern Routeman* g_pRouteMan;
 extern RouteManagerDialog* pRouteManagerDialog;
 extern MyConfig* pConfig;
 extern MyFrame* gFrame;
-extern PlugInManager* g_pi_manager;
 
 wxString timestamp2s(wxDateTime ts, int tz_selection, long LMT_offset,
                      int format) {
@@ -1730,7 +1730,7 @@ bool TrackPropDlg::SaveChanges(void) {
     v[_T("Name")] = m_pTrack->GetName();
     v[_T("GUID")] = m_pTrack->m_GUID;
     wxString msg_id(_T("OCPN_TRK_ACTIVATED"));
-    g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+    SendJSONMessageToAllPlugins(msg_id, v);
   }
 
   return true;

--- a/gui/src/canvasMenu.cpp
+++ b/gui/src/canvasMenu.cpp
@@ -49,6 +49,7 @@
 #include "model/nav_object_database.h"
 #include "model/own_ship.h"
 #include "model/own_ship.h"
+#include "model/plugin_comm.h"
 #include "model/route.h"
 #include "model/routeman.h"
 #include "model/select.h"
@@ -1367,7 +1368,7 @@ void CanvasMenuHandler::PopupMenuHandler(wxCommandEvent &event) {
         wxJSONValue v;
         v[_T("GUID")] = guid;
         wxString msg_id(_T("OCPN_ANCHOR_WATCH_CLEARED"));
-        g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+        SendJSONMessageToAllPlugins(msg_id, v);
       }
       break;
     }
@@ -1399,7 +1400,7 @@ void CanvasMenuHandler::PopupMenuHandler(wxCommandEvent &event) {
         wxJSONValue v;
         v[_T("GUID")] = guid;
         wxString msg_id(_T("OCPN_ANCHOR_WATCH_SET"));
-        g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+        SendJSONMessageToAllPlugins(msg_id, v);
       }
       break;
     }

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -50,6 +50,7 @@
 #include "model/nav_object_database.h"
 #include "model/navutil_base.h"
 #include "model/own_ship.h"
+#include "model/plugin_comm.h"
 #include "model/route.h"
 #include "model/routeman.h"
 #include "model/select.h"
@@ -2590,10 +2591,9 @@ void ChartCanvas::OnDeferredFocusTimerEvent(wxTimerEvent &event) {
 }
 
 void ChartCanvas::OnKeyChar(wxKeyEvent &event) {
-  if (g_pi_manager)
-    if (g_pi_manager->SendKeyEventToPlugins(event))
-      return;  // PlugIn did something, and does not want the canvas to do
-               // anything else
+  if (SendKeyEventToPlugins(event))
+    return;  // PlugIn did something, and does not want the canvas to do
+             // anything else
 
   int key_char = event.GetKeyCode();
   switch (key_char) {
@@ -2631,10 +2631,9 @@ void ChartCanvas::OnKeyChar(wxKeyEvent &event) {
 }
 
 void ChartCanvas::OnKeyDown(wxKeyEvent &event) {
-  if (g_pi_manager)
-    if (g_pi_manager->SendKeyEventToPlugins(event))
-      return;  // PlugIn did something, and does not want the canvas to do
-               // anything else
+  if (SendKeyEventToPlugins(event))
+    return;  // PlugIn did something, and does not want the canvas to do
+             // anything else
 
   bool b_handled = false;
 
@@ -3204,10 +3203,9 @@ void ChartCanvas::OnKeyDown(wxKeyEvent &event) {
 }
 
 void ChartCanvas::OnKeyUp(wxKeyEvent &event) {
-  if (g_pi_manager)
-    if (g_pi_manager->SendKeyEventToPlugins(event))
-      return;  // PlugIn did something, and does not want the canvas to do
-               // anything else
+  if (SendKeyEventToPlugins(event))
+    return;  // PlugIn did something, and does not want the canvas to do
+             // anything else
 
   switch (event.GetKeyCode()) {
     case WXK_TAB:
@@ -5077,7 +5075,7 @@ bool ChartCanvas::SetViewPoint(double lat, double lon, double scale_ppm,
     GetCanvasPixPoint(mouseX, mouseY, lat, lon);
     m_cursor_lat = lat;
     m_cursor_lon = lon;
-    if (g_pi_manager) g_pi_manager->SendCursorLatLonToAllPlugIns(lat, lon);
+    SendCursorLatLonToAllPlugIns(lat, lon);
   }
 
   if (!VPoint.b_quilt && m_singleChart) {
@@ -7203,10 +7201,9 @@ bool ChartCanvas::MouseEventSetup(wxMouseEvent &event, bool b_handle_dclick) {
   if (event.ButtonUp() && HasCapture()) ReleaseMouse();
 #endif
 
-  if (g_pi_manager)
-    if (g_pi_manager->SendMouseEventToPlugins(event))
-      return (true);  // PlugIn did something, and does not want the canvas to
-                      // do anything else
+  if (SendMouseEventToPlugins(event))
+    return (true);  // PlugIn did something, and does not want the canvas to
+                    // do anything else
 
   // Capture LeftUp's and time them, unless it already came from the timer.
 
@@ -7279,7 +7276,7 @@ bool ChartCanvas::MouseEventSetup(wxMouseEvent &event, bool b_handle_dclick) {
     //  Occasionally, MSW will produce nonsense events on right click....
     //  This results in an error in cursor geo position, so we skip this case
     if ((x >= 0) && (y >= 0))
-      g_pi_manager->SendCursorLatLonToAllPlugIns(m_cursor_lat, m_cursor_lon);
+      SendCursorLatLonToAllPlugIns(m_cursor_lat, m_cursor_lon);
   }
 
   if (!g_btouch) {
@@ -10898,8 +10895,7 @@ void ChartCanvas::UpdateCanvasS52PLIBConfig() {
     w.Write(v, out);
 
     if (!g_lastS52PLIBPluginMessage.IsSameAs(out)) {
-      g_pi_manager->SendMessageToAllPlugins(wxString(_T("OpenCPN Config")),
-                                            out);
+      SendMessageToAllPlugins(wxString("OpenCPN Config"), out);
       g_lastS52PLIBPluginMessage = out;
     }
   }

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -331,7 +331,6 @@ wxGLContext *g_pGLcontext;  // shared common context
 
 extern bool g_useMUI;
 extern unsigned int g_canvasConfig;
-extern wxString g_lastPluginMessage;
 
 extern ChartCanvas *g_focusCanvas;
 extern ChartCanvas *g_overlayCanvas;

--- a/gui/src/cm93.cpp
+++ b/gui/src/cm93.cpp
@@ -55,6 +55,7 @@
 #include "pluginmanager.h"  // for PlugInManager
 #include "OCPNPlatform.h"
 #include "model/wx28compat.h"
+#include "model/plugin_comm.h"
 #include "model/chartdata_input_stream.h"
 #include "DetailSlider.h"
 #include "chcanv.h"
@@ -86,8 +87,6 @@ extern PopUpDSlide *pPopupDetailSlider;
 extern int g_detailslider_dialog_x, g_detailslider_dialog_y;
 
 extern bool g_bopengl;
-extern PlugInManager *g_pi_manager;
-
 extern bool g_b_EnableVBO;
 
 // TODO  These should be gotten from the ctor
@@ -2275,9 +2274,8 @@ int cm93chart::CreateObjChain(int cell_index, int subcell,
         if (objnam.Len() > 0) {
           wxString cellname =
               wxString::Format(_T("%i_%i"), cell_index, subcell);
-          g_pi_manager->SendVectorChartObjectInfo(cellname, fe_name, objnam,
-                                                  obj->m_lat, obj->m_lon, scale,
-                                                  nativescale);
+          SendVectorChartObjectInfo(cellname, fe_name, objnam, obj->m_lat,
+                                    obj->m_lon, scale, nativescale);
         }
         //      Build/Maintain the ATON floating/rigid arrays
         if (GEO_POINT == obj->Primitive_type) {

--- a/gui/src/glChartCanvas.cpp
+++ b/gui/src/glChartCanvas.cpp
@@ -58,6 +58,7 @@
 #include <wx/window.h>
 
 #include "model/own_ship.h"
+#include "model/plugin_comm.h"
 #include "model/route.h"
 #include "model/routeman.h"
 #include "model/track.h"
@@ -1347,7 +1348,7 @@ void glChartCanvas::SendJSONConfigMessage() {
     v[_T("useVBO")] = g_b_EnableVBO;
     v[_T("TextureRectangleFormat")] = g_texture_rectangle_format;
     wxString msg_id(_T("OCPN_OPENGL_CONFIG"));
-    g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+    SendJSONMessageToAllPlugins(msg_id, v);
   }
 }
 void glChartCanvas::SetupCompression() {

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -75,6 +75,7 @@
 #include "model/nav_object_database.h"
 #include "model/navutil_base.h"
 #include "model/own_ship.h"
+#include "model/plugin_comm.h"
 #include "model/plugin_loader.h"
 #include "model/routeman.h"
 #include "model/select.h"
@@ -1563,7 +1564,7 @@ void MyFrame::OnCloseWindow(wxCloseEvent &event) {
   }
 
   //  Give any requesting plugins a PreShutdownHook call
-  g_pi_manager->SendPreShutdownHookToPlugins();
+  SendPreShutdownHookToPlugins();
 
   // We save perspective before closing to restore position next time
   // Pane is not closed so the child is not notified (OnPaneClose)
@@ -2989,7 +2990,7 @@ void MyFrame::ActivateMOB(void) {
     wxJSONValue v;
     v[_T("GUID")] = temp_route->m_GUID;
     wxString msg_id(_T("OCPN_MAN_OVERBOARD"));
-    g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+    SendJSONMessageToAllPlugins(msg_id, v);
   }
 
   if (RouteManagerDialog::getInstanceFlag()) {
@@ -3053,7 +3054,7 @@ void MyFrame::TrackOn(void) {
   v[_T("Name")] = name;
   v[_T("GUID")] = g_pActiveTrack->m_GUID;
   wxString msg_id(_T("OCPN_TRK_ACTIVATED"));
-  g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+  SendJSONMessageToAllPlugins(msg_id, v);
   g_FlushNavobjChangesTimeout =
       30;  // Every thirty seconds, consider flushing navob changes
 }
@@ -3065,7 +3066,7 @@ Track *MyFrame::TrackOff(bool do_add_point) {
     wxJSONValue v;
     wxString msg_id(_T("OCPN_TRK_DEACTIVATED"));
     v[_T("GUID")] = g_pActiveTrack->m_GUID;
-    g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+    SendJSONMessageToAllPlugins(msg_id, v);
 
     g_pActiveTrack->Stop(do_add_point);
 
@@ -5528,7 +5529,7 @@ void MyFrame::OnFrameTimer1(wxTimerEvent &event) {
     else
       GPSData.FixTime = wxDateTime::Now().GetTicks();
 
-    g_pi_manager->SendPositionFixToAllPlugIns(&GPSData);
+    SendPositionFixToAllPlugIns(&GPSData);
   }
 
   //   Check for anchorwatch alarms                                 // pjotrc
@@ -5871,7 +5872,7 @@ bool MyFrame::SendJSON_WMM_Var_Request(double lat, double lon,
     v[_T("Month")] = date.GetMonth();
     v[_T("Day")] = date.GetDay();
 
-    g_pi_manager->SendJSONMessageToAllPlugins(_T("WMM_VARIATION_REQUEST"), v);
+    SendJSONMessageToAllPlugins(_T("WMM_VARIATION_REQUEST"), v);
     return true;
   } else
     return false;
@@ -6466,14 +6467,14 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
           v[_T("NodeNr")] = i;
           i++;
           wxString msg_id(_T("OCPN_TRACKPOINTS_COORDS"));
-          g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+          SendJSONMessageToAllPlugins(msg_id, v);
         }
         return;
       }
       v[_T("error")] = true;
 
       wxString msg_id(_T("OCPN_TRACKPOINTS_COORDS"));
-      g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+      SendJSONMessageToAllPlugins(msg_id, v);
     }
   } else if (message_ID == _T("OCPN_ROUTE_REQUEST")) {
     wxJSONValue root;
@@ -6525,7 +6526,7 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
         }
         v[_T("waypoints")] = w;
         wxString msg_id(_T("OCPN_ROUTE_RESPONSE"));
-        g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+        SendJSONMessageToAllPlugins(msg_id, v);
         return;
       }
     }
@@ -6533,7 +6534,7 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
     v[_T("error")] = true;
 
     wxString msg_id(_T("OCPN_ROUTE_RESPONSE"));
-    g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+    SendJSONMessageToAllPlugins(msg_id, v);
   } else if (message_ID == _T("OCPN_ROUTELIST_REQUEST")) {
     wxJSONValue root;
     wxJSONReader reader;
@@ -6579,12 +6580,12 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
         }
       }
       wxString msg_id(_T("OCPN_ROUTELIST_RESPONSE"));
-      g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+      SendJSONMessageToAllPlugins(msg_id, v);
     } else {
       wxJSONValue v;
       v[0][_T("error")] = true;
       wxString msg_id(_T("OCPN_ROUTELIST_RESPONSE"));
-      g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+      SendJSONMessageToAllPlugins(msg_id, v);
     }
   } else if (message_ID == _T("OCPN_ACTIVE_ROUTELEG_REQUEST")) {
     wxJSONValue v;
@@ -6604,7 +6605,7 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
       }
     }
     wxString msg_id(_T("OCPN_ACTIVE_ROUTELEG_RESPONSE"));
-    g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+    SendJSONMessageToAllPlugins(msg_id, v);
   }
 }
 
@@ -6761,7 +6762,7 @@ void MyFrame::ActivateAISMOBRoute(const AisTargetData *ptarget) {
   wxJSONValue v;
   v[_T("GUID")] = pAISMOBRoute->m_GUID;
   wxString msg_id(_T("OCPN_MAN_OVERBOARD"));
-  g_pi_manager->SendJSONMessageToAllPlugins(msg_id, v);
+  SendJSONMessageToAllPlugins(msg_id, v);
   //}
 
   if (RouteManagerDialog::getInstanceFlag()) {

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -124,7 +124,6 @@ extern unsigned int g_canvasConfig;
 extern wxString g_CmdSoundString;
 
 unsigned int gs_plib_flags;
-wxString g_lastPluginMessage;
 extern ChartCanvas* g_focusCanvas;
 extern ChartCanvas* g_overlayCanvas;
 extern bool g_bquiting;

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -55,6 +55,7 @@
 #include "toolbar.h"
 #include "options.h"
 #include "s52plib.h"
+#include "model/plugin_comm.h"
 #include "model/route.h"
 #include "model/track.h"
 #include "routemanagerdialog.h"
@@ -400,7 +401,7 @@ ArrayOfPlugIn_AIS_Targets* GetAISTargetArray(void) {
 wxAuiManager* GetFrameAuiManager(void) { return g_pauimgr; }
 
 void SendPluginMessage(wxString message_id, wxString message_body) {
-  s_ppim->SendMessageToAllPlugins(message_id, message_body);
+  SendMessageToAllPlugins(message_id, message_body);
 
   //  We will send an event to the main application frame (gFrame)
   //  for informational purposes.

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -224,7 +224,6 @@ extern unsigned int g_canvasConfig;
 extern wxString g_CmdSoundString;
 
 extern unsigned int gs_plib_flags;
-extern wxString g_lastPluginMessage;
 extern ChartCanvas* g_focusCanvas;
 extern ChartCanvas* g_overlayCanvas;
 extern bool g_bquiting;
@@ -1909,8 +1908,6 @@ void PlugInManager::SendJSONMessageToAllPlugins(const wxString& message_id,
 
 void PlugInManager::SendMessageToAllPlugins(const wxString& message_id,
                                             const wxString& message_body) {
-  g_lastPluginMessage = message_body;
-
   auto msg = std::make_shared<PluginMsg>(
       PluginMsg(message_id.ToStdString(), message_body.ToStdString()));
   NavMsgBus::GetInstance().Notify(msg);

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -1911,6 +1911,10 @@ void PlugInManager::SendMessageToAllPlugins(const wxString& message_id,
                                             const wxString& message_body) {
   g_lastPluginMessage = message_body;
 
+  auto msg = std::make_shared<PluginMsg>(
+      PluginMsg(message_id.ToStdString(), message_body.ToStdString()));
+  NavMsgBus::GetInstance().Notify(msg);
+
   wxString decouple_message_id(
       message_id);  // decouples 'const wxString &' and 'wxString &' to keep bin
                     // compat for plugins

--- a/gui/src/s57chart.cpp
+++ b/gui/src/s57chart.cpp
@@ -48,6 +48,7 @@
 #include "model/georef.h"
 #include "navutil.h"  // for LogMessageOnce
 #include "model/navutil_base.h"
+#include "model/plugin_comm.h"
 #include "ocpn_pixel.h"
 #include "ocpndc.h"
 #include "s52utils.h"
@@ -4187,18 +4188,16 @@ int s57chart::BuildRAZFromSENCFile(const wxString &FullPath) {
     const wxString objnam = obj->GetAttrValueAsString("OBJNAM");
     if (objnam.Len() > 0) {
       const wxString fe_name = wxString(obj->FeatureName, wxConvUTF8);
-      g_pi_manager->SendVectorChartObjectInfo(FullPath, fe_name, objnam,
-                                              obj->m_lat, obj->m_lon, scale,
-                                              nativescale);
+      SendVectorChartObjectInfo(FullPath, fe_name, objnam, obj->m_lat,
+                                obj->m_lon, scale, nativescale);
     }
     // If there is a localized object name and it actually is different from the
     // object name, send it as well...
     const wxString nobjnam = obj->GetAttrValueAsString("NOBJNM");
     if (nobjnam.Len() > 0 && nobjnam != objnam) {
       const wxString fe_name = wxString(obj->FeatureName, wxConvUTF8);
-      g_pi_manager->SendVectorChartObjectInfo(FullPath, fe_name, nobjnam,
-                                              obj->m_lat, obj->m_lon, scale,
-                                              nativescale);
+      SendVectorChartObjectInfo(FullPath, fe_name, nobjnam, obj->m_lat,
+                                obj->m_lon, scale, nativescale);
     }
 
     switch (obj->Primitive_type) {

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -1827,11 +1827,16 @@ extern DECL_EXP const std::unordered_map<std::string, std::string>
 GetAttributes(DriverHandle handle);
 
 /* Writing to a specific driver  */
-
-/* Comm drivers on bus protocols other than NMEA2000 may write directly to the
+/**
+ * Send a non-NMEA2000 message.
  * port * using  a simple call.  The physical write operation will be queued,
  * and executed in order as bandwidth allows.
- * Return value is number of bytes queued for transmission.
+ * @param handle Obtained from GetActiveDrivers()
+ * @param payload Message data, for eaxample a complete Nmea0183 message.
+ *        From 1.19: if the handle "protocol" attribute is "internal" it is
+ *        parsed as <id><space><message> where the id is used when listening/
+ *        subscribing to message.
+ * @return value number of bytes queued for transmission.
  */
 extern DECL_EXP CommDriverResult WriteCommDriver(
     DriverHandle handle, const std::shared_ptr<std::vector<uint8_t>> &payload);

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -49,6 +49,7 @@ set(
   ${MODEL_HDR_DIR}/comm_driver.h
   ${MODEL_HDR_DIR}/comm_drv_factory.h
   ${MODEL_HDR_DIR}/comm_drv_file.h
+  ${MODEL_HDR_DIR}/comm_drv_internal.h
   ${MODEL_HDR_DIR}/comm_drv_n0183_android_bt.h
   ${MODEL_HDR_DIR}/comm_drv_n0183_android_int.h
   ${MODEL_HDR_DIR}/comm_drv_n0183.h
@@ -146,6 +147,7 @@ set(SRC
   #${MODEL_SRC_DIR}/comm_driver.cpp
   ${MODEL_SRC_DIR}/comm_drv_factory.cpp
   ${MODEL_SRC_DIR}/comm_drv_file.cpp
+  ${MODEL_SRC_DIR}/comm_drv_internal.cpp
   ${MODEL_SRC_DIR}/comm_drv_n0183.cpp
   ${MODEL_SRC_DIR}/comm_drv_n0183_net.cpp
   ${MODEL_SRC_DIR}/comm_drv_n0183_serial.cpp

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -101,6 +101,7 @@ set(
   ${MODEL_HDR_DIR}/pincode.h
   ${MODEL_HDR_DIR}/plugin_blacklist.h
   ${MODEL_HDR_DIR}/plugin_cache.h
+  ${MODEL_HDR_DIR}/plugin_comm.h
   ${MODEL_HDR_DIR}/plugin_handler.h
   ${MODEL_HDR_DIR}/plugin_loader.h
   ${MODEL_HDR_DIR}/plugin_paths.h
@@ -193,6 +194,7 @@ set(SRC
   ${MODEL_SRC_DIR}/plugin_api.cpp
   ${MODEL_SRC_DIR}/plugin_blacklist.cpp
   ${MODEL_SRC_DIR}/plugin_cache.cpp
+  ${MODEL_SRC_DIR}/plugin_comm.cpp
   ${MODEL_SRC_DIR}/plugin_handler.cpp
   ${MODEL_SRC_DIR}/plugin_loader.cpp
   ${MODEL_SRC_DIR}/plugin_paths.cpp

--- a/model/include/model/comm_drv_internal.h
+++ b/model/include/model/comm_drv_internal.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+ *   Copyright (C) 2024 by Alec Leamas                                     *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+/**
+ *  \file
+ *  Internal send-only driver, send to plugins.
+ */
+
+#ifndef _COMM_DRV_INTERNAL__H
+#define _COMM_DRV_INTERNAL__H
+
+#include "model/comm_driver.h"
+
+/**
+ * Send only driver facilitating sending messages to all plugins and core.
+ */
+class CommDriverInternal : public AbstractCommDriver {
+public:
+  CommDriverInternal(DriverListener& l);
+
+  ~CommDriverInternal() = default;
+
+  /** Register driver. */
+  void Activate() override;
+
+  /**
+   * Send a message to all plugins and core on internal bus.
+   * @param msg Must be PluginMsg, by convention a type + a json encoded
+   *            string.
+   * @param addr Not used
+   */
+  bool SendMessage(std::shared_ptr<const NavMsg> msg,
+                   std::shared_ptr<const NavAddr> addr) override;
+
+private:
+  DriverListener& m_listener;
+};
+
+#endif  //  _COMM_DRV_INTERNAL__H

--- a/model/include/model/plugin_comm.h
+++ b/model/include/model/plugin_comm.h
@@ -1,0 +1,61 @@
+/***************************************************************************
+ *   Copyright (C) 2024 Alec Leamas                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+/**
+ * \file
+ *  Tools to send data to plugins.
+ */
+
+#ifndef PLUGIN__COMM_H
+#define PLUGIN__COMM_H
+
+#include <wx/event.h>
+#include <wx/jsonval.h>
+#include <wx/string.h>
+
+#include "model/ocpn_types.h"
+
+void SendMessageToAllPlugins(const wxString& message_id,
+                             const wxString& message_body);
+
+void SendJSONMessageToAllPlugins(const wxString& message_id, wxJSONValue v);
+
+void SendAISSentenceToAllPlugIns(const wxString& sentence);
+
+void SendPositionFixToAllPlugIns(GenericPosDatEx* ppos);
+
+void SendActiveLegInfoToAllPlugIns(const ActiveLegDat* leg_info);
+
+bool SendMouseEventToPlugins(wxMouseEvent& event);
+
+bool SendKeyEventToPlugins(wxKeyEvent& event);
+
+void SendPreShutdownHookToPlugins();
+
+void SendCursorLatLonToAllPlugIns(double lat, double lon);
+
+void SendNMEASentenceToAllPlugIns(const wxString& sentence);
+
+int GetJSONMessageTargetCount();
+
+void SendVectorChartObjectInfo(const wxString& chart, const wxString& feature,
+                               const wxString& objname, double& lat,
+                               double& lon, double& scale, int& nativescale);
+
+#endif  //  PLUGIN__COMM_H

--- a/model/src/comm_drv_internal.cpp
+++ b/model/src/comm_drv_internal.cpp
@@ -1,0 +1,63 @@
+/***************************************************************************
+ *   Copyright (C) 2024 Alec Leamas                                        *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+/**
+ *  \file
+ *  Implement comm_drv_internal.h
+ */
+
+// For compilers that support precompilation, includes "wx.h".
+#include <wx/wxprec.h>
+
+#ifndef WX_PRECOMP
+#include <wx/wx.h>
+#endif
+
+#include <wx/log.h>
+#include <wx/string.h>
+
+#include "config.h"
+#include "model/comm_drv_internal.h"
+#include "model/comm_drv_registry.h"
+#include "model/comm_navmsg_bus.h"
+#include "model/logger.h"
+
+#include "observable.h"
+
+CommDriverInternal::CommDriverInternal(DriverListener& listener)
+    : AbstractCommDriver(NavAddr::Bus::Plugin, "internal"),
+      m_listener(listener) {
+  this->attributes["commPort"] = "internal";
+  this->attributes["ioDirection"] = "OUT";
+}
+
+void CommDriverInternal::Activate() {
+  CommDriverRegistry::GetInstance().Activate(shared_from_this());
+}
+
+bool CommDriverInternal::SendMessage(std::shared_ptr<const NavMsg> msg,
+                                     std::shared_ptr<const NavAddr> addr) {
+  auto msg_plugin = std::dynamic_pointer_cast<const PluginMsg>(msg);
+  if (!msg_plugin) {
+    WARNING_LOG << " CommDriverInternal::SendMessage::Illegal message type";
+    return false;
+  }
+  NavMsgBus::GetInstance().Notify(msg_plugin);
+  return true;
+}

--- a/model/src/plugin_api.cpp
+++ b/model/src/plugin_api.cpp
@@ -183,8 +183,17 @@ CommDriverResult WriteCommDriver(
     auto msg_out = std::make_shared<Nmea0183Msg>(id, msg, address);
     bool xmit_ok = d0183->SendMessage(msg_out, address);
     return xmit_ok ? RESULT_COMM_NO_ERROR : RESULT_COMM_TX_ERROR;
-  } else
+  } else if (protocol == "internal") {
+    std::string msg(payload->begin(), payload->end());
+    size_t space_pos = msg.find(" ");
+    if (space_pos == std::string::npos) return RESULT_COMM_INVALID_PARMS;
+    auto plugin_msg = std::make_shared<PluginMsg>(msg.substr(0, space_pos),
+                                                  msg.substr(space_pos + 1));
+    NavMsgBus::GetInstance().Notify(static_pointer_cast<NavMsg>(plugin_msg));
+    return RESULT_COMM_NO_ERROR;
+  } else {
     return RESULT_COMM_INVALID_PARMS;
+  }
 }
 
 CommDriverResult WriteCommDriverN2K(

--- a/model/src/plugin_comm.cpp
+++ b/model/src/plugin_comm.cpp
@@ -1,0 +1,416 @@
+/**************************************************************************
+ *   Copyright (C) 2022 by David Register                                  *
+ *   Copyright (C) 2022  Alec Leamas                                       *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
+/**
+ *  \file
+ *  Implement various ocpn_plugin.h methods.
+ */
+
+#include <setjmp.h>
+
+#include <wx/event.h>
+#include <wx/jsonval.h>
+#include <wx/jsonreader.h>
+#include <wx/jsonwriter.h>
+
+#include "model/comm_appmsg.h"
+#include "model/comm_navmsg_bus.h"
+#include "model/plugin_loader.h"
+
+#include "model/plugin_comm.h"
+
+#include "ocpn_plugin.h"
+
+#ifndef _WIN32
+
+static struct sigaction sa_all_PIM_previous;
+static sigjmp_buf env_PIM;
+
+static void catch_signals_PIM(int signo) {
+  switch (signo) {
+    case SIGSEGV:
+      siglongjmp(env_PIM, 1);  // jump back to the setjmp() point
+      break;
+
+    default:
+      break;
+  }
+}
+
+#endif
+
+void SendMessageToAllPlugins(const wxString& message_id,
+                             const wxString& message_body) {
+  auto msg = std::make_shared<PluginMsg>(
+      PluginMsg(message_id.ToStdString(), message_body.ToStdString()));
+  NavMsgBus::GetInstance().Notify(msg);
+
+  // decouple 'const wxString &' and 'wxString &' to keep bin
+  wxString decouple_message_id(message_id);
+  wxString decouple_message_body(message_body);
+
+  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
+    PlugInContainer* pic = plugin_array->Item(i);
+    if (pic->m_enabled && pic->m_init_state) {
+      if (pic->m_cap_flag & WANTS_PLUGIN_MESSAGING) {
+        switch (pic->m_api_version) {
+          case 106: {
+            auto* ppi = dynamic_cast<opencpn_plugin_16*>(pic->m_pplugin);
+            if (ppi)
+              ppi->SetPluginMessage(decouple_message_id, decouple_message_body);
+            break;
+          }
+          case 107: {
+            auto* ppi = dynamic_cast<opencpn_plugin_17*>(pic->m_pplugin);
+            if (ppi)
+              ppi->SetPluginMessage(decouple_message_id, decouple_message_body);
+            break;
+          }
+          case 108:
+          case 109:
+          case 110:
+          case 111:
+          case 112:
+          case 113:
+          case 114:
+          case 115:
+          case 116:
+          case 117:
+          case 118:
+          case 119: {
+            auto* ppi = dynamic_cast<opencpn_plugin_18*>(pic->m_pplugin);
+            if (ppi)
+              ppi->SetPluginMessage(decouple_message_id, decouple_message_body);
+            break;
+          }
+          default:
+            break;
+        }
+      }
+    }
+  }
+}
+
+void SendJSONMessageToAllPlugins(const wxString& message_id, wxJSONValue v) {
+  wxJSONWriter w;
+  wxString out;
+  w.Write(v, out);
+  SendMessageToAllPlugins(message_id, out);
+  wxLogDebug(message_id);
+  wxLogDebug(out);
+}
+
+void SendAISSentenceToAllPlugIns(const wxString& sentence) {
+  // decouple 'const wxString &' to keep interface.
+  wxString decouple_sentence(sentence);
+  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
+    PlugInContainer* pic = plugin_array->Item(i);
+    if (pic->m_enabled && pic->m_init_state) {
+      if (pic->m_cap_flag & WANTS_AIS_SENTENCES)
+        pic->m_pplugin->SetAISSentence(decouple_sentence);
+    }
+  }
+}
+
+void SendPositionFixToAllPlugIns(GenericPosDatEx* ppos) {
+  //    Send basic position fix
+  PlugIn_Position_Fix pfix;
+  pfix.Lat = ppos->kLat;
+  pfix.Lon = ppos->kLon;
+  pfix.Cog = ppos->kCog;
+  pfix.Sog = ppos->kSog;
+  pfix.Var = ppos->kVar;
+  pfix.FixTime = ppos->FixTime;
+  pfix.nSats = ppos->nSats;
+
+  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
+    PlugInContainer* pic = plugin_array->Item(i);
+    if (pic->m_enabled && pic->m_init_state) {
+      if (pic->m_cap_flag & WANTS_NMEA_EVENTS)
+        if (pic->m_pplugin) pic->m_pplugin->SetPositionFix(pfix);
+    }
+  }
+
+  //    Send extended position fix to PlugIns at API 108 and later
+  PlugIn_Position_Fix_Ex pfix_ex;
+  pfix_ex.Lat = ppos->kLat;
+  pfix_ex.Lon = ppos->kLon;
+  pfix_ex.Cog = ppos->kCog;
+  pfix_ex.Sog = ppos->kSog;
+  pfix_ex.Var = ppos->kVar;
+  pfix_ex.FixTime = ppos->FixTime;
+  pfix_ex.nSats = ppos->nSats;
+  pfix_ex.Hdt = ppos->kHdt;
+  pfix_ex.Hdm = ppos->kHdm;
+
+  for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
+    PlugInContainer* pic = plugin_array->Item(i);
+    if (pic->m_enabled && pic->m_init_state) {
+      if (pic->m_cap_flag & WANTS_NMEA_EVENTS) {
+        switch (pic->m_api_version) {
+          case 108:
+          case 109:
+          case 110:
+          case 111:
+          case 112:
+          case 113:
+          case 114:
+          case 115:
+          case 116:
+          case 117:
+          case 118:
+          case 119: {
+            auto* ppi = dynamic_cast<opencpn_plugin_18*>(pic->m_pplugin);
+            if (ppi) ppi->SetPositionFixEx(pfix_ex);
+            break;
+          }
+          default:
+            break;
+        }
+      }
+    }
+  }
+}
+
+void SendActiveLegInfoToAllPlugIns(const ActiveLegDat* leg_info) {
+  Plugin_Active_Leg_Info leg;
+  leg.Btw = leg_info->Btw;
+  leg.Dtw = leg_info->Dtw;
+  leg.wp_name = leg_info->wp_name;
+  leg.Xte = leg_info->Xte;
+  leg.arrival = leg_info->arrival;
+  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
+    PlugInContainer* pic = plugin_array->Item(i);
+    if (pic->m_enabled && pic->m_init_state) {
+      if (pic->m_cap_flag & WANTS_NMEA_EVENTS) {
+        switch (pic->m_api_version) {
+          case 108:
+          case 109:
+          case 110:
+          case 111:
+          case 112:
+          case 113:
+          case 114:
+          case 115:
+          case 116:
+            break;
+          case 117:
+          case 118:
+          case 119: {
+            auto* ppi = dynamic_cast<opencpn_plugin_117*>(pic->m_pplugin);
+            if (ppi) ppi->SetActiveLegInfo(leg);
+            break;
+          }
+          default:
+            break;
+        }
+      }
+    }
+  }
+}
+
+bool SendMouseEventToPlugins(wxMouseEvent& event) {
+  bool bret = false;
+  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
+    PlugInContainer* pic = plugin_array->Item(i);
+    if (pic->m_enabled && pic->m_init_state) {
+      if (pic->m_cap_flag & WANTS_MOUSE_EVENTS) {
+        switch (pic->m_api_version) {
+          case 112:
+          case 113:
+          case 114:
+          case 115:
+          case 116:
+          case 117:
+          case 118:
+          case 119: {
+            auto* ppi = dynamic_cast<opencpn_plugin_112*>(pic->m_pplugin);
+            if (ppi && ppi->MouseEventHook(event)) bret = true;
+            break;
+          }
+          default:
+            break;
+        }
+      }
+    }
+  }
+  return bret;
+}
+
+bool SendKeyEventToPlugins(wxKeyEvent& event) {
+  bool bret = false;
+  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
+    PlugInContainer* pic = plugin_array->Item(i);
+    if (pic->m_enabled && pic->m_init_state) {
+      if (pic->m_cap_flag & WANTS_KEYBOARD_EVENTS) {
+        {
+          switch (pic->m_api_version) {
+            case 113:
+            case 114:
+            case 115:
+            case 116:
+            case 117:
+            case 118:
+            case 119: {
+              auto* ppi = dynamic_cast<opencpn_plugin_113*>(pic->m_pplugin);
+              if (ppi && ppi->KeyboardEventHook(event)) bret = true;
+              break;
+            }
+            default:
+              break;
+          }
+        }
+      }
+    }
+  }
+
+  return bret;
+}
+
+void SendPreShutdownHookToPlugins() {
+  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
+    PlugInContainer* pic = plugin_array->Item(i);
+    if (pic->m_enabled && pic->m_init_state) {
+      if (pic->m_cap_flag & WANTS_PRESHUTDOWN_HOOK) {
+        switch (pic->m_api_version) {
+          case 119: {
+            auto* ppi = dynamic_cast<opencpn_plugin_119*>(pic->m_pplugin);
+            if (ppi) ppi->PreShutdownHook();
+            break;
+          }
+          default:
+            break;
+        }
+      }
+    }
+  }
+}
+
+void SendCursorLatLonToAllPlugIns(double lat, double lon) {
+  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
+    PlugInContainer* pic = plugin_array->Item(i);
+    if (pic->m_enabled && pic->m_init_state) {
+      if (pic->m_cap_flag & WANTS_CURSOR_LATLON)
+        if (pic->m_pplugin) pic->m_pplugin->SetCursorLatLon(lat, lon);
+    }
+  }
+}
+
+void SendNMEASentenceToAllPlugIns(const wxString& sentence) {
+  // decouple 'const wxString &' to keep plugin interface.
+  wxString decouple_sentence(sentence);
+#ifndef __WXMSW__
+  // Set up a framework to catch (some) sigsegv faults from plugins.
+  sigaction(SIGSEGV, NULL, &sa_all_PIM_previous);  // save existing
+                                                   // action for this signal
+  struct sigaction temp;
+  sigaction(SIGSEGV, NULL, &temp);  // inspect existing action for this signal
+
+  temp.sa_handler = catch_signals_PIM;  // point to my handler
+  sigemptyset(&temp.sa_mask);           // make the blocking set
+                                        // empty, so that all
+                                        // other signals will be
+                                        // unblocked during my handler
+  temp.sa_flags = 0;
+  sigaction(SIGSEGV, &temp, NULL);
+#endif
+  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
+    PlugInContainer* pic = plugin_array->Item(i);
+    if (pic->m_enabled && pic->m_init_state) {
+      if (pic->m_cap_flag & WANTS_NMEA_SENTENCES) {
+#ifndef __WXMSW__
+        if (sigsetjmp(env_PIM, 1)) {
+          //  Something in the "else" code block faulted.
+          // Probably safest to assume that all variables in this method are
+          // trash... So, simply clean up and return.
+          sigaction(SIGSEGV, &sa_all_PIM_previous, NULL);
+          // reset signal handler
+          return;
+        } else
+#endif
+        {
+          // volatile int *x = 0;
+          //*x = 0;
+          if (pic->m_pplugin)
+            pic->m_pplugin->SetNMEASentence(decouple_sentence);
+        }
+      }
+    }
+  }
+#ifndef __WXMSW__
+  sigaction(SIGSEGV, &sa_all_PIM_previous, NULL);  // reset signal handler
+#endif
+}
+
+int GetJSONMessageTargetCount() {
+  int rv = 0;
+  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
+    PlugInContainer* pic = plugin_array->Item(i);
+    if (pic->m_enabled && pic->m_init_state &&
+        (pic->m_cap_flag & WANTS_PLUGIN_MESSAGING))
+      rv++;
+  }
+  return rv;
+}
+
+void SendVectorChartObjectInfo(const wxString& chart, const wxString& feature,
+                               const wxString& objname, double& lat,
+                               double& lon, double& scale, int& nativescale) {
+  wxString decouple_chart(chart);
+  wxString decouple_feature(feature);
+  wxString decouple_objname(objname);
+  auto plugin_array = PluginLoader::getInstance()->GetPlugInArray();
+  for (unsigned int i = 0; i < plugin_array->GetCount(); i++) {
+    PlugInContainer* pic = (*plugin_array)[i];
+    if (pic->m_enabled && pic->m_init_state) {
+      if (pic->m_cap_flag & WANTS_VECTOR_CHART_OBJECT_INFO) {
+        switch (pic->m_api_version) {
+          case 112:
+          case 113:
+          case 114:
+          case 115:
+          case 116:
+          case 117:
+          case 118:
+          case 119: {
+            auto* ppi = dynamic_cast<opencpn_plugin_112*>(pic->m_pplugin);
+            if (ppi)
+              ppi->SendVectorChartObjectInfo(decouple_chart, decouple_feature,
+                                             decouple_objname, lat, lon, scale,
+                                             nativescale);
+            break;
+          }
+          default:
+            break;
+        }
+      }
+    }
+  }
+}

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -8,7 +8,6 @@
 #include <iostream>
 #include <thread>
 
-
 #include <wx/app.h>
 #include <wx/event.h>
 #include <wx/evtloop.h>
@@ -45,7 +44,8 @@
 #include "ocpn_plugin.h"
 
 // Macos up to 10.13
-#if (defined(OCPN_GHC_FILESYSTEM) || (defined(__clang_major__) && (__clang_major__ < 15)))
+#if (defined(OCPN_GHC_FILESYSTEM) || \
+     (defined(__clang_major__) && (__clang_major__ < 15)))
 #include <ghc/filesystem.hpp>
 namespace fs = ghc::filesystem;
 
@@ -86,7 +86,7 @@ wxLogStderr defaultLog;
 #ifdef _MSC_VER
 int setenv(const char* name, const char* value, bool overwrite) {
   if (!overwrite) {
-     if (getenv(name)) return 1;
+    if (getenv(name)) return 1;
   }
   return _putenv_s(name, value);
 }
@@ -107,15 +107,18 @@ static void ConfigSetup() {
 class SillyDriver : public AbstractCommDriver {
 public:
   SillyDriver() : AbstractCommDriver(NavAddr::Bus::TestBus, "silly") {}
-  SillyDriver(const std::string& s) : AbstractCommDriver(NavAddr::Bus::TestBus, s) {}
+  SillyDriver(const std::string& s)
+      : AbstractCommDriver(NavAddr::Bus::TestBus, s) {}
   virtual ~SillyDriver() = default;
 
   virtual bool SendMessage(std::shared_ptr<const NavMsg> msg,
-                           std::shared_ptr<const NavAddr> addr) {return false;}
+                           std::shared_ptr<const NavAddr> addr) {
+    return false;
+  }
 
   virtual void SetListener(DriverListener& listener) {}
 
-  virtual void Activate(){};
+  virtual void Activate() {};
 };
 
 class SillyListener : public DriverListener {
@@ -138,8 +141,7 @@ public:
   virtual void Notify(const AbstractCommDriver& driver) {}
 };
 
-
-class BasicTest  : public wxAppConsole  {
+class BasicTest : public wxAppConsole {
 public:
   BasicTest() {
     const auto config_orig = fs::path(TESTDATA) / "opencpn.conf";
@@ -160,7 +162,6 @@ public:
   }
   virtual void Work() { std::this_thread::sleep_for(20ms); }
 };
-
 
 class MsgCliApp : public BasicTest {
 public:
@@ -212,6 +213,94 @@ public:
     ProcessPendingEvents();
     EXPECT_EQ(s_result, std::string("payload data"));
     EXPECT_EQ(NavAddr::Bus::N2000, s_bus);
+  }
+};
+
+class PluginMsgApp : public BasicTest {
+public:
+  class Source {
+  public:
+    Source() {
+      auto msg = std::make_unique<PluginMsg>("foo", "bar");
+      NavMsgBus::GetInstance().Notify(std::move(msg));
+    }
+  };
+
+  class Sink : public wxEvtHandler {
+  public:
+    Sink() {
+      auto& t = NavMsgBus::GetInstance();
+      auto msg = PluginMsg("foo", "");
+      listener.Listen(msg, this, EVT_FOO);
+
+      Bind(EVT_FOO, [&](ObservedEvt ev) {
+        auto ptr = ev.GetSharedPtr();
+        auto plugin_msg = std::static_pointer_cast<const PluginMsg>(ptr);
+        s_result = plugin_msg->message;
+        s_bus = plugin_msg->bus;
+      });
+    }
+    ObservableListener listener;
+  };
+
+  PluginMsgApp() : BasicTest() {}
+
+  void Work() {
+    s_result = "";
+    s_bus = NavAddr::Bus::Undef;
+    Sink sink;
+    Source source;
+    ProcessPendingEvents();
+    EXPECT_EQ(s_result, std::string("bar"));
+    EXPECT_EQ(NavAddr::Bus::Plugin, s_bus);
+  }
+};
+
+class PluginMsgApp2 : public BasicTest {
+public:
+  class Source {
+  public:
+    Source() {
+      const auto& handles = GetActiveDrivers();
+      auto found = std::find_if(
+          handles.begin(), handles.end(), [](const DriverHandle& h) {
+            return GetAttributes(h).at("protocol") == "internal";
+          });
+      EXPECT_TRUE(found != handles.end());
+      static const std::string msg = "foo bar";
+      auto payload =
+          std::make_shared<std::vector<uint8_t>>(msg.begin(), msg.end());
+      WriteCommDriver(*found, payload);
+    }
+  };
+
+  class Sink : public wxEvtHandler {
+  public:
+    Sink() {
+      auto& t = NavMsgBus::GetInstance();
+      auto msg = PluginMsg("foo", "");
+      listener.Listen(msg, this, EVT_FOO);
+
+      Bind(EVT_FOO, [&](ObservedEvt ev) {
+        auto ptr = ev.GetSharedPtr();
+        auto plugin_msg = std::static_pointer_cast<const PluginMsg>(ptr);
+        s_result = plugin_msg->message;
+        s_bus = plugin_msg->bus;
+      });
+    }
+    ObservableListener listener;
+  };
+
+  PluginMsgApp2() : BasicTest() {}
+
+  void Work() {
+    s_result = "";
+    s_bus = NavAddr::Bus::Undef;
+    Sink sink;
+    Source source;
+    ProcessPendingEvents();
+    EXPECT_EQ(s_result, std::string("bar"));
+    EXPECT_EQ(NavAddr::Bus::Plugin, s_bus);
   }
 };
 
@@ -290,7 +379,7 @@ public:
     ObservableListener listener;
   };
 
-  All0183App() : BasicTest() { }
+  All0183App() : BasicTest() {}
 
   void Work() {
     s_bus = NavAddr::Bus::Undef;
@@ -334,7 +423,7 @@ public:
     std::vector<ObservableListener> listeners;
   };
 
-  ListenerCliApp() : BasicTest() { }
+  ListenerCliApp() : BasicTest() {}
 
   void Work() {
     s_bus = NavAddr::Bus::Undef;
@@ -345,7 +434,6 @@ public:
     EXPECT_EQ(s_result, std::string("payload data"));
     EXPECT_EQ(NavAddr::Bus::N2000, s_bus);
   }
-
 };
 
 class AppmsgCliApp : public BasicTest {
@@ -378,9 +466,9 @@ public:
     ObservableListener listener;
   };
 
-  AppmsgCliApp() : BasicTest() { }
-   void Work() {
-    s_apptype =  AppMsg::Type::Undef;
+  AppmsgCliApp() : BasicTest() {}
+  void Work() {
+    s_apptype = AppMsg::Type::Undef;
     s_bus = NavAddr::Bus::Undef;
     Sink sink;
     Source source;
@@ -400,7 +488,7 @@ const static std::string kSEP("/");
 
 class GuernseyApp : public BasicTest {
 public:
-  GuernseyApp() : BasicTest() { }
+  GuernseyApp() : BasicTest() {}
 
   void Work() {
     vector<string> log;
@@ -422,10 +510,9 @@ public:
   ObservableListener listener;
 };
 
-
 class FindDriverApp : public BasicTest {
 public:
-  FindDriverApp() : BasicTest() { }
+  FindDriverApp() : BasicTest() {}
 
   void Work() override {
     std::vector<DriverPtr> drivers;
@@ -472,7 +559,7 @@ public:
 
 class RegistryPersistApp : public BasicTest {
 public:
-  RegistryPersistApp() : BasicTest() { }
+  RegistryPersistApp() : BasicTest() {}
 
   void Work() {
     wxLog::SetActiveTarget(&defaultLog);
@@ -481,8 +568,7 @@ public:
       auto driver = std::make_shared<SillyDriver>();
       auto& registry = CommDriverRegistry::GetInstance();
       start_size = registry.GetDrivers().size();
-      registry.Activate(
-          std::static_pointer_cast<AbstractCommDriver>(driver));
+      registry.Activate(std::static_pointer_cast<AbstractCommDriver>(driver));
     }
     auto& registry = CommDriverRegistry::GetInstance();
     auto drivers = registry.GetDrivers();
@@ -494,12 +580,12 @@ public:
 
 class PriorityApp2 : public BasicTest {
 public:
-  PriorityApp2() : BasicTest() { }
+  PriorityApp2() : BasicTest() {}
   void Work() override {
     const char* const GPGGA_1 =
-      "$GPGGA,092212,5759.097,N,01144.345,E,1,06,1.9,3.5,M,39.4,M,,*4C";
+        "$GPGGA,092212,5759.097,N,01144.345,E,1,06,1.9,3.5,M,39.4,M,,*4C";
     const char* const GPGGA_2 =
-      "$GPGGA,092212,5755.043,N,01344.585,E,1,06,1.9,3.5,M,39.4,M,,*4C";
+        "$GPGGA,092212,5755.043,N,01344.585,E,1,06,1.9,3.5,M,39.4,M,,*4C";
     auto& msgbus = NavMsgBus::GetInstance();
     CommBridge comm_bridge;
     comm_bridge.Initialize();
@@ -576,7 +662,7 @@ public:
 
 class AisDecodeApp : public BasicTest {
 public:
-  AisDecodeApp() : BasicTest() { }
+  AisDecodeApp() : BasicTest() {}
   void Work() override {
     const char* AISVDO_1 = "!AIVDO,1,1,,,B3uBrjP0;h=Koh`Bp1tEowrUsP06,0*31";
     GenericPosDatEx gpd;
@@ -609,13 +695,11 @@ public:
   }
 };
 
-
 class ObsTorture : public wxAppConsole {
 public:
-
   class ObsListener : public wxEvtHandler {
   public:
-    ObsListener(): wxEvtHandler() {
+    ObsListener() : wxEvtHandler() {
       wxDEFINE_EVENT(EVT_OBS_NOTIFY, ObservedEvt);
       m_listener.Listen("key1", this, EVT_OBS_NOTIFY);
       Bind(EVT_OBS_NOTIFY, [&](ObservedEvt& o) { OnNotify(o); });
@@ -636,9 +720,10 @@ public:
     Observable o("key1");
     std::vector<std::thread> threads;
     for (int i = 0; i < 10; i += 1) {
-      threads.push_back(std::thread([&]{
+      threads.push_back(std::thread([&] {
         auto p = std::make_shared<const std::string>("arg1");
-        o.Notify(p); }));
+        o.Notify(p);
+      }));
     }
     for (auto& t : threads) t.join();
     ProcessPendingEvents();
@@ -648,12 +733,12 @@ public:
 #ifdef HAVE_UNISTD_H
 class WxInstanceChk : public BasicTest {
 public:
-  WxInstanceChk() : BasicTest()  { }
+  WxInstanceChk() : BasicTest() {}
 
   void Work() override {
-    auto cmd = std::string(CMAKE_BINARY_DIR) +  "/test/wx-instance";
+    auto cmd = std::string(CMAKE_BINARY_DIR) + "/test/wx-instance";
     auto stream = popen(cmd.c_str(), "w");
-    std::this_thread::sleep_for(200ms);    // Random time to catch up w IO
+    std::this_thread::sleep_for(200ms);  // Random time to catch up w IO
     WxInstanceCheck check1;
     EXPECT_TRUE(check1.IsMainInstance());
     fputs("foobar\n", stream);
@@ -666,10 +751,10 @@ public:
 
 class StdInstanceTest : public BasicTest {
 public:
-  StdInstanceTest(): BasicTest() {}
+  StdInstanceTest() : BasicTest() {}
 
   void Work() override {
-    auto cmd = std::string(CMAKE_BINARY_DIR) +  "/test/std-instance";
+    auto cmd = std::string(CMAKE_BINARY_DIR) + "/test/std-instance";
     auto stream = popen(cmd.c_str(), "w");
     std::this_thread::sleep_for(200ms);
     StdInstanceCheck check1;
@@ -683,17 +768,14 @@ public:
 };
 #endif
 
-
-static void UpdateBool0() {
-    bool_result0 = true;
-};
+static void UpdateBool0() { bool_result0 = true; };
 
 #ifdef __unix__
 class StdInstanceCheck2 : public wxAppConsole {
 public:
   StdInstanceCheck2() {
     SetAppName("opencpn_unittests");
-    auto cmd = std::string(CMAKE_BINARY_DIR) +  "/test/std-instance";
+    auto cmd = std::string(CMAKE_BINARY_DIR) + "/test/std-instance";
     auto stream = popen(cmd.c_str(), "w");
     std::this_thread::sleep_for(200ms);
     StdInstanceCheck check1;
@@ -711,13 +793,13 @@ public:
 #ifdef __unix__
 class IpcClientTest : public BasicTest {
 public:
-   IpcClientTest() : BasicTest() {
+  IpcClientTest() : BasicTest() {
     std::string server_cmd(CMAKE_BINARY_DIR);
     server_cmd += "/test/cli-server";
     stream = popen(server_cmd.c_str(), "r");
-    std::this_thread::sleep_for(25ms);    // Need some time to start server
+    std::this_thread::sleep_for(25ms);  // Need some time to start server
     char buff[1024];
-    char* line = fgets(buff, sizeof(buff), stream);   // initial line, throw.
+    char* line = fgets(buff, sizeof(buff), stream);  // initial line, throw.
     EXPECT_TRUE(line);
   }
   static std::string GetSocketPath() {
@@ -727,6 +809,7 @@ public:
     if (!wxFileName::DirExists(dirpath)) wxFileName::Mkdir(dirpath);
     return path.GetFullPath().ToStdString();
   }
+
 protected:
   FILE* stream;
 };
@@ -783,12 +866,10 @@ TEST(Messaging, All0183) { All0183App app; };
 TEST(Messaging, AppMsg) { AppmsgCliApp app; };
 #endif
 
-
-
-//static void p1() { ObsListener l1; l1.Start(); }
+// static void p1() { ObsListener l1; l1.Start(); }
 
 TEST(Observable, torture) {
-  int_result0  = 0;
+  int_result0 = 0;
   ObsTorture ot;
   EXPECT_EQ(int_result0, 10);
 }
@@ -809,18 +890,15 @@ TEST(Drivers, Registry) {
 
   /* Add another one, should be accepted */
   auto driver2 = std::make_shared<SillyDriver>("orvar");
-  registry.Activate(
-      std::static_pointer_cast<AbstractCommDriver>(driver2));
+  registry.Activate(std::static_pointer_cast<AbstractCommDriver>(driver2));
   EXPECT_EQ(registry.GetDrivers().size(), 2);
 
   /* Remove one, leaving one in place. */
-  registry.Deactivate(
-      std::static_pointer_cast<AbstractCommDriver>(driver2));
+  registry.Deactivate(std::static_pointer_cast<AbstractCommDriver>(driver2));
   EXPECT_EQ(registry.GetDrivers().size(), 1);
 
   /* Remove it again, should be ignored. */
-  registry.Deactivate(
-      std::static_pointer_cast<AbstractCommDriver>(driver2));
+  registry.Deactivate(std::static_pointer_cast<AbstractCommDriver>(driver2));
   EXPECT_EQ(registry.GetDrivers().size(), 1);
 }
 
@@ -922,11 +1000,13 @@ TEST(IpcClient, Raise) { CliRaise run_test; }
 
 TEST(IpcClient, Open) { IpcOpen run_test; }
 
+TEST(Plugin, Basic) { PluginMsgApp app; }
+
 TEST(WaitContinue, Basic) {
   using namespace std::chrono;
   WaitContinue waiter;
   auto t1 = high_resolution_clock::now();
-  std::thread t([&waiter]{ waiter.Wait(50ms); });
+  std::thread t([&waiter] { waiter.Wait(50ms); });
   t.join();
   auto t2 = high_resolution_clock::now();
   auto raw_elapsed = t2 - t1 - 50ms;
@@ -934,7 +1014,7 @@ TEST(WaitContinue, Basic) {
   EXPECT_NEAR(elapsed.count(), 0, 5);
 
   t1 = high_resolution_clock::now();
-  t = std::thread([&waiter]{ waiter.Wait(50ms); });
+  t = std::thread([&waiter] { waiter.Wait(50ms); });
   std::this_thread::sleep_for(25ms);
   waiter.Continue();
   t.join();
@@ -948,7 +1028,7 @@ TEST(FormatTime, Basic) {
   wxTimeSpan span(0, 0, 7200, 0);
   auto s = formatTimeDelta(span).ToStdString();
   EXPECT_EQ(s, " 2H  0M");
-  span =  wxTimeSpan(1, 60, 0, 0);
+  span = wxTimeSpan(1, 60, 0, 0);
   span += wxTimeSpan(0, 0, 0, 10);
   s = formatTimeDelta(span).ToStdString();
   EXPECT_EQ(s, " 2H  0M");


### PR DESCRIPTION
  - Modify SendMessageToAllPlugins() so it sends the message also on the new message bus.
  - Add support in WriteCommPort for sending PluginMsg i. e., a message ti the internal message bus.
  
Whichever way a message is sent, WriteCommPort(),  SendPluginMessage() or SendMessageToAllPlugins(), it is now possible for plugins to just listen for selected messages using the new API.

While on it refactor pluginmanager  moving lots of non-gui stuff to a new plugin_comm module. Less use of the dreaded g_pi_manager, and some more focus for the pluginmanager jack of all trades.

Closes: #4255

EDIT: This is basically about plugging a hole in the original implementation where we made a major effort to make anything injected by the new API available also in the old. This PR is about the opposite: making anything injected by the old API available also in the new.