### PR TITLE
Correct LW & HW calculation in Tide window

### DIFF
--- a/gui/src/TCWin.cpp
+++ b/gui/src/TCWin.cpp
@@ -627,13 +627,13 @@ void TCWin::OnPaint(wxPaintEvent &event) {
       // The tide/current modules calculate values based on PC local time
       // We want UTC, so adjust accordingly
       int tt_localtz = m_t_graphday_GMT + (m_diff_mins * 60);
+      //then eventually we could need LMT at station
+      if (m_tzoneDisplay == 0)
+        tt_localtz -= m_stationOffset_mins * 60;  // LMT at station
 
       // get tide flow sens ( flood or ebb ? )
       ptcmgr->GetTideFlowSens(tt_localtz, BACKWARD_TEN_MINUTES_STEP,
                               pIDX->IDX_rec_num, tcv[0], val, wt);
-
-      if (m_tzoneDisplay == 0)
-        tt_localtz -= m_stationOffset_mins * 60;  // LMT at station
 
       for (i = 0; i < 26; i++) {
         int tt = tt_localtz + (i * FORWARD_ONE_HOUR_STEP);

--- a/gui/src/TCWin.cpp
+++ b/gui/src/TCWin.cpp
@@ -627,7 +627,7 @@ void TCWin::OnPaint(wxPaintEvent &event) {
       // The tide/current modules calculate values based on PC local time
       // We want UTC, so adjust accordingly
       int tt_localtz = m_t_graphday_GMT + (m_diff_mins * 60);
-      //then eventually we could need LMT at station
+      // then eventually we could need LMT at station
       if (m_tzoneDisplay == 0)
         tt_localtz -= m_stationOffset_mins * 60;  // LMT at station
 


### PR DESCRIPTION
Error in the HM & LW showed in the tide window.
You can see that for the stations CONCARNEAU   at 9th December 2024, 1st January 2025 and BREST 1st February 2025 with the French HARMONIC_V10 tide database. 
In fact, "GetTideFlowSens()" & "GetHightOrLowTide()" need to have the same entry time to be coherent.
JP
