### PR TITLE
Add get available message types API

### DIFF
--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -54,6 +54,7 @@
 #include <wx/stdpaths.h>
 #include <wx/tokenzr.h>
 #include <wx/display.h>
+#include <wx/jsonreader.h>
 
 #include "model/ais_decoder.h"
 #include "model/ais_state_vars.h"

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -62,6 +62,7 @@
 #include <wx/hashset.h>
 #include <wx/hashmap.h>
 #include <wx/jsonval.h>
+#include <wx/jsonreader.h>
 #include <wx/uri.h>
 #include <wx/zipstrm.h>
 #include <wx/zstream.h>

--- a/model/include/model/comm_navmsg_bus.h
+++ b/model/include/model/comm_navmsg_bus.h
@@ -1,13 +1,6 @@
-/***************************************************************************
- *
- * Project:  OpenCPN
- * Purpose:  Raw messages layer, supports sending and recieving navmsg
- *           messages. This is the second layer in the three tier model
- *           drivers, raw messages and application messages.
- * Author:   David Register, Alec Leamas
- *
- ***************************************************************************
- *   Copyright (C) 2022 by David Register, Alec Leamas                     *
+/**************************************************************************
+ *   Copyright (C) 2022 by David Register                                  *
+ *   Copyright (C) 2022 Alec Leamas                                        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -25,16 +18,19 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 
-/* API handling raw partially decoded messages. */
+/**
+ * \file
+ * Raw messages layer, supports sending and recieving navmsg
+ * messages. This is the second layer in the three tier model
+ * drivers, raw messages and application messages.
+ */
 
 #ifndef _NAVMSG_BUS_H__
 #define _NAVMSG_BUS_H__
 
 #include <memory>
-#include <vector>
-
-#include <wx/event.h>
-#include <wx/jsonreader.h>
+#include <set>
+#include <string>
 
 #include "model/comm_driver.h"
 
@@ -47,9 +43,11 @@ public:
   NavMsgBus& operator=(NavMsgBus&) = delete;
   NavMsgBus(const NavMsgBus&) = delete;
 
+  /** Send a message to given destination using suitable driver. */
   void SendMessage(std::shared_ptr<const NavMsg> message,
                    std::shared_ptr<const NavAddr> address);
 
+  /** Accept message received by driver, make it available for upper layers. */
   void Notify(std::shared_ptr<const NavMsg> message);
 
   /* DriverListener implementation: */

--- a/model/include/model/comm_navmsg_bus.h
+++ b/model/include/model/comm_navmsg_bus.h
@@ -29,10 +29,12 @@
 #define _NAVMSG_BUS_H__
 
 #include <memory>
+#include <mutex>
 #include <set>
 #include <string>
 
 #include "model/comm_driver.h"
+#include "observable_evtvar.h"
 
 /** The raw message layer, a singleton. */
 class NavMsgBus : public DriverListener {
@@ -53,8 +55,17 @@ public:
   /* DriverListener implementation: */
   void Notify(const AbstractCommDriver& driver);
 
+  /** Return list of message types sent or received. */
+  const std::set<std::string>& GetActiveMessages() { return m_active_messages; }
+
+  /** Notified without data when new message type(s) are detected. */
+  EventVar NewMessageEvent;
+
 private:
+  std::mutex m_mutex;
   NavMsgBus() = default;
+
+  std::set<std::string> m_active_messages;
 };
 
 #endif  // NAVMSG_BUS_H

--- a/model/src/comm_navmsg_bus.cpp
+++ b/model/src/comm_navmsg_bus.cpp
@@ -26,6 +26,13 @@
 #include "model/comm_navmsg_bus.h"
 
 void NavMsgBus::Notify(std::shared_ptr<const NavMsg> msg) {
+  auto key = NavAddr::BusToString(msg->bus) + "::" + msg->GetKey();
+  {
+    std::lock_guard lock(m_mutex);
+    if (m_active_messages.find(key) == m_active_messages.end())
+      NewMessageEvent.Notify();
+    m_active_messages.insert(key);
+  }
   Observable(*msg).Notify(msg);
 }
 

--- a/model/src/comm_navmsg_bus.cpp
+++ b/model/src/comm_navmsg_bus.cpp
@@ -1,11 +1,6 @@
-/***************************************************************************
- *
- * Project:  OpenCPN
- * Purpose:  Implements comm_navmsg_bus -- raw, undecoded messages bus.
- * Author:   David Register, Alec Leamas
- *
- ***************************************************************************
- *   Copyright (C) 2022 by David Register, Alec Leamas                     *
+/**************************************************************************
+ *   Copyright (C) 2022 by David Register                                  *
+ *   Copyright (C) 2022 Alec Leamas                                        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -23,16 +18,12 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 
-// For compilers that support precompilation, includes "wx.h".
-#include <wx/wxprec.h>
-
-#ifndef WX_PRECOMP
-#include <wx/wx.h>
-#endif  // precompiled headers
+/**
+ * \file
+ * Implement comm_navmsg_bus.h i. e., NavMsgBus.
+ */
 
 #include "model/comm_navmsg_bus.h"
-
-using namespace std;
 
 void NavMsgBus::Notify(std::shared_ptr<const NavMsg> msg) {
   Observable(*msg).Notify(msg);


### PR DESCRIPTION
Add a new, internal API which makes it possible to list currently available message types.

Closes: #4266