### PR TITLE
Update memory leak detection for MSVC using wxWidgets

### DIFF
--- a/gui/include/gui/dychart.h
+++ b/gui/include/gui/dychart.h
@@ -115,13 +115,8 @@
 //          Some Memory Leak Detection Code
 //------------------------------------------------------------------------------
 
-#ifdef __MSVC__
-#ifdef _DEBUG
-#define _CRTDBG_MAP_ALLOC
-#include <crtdbg.h>
-#define DEBUG_NEW new (_NORMAL_BLOCK, __FILE__, __LINE__)
-#define new DEBUG_NEW
-#endif
+#ifdef __VISUALC__
+#include <wx/msw/msvcrt.h>
 #endif
 
 //----------------------------------------------------------------------------

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -121,12 +121,8 @@
 #include "glChartCanvas.h"
 #endif
 
-#ifdef __MSVC__
-#define _CRTDBG_MAP_ALLOC
-#include <stdlib.h>
-#include <crtdbg.h>
-#define DEBUG_NEW new (_NORMAL_BLOCK, __FILE__, __LINE__)
-#define new DEBUG_NEW
+#ifdef __VISUALC__
+#include <wx/msw/msvcrt.h>
 #endif
 
 #ifndef __WXMSW__

--- a/gui/src/cm93.cpp
+++ b/gui/src/cm93.cpp
@@ -70,12 +70,8 @@
 extern ocpnGLOptions g_GLOptions;
 #endif
 
-#ifdef __MSVC__
-#define _CRTDBG_MAP_ALLOC
-#include <stdlib.h>
-#include <crtdbg.h>
-#define DEBUG_NEW new (_NORMAL_BLOCK, __FILE__, __LINE__)
-#define new DEBUG_NEW
+#ifdef __VISUALC__
+#include <wx/msw/msvcrt.h>
 #endif
 
 extern CM93OffsetDialog *g_pCM93OffsetDialog;

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -677,12 +677,8 @@ DEFINE_GUID(GARMIN_DETECT_GUID, 0x2c9c45c2L, 0x8e7d, 0x4c08, 0xa1, 0x2d, 0x81,
             0x6b, 0xba, 0xe7, 0x22, 0xc0);
 #endif
 
-#ifdef __MSVC__
-#define _CRTDBG_MAP_ALLOC
-#include <stdlib.h>
-#include <crtdbg.h>
-#define DEBUG_NEW new (_NORMAL_BLOCK, __FILE__, __LINE__)
-#define new DEBUG_NEW
+#ifdef __VISUALC__
+#include <wx/msw/msvcrt.h>
 #endif
 
 #if !defined(NAN)

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -347,12 +347,8 @@ DWORD color_inactiveborder;
 
 #endif
 
-#ifdef __MSVC__
-#define _CRTDBG_MAP_ALLOC
-#include <stdlib.h>
-#include <crtdbg.h>
-#define DEBUG_NEW new (_NORMAL_BLOCK, __FILE__, __LINE__)
-#define new DEBUG_NEW
+#ifdef __VISUALC__
+#include <wx/msw/msvcrt.h>
 #endif
 
 #if !defined(NAN)

--- a/gui/src/s57chart.cpp
+++ b/gui/src/s57chart.cpp
@@ -70,12 +70,8 @@
 #include "Quilt.h"
 #include "ocpn_frame.h"
 
-#ifdef __MSVC__
-#define _CRTDBG_MAP_ALLOC
-#include <stdlib.h>
-#include <crtdbg.h>
-#define DEBUG_NEW new (_NORMAL_BLOCK, __FILE__, __LINE__)
-#define new DEBUG_NEW
+#ifdef __VISUALC__
+#include <wx/msw/msvcrt.h>
 #endif
 
 #ifdef ocpnUSE_GL

--- a/gui/src/s57obj.cpp
+++ b/gui/src/s57obj.cpp
@@ -60,12 +60,8 @@
 
 #include "Osenc.h"
 
-#ifdef __MSVC__
-#define _CRTDBG_MAP_ALLOC
-#include <stdlib.h>
-#include <crtdbg.h>
-#define DEBUG_NEW new (_NORMAL_BLOCK, __FILE__, __LINE__)
-#define new DEBUG_NEW
+#ifdef __VISUALC__
+#include <wx/msw/msvcrt.h>
 #endif
 
 #ifdef ocpnUSE_GL

--- a/gui/src/viewport.cpp
+++ b/gui/src/viewport.cpp
@@ -92,12 +92,8 @@
 
 #include "ais.h"
 
-#ifdef __MSVC__
-#define _CRTDBG_MAP_ALLOC
-#include <stdlib.h>
-#include <crtdbg.h>
-#define DEBUG_NEW new (_NORMAL_BLOCK, __FILE__, __LINE__)
-#define new DEBUG_NEW
+#ifdef __VISUALC__
+#include <wx/msw/msvcrt.h>
 #endif
 
 #ifndef __WXMSW__


### PR DESCRIPTION
Replaced `__MSVC__` with `__VISUALC__` because some compilers define __MSVC__. Included `wx/msw/msvcrt.h` from wxWidgets library instead of manually creating 'new' macro. Changes applied to: dychart.h, chcanv.cpp, cm93.cpp, ocpn_app.cpp, ocpn_frame.cpp, s57chart.cpp, s57obj.cpp, and viewport.cpp.
Simplifies and potentially improves memory leak detection by leveraging wxWidgets utilities.