### PR TITLE
Replace NULL with nullptr

### DIFF
--- a/plugins/grib_pi/src/CursorData.cpp
+++ b/plugins/grib_pi/src/CursorData.cpp
@@ -57,7 +57,7 @@ CursorData::CursorData(wxWindow *window, GRIBUICtrlBar &parent)
   m_bLeftDown = false;
 
   m_tCursorTrackTimer.Connect(
-      wxEVT_TIMER, wxTimerEventHandler(CursorData::OnCursorTrackTimer), NULL,
+      wxEVT_TIMER, wxTimerEventHandler(CursorData::OnCursorTrackTimer), nullptr,
       this);
 
   DimeWindow(this);
@@ -149,15 +149,15 @@ void CursorData::PopulateTrackingControls(bool vertical) {
   // Get text controls sizing data
   wxFont *font = OCPNGetFont(_("Dialog"), 10);
   int wn, wd, ws, wl;
-  GetTextExtent(_T("abcdefghihjk"), &wn, NULL, 0, 0,
+  GetTextExtent(_T("abcdefghihjk"), &wn, nullptr, 0, 0,
                 font);  // normal width text control size
-  GetTextExtent(_T("abcdef"), &ws, NULL, 0, 0,
+  GetTextExtent(_T("abcdef"), &ws, nullptr, 0, 0,
                 font);  // short width text control size for direction only
   GetTextExtent(
-      _T("abcdefghijklmopq"), &wd, NULL, 0, 0,
+      _T("abcdefghijklmopq"), &wd, nullptr, 0, 0,
       font);  // long width text control size for double unit wind display
   GetTextExtent(
-      _T("abcdefghijklm"), &wl, NULL, 0, 0,
+      _T("abcdefghijklm"), &wl, nullptr, 0, 0,
       font);  // long width text control size for double unit wave display
   //
   // create a dummy textCtrl to be used as a "space" in vertical display

--- a/plugins/grib_pi/src/CustomGrid.cpp
+++ b/plugins/grib_pi/src/CustomGrid.cpp
@@ -76,7 +76,7 @@ CustomGrid::CustomGrid(wxWindow* parent, wxWindowID id, const wxPoint& pos,
   SetLabelBackgroundColour(colour);
   // set row label size
   int w;
-  GetTextExtent(_T("Ab"), &w, NULL, 0, 0, &labelfont);
+  GetTextExtent(_T("Ab"), &w, nullptr, 0, 0, &labelfont);
   double x = (double)w * 6.5;
   SetRowLabelSize((int)x);
 
@@ -86,21 +86,21 @@ CustomGrid::CustomGrid(wxWindow* parent, wxWindowID id, const wxPoint& pos,
 
   // connect events at dialog level
   Connect(wxEVT_SCROLLWIN_THUMBTRACK,
-          wxScrollEventHandler(CustomGrid::OnScroll), NULL, this);
-  Connect(wxEVT_SIZE, wxSizeEventHandler(CustomGrid::OnResize), NULL, this);
+          wxScrollEventHandler(CustomGrid::OnScroll), nullptr, this);
+  Connect(wxEVT_SIZE, wxSizeEventHandler(CustomGrid::OnResize), nullptr, this);
   Connect(wxEVT_GRID_LABEL_LEFT_CLICK,
-          wxGridEventHandler(CustomGrid::OnLabeClick), NULL, this);
+          wxGridEventHandler(CustomGrid::OnLabeClick), nullptr, this);
   // connect events at grid level
   GetGridWindow()->Connect(wxEVT_LEFT_DOWN,
-                           wxMouseEventHandler(CustomGrid::OnMouseEvent), NULL,
+                           wxMouseEventHandler(CustomGrid::OnMouseEvent), nullptr,
                            this);
   GetGridWindow()->Connect(
-      wxEVT_LEFT_UP, wxMouseEventHandler(CustomGrid::OnMouseEvent), NULL, this);
+      wxEVT_LEFT_UP, wxMouseEventHandler(CustomGrid::OnMouseEvent), nullptr, this);
   GetGridWindow()->Connect(
-      wxEVT_MOTION, wxMouseEventHandler(CustomGrid::OnMouseEvent), NULL, this);
+      wxEVT_MOTION, wxMouseEventHandler(CustomGrid::OnMouseEvent), nullptr, this);
   // timer event
   m_tRefreshTimer.Connect(
-      wxEVT_TIMER, wxTimerEventHandler(CustomGrid::OnRefreshTimer), NULL, this);
+      wxEVT_TIMER, wxTimerEventHandler(CustomGrid::OnRefreshTimer), nullptr, this);
 }
 
 CustomGrid::~CustomGrid() {

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -144,7 +144,7 @@ static GLboolean QueryExtension( const char *extName )
     extNameLen = strlen( extName );
 
     p = (char *) glGetString( GL_EXTENSIONS );
-    if( NULL == p ) {
+    if( nullptr == p ) {
         return GL_FALSE;
     }
 
@@ -238,23 +238,23 @@ GRIBOverlayFactory::GRIBOverlayFactory(GRIBUICtrlBar &dlg)
 
   // qDebug() <<  "m_pixelMM: " << m_pixelMM;
 
-  m_pGribTimelineRecordSet = NULL;
+  m_pGribTimelineRecordSet = nullptr;
   m_last_vp_scale = 0.;
 
-  m_oDC = NULL;
+  m_oDC = nullptr;
 #if wxUSE_GRAPHICS_CONTEXT
-  m_gdc = NULL;
+  m_gdc = nullptr;
 #endif
-  m_Font_Message = NULL;
+  m_Font_Message = nullptr;
 
   InitColorsTable();
   for (int i = 0; i < GribOverlaySettings::SETTINGS_COUNT; i++)
-    m_pOverlay[i] = NULL;
+    m_pOverlay[i] = nullptr;
 
-  m_ParticleMap = NULL;
+  m_ParticleMap = nullptr;
   m_tParticleTimer.Connect(
       wxEVT_TIMER, wxTimerEventHandler(GRIBOverlayFactory::OnParticleTimer),
-      NULL, this);
+      nullptr, this);
   m_bUpdateParticles = false;
 
   // Generate the wind arrow cache
@@ -386,7 +386,7 @@ GRIBOverlayFactory::~GRIBOverlayFactory() {
 }
 
 void GRIBOverlayFactory::Reset() {
-  m_pGribTimelineRecordSet = NULL;
+  m_pGribTimelineRecordSet = nullptr;
 
   ClearCachedData();
 }
@@ -414,7 +414,7 @@ void GRIBOverlayFactory::ClearCachedData(void) {
   //    Clear out the cached bitmaps
   for (int i = 0; i < GribOverlaySettings::SETTINGS_COUNT; i++) {
     delete m_pOverlay[i];
-    m_pOverlay[i] = NULL;
+    m_pOverlay[i] = nullptr;
   }
 }
 
@@ -446,9 +446,9 @@ bool GRIBOverlayFactory::RenderGLGribOverlay(wxGLContext *pcontext,
   }
 
   m_oDC->SetVP(vp);
-  m_oDC->SetDC(NULL);
+  m_oDC->SetDC(nullptr);
 
-  m_pdc = NULL;  // inform lower layers that this is OpenGL render
+  m_pdc = nullptr;  // inform lower layers that this is OpenGL render
 
   bool rv = DoRenderGribOverlay(vp);
 
@@ -1251,7 +1251,7 @@ wxImage &GRIBOverlayFactory::getLabel(double value, int settings,
 
   wxScreenDC sdc;
   int w, h;
-  sdc.GetTextExtent(labels, &w, &h, NULL, NULL, &mfont);
+  sdc.GetTextExtent(labels, &w, &h, nullptr, nullptr, &mfont);
 
   int label_offset = 5;
 
@@ -1417,7 +1417,7 @@ void GRIBOverlayFactory::RenderGribIsobar(int settings, GribRecord **pGR,
   SettingsIdToGribId(settings, idx, idy, polar);
   if (idx < 0) return;
 
-  GribRecord *pGRA = pGR[idx], *pGRM = NULL;
+  GribRecord *pGRA = pGR[idx], *pGRM = nullptr;
 
   if (!pGRA) return;
 
@@ -1460,7 +1460,7 @@ void GRIBOverlayFactory::RenderGribIsobar(int settings, GribRecord **pGR,
         wxDateTime now = wxDateTime::Now();
         if ((now - start).GetSeconds() > 3 && press - min < (max - min) / 2) {
           progressdialog = new wxGenericProgressDialog(
-              _("Building Isobar map"), _("Wind"), max - min + 1, NULL,
+              _("Building Isobar map"), _("Wind"), max - min + 1, nullptr,
               wxPD_SMOOTH | wxPD_ELAPSED_TIME | wxPD_REMAINING_TIME);
         }
       }
@@ -1728,7 +1728,7 @@ void GRIBOverlayFactory::RenderGribOverlayMap(int settings, GribRecord **pGR,
   SettingsIdToGribId(settings, idx, idy, polar);
   if (idx < 0 || !pGR[idx]) return;
 
-  GribRecord *pGRA = pGR[idx], *pGRM = NULL;
+  GribRecord *pGRA = pGR[idx], *pGRM = nullptr;
   if (!pGRA) return;
 
   if (idy >= 0 && !polar && pGR[idy]) {
@@ -1836,7 +1836,7 @@ void GRIBOverlayFactory::RenderGribNumbers(int settings, GribRecord **pGR,
   SettingsIdToGribId(settings, idx, idy, polar);
   if (idx < 0) return;
 
-  GribRecord *pGRA = pGR[idx], *pGRM = NULL;
+  GribRecord *pGRA = pGR[idx], *pGRM = nullptr;
 
   if (!pGRA) return;
 
@@ -1854,7 +1854,7 @@ void GRIBOverlayFactory::RenderGribNumbers(int settings, GribRecord **pGR,
 
   // set an arbitrary width for numbers
   int wstring;
-  m_TexFontNumbers.GetTextExtent(_T("1234"), &wstring, NULL);
+  m_TexFontNumbers.GetTextExtent(_T("1234"), &wstring, nullptr);
 
   if (m_Settings.Settings[settings].m_bNumFixSpac) {  // fixed spacing
 
@@ -2306,7 +2306,7 @@ void GRIBOverlayFactory::RenderGribParticles(int settings, GribRecord **pGR,
     int i = it->m_HistoryPos;
 
     bool lip_valid = false;
-    float *lp = NULL, lip[2];
+    float *lp = nullptr, lip[2];
     wxUint8 lc[4];
     float lcf[4];
 

--- a/plugins/grib_pi/src/GribOverlayFactory.h
+++ b/plugins/grib_pi/src/GribOverlayFactory.h
@@ -44,7 +44,7 @@ class GribOverlay {
 public:
   GribOverlay(void) {
     m_iTexture = 0;
-    m_pDCBitmap = NULL, m_pRGBA = NULL;
+    m_pDCBitmap = nullptr, m_pRGBA = nullptr;
   }
 
   ~GribOverlay(void) {
@@ -90,9 +90,9 @@ public:
       : m_Setting(settings),
         history_size(0),
         array_size(0),
-        color_array(NULL),
-        vertex_array(NULL),
-        color_float_array(NULL) {
+        color_array(nullptr),
+        vertex_array(nullptr),
+        color_float_array(nullptr) {
     // XXX should be done in default PlugIn_ViewPort CTOR
     last_viewport.bValid = false;
   }
@@ -122,7 +122,7 @@ class LineBuffer {
 public:
   LineBuffer() {
     count = 0;
-    lines = NULL;
+    lines = nullptr;
   }
   ~LineBuffer() { delete[] lines; }
 
@@ -176,7 +176,7 @@ public:
   void ClearCachedLabel(void) { m_labelCache.clear(); }
   void ClearParticles() {
     delete m_ParticleMap;
-    m_ParticleMap = NULL;
+    m_ParticleMap = nullptr;
   }
 
   GribTimelineRecordSet *m_pGribTimelineRecordSet;

--- a/plugins/grib_pi/src/GribReader.cpp
+++ b/plugins/grib_pi/src/GribReader.cpp
@@ -45,9 +45,9 @@ GribReader::GribReader(const wxString fname) {
 //-------------------------------------------------------------------------------
 GribReader::~GribReader() {
   clean_all_vectors();
-  if (file != NULL) {
+  if (file != nullptr) {
     zu_close(file);
-    file = NULL;
+    file = nullptr;
   }
 }
 
@@ -66,7 +66,7 @@ void GribReader::clean_vector(std::vector<GribRecord *> &ls) {
   std::vector<GribRecord *>::iterator it;
   for (it = ls.begin(); it != ls.end(); it++) {
     delete *it;
-    *it = NULL;
+    *it = nullptr;
   }
   ls.clear();
 }
@@ -115,8 +115,8 @@ void GribReader::readAllGribRecords() {
   // Lecture de l'ensemble des GribRecord du fichier
   // et stockage dans les listes appropriées.
   //--------------------------------------------------------
-  GribRecord *rec = 0;
-  GribRecord *prevDataSet = 0;
+  GribRecord *rec = nullptr;
+  GribRecord *prevDataSet = nullptr;
   int id = 0;
   time_t firstdate = -1;
   bool b_EOF;
@@ -151,7 +151,7 @@ void GribReader::readAllGribRecords() {
         rec = new GribV1Record(file, id);
       }
     }
-    prevDataSet = 0;
+    prevDataSet = nullptr;
     if (rec->isOk() == false) {
       delete rec;
       break;
@@ -160,9 +160,9 @@ void GribReader::readAllGribRecords() {
 
     if (!rec->isDataKnown()) {
       GribV2Record *rec2 = dynamic_cast<GribV2Record *>(rec);
-      if (rec2 == 0 || !rec2->hasMoreDataSet()) {
+      if (rec2 == nullptr || !rec2->hasMoreDataSet()) {
         delete rec;
-        rec = 0;
+        rec = nullptr;
       } else {  // must delete it in the next iteration
         prevDataSet = rec;
       }
@@ -270,9 +270,9 @@ void GribReader::readAllGribRecords() {
                        rec->getIdCenter(), rec->getIdModel(), rec->getIdGrid()
                 );
 #endif
-      if (rec2 == 0 || !rec2->hasMoreDataSet()) {
+      if (rec2 == nullptr || !rec2->hasMoreDataSet()) {
         delete rec;
-        rec = 0;
+        rec = nullptr;
       } else {
         prevDataSet = rec;
       }
@@ -286,9 +286,9 @@ void GribReader::copyFirstCumulativeRecord(int dataType, int levelType,
                                            int levelValue) {
   time_t dateref = getRefDate();
   GribRecord *rec = getGribRecord(dataType, levelType, levelValue, dateref);
-  if (rec == NULL) {
+  if (rec == nullptr) {
     rec = getFirstGribRecord(dataType, levelType, levelValue);
-    if (rec != NULL) {
+    if (rec != nullptr) {
       GribRecord *r2 = new GribRecord(*rec);
       r2->setRecordCurrentDate(dateref);  // 1er enregistrement factice
       storeRecordInMap(r2);
@@ -303,10 +303,10 @@ levelValue)
     time_t dateref = getRefDate();
     GribRecord *rec = getFirstGribRecord(dataType, levelType, levelValue);
 
-    if (rec!=NULL  &&  rec->getRecordCurrentDate() == dateref)
+    if (rec!=nullptr  &&  rec->getRecordCurrentDate() == dateref)
     {
         std::vector<GribRecord *> *liste = getListOfGribRecords(dataType,
-levelType, levelValue); if (liste != NULL) { std::vector<GribRecord *>::iterator
+levelType, levelValue); if (liste != nullptr) { std::vector<GribRecord *>::iterator
 it; for (it=liste->begin(); it!=liste->end() && (*it)!=rec; it++)
             {
             }
@@ -324,7 +324,7 @@ void GribReader::copyMissingWaveRecords(int dataType, int levelType,
   for (itd = setdates.begin(); itd != setdates.end(); itd++) {
     time_t date = *itd;
     GribRecord *rec = getGribRecord(dataType, levelType, levelValue, date);
-    if (rec == NULL) {
+    if (rec == nullptr) {
       itd2 = itd;
       itd2++;  // next date
       if (itd2 != setdates.end()) {
@@ -485,9 +485,9 @@ int GribReader::getTotalNumberOfGribRecords() {
 
 //---------------------------------------------------
 std::vector<GribRecord *> *GribReader::getFirstNonEmptyList() {
-  std::vector<GribRecord *> *ls = NULL;
+  std::vector<GribRecord *> *ls = nullptr;
   std::map<std::string, std::vector<GribRecord *> *>::iterator it;
-  for (it = mapGribRecords.begin(); ls == NULL && it != mapGribRecords.end();
+  for (it = mapGribRecords.begin(); ls == nullptr && it != mapGribRecords.end();
        it++) {
     if ((*it).second->size() > 0) ls = (*it).second;
   }
@@ -499,7 +499,7 @@ int GribReader::getNumberOfGribRecords(int dataType, int levelType,
                                        int levelValue) {
   std::vector<GribRecord *> *liste =
       getListOfGribRecords(dataType, levelType, levelValue);
-  if (liste != NULL)
+  if (liste != nullptr)
     return liste->size();
   else
     return 0;
@@ -513,7 +513,7 @@ std::vector<GribRecord *> *GribReader::getListOfGribRecords(int dataType,
   if (mapGribRecords.find(key) != mapGribRecords.end())
     return mapGribRecords[key];
   else
-    return NULL;
+    return nullptr;
 }
 //---------------------------------------------------------------------------
 double GribReader::getTimeInterpolatedValue(int dataType, int levelType,
@@ -531,17 +531,17 @@ void GribReader::findGribsAroundDate(int dataType, int levelType,
   // Cherche les GribRecord qui encadrent la date
   std::vector<GribRecord *> *ls =
       getListOfGribRecords(dataType, levelType, levelValue);
-  *before = NULL;
-  *after = NULL;
+  *before = nullptr;
+  *after = nullptr;
   zuint nb = ls->size();
-  for (zuint i = 0; i < nb && *before == NULL && *after == NULL; i++) {
+  for (zuint i = 0; i < nb && *before == nullptr && *after == nullptr; i++) {
     GribRecord *rec = (*ls)[i];
     if (rec->getRecordCurrentDate() == date) {
       *before = rec;
       *after = rec;
     } else if (rec->getRecordCurrentDate() < date) {
       *before = rec;
-    } else if (rec->getRecordCurrentDate() > date && *before != NULL) {
+    } else if (rec->getRecordCurrentDate() > date && *before != nullptr) {
       *after = rec;
     }
   }
@@ -553,7 +553,7 @@ double GribReader::get2GribsInterpolatedValueByDate(double px, double py,
                                                     GribRecord *before,
                                                     GribRecord *after) {
   double val = GRIB_NOTDEF;
-  if (before != NULL && after != NULL) {
+  if (before != nullptr && after != nullptr) {
     if (before == after) {
       val = before->getInterpolatedValue(px, py);
     } else {
@@ -578,10 +578,10 @@ double GribReader::get2GribsInterpolatedValueByDate(double px, double py,
 // Premier GribRecord trouvé (pour récupérer la grille)
 GribRecord *GribReader::getFirstGribRecord() {
   std::vector<GribRecord *> *ls = getFirstNonEmptyList();
-  if (ls != NULL) {
+  if (ls != nullptr) {
     return ls->at(0);
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 //---------------------------------------------------
@@ -589,8 +589,8 @@ GribRecord *GribReader::getFirstGribRecord() {
 GribRecord *GribReader::getFirstGribRecord(int dataType, int levelType,
                                            int levelValue) {
   std::set<time_t>::iterator it;
-  GribRecord *rec = NULL;
-  for (it = setAllDates.begin(); rec == NULL && it != setAllDates.end(); it++) {
+  GribRecord *rec = nullptr;
+  for (it = setAllDates.begin(); rec == nullptr && it != setAllDates.end(); it++) {
     time_t date = *it;
     rec = getGribRecord(dataType, levelType, levelValue, date);
   }
@@ -603,7 +603,7 @@ GribRecord *GribReader::getFirstGribRecord(int dataType, int levelType,
 double GribReader::computeHoursBeetweenGribRecords() {
   double res = 1;
   std::vector<GribRecord *> *ls = getFirstNonEmptyList();
-  if (ls != NULL) {
+  if (ls != nullptr) {
     time_t t0 = (*ls)[0]->getRecordCurrentDate();
     time_t t1 = (*ls)[1]->getRecordCurrentDate();
     res = fabs((double)(t1 - t0)) / 3600.0;
@@ -616,16 +616,16 @@ GribRecord *GribReader::getGribRecord(int dataType, int levelType,
                                       int levelValue, time_t date) {
   std::vector<GribRecord *> *ls =
       getListOfGribRecords(dataType, levelType, levelValue);
-  if (ls != NULL) {
+  if (ls != nullptr) {
     // Cherche le premier enregistrement à la bonne date
-    GribRecord *res = NULL;
+    GribRecord *res = nullptr;
     zuint nb = ls->size();
-    for (zuint i = 0; i < nb && res == NULL; i++) {
+    for (zuint i = 0; i < nb && res == nullptr; i++) {
       if ((*ls)[i]->getRecordCurrentDate() == date) res = (*ls)[i];
     }
     return res;
   } else {
-    return NULL;
+    return nullptr;
   }
 }
 
@@ -648,7 +648,7 @@ double GribReader::computeDewPoint(double lon, double lat, time_t now) {
   double diewpoint = GRIB_NOTDEF;
 
   GribRecord *recTempDiew = getGribRecord(GRB_DEWPOINT, LV_ABOV_GND, 2, now);
-  if (recTempDiew != NULL) {
+  if (recTempDiew != nullptr) {
     // GRIB file contains diew point data
     diewpoint = recTempDiew->getInterpolatedValue(lon, lat);
   } else {
@@ -687,7 +687,7 @@ void GribReader::openFile(const wxString fname) {
   // Open the file
   //--------------------------------------------------------
   file = zu_open((const char *)fname.mb_str(), "rb", ZU_COMPRESS_AUTO);
-  if (file == NULL) {
+  if (file == nullptr) {
     erreur("Can't open file: %s", (const char *)fname.mb_str());
     return;
   }
@@ -695,22 +695,22 @@ void GribReader::openFile(const wxString fname) {
 
   // Look for compressed files with alternate extensions
   if (!ok) {
-    if (file != NULL) zu_close(file);
+    if (file != nullptr) zu_close(file);
     file = zu_open((const char *)fname.mb_str(), "rb", ZU_COMPRESS_BZIP);
-    if (file != NULL) readGribFileContent();
+    if (file != nullptr) readGribFileContent();
   }
   if (!ok) {
-    if (file != NULL) zu_close(file);
+    if (file != nullptr) zu_close(file);
     file = zu_open((const char *)fname.mb_str(), "rb", ZU_COMPRESS_GZIP);
-    if (file != NULL) readGribFileContent();
+    if (file != nullptr) readGribFileContent();
   }
   if (!ok) {
-    if (file != NULL) zu_close(file);
+    if (file != nullptr) zu_close(file);
     file = zu_open((const char *)fname.mb_str(), "rb", ZU_COMPRESS_NONE);
-    if (file != NULL) readGribFileContent();
+    if (file != nullptr) readGribFileContent();
   }
-  if (file != NULL) {
+  if (file != nullptr) {
     zu_close(file);
-    file = NULL;
+    file = nullptr;
   }
 }

--- a/plugins/grib_pi/src/GribRecord.cpp
+++ b/plugins/grib_pi/src/GribRecord.cpp
@@ -56,12 +56,12 @@ GribRecord::GribRecord(const GribRecord &rec) {
   *this = rec;
   IsDuplicated = true;
   // recopie les champs de bits
-  if (rec.data != NULL) {
+  if (rec.data != nullptr) {
     int size = rec.Ni * rec.Nj;
     this->data = new double[size];
     for (int i = 0; i < size; i++) this->data[i] = rec.data[i];
   }
-  if (rec.BMSbits != NULL) {
+  if (rec.BMSbits != nullptr) {
     int size = rec.BMSsize;
     this->BMSbits = new zuchar[size];
     for (int i = 0; i < size; i++) this->BMSbits[i] = rec.BMSbits[i];
@@ -162,14 +162,14 @@ GribRecord *GribRecord::InterpolatedRecord(const GribRecord &rec1,
   if (!GetInterpolatedParameters(rec1, rec2, La1, Lo1, La2, Lo2, Di, Dj, im1,
                                  jm1, im2, jm2, Ni, Nj, rec1offi, rec1offj,
                                  rec2offi, rec2offj))
-    return NULL;
+    return nullptr;
 
   // recopie les champs de bits
   int size = Ni * Nj;
   double *data = new double[size];
 
-  zuchar *BMSbits = NULL;
-  if (rec1.BMSbits != NULL && rec2.BMSbits != NULL)
+  zuchar *BMSbits = nullptr;
+  if (rec1.BMSbits != nullptr && rec2.BMSbits != nullptr)
     BMSbits = new zuchar[(Ni * Nj - 1) / 8 + 1]();
 
   for (int i = 0; i < Ni; i++)
@@ -233,7 +233,7 @@ GribRecord *GribRecord::Interpolated2DRecord(
   if (!GetInterpolatedParameters(rec1x, rec2x, La1, Lo1, La2, Lo2, Di, Dj, im1,
                                  jm1, im2, jm2, Ni, Nj, rec1offi, rec1offj,
                                  rec2offi, rec2offj))
-    return NULL;
+    return nullptr;
 
   if (!rec1y.data || !rec2y.data || !rec1y.isOk() || !rec2y.isOk() ||
       rec1x.Di != rec1y.Di || rec1x.Dj != rec1y.Dj || rec2x.Di != rec2y.Di ||
@@ -291,7 +291,7 @@ GribRecord *GribRecord::Interpolated2DRecord(
   ret->Lo1 = Lo1, ret->Lo2 = Lo2;
 
   ret->data = datax;
-  ret->BMSbits = NULL;
+  ret->BMSbits = nullptr;
   ret->hasBMS = false;  // I don't think wind or current ever use BMS correct?
 
   ret->latMin = wxMin(La1, La2), ret->latMax = wxMax(La1, La2);
@@ -301,7 +301,7 @@ GribRecord *GribRecord::Interpolated2DRecord(
   *rety = *ret;
   rety->dataType = rec1y.dataType;
   rety->data = datay;
-  rety->BMSbits = NULL;
+  rety->BMSbits = nullptr;
   rety->hasBMS = false;
 
   return ret;
@@ -322,7 +322,7 @@ GribRecord *GribRecord::MagnitudeRecord(const GribRecord &rec1,
   } else
     rec->ok = false;
 
-  if (rec1.BMSbits != NULL && rec2.BMSbits != NULL) {
+  if (rec1.BMSbits != nullptr && rec2.BMSbits != nullptr) {
     if (rec1.BMSsize == rec2.BMSsize) {
       int size = rec1.BMSsize;
       for (int i = 0; i < size; i++)
@@ -438,11 +438,11 @@ std::string GribRecord::makeKey(
 GribRecord::~GribRecord() {
   if (data) {
     delete[] data;
-    data = NULL;
+    data = nullptr;
   }
   if (BMSbits) {
     delete[] BMSbits;
-    BMSbits = NULL;
+    BMSbits = nullptr;
   }
 
   // if (dataType==GRB_TEMP) printf("record destroyed %s   %d\n",

--- a/plugins/grib_pi/src/GribRequestDialog.cpp
+++ b/plugins/grib_pi/src/GribRequestDialog.cpp
@@ -270,7 +270,7 @@ void GribRequestSetting::InitRequestConfig() {
 
   m_tMouseEventTimer.Connect(
       wxEVT_TIMER, wxTimerEventHandler(GribRequestSetting::OnMouseEventTimer),
-      NULL, this);
+      nullptr, this);
 
   m_RenderZoneOverlay = 0;
 
@@ -316,7 +316,7 @@ void GribRequestSetting::OnClose(wxCloseEvent &event) {
 void GribRequestSetting::SetRequestDialogSize() {
   int y;
   /*first let's size the mail display space*/
-  GetTextExtent(_T("abc"), NULL, &y, 0, 0, OCPNGetFont(_("Dialog"), 10));
+  GetTextExtent(_T("abc"), nullptr, &y, 0, 0, OCPNGetFont(_("Dialog"), 10));
   m_MailImage->SetMinSize(
       wxSize(-1, ((y * m_MailImage->GetNumberOfLines()) + 10)));
 
@@ -1301,7 +1301,7 @@ bool GribRequestSetting::DoRenderZoneOverlay() {
 
 bool GribRequestSetting::RenderGlZoneOverlay() {
   if (m_RenderZoneOverlay == 0) return false;
-  m_pdc = NULL;  // inform lower layers that this is OpenGL render
+  m_pdc = nullptr;  // inform lower layers that this is OpenGL render
   return DoRenderZoneOverlay();
 }
 

--- a/plugins/grib_pi/src/GribSettingsDialog.cpp
+++ b/plugins/grib_pi/src/GribSettingsDialog.cpp
@@ -931,11 +931,11 @@ void GribSettingsDialog::ShowFittingSettings(int settings) {
   // Hide all Parameters
   ShowSettings(B_ARROWS, false);
   ShowSettings(ISO_LINE, false);
-  if (m_fIsoBarSpacing->GetItem(m_sIsoBarSpacing) != NULL)
+  if (m_fIsoBarSpacing->GetItem(m_sIsoBarSpacing) != nullptr)
     m_fIsoBarSpacing->Detach(m_sIsoBarSpacing);
-  if (m_fIsoBarVisibility->GetItem(m_sIsoBarSpacing) != NULL)
+  if (m_fIsoBarVisibility->GetItem(m_sIsoBarSpacing) != nullptr)
     m_fIsoBarVisibility->Detach(m_sIsoBarSpacing);
-  if (m_fIsoBarVisibility->GetItem(m_sIsoBarVisibility) != NULL)
+  if (m_fIsoBarVisibility->GetItem(m_sIsoBarVisibility) != nullptr)
     m_fIsoBarVisibility->Detach(m_sIsoBarVisibility);
   ShowSettings(ISO_ABBR, false);
   ShowSettings(D_ARROWS, false);

--- a/plugins/grib_pi/src/GribTable.cpp
+++ b/plugins/grib_pi/src/GribTable.cpp
@@ -256,7 +256,7 @@ void GRIBTable::InitGribTable(int zone, ArrayOfGribRecordSets *rsa,
   datarow->DecRef();  // Give up pointer contrl to Grid
 
   m_tScrollToNowTimer.Connect(
-      wxEVT_TIMER, wxTimerEventHandler(GRIBTable::OnScrollToNowTimer), NULL,
+      wxEVT_TIMER, wxTimerEventHandler(GRIBTable::OnScrollToNowTimer), nullptr,
       this);
 }
 

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -137,7 +137,7 @@ wxWindow *GetGRIBCanvas() {
    screen */
 GribTimelineRecordSet::GribTimelineRecordSet(unsigned int cnt)
     : GribRecordSet(cnt) {
-  for (int i = 0; i < Idx_COUNT; i++) m_IsobarArray[i] = NULL;
+  for (int i = 0; i < Idx_COUNT; i++) m_IsobarArray[i] = nullptr;
 }
 
 GribTimelineRecordSet::~GribTimelineRecordSet() {
@@ -154,7 +154,7 @@ void GribTimelineRecordSet::ClearCachedData() {
         delete piso;
       }
       delete m_IsobarArray[i];
-      m_IsobarArray[i] = NULL;
+      m_IsobarArray[i] = nullptr;
     }
   }
 }
@@ -172,11 +172,11 @@ GRIBUICtrlBar::GRIBUICtrlBar(wxWindow *parent, wxWindowID id,
   // Preinitialize the vierwport with an existing value, see
   // https://github.com/OpenCPN/OpenCPN/pull/4002/files
   m_vp = new PlugIn_ViewPort(pPlugIn->GetCurrentViewPort());
-  pReq_Dialog = NULL;
-  m_bGRIBActiveFile = NULL;
-  m_pTimelineSet = NULL;
-  m_gCursorData = NULL;
-  m_gGRIBUICData = NULL;
+  pReq_Dialog = nullptr;
+  m_bGRIBActiveFile = nullptr;
+  m_pTimelineSet = nullptr;
+  m_gCursorData = nullptr;
+  m_gGRIBUICData = nullptr;
   m_gtk_started = false;
 
   wxFileConfig *pConf = GetOCPNConfigObject();
@@ -262,7 +262,7 @@ GRIBUICtrlBar::GRIBUICtrlBar(wxWindow *parent, wxWindowID id,
 
   // connect Timer
   m_tPlayStop.Connect(wxEVT_TIMER,
-                      wxTimerEventHandler(GRIBUICtrlBar::OnPlayStopTimer), NULL,
+                      wxTimerEventHandler(GRIBUICtrlBar::OnPlayStopTimer), nullptr,
                       this);
   // connect functions
   Connect(wxEVT_MOVE, wxMoveEventHandler(GRIBUICtrlBar::OnMove));
@@ -421,7 +421,7 @@ void GRIBUICtrlBar::SetScaledBitmap(double factor) {
 }
 
 void GRIBUICtrlBar::SetRequestBitmap(int type) {
-  if (NULL == m_bpRequest) return;
+  if (nullptr == m_bpRequest) return;
 
   switch (type) {
     case AUTO_SELECTION:
@@ -454,7 +454,7 @@ void GRIBUICtrlBar::OpenFile(bool newestFile) {
   m_FileIntervalIndex = m_OverlaySettings.m_SlicesPerUpdate;
   delete m_bGRIBActiveFile;
   delete m_pTimelineSet;
-  m_pTimelineSet = NULL;
+  m_pTimelineSet = nullptr;
   m_sTimeline->SetValue(0);
   m_TimeLineHours = 0;
   m_InterpolateMode = false;
@@ -485,7 +485,7 @@ void GRIBUICtrlBar::OpenFile(bool newestFile) {
     title.Append(fn.GetFullName());
     if (rsa->GetCount() == 0) {  // valid but empty file
       delete m_bGRIBActiveFile;
-      m_bGRIBActiveFile = NULL;
+      m_bGRIBActiveFile = nullptr;
       title.Prepend(_("Error! ")).Append(_(" contains no valid data!"));
     } else {
       PopulateComboDataList();
@@ -520,7 +520,7 @@ void GRIBUICtrlBar::OpenFile(bool newestFile) {
     }
   } else {
     delete m_bGRIBActiveFile;
-    m_bGRIBActiveFile = NULL;
+    m_bGRIBActiveFile = nullptr;
     title = _("No valid GRIB file");
   }
   pPlugIn->GetGRIBOverlayFactory()->SetMessage(title);
@@ -548,21 +548,21 @@ void GRIBUICtrlBar::OpenFile(bool newestFile) {
 #ifdef __OCPN__ANDROID__
   m_bpSettings->Enable(true);
 #else
-  m_bpSettings->Enable(m_pTimelineSet != NULL);
+  m_bpSettings->Enable(m_pTimelineSet != nullptr);
 #endif
-  m_bpZoomToCenter->Enable(m_pTimelineSet != NULL);
+  m_bpZoomToCenter->Enable(m_pTimelineSet != nullptr);
 
-  m_sTimeline->Enable(m_pTimelineSet != NULL && m_TimeLineHours);
-  m_bpPlay->Enable(m_pTimelineSet != NULL && m_TimeLineHours);
+  m_sTimeline->Enable(m_pTimelineSet != nullptr && m_TimeLineHours);
+  m_bpPlay->Enable(m_pTimelineSet != nullptr && m_TimeLineHours);
 
-  m_bpPrev->Enable(m_pTimelineSet != NULL && m_TimeLineHours);
-  m_bpNext->Enable(m_pTimelineSet != NULL && m_TimeLineHours);
-  m_bpNow->Enable(m_pTimelineSet != NULL && m_TimeLineHours);
+  m_bpPrev->Enable(m_pTimelineSet != nullptr && m_TimeLineHours);
+  m_bpNext->Enable(m_pTimelineSet != nullptr && m_TimeLineHours);
+  m_bpNow->Enable(m_pTimelineSet != nullptr && m_TimeLineHours);
 
   SetCanvasContextMenuItemViz(pPlugIn->m_MenuItem, m_TimeLineHours != 0);
 
   //
-  if (m_bGRIBActiveFile == NULL) {
+  if (m_bGRIBActiveFile == nullptr) {
     // there's no data we can use in this file
     return;
   }
@@ -759,7 +759,7 @@ void GRIBUICtrlBar::SetDialogsStyleSizePosition(bool force_recompute) {
   // necessary )
   if (m_gGRIBUICData) {
     m_gGRIBUICData->Destroy();
-    m_gGRIBUICData = NULL;
+    m_gGRIBUICData = nullptr;
   }
 
   if ((m_DialogStyle >> 1 == SEPARATED || !m_CDataIsShown) &&
@@ -776,7 +776,7 @@ void GRIBUICtrlBar::SetDialogsStyleSizePosition(bool force_recompute) {
       pPlugIn->SetDialogFont(m_gCursorData);
       m_gCursorData->PopulateTrackingControls(false);
       // attach CursorData to CtrlBar if necessary
-      if (m_fgCDataSizer->GetItem(m_gCursorData) == NULL)
+      if (m_fgCDataSizer->GetItem(m_gCursorData) == nullptr)
         m_fgCDataSizer->Add(m_gCursorData, 0);
       m_gCursorData->Show();
 
@@ -834,7 +834,7 @@ void GRIBUICtrlBar::SetDialogsStyleSizePosition(bool force_recompute) {
         sFont = FindOrCreateFont_PlugIn(pointSize, wxFONTFAMILY_DEFAULT,
                                         wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL,
                                         FALSE);
-        dc.GetTextExtent(_T("W"), &width, &height, NULL, NULL, sFont);
+        dc.GetTextExtent(_T("W"), &width, &height, nullptr, nullptr, sFont);
         if (width <= target_char_width) bOK = true;
         pointSize--;
         if (pointSize <= 10) bOK = true;
@@ -865,7 +865,7 @@ void GRIBUICtrlBar::OnAltitude(wxCommandEvent &event) {
 
   wxMenu *amenu = new wxMenu();
   amenu->Connect(wxEVT_COMMAND_MENU_SELECTED,
-                 wxMenuEventHandler(GRIBUICtrlBar::OnMenuEvent), NULL, this);
+                 wxMenuEventHandler(GRIBUICtrlBar::OnMenuEvent), nullptr, this);
 
   for (int i = 0; i < 5; i++) {
     if (((m_pTimelineSet &&
@@ -973,12 +973,12 @@ void GRIBUICtrlBar::OnMouseEvent(wxMouseEvent &event) {
     // populate menu
     wxMenu *xmenu = new wxMenu();
     xmenu->Connect(wxEVT_COMMAND_MENU_SELECTED,
-                   wxMenuEventHandler(GRIBUICtrlBar::OnMenuEvent), NULL, this);
+                   wxMenuEventHandler(GRIBUICtrlBar::OnMenuEvent), nullptr, this);
 
     if (m_HasAltitude) {  // eventually populate altitude choice
       wxMenu *smenu = new wxMenu();
       smenu->Connect(wxEVT_COMMAND_MENU_SELECTED,
-                     wxMenuEventHandler(GRIBUICtrlBar::OnMenuEvent), NULL,
+                     wxMenuEventHandler(GRIBUICtrlBar::OnMenuEvent), nullptr,
                      this);
 
       for (int i = 0; i < 5; i++) {
@@ -1156,7 +1156,7 @@ void GRIBUICtrlBar::OnRequest(wxCommandEvent &event) {
     pReq_Dialog->SetRequestDialogSize();
     // need to set a position at start
     int w;
-    ::wxDisplaySize(&w, NULL);
+    ::wxDisplaySize(&w, nullptr);
     pReq_Dialog->Move((w - pReq_Dialog->GetSize().GetX()) / 2, 30);
 
   }  // end create new request dialog
@@ -1195,7 +1195,7 @@ void GRIBUICtrlBar::OnSettings(wxCommandEvent &event) {
   dialog->SetSettingsDialogSize();
   // need to set a position at start
   int w;
-  ::wxDisplaySize(&w, NULL);
+  ::wxDisplaySize(&w, nullptr);
   dialog->Move((w - dialog->GetSize().GetX()) / 2, 30);
   // end set position
 
@@ -1359,7 +1359,7 @@ void GRIBUICtrlBar::StopPlayBack() {
 
 void GRIBUICtrlBar::TimelineChanged() {
   if (!m_bGRIBActiveFile || (m_bGRIBActiveFile && !m_bGRIBActiveFile->IsOK())) {
-    pPlugIn->GetGRIBOverlayFactory()->SetGribTimelineRecordSet(NULL);
+    pPlugIn->GetGRIBOverlayFactory()->SetGribTimelineRecordSet(nullptr);
     return;
   }
 
@@ -1479,16 +1479,16 @@ wxDateTime GRIBUICtrlBar::MinTime() {
 }
 
 GribTimelineRecordSet *GRIBUICtrlBar::GetTimeLineRecordSet(wxDateTime time) {
-  if (m_bGRIBActiveFile == NULL) return NULL;
+  if (m_bGRIBActiveFile == nullptr) return nullptr;
   ArrayOfGribRecordSets *rsa = m_bGRIBActiveFile->GetRecordSetArrayPtr();
 
-  if (rsa->GetCount() == 0) return NULL;
+  if (rsa->GetCount() == 0) return nullptr;
 
   GribTimelineRecordSet *set =
       new GribTimelineRecordSet(m_bGRIBActiveFile->GetCounter());
   for (int i = 0; i < Idx_COUNT; i++) {
-    GribRecordSet *GRS1 = NULL, *GRS2 = NULL;
-    GribRecord *GR1 = NULL, *GR2 = NULL;
+    GribRecordSet *GRS1 = nullptr, *GRS2 = nullptr;
+    GribRecord *GR1 = nullptr, *GR2 = nullptr;
     wxDateTime GR1time, GR2time;
 
     // already computed using polar interpolation from first axis
@@ -1708,7 +1708,7 @@ void GRIBUICtrlBar::OnOpenFile(wxCommandEvent &event) {
   if (wxDir::Exists(m_grib_dir)) l_grib_dir = m_grib_dir;
 
   wxFileDialog *dialog =
-      new wxFileDialog(NULL, _("Select a GRIB file"), l_grib_dir, _T(""),
+      new wxFileDialog(nullptr, _("Select a GRIB file"), l_grib_dir, _T(""),
                        wxT("Grib files "
                            "(*.grb;*.bz2;*.gz;*.grib2;*.grb2)|*.grb;*.bz2;*.gz;"
                            "*.grib2;*.grb2|All files (*)|*.*"),
@@ -1735,7 +1735,7 @@ void GRIBUICtrlBar::OnOpenFile(wxCommandEvent &event) {
 
   wxString file;
   int response = PlatformFileSelectorDialog(
-      NULL, &file, _("Select a GRIB file"), m_grib_dir, _T(""), _T("*.*"));
+      nullptr, &file, _("Select a GRIB file"), m_grib_dir, _T(""), _T("*.*"));
 
   if (response == wxID_OK) {
     wxFileName fn(file);
@@ -1750,7 +1750,7 @@ void GRIBUICtrlBar::OnOpenFile(wxCommandEvent &event) {
 
 void GRIBUICtrlBar::CreateActiveFileFromNames(const wxArrayString &filenames) {
   if (filenames.GetCount() != 0) {
-    m_bGRIBActiveFile = NULL;
+    m_bGRIBActiveFile = nullptr;
     m_bGRIBActiveFile = new GRIBFile(filenames, pPlugIn->GetCopyFirstCumRec(),
                                      pPlugIn->GetCopyMissWaveRec());
   }
@@ -1804,8 +1804,8 @@ void GRIBUICtrlBar::OnZoomToCenterClick(wxCommandEvent &event) {
 
     //Calculate overlay width & height in nm (around the center)
     double ow, oh;
-    DistanceBearingMercator_Plugin(clat, lonmin, clat, lonmax, NULL, &ow );
-    DistanceBearingMercator_Plugin( latmin, clon, latmax, clon, NULL, &oh );
+    DistanceBearingMercator_Plugin(clat, lonmin, clat, lonmax, nullptr, &ow );
+    DistanceBearingMercator_Plugin( latmin, clon, latmax, clon, nullptr, &oh );
 
     //calculate screen size
     int w = pPlugIn->GetGRIBOverlayFactory()->m_ParentSize.GetWidth();
@@ -1852,8 +1852,8 @@ void GRIBUICtrlBar::DoZoomToCenter() {
 
   // Calculate overlay width & height in nm (around the center)
   double ow, oh;
-  DistanceBearingMercator_Plugin(clat, lonmin, clat, lonmax, NULL, &ow);
-  DistanceBearingMercator_Plugin(latmin, clon, latmax, clon, NULL, &oh);
+  DistanceBearingMercator_Plugin(clat, lonmin, clat, lonmax, nullptr, &ow);
+  DistanceBearingMercator_Plugin(latmin, clon, latmax, clon, nullptr, &oh);
 
   wxWindow *wx = GetGRIBCanvas();
   // calculate screen size
@@ -1922,7 +1922,7 @@ void GRIBUICtrlBar::OnNext(wxCommandEvent &event) {
 
 void GRIBUICtrlBar::ComputeBestForecastForNow() {
   if (!m_bGRIBActiveFile || (m_bGRIBActiveFile && !m_bGRIBActiveFile->IsOK())) {
-    pPlugIn->GetGRIBOverlayFactory()->SetGribTimelineRecordSet(NULL);
+    pPlugIn->GetGRIBOverlayFactory()->SetGribTimelineRecordSet(nullptr);
     return;
   }
 
@@ -2017,7 +2017,7 @@ GRIBFile::GRIBFile(const wxArrayString &file_names, bool CumRec, bool WaveRec,
                    bool newestFile)
     : m_counter(++ID) {
   m_bOK = false;  // Assume ok until proven otherwise
-  m_pGribReader = NULL;
+  m_pGribReader = nullptr;
   m_last_message = wxEmptyString;
   for (unsigned int i = 0; i < file_names.GetCount(); i++) {
     wxString file_name = file_names[i];
@@ -2427,7 +2427,7 @@ void GRIBUICData::OnMove(wxMoveEvent &event) {
 
 bool CheckPendingJNIException() {
   if (!java_vm) {
-    // qDebug() << "java_vm is NULL.";
+    // qDebug() << "java_vm is nullptr.";
     return true;
   }
 
@@ -2447,7 +2447,7 @@ bool CheckPendingJNIException() {
 
 wxString callActivityMethod_ss(const char *method, wxString parm) {
   if (!java_vm) {
-    // qDebug() << "java_vm is NULL.";
+    // qDebug() << "java_vm is nullptr.";
     return _T("NOK");
   }
 
@@ -2486,7 +2486,7 @@ wxString callActivityMethod_ss(const char *method, wxString parm) {
   jstring s = data.object<jstring>();
 
   if ((jenv)->GetStringLength(s)) {
-    const char *ret_string = (jenv)->GetStringUTFChars(s, NULL);
+    const char *ret_string = (jenv)->GetStringUTFChars(s, nullptr);
     return_string = wxString(ret_string, wxConvUTF8);
   }
 

--- a/plugins/grib_pi/src/GribUIDialog.h
+++ b/plugins/grib_pi/src/GribUIDialog.h
@@ -214,7 +214,7 @@ private:
   void OnMove(wxMoveEvent &event);
   void OnMenuEvent(wxMenuEvent &event);
   void MenuAppend(wxMenu *menu, int id, wxString label, wxItemKind kind,
-                  wxBitmap bitmap = wxNullBitmap, wxMenu *submenu = NULL);
+                  wxBitmap bitmap = wxNullBitmap, wxMenu *submenu = nullptr);
   void OnZoomToCenterClick(wxCommandEvent &event);
   void OnPrev(wxCommandEvent &event);
   void OnRecordForecast(wxCommandEvent &event) {

--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -15,7 +15,7 @@ GRIBUICtrlBarBase::GRIBUICtrlBarBase(wxWindow* parent, wxWindowID id,
                                      const wxString& title, const wxPoint& pos,
                                      const wxSize& size, long style)
     : wxDialog(parent, id, title, pos, size, style) {
-  m_ProjectBoatPanel = NULL;
+  m_ProjectBoatPanel = nullptr;
 
 #ifdef __OCPN__ANDROID__
   const bool m_bcompact = true;
@@ -99,7 +99,7 @@ GRIBUICtrlBarBase::GRIBUICtrlBarBase(wxWindow* parent, wxWindowID id,
 
     fgSizer51->Add(0, 0, 1, wxEXPAND | wxLEFT | wxRIGHT, 1);
 
-    m_bpOpenFile = NULL;
+    m_bpOpenFile = nullptr;
     //         m_bpOpenFile = new wxBitmapButton( this, ID_BTNOPENFILE,
     //         wxNullBitmap, wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
     //         m_bpOpenFile->SetToolTip( _("Open a new file") );
@@ -112,7 +112,7 @@ GRIBUICtrlBarBase::GRIBUICtrlBarBase(wxWindow* parent, wxWindowID id,
 
     fgSizer51->Add(m_bpSettings, 0, wxALL, 1);
 
-    m_bpRequest = NULL;
+    m_bpRequest = nullptr;
 
     //         m_bpRequest = new wxBitmapButton( this, ID_BTNREQUEST,
     //         wxNullBitmap, wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW );
@@ -302,113 +302,113 @@ GRIBUICtrlBarBase::GRIBUICtrlBarBase(wxWindow* parent, wxWindowID id,
   this->Connect(wxEVT_PAINT, wxPaintEventHandler(GRIBUICtrlBarBase::OnPaint));
 #endif
   m_bpPrev->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
-                    wxCommandEventHandler(GRIBUICtrlBarBase::OnPrev), NULL,
+                    wxCommandEventHandler(GRIBUICtrlBarBase::OnPrev), nullptr,
                     this);
   m_bpPrev->Connect(wxEVT_RIGHT_DOWN,
-                    wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent), NULL,
+                    wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent), nullptr,
                     this);
   m_cRecordForecast->Connect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GRIBUICtrlBarBase::OnRecordForecast), NULL, this);
+      wxCommandEventHandler(GRIBUICtrlBarBase::OnRecordForecast), nullptr, this);
   m_cRecordForecast->Connect(
       wxEVT_RIGHT_DOWN, wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-      NULL, this);
+      nullptr, this);
   m_bpNext->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
-                    wxCommandEventHandler(GRIBUICtrlBarBase::OnNext), NULL,
+                    wxCommandEventHandler(GRIBUICtrlBarBase::OnNext), nullptr,
                     this);
   m_bpNext->Connect(wxEVT_RIGHT_DOWN,
-                    wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent), NULL,
+                    wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent), nullptr,
                     this);
   m_bpAltitude->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
                         wxCommandEventHandler(GRIBUICtrlBarBase::OnAltitude),
-                        NULL, this);
+                        nullptr, this);
   m_bpAltitude->Connect(wxEVT_RIGHT_DOWN,
                         wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-                        NULL, this);
+                        nullptr, this);
   m_bpNow->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
-                   wxCommandEventHandler(GRIBUICtrlBarBase::OnNow), NULL, this);
+                   wxCommandEventHandler(GRIBUICtrlBarBase::OnNow), nullptr, this);
   m_bpNow->Connect(wxEVT_RIGHT_DOWN,
-                   wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent), NULL,
+                   wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent), nullptr,
                    this);
   m_bpZoomToCenter->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GRIBUICtrlBarBase::OnZoomToCenterClick), NULL,
+      wxCommandEventHandler(GRIBUICtrlBarBase::OnZoomToCenterClick), nullptr,
       this);
   m_bpZoomToCenter->Connect(
       wxEVT_RIGHT_DOWN, wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-      NULL, this);
+      nullptr, this);
   m_bpShowCursorData->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GRIBUICtrlBarBase::OnShowCursorData), NULL, this);
+      wxCommandEventHandler(GRIBUICtrlBarBase::OnShowCursorData), nullptr, this);
   m_bpShowCursorData->Connect(
       wxEVT_RIGHT_DOWN, wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-      NULL, this);
+      nullptr, this);
   m_bpPlay->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
-                    wxCommandEventHandler(GRIBUICtrlBarBase::OnPlayStop), NULL,
+                    wxCommandEventHandler(GRIBUICtrlBarBase::OnPlayStop), nullptr,
                     this);
   m_bpPlay->Connect(wxEVT_RIGHT_DOWN,
-                    wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent), NULL,
+                    wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent), nullptr,
                     this);
   m_sTimeline->Connect(wxEVT_RIGHT_DOWN,
                        wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-                       NULL, this);
+                       nullptr, this);
   m_sTimeline->Connect(wxEVT_SCROLL_TOP,
                        wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                       NULL, this);
+                       nullptr, this);
   m_sTimeline->Connect(wxEVT_SCROLL_BOTTOM,
                        wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                       NULL, this);
+                       nullptr, this);
   m_sTimeline->Connect(wxEVT_SCROLL_LINEUP,
                        wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                       NULL, this);
+                       nullptr, this);
   m_sTimeline->Connect(wxEVT_SCROLL_LINEDOWN,
                        wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                       NULL, this);
+                       nullptr, this);
   m_sTimeline->Connect(wxEVT_SCROLL_PAGEUP,
                        wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                       NULL, this);
+                       nullptr, this);
   m_sTimeline->Connect(wxEVT_SCROLL_PAGEDOWN,
                        wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                       NULL, this);
+                       nullptr, this);
   m_sTimeline->Connect(wxEVT_SCROLL_THUMBTRACK,
                        wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                       NULL, this);
+                       nullptr, this);
   m_sTimeline->Connect(wxEVT_SCROLL_THUMBRELEASE,
                        wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                       NULL, this);
+                       nullptr, this);
   m_sTimeline->Connect(wxEVT_SCROLL_CHANGED,
                        wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                       NULL, this);
+                       nullptr, this);
 
   if (m_bpOpenFile) {
     m_bpOpenFile->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
                           wxCommandEventHandler(GRIBUICtrlBarBase::OnOpenFile),
-                          NULL, this);
+                          nullptr, this);
     m_bpOpenFile->Connect(wxEVT_RIGHT_DOWN,
                           wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-                          NULL, this);
+                          nullptr, this);
   }
 
 #ifdef __OCPN__ANDROID__
   m_bpSettings->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GRIBUICtrlBarBase::OnCompositeDialog), NULL, this);
+      wxCommandEventHandler(GRIBUICtrlBarBase::OnCompositeDialog), nullptr, this);
 #else
   m_bpSettings->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
                         wxCommandEventHandler(GRIBUICtrlBarBase::OnSettings),
-                        NULL, this);
+                        nullptr, this);
   m_bpSettings->Connect(wxEVT_RIGHT_DOWN,
                         wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-                        NULL, this);
+                        nullptr, this);
 #endif
 
   if (m_bpRequest) {
     m_bpRequest->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
                          wxCommandEventHandler(GRIBUICtrlBarBase::OnRequest),
-                         NULL, this);
+                         nullptr, this);
     m_bpRequest->Connect(wxEVT_RIGHT_DOWN,
                          wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-                         NULL, this);
+                         nullptr, this);
   }
 }
 
@@ -446,108 +446,108 @@ GRIBUICtrlBarBase::~GRIBUICtrlBarBase() {
                    wxPaintEventHandler(GRIBUICtrlBarBase::OnPaint));
   this->Disconnect(wxEVT_SIZE, wxSizeEventHandler(GRIBUICtrlBarBase::OnSize));
   m_bpPrev->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
-                       wxCommandEventHandler(GRIBUICtrlBarBase::OnPrev), NULL,
+                       wxCommandEventHandler(GRIBUICtrlBarBase::OnPrev), nullptr,
                        this);
   m_bpPrev->Disconnect(wxEVT_RIGHT_DOWN,
                        wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-                       NULL, this);
+                       nullptr, this);
   m_cRecordForecast->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GRIBUICtrlBarBase::OnRecordForecast), NULL, this);
+      wxCommandEventHandler(GRIBUICtrlBarBase::OnRecordForecast), nullptr, this);
   m_cRecordForecast->Disconnect(
       wxEVT_RIGHT_DOWN, wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-      NULL, this);
+      nullptr, this);
   m_bpNext->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
-                       wxCommandEventHandler(GRIBUICtrlBarBase::OnNext), NULL,
+                       wxCommandEventHandler(GRIBUICtrlBarBase::OnNext), nullptr,
                        this);
   m_bpNext->Disconnect(wxEVT_RIGHT_DOWN,
                        wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-                       NULL, this);
+                       nullptr, this);
   m_bpAltitude->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
                            wxCommandEventHandler(GRIBUICtrlBarBase::OnAltitude),
-                           NULL, this);
+                           nullptr, this);
   m_bpAltitude->Disconnect(wxEVT_RIGHT_DOWN,
                            wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-                           NULL, this);
+                           nullptr, this);
   m_bpNow->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
-                      wxCommandEventHandler(GRIBUICtrlBarBase::OnNow), NULL,
+                      wxCommandEventHandler(GRIBUICtrlBarBase::OnNow), nullptr,
                       this);
   m_bpNow->Disconnect(wxEVT_RIGHT_DOWN,
                       wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-                      NULL, this);
+                      nullptr, this);
   m_bpZoomToCenter->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GRIBUICtrlBarBase::OnZoomToCenterClick), NULL,
+      wxCommandEventHandler(GRIBUICtrlBarBase::OnZoomToCenterClick), nullptr,
       this);
   m_bpZoomToCenter->Disconnect(
       wxEVT_RIGHT_DOWN, wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-      NULL, this);
+      nullptr, this);
   m_bpShowCursorData->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GRIBUICtrlBarBase::OnShowCursorData), NULL, this);
+      wxCommandEventHandler(GRIBUICtrlBarBase::OnShowCursorData), nullptr, this);
   m_bpShowCursorData->Disconnect(
       wxEVT_RIGHT_DOWN, wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-      NULL, this);
+      nullptr, this);
   m_bpPlay->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
                        wxCommandEventHandler(GRIBUICtrlBarBase::OnPlayStop),
-                       NULL, this);
+                       nullptr, this);
   m_bpPlay->Disconnect(wxEVT_RIGHT_DOWN,
                        wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-                       NULL, this);
+                       nullptr, this);
   m_sTimeline->Disconnect(wxEVT_RIGHT_DOWN,
                           wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-                          NULL, this);
+                          nullptr, this);
   m_sTimeline->Disconnect(wxEVT_SCROLL_TOP,
                           wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                          NULL, this);
+                          nullptr, this);
   m_sTimeline->Disconnect(wxEVT_SCROLL_BOTTOM,
                           wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                          NULL, this);
+                          nullptr, this);
   m_sTimeline->Disconnect(wxEVT_SCROLL_LINEUP,
                           wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                          NULL, this);
+                          nullptr, this);
   m_sTimeline->Disconnect(wxEVT_SCROLL_LINEDOWN,
                           wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                          NULL, this);
+                          nullptr, this);
   m_sTimeline->Disconnect(wxEVT_SCROLL_PAGEUP,
                           wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                          NULL, this);
+                          nullptr, this);
   m_sTimeline->Disconnect(wxEVT_SCROLL_PAGEDOWN,
                           wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                          NULL, this);
+                          nullptr, this);
   m_sTimeline->Disconnect(wxEVT_SCROLL_THUMBTRACK,
                           wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                          NULL, this);
+                          nullptr, this);
   m_sTimeline->Disconnect(wxEVT_SCROLL_THUMBRELEASE,
                           wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                          NULL, this);
+                          nullptr, this);
   m_sTimeline->Disconnect(wxEVT_SCROLL_CHANGED,
                           wxScrollEventHandler(GRIBUICtrlBarBase::OnTimeline),
-                          NULL, this);
+                          nullptr, this);
 
   if (m_bpOpenFile) {
     m_bpOpenFile->Disconnect(
         wxEVT_COMMAND_BUTTON_CLICKED,
-        wxCommandEventHandler(GRIBUICtrlBarBase::OnOpenFile), NULL, this);
+        wxCommandEventHandler(GRIBUICtrlBarBase::OnOpenFile), nullptr, this);
     m_bpOpenFile->Disconnect(
         wxEVT_RIGHT_DOWN, wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-        NULL, this);
+        nullptr, this);
   }
 
   m_bpSettings->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
                            wxCommandEventHandler(GRIBUICtrlBarBase::OnSettings),
-                           NULL, this);
+                           nullptr, this);
   m_bpSettings->Disconnect(wxEVT_RIGHT_DOWN,
                            wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-                           NULL, this);
+                           nullptr, this);
 
   if (m_bpRequest) {
     m_bpRequest->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
                             wxCommandEventHandler(GRIBUICtrlBarBase::OnRequest),
-                            NULL, this);
+                            nullptr, this);
     m_bpRequest->Disconnect(
         wxEVT_RIGHT_DOWN, wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
-        NULL, this);
+        nullptr, this);
   }
 }
 
@@ -865,105 +865,105 @@ CursorDataBase::CursorDataBase(wxWindow* parent, wxWindowID id,
                 wxMouseEventHandler(CursorDataBase::OnMouseEvent));
   m_stTrackingText->Connect(wxEVT_LEFT_DOWN,
                             wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-                            NULL, this);
+                            nullptr, this);
   m_stTrackingText->Connect(wxEVT_LEFT_UP,
                             wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-                            NULL, this);
+                            nullptr, this);
   m_stTrackingText->Connect(wxEVT_MIDDLE_DOWN,
                             wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-                            NULL, this);
+                            nullptr, this);
   m_stTrackingText->Connect(wxEVT_MIDDLE_UP,
                             wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-                            NULL, this);
+                            nullptr, this);
   m_stTrackingText->Connect(wxEVT_RIGHT_DOWN,
                             wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-                            NULL, this);
+                            nullptr, this);
   m_stTrackingText->Connect(wxEVT_RIGHT_UP,
                             wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-                            NULL, this);
+                            nullptr, this);
   m_stTrackingText->Connect(wxEVT_MOTION,
                             wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-                            NULL, this);
+                            nullptr, this);
   m_stTrackingText->Connect(wxEVT_LEFT_DCLICK,
                             wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-                            NULL, this);
+                            nullptr, this);
   m_stTrackingText->Connect(wxEVT_MIDDLE_DCLICK,
                             wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-                            NULL, this);
+                            nullptr, this);
   m_stTrackingText->Connect(wxEVT_RIGHT_DCLICK,
                             wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-                            NULL, this);
+                            nullptr, this);
   m_stTrackingText->Connect(wxEVT_LEAVE_WINDOW,
                             wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-                            NULL, this);
+                            nullptr, this);
   m_stTrackingText->Connect(wxEVT_ENTER_WINDOW,
                             wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-                            NULL, this);
+                            nullptr, this);
   m_stTrackingText->Connect(wxEVT_MOUSEWHEEL,
                             wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-                            NULL, this);
+                            nullptr, this);
   m_cbWind->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                    wxCommandEventHandler(CursorDataBase::OnCBAny), NULL, this);
+                    wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr, this);
   m_cbWind->Connect(wxEVT_RIGHT_DOWN,
-                    wxMouseEventHandler(CursorDataBase::OnMenuCallBack), NULL,
+                    wxMouseEventHandler(CursorDataBase::OnMenuCallBack), nullptr,
                     this);
   m_cbWindGust->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                        wxCommandEventHandler(CursorDataBase::OnCBAny), NULL,
+                        wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr,
                         this);
   m_cbWindGust->Connect(wxEVT_RIGHT_DOWN,
                         wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-                        NULL, this);
+                        nullptr, this);
   m_cbPressure->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                        wxCommandEventHandler(CursorDataBase::OnCBAny), NULL,
+                        wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr,
                         this);
   m_cbPressure->Connect(wxEVT_RIGHT_DOWN,
                         wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-                        NULL, this);
+                        nullptr, this);
   m_cbWave->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                    wxCommandEventHandler(CursorDataBase::OnCBAny), NULL, this);
+                    wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr, this);
   m_cbWave->Connect(wxEVT_RIGHT_DOWN,
-                    wxMouseEventHandler(CursorDataBase::OnMenuCallBack), NULL,
+                    wxMouseEventHandler(CursorDataBase::OnMenuCallBack), nullptr,
                     this);
   m_cbCurrent->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                       wxCommandEventHandler(CursorDataBase::OnCBAny), NULL,
+                       wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr,
                        this);
   m_cbCurrent->Connect(wxEVT_RIGHT_DOWN,
                        wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-                       NULL, this);
+                       nullptr, this);
   m_cbPrecipitation->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                              wxCommandEventHandler(CursorDataBase::OnCBAny),
-                             NULL, this);
+                             nullptr, this);
   m_cbPrecipitation->Connect(
       wxEVT_RIGHT_DOWN, wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-      NULL, this);
+      nullptr, this);
   m_cbCloud->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                     wxCommandEventHandler(CursorDataBase::OnCBAny), NULL,
+                     wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr,
                      this);
   m_cbCloud->Connect(wxEVT_RIGHT_DOWN,
-                     wxMouseEventHandler(CursorDataBase::OnMenuCallBack), NULL,
+                     wxMouseEventHandler(CursorDataBase::OnMenuCallBack), nullptr,
                      this);
   m_cbAirTemperature->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                               wxCommandEventHandler(CursorDataBase::OnCBAny),
-                              NULL, this);
+                              nullptr, this);
   m_cbAirTemperature->Connect(
       wxEVT_RIGHT_DOWN, wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-      NULL, this);
+      nullptr, this);
   m_cbSeaTemperature->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                               wxCommandEventHandler(CursorDataBase::OnCBAny),
-                              NULL, this);
+                              nullptr, this);
   m_cbSeaTemperature->Connect(
       wxEVT_RIGHT_DOWN, wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-      NULL, this);
+      nullptr, this);
   m_cbCAPE->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                    wxCommandEventHandler(CursorDataBase::OnCBAny), NULL, this);
+                    wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr, this);
   m_cbCAPE->Connect(wxEVT_RIGHT_DOWN,
-                    wxMouseEventHandler(CursorDataBase::OnMenuCallBack), NULL,
+                    wxMouseEventHandler(CursorDataBase::OnMenuCallBack), nullptr,
                     this);
   m_cbReflC->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                     wxCommandEventHandler(CursorDataBase::OnCBAny), NULL,
+                     wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr,
                      this);
   m_cbReflC->Connect(wxEVT_RIGHT_DOWN,
-                     wxMouseEventHandler(CursorDataBase::OnMenuCallBack), NULL,
+                     wxMouseEventHandler(CursorDataBase::OnMenuCallBack), nullptr,
                      this);
 }
 
@@ -996,110 +996,110 @@ CursorDataBase::~CursorDataBase() {
   this->Disconnect(wxEVT_MOUSEWHEEL,
                    wxMouseEventHandler(CursorDataBase::OnMouseEvent));
   m_stTrackingText->Disconnect(
-      wxEVT_LEFT_DOWN, wxMouseEventHandler(CursorDataBase::OnMouseEvent), NULL,
+      wxEVT_LEFT_DOWN, wxMouseEventHandler(CursorDataBase::OnMouseEvent), nullptr,
       this);
   m_stTrackingText->Disconnect(
-      wxEVT_LEFT_UP, wxMouseEventHandler(CursorDataBase::OnMouseEvent), NULL,
+      wxEVT_LEFT_UP, wxMouseEventHandler(CursorDataBase::OnMouseEvent), nullptr,
       this);
   m_stTrackingText->Disconnect(
       wxEVT_MIDDLE_DOWN, wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-      NULL, this);
+      nullptr, this);
   m_stTrackingText->Disconnect(
-      wxEVT_MIDDLE_UP, wxMouseEventHandler(CursorDataBase::OnMouseEvent), NULL,
+      wxEVT_MIDDLE_UP, wxMouseEventHandler(CursorDataBase::OnMouseEvent), nullptr,
       this);
   m_stTrackingText->Disconnect(
-      wxEVT_RIGHT_DOWN, wxMouseEventHandler(CursorDataBase::OnMouseEvent), NULL,
+      wxEVT_RIGHT_DOWN, wxMouseEventHandler(CursorDataBase::OnMouseEvent), nullptr,
       this);
   m_stTrackingText->Disconnect(
-      wxEVT_RIGHT_UP, wxMouseEventHandler(CursorDataBase::OnMouseEvent), NULL,
+      wxEVT_RIGHT_UP, wxMouseEventHandler(CursorDataBase::OnMouseEvent), nullptr,
       this);
   m_stTrackingText->Disconnect(
-      wxEVT_MOTION, wxMouseEventHandler(CursorDataBase::OnMouseEvent), NULL,
+      wxEVT_MOTION, wxMouseEventHandler(CursorDataBase::OnMouseEvent), nullptr,
       this);
   m_stTrackingText->Disconnect(
       wxEVT_LEFT_DCLICK, wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-      NULL, this);
+      nullptr, this);
   m_stTrackingText->Disconnect(
       wxEVT_MIDDLE_DCLICK, wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-      NULL, this);
+      nullptr, this);
   m_stTrackingText->Disconnect(
       wxEVT_RIGHT_DCLICK, wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-      NULL, this);
+      nullptr, this);
   m_stTrackingText->Disconnect(
       wxEVT_LEAVE_WINDOW, wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-      NULL, this);
+      nullptr, this);
   m_stTrackingText->Disconnect(
       wxEVT_ENTER_WINDOW, wxMouseEventHandler(CursorDataBase::OnMouseEvent),
-      NULL, this);
+      nullptr, this);
   m_stTrackingText->Disconnect(
-      wxEVT_MOUSEWHEEL, wxMouseEventHandler(CursorDataBase::OnMouseEvent), NULL,
+      wxEVT_MOUSEWHEEL, wxMouseEventHandler(CursorDataBase::OnMouseEvent), nullptr,
       this);
   m_cbWind->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                       wxCommandEventHandler(CursorDataBase::OnCBAny), NULL,
+                       wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr,
                        this);
   m_cbWind->Disconnect(wxEVT_RIGHT_DOWN,
                        wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-                       NULL, this);
+                       nullptr, this);
   m_cbWindGust->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                           wxCommandEventHandler(CursorDataBase::OnCBAny), NULL,
+                           wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr,
                            this);
   m_cbWindGust->Disconnect(wxEVT_RIGHT_DOWN,
                            wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-                           NULL, this);
+                           nullptr, this);
   m_cbPressure->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                           wxCommandEventHandler(CursorDataBase::OnCBAny), NULL,
+                           wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr,
                            this);
   m_cbPressure->Disconnect(wxEVT_RIGHT_DOWN,
                            wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-                           NULL, this);
+                           nullptr, this);
   m_cbWave->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                       wxCommandEventHandler(CursorDataBase::OnCBAny), NULL,
+                       wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr,
                        this);
   m_cbWave->Disconnect(wxEVT_RIGHT_DOWN,
                        wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-                       NULL, this);
+                       nullptr, this);
   m_cbCurrent->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                          wxCommandEventHandler(CursorDataBase::OnCBAny), NULL,
+                          wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr,
                           this);
   m_cbCurrent->Disconnect(wxEVT_RIGHT_DOWN,
                           wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-                          NULL, this);
+                          nullptr, this);
   m_cbPrecipitation->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                                 wxCommandEventHandler(CursorDataBase::OnCBAny),
-                                NULL, this);
+                                nullptr, this);
   m_cbPrecipitation->Disconnect(
       wxEVT_RIGHT_DOWN, wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-      NULL, this);
+      nullptr, this);
   m_cbCloud->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                        wxCommandEventHandler(CursorDataBase::OnCBAny), NULL,
+                        wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr,
                         this);
   m_cbCloud->Disconnect(wxEVT_RIGHT_DOWN,
                         wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-                        NULL, this);
+                        nullptr, this);
   m_cbAirTemperature->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                                  wxCommandEventHandler(CursorDataBase::OnCBAny),
-                                 NULL, this);
+                                 nullptr, this);
   m_cbAirTemperature->Disconnect(
       wxEVT_RIGHT_DOWN, wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-      NULL, this);
+      nullptr, this);
   m_cbSeaTemperature->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                                  wxCommandEventHandler(CursorDataBase::OnCBAny),
-                                 NULL, this);
+                                 nullptr, this);
   m_cbSeaTemperature->Disconnect(
       wxEVT_RIGHT_DOWN, wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-      NULL, this);
+      nullptr, this);
   m_cbCAPE->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                       wxCommandEventHandler(CursorDataBase::OnCBAny), NULL,
+                       wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr,
                        this);
   m_cbCAPE->Disconnect(wxEVT_RIGHT_DOWN,
                        wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-                       NULL, this);
+                       nullptr, this);
   m_cbReflC->Disconnect(wxEVT_COMMAND_CHECKBOX_CLICKED,
-                        wxCommandEventHandler(CursorDataBase::OnCBAny), NULL,
+                        wxCommandEventHandler(CursorDataBase::OnCBAny), nullptr,
                         this);
   m_cbReflC->Disconnect(wxEVT_RIGHT_DOWN,
                         wxMouseEventHandler(CursorDataBase::OnMenuCallBack),
-                        NULL, this);
+                        nullptr, this);
 }
 
 GribSettingsDialogBase::GribSettingsDialogBase(wxWindow* parent, wxWindowID id,
@@ -1854,202 +1854,202 @@ GribSettingsDialogBase::GribSettingsDialogBase(wxWindow* parent, wxWindowID id,
   // Connect Events
   m_nSettingsBook->Connect(
       wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED,
-      wxNotebookEventHandler(GribSettingsDialogBase::OnPageChange), NULL, this);
+      wxNotebookEventHandler(GribSettingsDialogBase::OnPageChange), nullptr, this);
   m_cDataType->Connect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnDataTypeChoice), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnDataTypeChoice), nullptr,
       this);
   m_cDataUnits->Connect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnUnitChange), NULL, this);
+      wxCommandEventHandler(GribSettingsDialogBase::OnUnitChange), nullptr, this);
   m_cBarbArrFixSpac->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), nullptr,
       this);
   m_cBarbArrMinSpac->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), nullptr,
       this);
   m_cDirArrFixSpac->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), nullptr,
       this);
   m_cDirArrMinSpac->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), nullptr,
       this);
   m_cNumFixSpac->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), nullptr,
       this);
   m_cNumMinSpac->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), nullptr,
       this);
   m_sTransparency->Connect(
       wxEVT_SCROLL_TOP,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Connect(
       wxEVT_SCROLL_BOTTOM,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Connect(
       wxEVT_SCROLL_LINEUP,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Connect(
       wxEVT_SCROLL_LINEDOWN,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Connect(
       wxEVT_SCROLL_PAGEUP,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Connect(
       wxEVT_SCROLL_PAGEDOWN,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Connect(
       wxEVT_SCROLL_THUMBTRACK,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Connect(
       wxEVT_SCROLL_THUMBRELEASE,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Connect(
       wxEVT_SCROLL_CHANGED,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_cLoopMode->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnIntepolateChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnIntepolateChange), nullptr,
       this);
   m_cInterpolate->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnIntepolateChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnIntepolateChange), nullptr,
       this);
   m_rbCurDataAttaWCap->Connect(
       wxEVT_COMMAND_RADIOBUTTON_SELECTED,
       wxCommandEventHandler(GribSettingsDialogBase::OnCtrlandDataStyleChanged),
-      NULL, this);
+      nullptr, this);
   m_rbCurDataAttaWoCap->Connect(
       wxEVT_COMMAND_RADIOBUTTON_SELECTED,
       wxCommandEventHandler(GribSettingsDialogBase::OnCtrlandDataStyleChanged),
-      NULL, this);
+      nullptr, this);
   m_rbCurDataIsolHoriz->Connect(
       wxEVT_COMMAND_RADIOBUTTON_SELECTED,
       wxCommandEventHandler(GribSettingsDialogBase::OnCtrlandDataStyleChanged),
-      NULL, this);
+      nullptr, this);
   m_rbCurDataIsolVertic->Connect(
       wxEVT_COMMAND_RADIOBUTTON_SELECTED,
       wxCommandEventHandler(GribSettingsDialogBase::OnCtrlandDataStyleChanged),
-      NULL, this);
+      nullptr, this);
   m_sButtonApply->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnApply), NULL, this);
+      wxCommandEventHandler(GribSettingsDialogBase::OnApply), nullptr, this);
 }
 
 GribSettingsDialogBase::~GribSettingsDialogBase() {
   // Disconnect Events
   m_nSettingsBook->Disconnect(
       wxEVT_COMMAND_NOTEBOOK_PAGE_CHANGED,
-      wxNotebookEventHandler(GribSettingsDialogBase::OnPageChange), NULL, this);
+      wxNotebookEventHandler(GribSettingsDialogBase::OnPageChange), nullptr, this);
   m_cDataType->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnDataTypeChoice), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnDataTypeChoice), nullptr,
       this);
   m_cDataUnits->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnUnitChange), NULL, this);
+      wxCommandEventHandler(GribSettingsDialogBase::OnUnitChange), nullptr, this);
   m_cBarbArrFixSpac->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), nullptr,
       this);
   m_cBarbArrMinSpac->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), nullptr,
       this);
   m_cDirArrFixSpac->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), nullptr,
       this);
   m_cDirArrMinSpac->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), nullptr,
       this);
   m_cNumFixSpac->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), nullptr,
       this);
   m_cNumMinSpac->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnSpacingModeChange), nullptr,
       this);
   m_sTransparency->Disconnect(
       wxEVT_SCROLL_TOP,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Disconnect(
       wxEVT_SCROLL_BOTTOM,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Disconnect(
       wxEVT_SCROLL_LINEUP,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Disconnect(
       wxEVT_SCROLL_LINEDOWN,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Disconnect(
       wxEVT_SCROLL_PAGEUP,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Disconnect(
       wxEVT_SCROLL_PAGEDOWN,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Disconnect(
       wxEVT_SCROLL_THUMBTRACK,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Disconnect(
       wxEVT_SCROLL_THUMBRELEASE,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_sTransparency->Disconnect(
       wxEVT_SCROLL_CHANGED,
-      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), NULL,
+      wxScrollEventHandler(GribSettingsDialogBase::OnTransparencyChange), nullptr,
       this);
   m_cLoopMode->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnIntepolateChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnIntepolateChange), nullptr,
       this);
   m_cInterpolate->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnIntepolateChange), NULL,
+      wxCommandEventHandler(GribSettingsDialogBase::OnIntepolateChange), nullptr,
       this);
   m_rbCurDataAttaWCap->Disconnect(
       wxEVT_COMMAND_RADIOBUTTON_SELECTED,
       wxCommandEventHandler(GribSettingsDialogBase::OnCtrlandDataStyleChanged),
-      NULL, this);
+      nullptr, this);
   m_rbCurDataAttaWoCap->Disconnect(
       wxEVT_COMMAND_RADIOBUTTON_SELECTED,
       wxCommandEventHandler(GribSettingsDialogBase::OnCtrlandDataStyleChanged),
-      NULL, this);
+      nullptr, this);
   m_rbCurDataIsolHoriz->Disconnect(
       wxEVT_COMMAND_RADIOBUTTON_SELECTED,
       wxCommandEventHandler(GribSettingsDialogBase::OnCtrlandDataStyleChanged),
-      NULL, this);
+      nullptr, this);
   m_rbCurDataIsolVertic->Disconnect(
       wxEVT_COMMAND_RADIOBUTTON_SELECTED,
       wxCommandEventHandler(GribSettingsDialogBase::OnCtrlandDataStyleChanged),
-      NULL, this);
+      nullptr, this);
   m_sButtonApply->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribSettingsDialogBase::OnApply), NULL, this);
+      wxCommandEventHandler(GribSettingsDialogBase::OnApply), nullptr, this);
 }
 
 #ifndef __OCPN__ANDROID__
@@ -2185,7 +2185,7 @@ GribPreferencesDialogBase::GribPreferencesDialogBase(
   bSizerPrefsMain->Add(SetSaveButton, 0, wxALL | wxEXPAND, 5);
   SetSaveButton->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribPreferencesDialogBase::OnDirSelClick), NULL,
+      wxCommandEventHandler(GribPreferencesDialogBase::OnDirSelClick), nullptr,
       this);
 
   Layout();
@@ -2195,10 +2195,10 @@ GribPreferencesDialogBase::GribPreferencesDialogBase(
   m_rbStartOptions->Connect(
       wxEVT_COMMAND_RADIOBOX_SELECTED,
       wxCommandEventHandler(GribPreferencesDialogBase::OnStartOptionChange),
-      NULL, this);
+      nullptr, this);
   m_sdbSizer2OK->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribPreferencesDialogBase::OnOKClick), NULL, this);
+      wxCommandEventHandler(GribPreferencesDialogBase::OnOKClick), nullptr, this);
 }
 #else
 
@@ -2310,10 +2310,10 @@ GribPreferencesDialogBase::GribPreferencesDialogBase(
   m_rbStartOptions->Connect(
       wxEVT_COMMAND_RADIOBOX_SELECTED,
       wxCommandEventHandler(GribPreferencesDialogBase::OnStartOptionChange),
-      NULL, this);
+      nullptr, this);
   m_sdbButtonSizerOK->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribPreferencesDialogBase::OnOKClick), NULL, this);
+      wxCommandEventHandler(GribPreferencesDialogBase::OnOKClick), nullptr, this);
 }
 
 #endif
@@ -2323,7 +2323,7 @@ GribPreferencesDialogBase::~GribPreferencesDialogBase() {
   m_rbStartOptions->Disconnect(
       wxEVT_COMMAND_RADIOBOX_SELECTED,
       wxCommandEventHandler(GribPreferencesDialogBase::OnStartOptionChange),
-      NULL, this);
+      nullptr, this);
 }
 
 void GribPreferencesDialogBase::OnDirSelClick(wxCommandEvent& event) {
@@ -2993,208 +2993,208 @@ GribRequestSettingBase::GribRequestSettingBase(wxWindow* parent, wxWindowID id,
                 wxCloseEventHandler(GribRequestSettingBase::OnClose));
   m_chForecastLength->Connect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnWorldLengthChoice), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnWorldLengthChoice), nullptr,
       this);
   m_btnDownloadWorld->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnWorldDownload), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnWorldDownload), nullptr,
       this);
   m_SourcesTreeCtrl1->Connect(
       wxEVT_COMMAND_TREE_ITEM_EXPANDED,
-      wxTreeEventHandler(GribRequestSettingBase::OnLocalTreeItemExpanded), NULL,
+      wxTreeEventHandler(GribRequestSettingBase::OnLocalTreeItemExpanded), nullptr,
       this);
   m_SourcesTreeCtrl1->Connect(
       wxEVT_COMMAND_TREE_SEL_CHANGED,
-      wxTreeEventHandler(GribRequestSettingBase::OnLocalTreeSelChanged), NULL,
+      wxTreeEventHandler(GribRequestSettingBase::OnLocalTreeSelChanged), nullptr,
       this);
   m_buttonUpdateCatalog->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnUpdateLocalCatalog), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnUpdateLocalCatalog), nullptr,
       this);
   m_btnDownloadLocal->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnDownloadLocal), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnDownloadLocal), nullptr,
       this);
   m_pMailTo->Connect(wxEVT_COMMAND_CHOICE_SELECTED,
                      wxCommandEventHandler(GribRequestSettingBase::OnTopChange),
-                     NULL, this);
+                     nullptr, this);
   m_pModel->Connect(wxEVT_COMMAND_CHOICE_SELECTED,
                     wxCommandEventHandler(GribRequestSettingBase::OnTopChange),
-                    NULL, this);
+                    nullptr, this);
   m_cMovingGribEnabled->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnMovingClick), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnMovingClick), nullptr, this);
   m_sMovingSpeed->Connect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
-      wxSpinEventHandler(GribRequestSettingBase::OnAnySpinChange), NULL, this);
+      wxSpinEventHandler(GribRequestSettingBase::OnAnySpinChange), nullptr, this);
   m_sMovingCourse->Connect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
-      wxSpinEventHandler(GribRequestSettingBase::OnAnySpinChange), NULL, this);
+      wxSpinEventHandler(GribRequestSettingBase::OnAnySpinChange), nullptr, this);
   m_pLogin->Connect(wxEVT_COMMAND_TEXT_UPDATED,
                     wxCommandEventHandler(GribRequestSettingBase::OnAnyChange),
-                    NULL, this);
+                    nullptr, this);
   m_pCode->Connect(wxEVT_COMMAND_TEXT_UPDATED,
                    wxCommandEventHandler(GribRequestSettingBase::OnAnyChange),
-                   NULL, this);
+                   nullptr, this);
   m_pResolution->Connect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pInterval->Connect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pTimeRange->Connect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnTimeRangeChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnTimeRangeChange), nullptr,
       this);
   m_cManualZoneSel->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
       wxCommandEventHandler(GribRequestSettingBase::OnZoneSelectionModeChange),
-      NULL, this);
+      nullptr, this);
   m_cUseSavedZone->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
       wxCommandEventHandler(GribRequestSettingBase::OnZoneSelectionModeChange),
-      NULL, this);
+      nullptr, this);
   m_spMaxLat->Connect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
-      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), NULL,
+      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), nullptr,
       this);
   m_spMaxLon->Connect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
-      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), NULL,
+      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), nullptr,
       this);
   m_spMinLat->Connect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
-      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), NULL,
+      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), nullptr,
       this);
   m_spMinLon->Connect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
-      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), NULL,
+      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), nullptr,
       this);
   m_pWind->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                    wxCommandEventHandler(GribRequestSettingBase::OnAnyChange),
-                   NULL, this);
+                   nullptr, this);
   m_pPress->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                     wxCommandEventHandler(GribRequestSettingBase::OnAnyChange),
-                    NULL, this);
+                    nullptr, this);
   m_pWindGust->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pRainfall->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pCloudCover->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pAirTemp->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pCAPE->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                    wxCommandEventHandler(GribRequestSettingBase::OnAnyChange),
-                   NULL, this);
+                   nullptr, this);
   m_pReflectivity->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pSeaTemp->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pCurrent->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pWaves->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                     wxCommandEventHandler(GribRequestSettingBase::OnAnyChange),
-                    NULL, this);
+                    nullptr, this);
   m_pWModel->Connect(wxEVT_COMMAND_CHOICE_SELECTED,
                      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange),
-                     NULL, this);
+                     nullptr, this);
   m_pAltitudeData->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_p850hpa->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange),
-                     NULL, this);
+                     nullptr, this);
   m_p700hpa->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange),
-                     NULL, this);
+                     nullptr, this);
   m_p500hpa->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange),
-                     NULL, this);
+                     nullptr, this);
   m_p300hpa->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange),
-                     NULL, this);
+                     nullptr, this);
   m_rButtonApply->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnSaveMail), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnSaveMail), nullptr, this);
   m_rButtonCancel->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnCancel), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnCancel), nullptr, this);
   m_rButtonYes->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnSendMaiL), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnSendMaiL), nullptr, this);
 
   // Connect XyGrib related callbacks
   m_xygribPanel->m_download_button->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
       wxCommandEventHandler(GribRequestSettingBase::OnXyGribDownloadButton),
-      NULL, this);
+      nullptr, this);
   m_xygribPanel->m_atmmodel_choice->Connect(
       wxEVT_COMMAND_CHOICE_SELECTED,
       wxCommandEventHandler(GribRequestSettingBase::OnXyGribAtmModelChoice),
-      NULL, this);
+      nullptr, this);
   m_xygribPanel->m_wavemodel_choice->Connect(
       wxEVT_COMMAND_CHOICE_SELECTED,
       wxCommandEventHandler(GribRequestSettingBase::OnXyGribWaveModelChoice),
-      NULL, this);
+      nullptr, this);
   m_xygribPanel->m_wind_cbox->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_gust_cbox->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_reflectivity_cbox->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_precipitation_cbox->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_cape_cbox->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_pressure_cbox->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_cloudcover_cbox->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_temperature_cbox->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_waveheight_cbox->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_windwave_cbox->Connect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_resolution_choice->Connect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_duration_choice->Connect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_interval_choice->Connect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
 }
 
@@ -3204,208 +3204,208 @@ GribRequestSettingBase::~GribRequestSettingBase() {
                    wxCloseEventHandler(GribRequestSettingBase::OnClose));
   m_chForecastLength->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnWorldLengthChoice), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnWorldLengthChoice), nullptr,
       this);
   m_btnDownloadWorld->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnWorldDownload), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnWorldDownload), nullptr,
       this);
   m_SourcesTreeCtrl1->Disconnect(
       wxEVT_COMMAND_TREE_ITEM_EXPANDED,
-      wxTreeEventHandler(GribRequestSettingBase::OnLocalTreeItemExpanded), NULL,
+      wxTreeEventHandler(GribRequestSettingBase::OnLocalTreeItemExpanded), nullptr,
       this);
   m_SourcesTreeCtrl1->Disconnect(
       wxEVT_COMMAND_TREE_SEL_CHANGED,
-      wxTreeEventHandler(GribRequestSettingBase::OnLocalTreeSelChanged), NULL,
+      wxTreeEventHandler(GribRequestSettingBase::OnLocalTreeSelChanged), nullptr,
       this);
   m_buttonUpdateCatalog->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnUpdateLocalCatalog), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnUpdateLocalCatalog), nullptr,
       this);
   m_btnDownloadLocal->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnDownloadLocal), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnDownloadLocal), nullptr,
       this);
   m_pMailTo->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnTopChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnTopChange), nullptr, this);
   m_pModel->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnTopChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnTopChange), nullptr, this);
   m_cMovingGribEnabled->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnMovingClick), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnMovingClick), nullptr, this);
   m_sMovingSpeed->Disconnect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
-      wxSpinEventHandler(GribRequestSettingBase::OnAnySpinChange), NULL, this);
+      wxSpinEventHandler(GribRequestSettingBase::OnAnySpinChange), nullptr, this);
   m_sMovingCourse->Disconnect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
-      wxSpinEventHandler(GribRequestSettingBase::OnAnySpinChange), NULL, this);
+      wxSpinEventHandler(GribRequestSettingBase::OnAnySpinChange), nullptr, this);
   m_pLogin->Disconnect(
       wxEVT_COMMAND_TEXT_UPDATED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pCode->Disconnect(
       wxEVT_COMMAND_TEXT_UPDATED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pResolution->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pInterval->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pTimeRange->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnTimeRangeChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnTimeRangeChange), nullptr,
       this);
   m_cManualZoneSel->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
       wxCommandEventHandler(GribRequestSettingBase::OnZoneSelectionModeChange),
-      NULL, this);
+      nullptr, this);
   m_cUseSavedZone->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
       wxCommandEventHandler(GribRequestSettingBase::OnZoneSelectionModeChange),
-      NULL, this);
+      nullptr, this);
   m_spMaxLat->Disconnect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
-      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), NULL,
+      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), nullptr,
       this);
   m_spMaxLon->Disconnect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
-      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), NULL,
+      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), nullptr,
       this);
   m_spMinLat->Disconnect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
-      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), NULL,
+      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), nullptr,
       this);
   m_spMinLon->Disconnect(
       wxEVT_COMMAND_SPINCTRL_UPDATED,
-      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), NULL,
+      wxSpinEventHandler(GribRequestSettingBase::OnCoordinatesChange), nullptr,
       this);
   m_pWind->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pPress->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pWindGust->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pRainfall->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pCloudCover->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pAirTemp->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pCAPE->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pReflectivity->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pSeaTemp->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pCurrent->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pWaves->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pWModel->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_pAltitudeData->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_p850hpa->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_p700hpa->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_p500hpa->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_p300hpa->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange), nullptr, this);
   m_rButtonApply->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnSaveMail), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnSaveMail), nullptr, this);
   m_rButtonCancel->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnCancel), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnCancel), nullptr, this);
   m_rButtonYes->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnSendMaiL), NULL, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnSendMaiL), nullptr, this);
 
   // Disconnect XyGrib related callbacks
   m_xygribPanel->m_download_button->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
       wxCommandEventHandler(GribRequestSettingBase::OnXyGribDownloadButton),
-      NULL, this);
+      nullptr, this);
   m_xygribPanel->m_atmmodel_choice->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
       wxCommandEventHandler(GribRequestSettingBase::OnXyGribAtmModelChoice),
-      NULL, this);
+      nullptr, this);
   m_xygribPanel->m_wavemodel_choice->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
       wxCommandEventHandler(GribRequestSettingBase::OnXyGribWaveModelChoice),
-      NULL, this);
+      nullptr, this);
   m_xygribPanel->m_wind_cbox->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_gust_cbox->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_reflectivity_cbox->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_precipitation_cbox->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_cape_cbox->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_pressure_cbox->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_cloudcover_cbox->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_temperature_cbox->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_waveheight_cbox->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_windwave_cbox->Disconnect(
       wxEVT_COMMAND_CHECKBOX_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_resolution_choice->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_duration_choice->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
   m_xygribPanel->m_interval_choice->Disconnect(
       wxEVT_COMMAND_CHOICE_SELECTED,
-      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), NULL,
+      wxCommandEventHandler(GribRequestSettingBase::OnXyGribConfigChange), nullptr,
       this);
 }
 
@@ -3480,7 +3480,7 @@ GRIBTableBase::GRIBTableBase(wxWindow* parent, wxWindowID id,
                 wxCloseEventHandler(GRIBTableBase::OnClose));
   m_pButtonTableOK->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
                             wxCommandEventHandler(GRIBTableBase::OnOKButton),
-                            NULL, this);
+                            nullptr, this);
 }
 
 GRIBTableBase::~GRIBTableBase() {
@@ -3489,7 +3489,7 @@ GRIBTableBase::~GRIBTableBase() {
                    wxCloseEventHandler(GRIBTableBase::OnClose));
   m_pButtonTableOK->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
                                wxCommandEventHandler(GRIBTableBase::OnOKButton),
-                               NULL, this);
+                               nullptr, this);
 }
 
 ProjectBoatPanel::ProjectBoatPanel(wxWindow* parent, wxWindowID id,

--- a/plugins/grib_pi/src/GribV1Record.cpp
+++ b/plugins/grib_pi/src/GribV1Record.cpp
@@ -318,8 +318,8 @@ void GribV1Record::translateDataType() {
 GribV1Record::GribV1Record(ZUFILE* file, int id_) {
   id = id_;
   //   seekStart = zu_tell(file);           // moved to section 0 read
-  data = NULL;
-  BMSbits = NULL;
+  data = nullptr;
+  BMSbits = nullptr;
   eof = false;
   knownData = true;
   IsDuplicated = false;

--- a/plugins/grib_pi/src/GribV2Record.cpp
+++ b/plugins/grib_pi/src/GribV2Record.cpp
@@ -216,7 +216,7 @@ static int dec_jpeg2000(char *injpc, int bufsize, int *outfld)
 {
   int ier;
   int i, j, k;
-  jas_image_t *image = 0;
+  jas_image_t *image = nullptr;
   jas_stream_t *jpcstream;
   jas_image_cmpt_t *pcmpt;
   char *opts = 0;
@@ -238,7 +238,7 @@ static int dec_jpeg2000(char *injpc, int bufsize, int *outfld)
   //     Decode JPEG200 codestream into jas_image_t structure.
   //
   image = jpc_decode(jpcstream, opts);
-  if (image == 0) {
+  if (image == nullptr) {
     printf(" jpc_decode return = %d \n", ier);
     return -3;
   }
@@ -725,9 +725,9 @@ static bool unpackBMS(GRIBMessage *grib_msg) {
       break;
     case 255:  // A bit map does not apply to this product.
       delete[] grib_msg->md.bitmap;
-      grib_msg->md.bitmap = NULL;
+      grib_msg->md.bitmap = nullptr;
       delete[] grib_msg->md.bms;
-      grib_msg->md.bms = NULL;
+      grib_msg->md.bms = nullptr;
       grib_msg->md.bmssize = 0;
       break;
     default:
@@ -762,7 +762,7 @@ static bool unpackDS(GRIBMessage *grib_msg) {
     case 0:
       grib_msg->grids.gridpoints = new double[npoints];
       for (l = 0; l < npoints; l++) {
-        if (grib_msg->md.bitmap == NULL || grib_msg->md.bitmap[l] == 1) {
+        if (grib_msg->md.bitmap == nullptr || grib_msg->md.bitmap[l] == 1) {
           getBits(grib_msg->buffer, &pval, off, grib_msg->md.pack_width);
           grib_msg->grids.gridpoints[l] = grib_msg->md.R + pval * E / D;
           off += grib_msg->md.pack_width;
@@ -854,7 +854,7 @@ static bool unpackDS(GRIBMessage *grib_msg) {
             groups.group_miss_val = GRIB_MISSING_VALUE;
           }
           for (int i = 0; i < groups.lengths[n];) {
-            if (grib_msg->md.bitmap != NULL && grib_msg->md.bitmap[l] == 0) {
+            if (grib_msg->md.bitmap != nullptr && grib_msg->md.bitmap[l] == 0) {
               grib_msg->grids.gridpoints[l] = GRIB_MISSING_VALUE;
             } else {
               getBits(grib_msg->buffer, &pval, off, groups.widths[n]);
@@ -871,7 +871,7 @@ static bool unpackDS(GRIBMessage *grib_msg) {
           }
         } else {  // constant group XXX bitmap?
           for (int i = 0; i < groups.lengths[n];) {
-            if (grib_msg->md.bitmap != NULL && grib_msg->md.bitmap[l] == 0) {
+            if (grib_msg->md.bitmap != nullptr && grib_msg->md.bitmap[l] == 0) {
               grib_msg->grids.gridpoints[l] = GRIB_MISSING_VALUE;
             } else {
               if (groups.ref_vals[n] == groups.miss_val) {
@@ -986,7 +986,7 @@ static bool unpackDS(GRIBMessage *grib_msg) {
                      jvals);
       cnt = 0;
       for (l = 0; l < npoints; l++) {
-        if (grib_msg->md.bitmap == NULL || grib_msg->md.bitmap[l] == 1) {
+        if (grib_msg->md.bitmap == nullptr || grib_msg->md.bitmap[l] == 1) {
           if (len == 0) jvals[cnt] = 0;
           grib_msg->grids.gridpoints[l] = grib_msg->md.R + jvals[cnt++] * E / D;
         } else
@@ -1540,8 +1540,8 @@ void GribV2Record::readDataSet(ZUFILE *file) {
   bool DS = false;
   int len, sec_num;
 
-  data = NULL;
-  BMSbits = NULL;
+  data = nullptr;
+  BMSbits = nullptr;
   hasBMS = false;
   knownData = false;
   IsDuplicated = false;
@@ -1706,9 +1706,9 @@ void GribV2Record::readDataSet(ZUFILE *file) {
 GribV2Record::GribV2Record(ZUFILE *file, int id_) {
   id = id_;
   seekStart = zu_tell(file);  // moved to section 0 read
-  data = NULL;
+  data = nullptr;
   BMSsize = 0;
-  BMSbits = NULL;
+  BMSbits = nullptr;
   hasBMS = false;
   eof = false;
   knownData = false;
@@ -1816,9 +1816,9 @@ static bool unpackIS(ZUFILE *fp, GRIBMessage *grib_msg) {
   int status;
   size_t num;
 
-  if (grib_msg->buffer != NULL) {
+  if (grib_msg->buffer != nullptr) {
     delete[] grib_msg->buffer;
-    grib_msg->buffer = NULL;
+    grib_msg->buffer = nullptr;
   }
   grib_msg->num_grids = 0;
 

--- a/plugins/grib_pi/src/IsoLine.cpp
+++ b/plugins/grib_pi/src/IsoLine.cpp
@@ -229,7 +229,7 @@ IsoLine::~IsoLine() {
   std::list<Segment *>::iterator it;
   for (it = trace.begin(); it != trace.end(); it++) {
     delete *it;
-    *it = NULL;
+    *it = nullptr;
   }
   trace.clear();
 
@@ -289,7 +289,7 @@ MySegList *IsoLine::BuildContinuousSegment(void) {
     if (badded == true)
       tseg = seg;
     else
-      tseg = NULL;
+      tseg = nullptr;
   }
 
   //     Build a chain extending from the "1" end of the target segment
@@ -337,7 +337,7 @@ MySegList *IsoLine::BuildContinuousSegment(void) {
     if (badded == true)
       tseg = seg;
     else
-      tseg = NULL;
+      tseg = nullptr;
   }
 
   //     Now have two lists...
@@ -374,7 +374,7 @@ void IsoLine::drawIsoLine(GRIBOverlayFactory *pof, wxDC *dc,
   GetGlobalColor(_T ( "UITX1" ), &isoLineColor);
 
 #if wxUSE_GRAPHICS_CONTEXT
-  wxGraphicsContext *pgc = NULL;
+  wxGraphicsContext *pgc = nullptr;
 #endif
 
   if (dc) {
@@ -875,7 +875,7 @@ void GenSpline(wxList *points) {
 
   while ((node = node->GetNext())
 #if !wxUSE_STL
-         != NULL
+         != nullptr
 #endif  // !wxUSE_STL
   ) {
     p = (wxPoint *)node->GetData();

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -88,7 +88,7 @@ grib_pi::grib_pi(void *ppimgr) : opencpn_plugin_116(ppimgr) {
   else
     wxLogMessage(_T("    GRIB panel icon NOT loaded"));
 
-  m_pLastTimelineSet = NULL;
+  m_pLastTimelineSet = nullptr;
   m_bShowGrib = false;
   m_GUIScaleFactor = -1.;
   g_pi = this;
@@ -107,8 +107,8 @@ int grib_pi::Init(void) {
   m_CtrlBarxy = wxPoint(0, 0);
   m_CursorDataxy = wxPoint(0, 0);
 
-  m_pGribCtrlBar = NULL;
-  m_pGRIBOverlayFactory = NULL;
+  m_pGribCtrlBar = nullptr;
+  m_pGRIBOverlayFactory = nullptr;
 
   ::wxDisplaySize(&m_display_width, &m_display_height);
 
@@ -161,7 +161,7 @@ int grib_pi::Init(void) {
     wxLogMessage(normalIcon);
     m_leftclick_tool_id = InsertPlugInToolSVG(
         _T(""), normalIcon, rolloverIcon, toggledIcon, wxITEM_CHECK, _("Grib"),
-        _T(""), NULL, GRIB_TOOL_POSITION, 0, this);
+        _T(""), nullptr, GRIB_TOOL_POSITION, 0, this);
   }
 
   if (!QualifyCtrlBarPosition(m_CtrlBarxy, m_CtrlBar_Sizexy)) {
@@ -179,11 +179,11 @@ bool grib_pi::DeInit(void) {
   if (m_pGribCtrlBar) {
     m_pGribCtrlBar->Close();
     delete m_pGribCtrlBar;
-    m_pGribCtrlBar = NULL;
+    m_pGribCtrlBar = nullptr;
   }
 
   delete m_pGRIBOverlayFactory;
-  m_pGRIBOverlayFactory = NULL;
+  m_pGRIBOverlayFactory = nullptr;
 
   return true;
 }
@@ -384,7 +384,7 @@ bool grib_pi::QualifyCtrlBarPosition(
                                 ? position.y + 30
                                 : position.y + size.y;
 
-  if (NULL == MonitorFromRect(&frame_title_rect, MONITOR_DEFAULTTONULL))
+  if (nullptr == MonitorFromRect(&frame_title_rect, MONITOR_DEFAULTTONULL))
     b_reset_pos = true;
 #else
   wxRect window_title_rect;  // conservative estimate
@@ -551,7 +551,7 @@ void grib_pi::OnGribCtrlBarClose() {
 
   if (m_DialogStyleChanged) {
     m_pGribCtrlBar->Destroy();
-    m_pGribCtrlBar = NULL;
+    m_pGribCtrlBar = nullptr;
     m_DialogStyleChanged = false;
   }
 }
@@ -729,7 +729,7 @@ void grib_pi::SetPluginMessage(wxString &message_id, wxString &message_body) {
     if (!m_pGribCtrlBar) OnToolbarToolCallback(0);
 
     GribTimelineRecordSet *set =
-        m_pGribCtrlBar ? m_pGribCtrlBar->GetTimeLineRecordSet(time) : NULL;
+        m_pGribCtrlBar ? m_pGribCtrlBar->GetTimeLineRecordSet(time) : nullptr;
 
     char ptr[64];
     snprintf(ptr, sizeof ptr, "%p", set);

--- a/plugins/grib_pi/src/jsonreader.cpp
+++ b/plugins/grib_pi/src/jsonreader.cpp
@@ -256,7 +256,7 @@ wxJSONReader::~wxJSONReader() {}
  JSON text stored in a wxString object or in a wxInputStream
  object.
 
- If \c val is a NULL pointer, the function does not store the
+ If \c val is a nullptr pointer, the function does not store the
  values: it can be used as a JSON checker in order to check the
  syntax of the document.
  Returns the number of \b errors found in the document.
@@ -292,7 +292,7 @@ wxJSONReader::~wxJSONReader() {}
  Next, the overloaded Parse function is called.
 
  @param doc    the JSON text that has to be parsed
- @param val    the wxJSONValue object that contains the parsed text; if NULL the
+ @param val    the wxJSONValue object that contains the parsed text; if nullptr the
          parser do not store anything but errors and warnings are reported
  @return the total number of errors encontered
 */
@@ -305,7 +305,7 @@ int wxJSONReader::Parse(const wxString& doc, wxJSONValue* val) {
 
   // convert the string to a UTF-8 / ANSI memory stream and calls overloaded
   // Parse()
-  char* readBuff = 0;
+  char* readBuff = nullptr;
   wxCharBuffer utf8CB = doc.ToUTF8();  // the UTF-8 buffer
 #if !defined(wxJSON_USE_UNICODE)
   wxCharBuffer ansiCB(doc.c_str());  // the ANSI buffer
@@ -344,7 +344,7 @@ int wxJSONReader::Parse(wxInputStream& is, wxJSONValue* val) {
   // if a wxJSONValue is not passed to the Parse function
   // we set the temparary object created on the stack
   // I know this will slow down the validation of input
-  if (val == 0) {
+  if (val == nullptr) {
     val = &temp;
   }
   wxASSERT(val);
@@ -600,7 +600,7 @@ int wxJSONReader::DoRead(wxInputStream& is, wxJSONValue& parent) {
         // close-object: store the current value, if any
         StoreValue(ch, key, value, parent);
         m_current = &parent;
-        m_next = 0;
+        m_next = nullptr;
         m_current->SetLineNo(m_lineNo);
         ch = ReadChar(is);
         return ch;
@@ -635,7 +635,7 @@ int wxJSONReader::DoRead(wxInputStream& is, wxJSONValue& parent) {
         }
         StoreValue(ch, key, value, parent);
         m_current = &parent;
-        m_next = 0;
+        m_next = nullptr;
         m_current->SetLineNo(m_lineNo);
         return 0;  // returning ZERO for reading the next char
         break;
@@ -650,19 +650,19 @@ int wxJSONReader::DoRead(wxInputStream& is, wxJSONValue& parent) {
       case '\"':
         ch = ReadString(is, value);  // read a JSON string type
         m_current = &value;
-        m_next = 0;
+        m_next = nullptr;
         break;
 
       case '\'':
         ch = ReadMemoryBuff(is, value);  // read a memory buffer type
         m_current = &value;
-        m_next = 0;
+        m_next = nullptr;
         break;
 
       case ':':  // key / value separator
         m_current = &value;
         m_current->SetLineNo(m_lineNo);
-        m_next = 0;
+        m_next = nullptr;
         if (!parent.IsObject()) {
           AddError(_T( "\':\' can only used in object's values" ));
         } else if (!value.IsString()) {
@@ -684,7 +684,7 @@ int wxJSONReader::DoRead(wxInputStream& is, wxJSONValue& parent) {
         // errors are checked in the 'ReadValue()' function.
         m_current = &value;
         m_current->SetLineNo(m_lineNo);
-        m_next = 0;
+        m_next = nullptr;
         ch = ReadValue(is, ch, value);
         break;
     }  // end switch
@@ -1317,10 +1317,10 @@ int wxJSONReader::ReadValue(wxInputStream& is, int ch, wxJSONValue& val) {
   // first try the literal strings lowercase and nocase
   if (s == _T("null")) {
     val.SetType(wxJSONTYPE_NULL);
-    wxLogTrace(traceMask, _T("(%s) value = NULL"), __PRETTY_FUNCTION__);
+    wxLogTrace(traceMask, _T("(%s) value = nullptr"), __PRETTY_FUNCTION__);
     return nextCh;
   } else if (s.CmpNoCase(_T( "null" )) == 0) {
-    wxLogTrace(traceMask, _T("(%s) value = NULL"), __PRETTY_FUNCTION__);
+    wxLogTrace(traceMask, _T("(%s) value = nullptr"), __PRETTY_FUNCTION__);
     AddWarning(wxJSONREADER_CASE,
                _T( "the \'null\' literal must be lowercase" ));
     val.SetType(wxJSONTYPE_NULL);
@@ -1516,7 +1516,7 @@ int wxJSONReader::AppendUES(wxMemoryBuffer& utf8Buff, const char* uesBuffer) {
   char buffer[16];
   size_t len = wxConvUTF8.FromWChar(buffer, 10, &ch, 1);
 
-  // seems that the wxMBConv classes always appends a NULL byte to
+  // seems that the wxMBConv classes always appends a nullptr byte to
   // the converted buffer
   if (len > 1) {
     len = len - 1;

--- a/plugins/grib_pi/src/jsonval.cpp
+++ b/plugins/grib_pi/src/jsonval.cpp
@@ -69,7 +69,7 @@ int wxJSONRefData::sm_progr = 1;
 wxJSONRefData::wxJSONRefData() {
   m_lineNo = -1;
   m_refCount = 1;
-  m_memBuff = 0;
+  m_memBuff = nullptr;
 
 #if defined(WXJSON_USE_VALUE_COUNTER)
   m_progr = sm_progr;
@@ -178,7 +178,7 @@ int wxJSONValue::sm_progr = 1;
  \endcode
 */
 wxJSONValue::wxJSONValue() {
-  m_refData = 0;
+  m_refData = nullptr;
   Init(wxJSONTYPE_NULL);
 }
 
@@ -188,7 +188,7 @@ wxJSONValue::wxJSONValue() {
  the wxJSONRefData class and sets the type of the JSON value.
  Note that only the type is set, not the value.
  Also note that this function may be called from other memberfunctions
- if the \c m_refData data member is NULL.
+ if the \c m_refData data member is nullptr.
 */
 wxJSONRefData* wxJSONValue::Init(wxJSONType type) {
   wxJSONRefData* data = GetRefData();
@@ -219,13 +219,13 @@ wxJSONRefData* wxJSONValue::Init(wxJSONType type) {
 
 //! \overload wxJSONValue()
 wxJSONValue::wxJSONValue(wxJSONType type) {
-  m_refData = 0;
+  m_refData = nullptr;
   Init(type);
 }
 
 //! \overload wxJSONValue()
 wxJSONValue::wxJSONValue(int i) {
-  m_refData = 0;
+  m_refData = nullptr;
   wxJSONRefData* data = Init(wxJSONTYPE_INT);
   wxJSON_ASSERT(data);
   if (data != 0) {
@@ -237,7 +237,7 @@ wxJSONValue::wxJSONValue(int i) {
 
 //! \overload wxJSONValue()
 wxJSONValue::wxJSONValue(unsigned int ui) {
-  m_refData = 0;
+  m_refData = nullptr;
   wxJSONRefData* data = Init(wxJSONTYPE_UINT);
   wxJSON_ASSERT(data);
   if (data != 0) {
@@ -249,7 +249,7 @@ wxJSONValue::wxJSONValue(unsigned int ui) {
 
 //! \overload wxJSONValue()
 wxJSONValue::wxJSONValue(short int i) {
-  m_refData = 0;
+  m_refData = nullptr;
   wxJSONRefData* data = Init(wxJSONTYPE_INT);
   wxJSON_ASSERT(data);
   if (data != 0) {
@@ -261,7 +261,7 @@ wxJSONValue::wxJSONValue(short int i) {
 
 //! \overload wxJSONValue()
 wxJSONValue::wxJSONValue(unsigned short ui) {
-  m_refData = 0;
+  m_refData = nullptr;
   wxJSONRefData* data = Init(wxJSONTYPE_UINT);
   wxJSON_ASSERT(data);
   if (data != 0) {
@@ -273,7 +273,7 @@ wxJSONValue::wxJSONValue(unsigned short ui) {
 
 //! \overload wxJSONValue()
 wxJSONValue::wxJSONValue(bool b) {
-  m_refData = 0;
+  m_refData = nullptr;
   wxJSONRefData* data = Init(wxJSONTYPE_BOOL);
   wxJSON_ASSERT(data);
   if (data != 0) {
@@ -283,7 +283,7 @@ wxJSONValue::wxJSONValue(bool b) {
 
 //! \overload wxJSONValue()
 wxJSONValue::wxJSONValue(double d) {
-  m_refData = 0;
+  m_refData = nullptr;
   wxJSONRefData* data = Init(wxJSONTYPE_DOUBLE);
   wxJSON_ASSERT(data);
   if (data != 0) {
@@ -293,7 +293,7 @@ wxJSONValue::wxJSONValue(double d) {
 
 //! \overload wxJSONValue()
 wxJSONValue::wxJSONValue(const wxChar* str) {
-  m_refData = 0;
+  m_refData = nullptr;
   wxJSONRefData* data = Init(wxJSONTYPE_CSTRING);
   wxJSON_ASSERT(data);
   if (data != 0) {
@@ -308,7 +308,7 @@ wxJSONValue::wxJSONValue(const wxChar* str) {
 
 //! \overload wxJSONValue()
 wxJSONValue::wxJSONValue(const wxString& str) {
-  m_refData = 0;
+  m_refData = nullptr;
   wxJSONRefData* data = Init(wxJSONTYPE_STRING);
   wxJSON_ASSERT(data);
   if (data != 0) {
@@ -318,7 +318,7 @@ wxJSONValue::wxJSONValue(const wxString& str) {
 
 //! \overload wxJSONValue()
 wxJSONValue::wxJSONValue(long int l) {
-  m_refData = 0;
+  m_refData = nullptr;
   wxJSONRefData* data = Init(wxJSONTYPE_INT);
   wxJSON_ASSERT(data);
   if (data != 0) {
@@ -328,7 +328,7 @@ wxJSONValue::wxJSONValue(long int l) {
 
 //! \overload wxJSONValue()
 wxJSONValue::wxJSONValue(unsigned long int ul) {
-  m_refData = 0;
+  m_refData = nullptr;
   wxJSONRefData* data = Init(wxJSONTYPE_UINT);
   wxJSON_ASSERT(data);
   if (data != 0) {
@@ -343,7 +343,7 @@ wxJSONValue::wxJSONValue(unsigned long int ul) {
  JSON value.
 */
 wxJSONValue::wxJSONValue(const wxMemoryBuffer& buff) {
-  m_refData = 0;
+  m_refData = nullptr;
   wxJSONRefData* data = Init(wxJSONTYPE_MEMORYBUFF);
   wxJSON_ASSERT(data);
   if (data != 0) {
@@ -363,7 +363,7 @@ wxJSONValue::wxJSONValue(const wxMemoryBuffer& buff) {
  JSON value.
 */
 wxJSONValue::wxJSONValue(const void* buff, size_t len) {
-  m_refData = 0;
+  m_refData = nullptr;
   wxJSONRefData* data = Init(wxJSONTYPE_MEMORYBUFF);
   wxJSON_ASSERT(data);
   if (data != 0 && len > 0) {
@@ -381,7 +381,7 @@ wxJSONValue::wxJSONValue(const void* buff, size_t len) {
  the reference count of the \c wxJSONRefData structure.
 */
 wxJSONValue::wxJSONValue(const wxJSONValue& other) {
-  m_refData = 0;
+  m_refData = nullptr;
   Ref(other);
 
   // the progressive counter of the ctor is not copied from
@@ -404,12 +404,12 @@ wxJSONValue::~wxJSONValue() { UnRef(); }
 //! Return the type of the value stored in the object.
 /*!
  This function is the only one that does not ASSERT that the
- \c m_refData data member is not NULL.
+ \c m_refData data member is not nullptr.
  In fact, if the JSON value object does not contain a pointer
  to a wxJSONRefData structure, the function returns the
  wxJSONTYPE_INVALID constant which represent an invalid JSON value object.
  Also note that the pointer to the referenced data structure
- should NEVER be NULL.
+ should NEVER be nullptr.
 
  \par Integer types
 
@@ -846,7 +846,7 @@ double wxJSONValue::AsDouble() const {
 
  \li for booleans the string returned is: \b true or \b false.
 
- \li if the value is a NULL value the \b null literal string is returned.
+ \li if the value is a nullptr value the \b null literal string is returned.
 
  \li if the value is of type wxJSONTYPE_INVALID, the literal string \b
  &lt;invalid&gt; is returned. Note that this is NOT a valid JSON text.
@@ -931,18 +931,18 @@ wxString wxJSONValue::AsString() const {
  function just returns that pointer.
  If the stored value is a wxString object, the function returns the
  pointer returned by the \b wxString::c_str() function.
- If the stored value is of all other JSON types, the functions returns a NULL
+ If the stored value is of all other JSON types, the functions returns a nullptr
  pointer.
 
  Note that in versions prior to 0.5, the
- function returned a NULL pointer also if the value is a \c wxString object.
+ function returned a nullptr pointer also if the value is a \c wxString object.
 
  \sa \ref json_internals_cstring
  \sa \ref wxjson_tutorial_get
 
 */
 const wxChar* wxJSONValue::AsCString() const {
-  const wxChar* s = 0;
+  const wxChar* s = nullptr;
   wxJSONRefData* data = GetRefData();
   wxJSON_ASSERT(data);
   switch (data->m_type) {
@@ -1255,13 +1255,13 @@ bool wxJSONValue::AsMemoryBuff(wxMemoryBuffer& buff) const {
  This function is for testing and debugging purposes and you shold never use it.
  To retreive values from an array or map JSON object use the \c Item() or
  ItemAt() memberfunctions or the subscript operator. If the stored value is not
- a map type, returns a NULL pointer.
+ a map type, returns a nullptr pointer.
 */
 const wxJSONInternalMap* wxJSONValue::AsMap() const {
   wxJSONRefData* data = GetRefData();
   wxJSON_ASSERT(data);
 
-  const wxJSONInternalMap* v = 0;
+  const wxJSONInternalMap* v = nullptr;
   if (data->m_type == wxJSONTYPE_OBJECT) {
     v = &(data->m_valMap);
   }
@@ -1273,13 +1273,13 @@ const wxJSONInternalMap* wxJSONValue::AsMap() const {
  This function is for testing and debugging purposes and you shold never use it.
  To retreive values from an array or map JSON object use the \c Item() or
  ItemAt() memberfunctions or the subscript operator. If the stored value is not
- an array type, returns a NULL pointer.
+ an array type, returns a nullptr pointer.
 */
 const wxJSONInternalArray* wxJSONValue::AsArray() const {
   wxJSONRefData* data = GetRefData();
   wxJSON_ASSERT(data);
 
-  const wxJSONInternalArray* v = 0;
+  const wxJSONInternalArray* v = nullptr;
   if (data->m_type == wxJSONTYPE_ARRAY) {
     v = &(data->m_valArray);
   }
@@ -1591,7 +1591,7 @@ void wxJSONValue::Clear() {
  index.
  If the element does not exist, the array is enlarged to \c index + 1
  elements and a reference to the last element will be returned.
- New elements will contain NULL values.
+ New elements will contain nullptr values.
  If this object does not contain an array, the old value is
  replaced by an array object which will be enlarged to the needed
  dimension.
@@ -1619,7 +1619,7 @@ wxJSONValue& wxJSONValue::Item(unsigned index) {
 /*!
  The function returns a reference to the object in the map
  that has the specified key.
- If \c key does not exist, a new NULL value is created with
+ If \c key does not exist, a new nullptr value is created with
  the provided key and a reference to it is returned.
  If this object does not contain a map, the old value is
  replaced by a map object.
@@ -1697,7 +1697,7 @@ wxJSONValue wxJSONValue::ItemAt(const wxString& key) const {
  index.
  If the element does not exist, the array is enlarged to \c index + 1
  elements and a reference to the last element will be returned.
- New elements will contain NULL values.
+ New elements will contain nullptr values.
  If this object does not contain an array, the old value is
  replaced by an array object.
 */
@@ -1710,7 +1710,7 @@ wxJSONValue& wxJSONValue::operator[](unsigned index) {
 /*!
  The function returns a reference to the object in the map
  that has the specified key.
- If \c key does not exist, a new NULL value is created with
+ If \c key does not exist, a new nullptr value is created with
  the provided key and a reference to it is returned.
  If this object does not contain a map, the old value is
  replaced by a map object.
@@ -1896,15 +1896,15 @@ wxJSONValue wxJSONValue::Get(const wxString& key,
 //! Find an element
 /*!
  The function returns a pointer to the element at index \c index
- or a NULL pointer if \c index does not exist.
- A NULL pointer is also returned if the object does not contain an
+ or a nullptr pointer if \c index does not exist.
+ A nullptr pointer is also returned if the object does not contain an
  array nor a key/value map.
 */
 wxJSONValue* wxJSONValue::Find(unsigned index) const {
   wxJSONRefData* data = GetRefData();
   wxJSON_ASSERT(data);
 
-  wxJSONValue* vp = 0;
+  wxJSONValue* vp = nullptr;
 
   if (data->m_type == wxJSONTYPE_ARRAY) {
     size_t size = data->m_valArray.GetCount();
@@ -1918,15 +1918,15 @@ wxJSONValue* wxJSONValue::Find(unsigned index) const {
 //! Find an element
 /*!
  The function returns a pointer to the element with key \c key
- or a NULL pointer if \c key does not exist.
- A NULL pointer is also returned if the object does not contain a
+ or a nullptr pointer if \c key does not exist.
+ A nullptr pointer is also returned if the object does not contain a
  key/value map.
 */
 wxJSONValue* wxJSONValue::Find(const wxString& key) const {
   wxJSONRefData* data = GetRefData();
   wxJSON_ASSERT(data);
 
-  wxJSONValue* vp = 0;
+  wxJSONValue* vp = nullptr;
 
   if (data->m_type == wxJSONTYPE_OBJECT) {
     wxJSONInternalMap::iterator it = data->m_valMap.find(key);
@@ -2489,7 +2489,7 @@ void wxJSONValue::ClearComments() {
  The \c type argument can be one of the following:
 
   \li wxJSONTYPE_INVALID: an empty (not initialized) JSON value
-  \li wxJSONTYPE_NULL: a NULL value
+  \li wxJSONTYPE_NULL: a nullptr value
   \li wxJSONTYPE_INT: an integer value
   \li wxJSONTYPE_UINT: an unsigned integer
   \li wxJSONTYPE_DOUBLE: a double precision number
@@ -2658,7 +2658,7 @@ void wxJSONValue::UnRef() {
 
     if (--m_refData->m_refCount == 0) {
       delete m_refData;
-      m_refData = NULL;
+      m_refData = nullptr;
     }
   }
 }
@@ -2966,7 +2966,7 @@ wxMemoryBuffer wxJSONValue::ArrayToMemoryBuff(const wxJSONValue& value) {
 
 //! \overload wxJSONValue()
 wxJSONValue::wxJSONValue(wxInt64 i) {
-  m_refData = 0;
+  m_refData = nullptr;
   wxJSONRefData* data = Init(wxJSONTYPE_INT);
   wxJSON_ASSERT(data);
   if (data != 0) {
@@ -2976,7 +2976,7 @@ wxJSONValue::wxJSONValue(wxInt64 i) {
 
 //! \overload wxJSONValue()
 wxJSONValue::wxJSONValue(wxUint64 ui) {
-  m_refData = 0;
+  m_refData = nullptr;
   wxJSONRefData* data = Init(wxJSONTYPE_UINT);
   wxJSON_ASSERT(data);
   if (data != 0) {

--- a/plugins/grib_pi/src/jsonval.h
+++ b/plugins/grib_pi/src/jsonval.h
@@ -47,7 +47,7 @@ class WXDLLIMPEXP_JSON wxJSONInternalArray;
 //! The type of the value held by the wxJSONRefData class
 enum wxJSONType {
   wxJSONTYPE_INVALID = 0, /*!< the object is not uninitialized        */
-  wxJSONTYPE_NULL,        /*!< the object contains a NULL value         */
+  wxJSONTYPE_NULL,        /*!< the object contains a nullptr value         */
   wxJSONTYPE_INT,         /*!< the object contains an integer           */
   wxJSONTYPE_UINT,        /*!< the object contains an unsigned integer  */
   wxJSONTYPE_DOUBLE,      /*!< the object contains a double             */

--- a/plugins/grib_pi/src/jsonwriter.cpp
+++ b/plugins/grib_pi/src/jsonwriter.cpp
@@ -307,7 +307,7 @@ void wxJSONWriter::SetDoubleFmtString(const char* fmt) { m_fmt = (char*)fmt; }
  This is a recursive function that gets the type of the \c value object and
  calls several protected functions depending on the type:
 
- \li \c WriteNullvalue for type NULL
+ \li \c WriteNullvalue for type nullptr
  \li \c WriteStringValue() for STRING and CSTRING types
  \li \c WriteIntValue for INT types
  \li \c WriteUIntValue for UINT types
@@ -324,7 +324,7 @@ int wxJSONWriter::DoWrite(wxOutputStream& os, const wxJSONValue& value,
   // note that this function is recursive
 
   // some variables that cannot be allocated in the switch statement
-  const wxJSONInternalMap* map = 0;
+  const wxJSONInternalMap* map = nullptr;
   int size;
   m_colNo = 1;
   m_lineNo = 1;
@@ -362,7 +362,7 @@ int wxJSONWriter::DoWrite(wxOutputStream& os, const wxJSONValue& value,
     return lastChar;
   }
 
-  // now write the key if it is not NULL
+  // now write the key if it is not nullptr
   if (key) {
     lastChar = WriteKey(os, *key);
   }
@@ -654,7 +654,7 @@ int wxJSONWriter::WriteStringValue(wxOutputStream& os, const wxString& str) {
 
   // NOTE: in ANSI builds UTF-8 conversion may fail (see samples/test5.cpp,
   // test 7.3) although I do not know why
-  if (writeBuff == 0) {
+  if (writeBuff == nullptr) {
     const char* err =
         "<wxJSONWriter::WriteStringValue(): error converting the string to a "
         "UTF8 buffer>";
@@ -811,7 +811,7 @@ int wxJSONWriter::WriteString(wxOutputStream& os, const wxString& str) {
   wxLogTrace(writerTraceMask, _T("(%s) string to write=%s"),
              __PRETTY_FUNCTION__, str.c_str());
   int lastChar = 0;
-  char* writeBuff = 0;
+  char* writeBuff = nullptr;
 
   // the buffer that has to be written is either UTF-8 or ANSI c_str() depending
   // on the 'm_noUtf8' flag
@@ -830,7 +830,7 @@ int wxJSONWriter::WriteString(wxOutputStream& os, const wxString& str) {
 
   // NOTE: in ANSI builds UTF-8 conversion may fail (see samples/test5.cpp,
   // test 7.3) although I do not know why
-  if (writeBuff == 0) {
+  if (writeBuff == nullptr) {
     const char* err =
         "<wxJSONWriter::WriteComment(): error converting the string to UTF-8>";
     os.Write(err, strlen(err));
@@ -848,7 +848,7 @@ int wxJSONWriter::WriteString(wxOutputStream& os, const wxString& str) {
   return lastChar;
 }
 
-//! Write the NULL JSON value to the output stream.
+//! Write the nullptr JSON value to the output stream.
 /*!
  The function writes the \b null literal string to the output stream.
 */
@@ -1025,7 +1025,7 @@ int wxJSONWriter::WriteKey(wxOutputStream& os, const wxString& key) {
  An invalid wxJSONValue is a value that was not initialized and it is
  an error. You should never write invalid values to JSON text because
  the output is not valid JSON text.
- Note that the NULL value is a legal JSON text and it is written:
+ Note that the nullptr value is a legal JSON text and it is written:
  \code
   null
  \endcode

--- a/plugins/grib_pi/src/pi_ocpndc.cpp
+++ b/plugins/grib_pi/src/pi_ocpndc.cpp
@@ -89,22 +89,22 @@ int NextPow2(int size) {
 }
 
 //----------------------------------------------------------------------------
-/* pass the dc to the constructor, or NULL to use opengl */
+/* pass the dc to the constructor, or nullptr to use opengl */
 pi_ocpnDC::pi_ocpnDC(wxGLCanvas &canvas)
     : glcanvas(&canvas),
-      dc(NULL),
+      dc(nullptr),
       m_pen(wxNullPen),
       m_brush(wxNullBrush),
       m_buseGL(true) {
 #ifdef ocpnUSE_GL
 #if wxUSE_GRAPHICS_CONTEXT
-  pgc = NULL;
+  pgc = nullptr;
 #endif
   m_textforegroundcolour = wxColour(0, 0, 0);
   m_buseTex = false;  // GetLocaleCanonicalName().IsSameAs(_T("en_US"));
-  workBuf = NULL;
+  workBuf = nullptr;
   workBufSize = 0;
-  s_odc_tess_work_buf = NULL;
+  s_odc_tess_work_buf = nullptr;
 
 #ifdef USE_ANDROID_GLES2
   s_odc_tess_vertex_idx = 0;
@@ -120,13 +120,13 @@ pi_ocpnDC::pi_ocpnDC(wxGLCanvas &canvas)
 }
 
 pi_ocpnDC::pi_ocpnDC(wxDC &pdc)
-    : glcanvas(NULL),
+    : glcanvas(nullptr),
       dc(&pdc),
       m_pen(wxNullPen),
       m_brush(wxNullBrush),
       m_buseGL(false) {
 #if wxUSE_GRAPHICS_CONTEXT
-  pgc = NULL;
+  pgc = nullptr;
   auto pmdc = dynamic_cast<wxMemoryDC *>(dc);
   if (pmdc)
     pgc = wxGraphicsContext::Create(*pmdc);
@@ -137,28 +137,28 @@ pi_ocpnDC::pi_ocpnDC(wxDC &pdc)
 #endif
   m_textforegroundcolour = wxColour(0, 0, 0);
   m_buseTex = false;  // GetLocaleCanonicalName().IsSameAs(_T("en_US"));
-  workBuf = NULL;
+  workBuf = nullptr;
   workBufSize = 0;
 #ifdef ocpnUSE_GL
-  s_odc_tess_work_buf = NULL;
+  s_odc_tess_work_buf = nullptr;
 #endif
 }
 
 pi_ocpnDC::pi_ocpnDC()
-    : glcanvas(NULL),
-      dc(NULL),
+    : glcanvas(nullptr),
+      dc(nullptr),
       m_pen(wxNullPen),
       m_brush(wxNullBrush),
       m_buseGL(true) {
 #if wxUSE_GRAPHICS_CONTEXT
-  pgc = NULL;
+  pgc = nullptr;
 #endif
   m_textforegroundcolour = wxColour(0, 0, 0);
   m_buseTex = false;  // GetLocaleCanonicalName().IsSameAs(_T("en_US"));
-  workBuf = NULL;
+  workBuf = nullptr;
   workBufSize = 0;
 #ifdef ocpnUSE_GL
-  s_odc_tess_work_buf = NULL;
+  s_odc_tess_work_buf = nullptr;
   pi_loadShaders();
 #endif
 }
@@ -1641,9 +1641,9 @@ void pi_odc_vertexCallbackD_GLSL(GLvoid *vertex, void *data) {
 
     pDC->s_odc_tess_work_buf = (GLfloat *)realloc(
         pDC->s_odc_tess_work_buf, new_buf_len * sizeof(GLfloat));
-    if (NULL == pDC->s_odc_tess_work_buf) {
+    if (nullptr == pDC->s_odc_tess_work_buf) {
       free(tmp);
-      tmp = NULL;
+      tmp = nullptr;
     } else
       pDC->s_odc_tess_buf_len = new_buf_len;
   }
@@ -1761,7 +1761,7 @@ void pi_ocpnDC::DrawPolygonTessellated(int n, wxPoint points[], wxCoord xoffset,
     //         odc_combine_work_data.clear();
   }
 #else
-    static GLUtesselator *tobj = NULL;
+    static GLUtesselator *tobj = nullptr;
     if (!tobj) tobj = gluNewTess();
 
     gluTessCallback(tobj, GLU_TESS_VERTEX, (_GLUfuncptr)&ocpnDCvertexCallback);
@@ -1775,7 +1775,7 @@ void pi_ocpnDC::DrawPolygonTessellated(int n, wxPoint points[], wxCoord xoffset,
     gluTessProperty(tobj, GLU_TESS_WINDING_RULE, GLU_TESS_WINDING_NONZERO);
 
     if (ConfigureBrush()) {
-      gluTessBeginPolygon(tobj, NULL);
+      gluTessBeginPolygon(tobj, nullptr);
       gluTessBeginContour(tobj);
 
       for (int i = 0; i < n; i++) {
@@ -1938,7 +1938,7 @@ void pi_ocpnDC::DrawText(const wxString &text, wxCoord x, wxCoord y) {
     } else {
       wxScreenDC sdc;
       sdc.SetFont(m_font);
-      sdc.GetMultiLineTextExtent(text, &w, &h, NULL,
+      sdc.GetMultiLineTextExtent(text, &w, &h, nullptr,
                                  &m_font); /*we need to handle multiline*/
       int ww, hw;
       sdc.GetTextExtent("W", &ww, &hw);  // metric
@@ -2018,7 +2018,7 @@ void pi_ocpnDC::DrawText(const wxString &text, wxCoord x, wxCoord y) {
       int TextureWidth = NextPow2(w);
       int TextureHeight = NextPow2(h);
       glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, TextureWidth, TextureHeight, 0,
-                   GL_RGBA, GL_UNSIGNED_BYTE, NULL);
+                   GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
       glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, w, h, GL_RGBA, GL_UNSIGNED_BYTE,
                       data);
 
@@ -2168,7 +2168,7 @@ void pi_ocpnDC::GetTextExtent(const wxString &string, wxCoord *w, wxCoord *h,
 
   /*we need to handle multiline to get true w & h */
   if (dc)
-    dc->GetMultiLineTextExtent(string, w, h, NULL, font);
+    dc->GetMultiLineTextExtent(string, w, h, nullptr, font);
   else {
     wxFont f = m_font;
     if (font) f = *font;
@@ -2179,13 +2179,13 @@ void pi_ocpnDC::GetTextExtent(const wxString &string, wxCoord *w, wxCoord *h,
       m_texfont.GetTextExtent(string, w, h);
 #else
       wxMemoryDC temp_dc;
-      temp_dc.GetMultiLineTextExtent(string, w, h, NULL, &f);
+      temp_dc.GetMultiLineTextExtent(string, w, h, nullptr, &f);
       if (w) (*w) *= OCPN_GetWinDIPScaleFactor();
       if (h) (*h) *= OCPN_GetWinDIPScaleFactor();
 #endif
     } else {
       wxMemoryDC temp_dc;
-      temp_dc.GetMultiLineTextExtent(string, w, h, NULL, &f);
+      temp_dc.GetMultiLineTextExtent(string, w, h, nullptr, &f);
       if (w) (*w) *= OCPN_GetWinDIPScaleFactor();
       if (h) (*h) *= OCPN_GetWinDIPScaleFactor();
     }

--- a/plugins/grib_pi/src/pi_ocpndc.h
+++ b/plugins/grib_pi/src/pi_ocpndc.h
@@ -107,8 +107,8 @@ public:
 
   void DrawText(const wxString &text, wxCoord x, wxCoord y);
   void GetTextExtent(const wxString &string, wxCoord *w, wxCoord *h,
-                     wxCoord *descent = NULL, wxCoord *externalLeading = NULL,
-                     wxFont *font = NULL);
+                     wxCoord *descent = nullptr, wxCoord *externalLeading = nullptr,
+                     wxFont *font = nullptr);
 
   void ResetBoundingBox();
   void CalcBoundingBox(wxCoord x, wxCoord y);

--- a/plugins/grib_pi/src/pi_shaders.cpp
+++ b/plugins/grib_pi/src/pi_shaders.cpp
@@ -225,11 +225,11 @@ bool pi_loadShaders() {
     /* Vertex shader */
     pi_color_tri_vertex_shader = glCreateShader(GL_VERTEX_SHADER);
     glShaderSource(pi_color_tri_vertex_shader, 1,
-                   &color_tri_vertex_shader_source, NULL);
+                   &color_tri_vertex_shader_source, nullptr);
     glCompileShader(pi_color_tri_vertex_shader);
     glGetShaderiv(pi_color_tri_vertex_shader, GL_COMPILE_STATUS, &success);
     if (!success) {
-      glGetShaderInfoLog(pi_color_tri_vertex_shader, INFOLOG_LEN, NULL,
+      glGetShaderInfoLog(pi_color_tri_vertex_shader, INFOLOG_LEN, nullptr,
                          infoLog);
       printf("ERROR::SHADER::VERTEX::COMPILATION_FAILED\n%s\n", infoLog);
       ret_val = false;
@@ -240,11 +240,11 @@ bool pi_loadShaders() {
     /* Fragment shader */
     pi_color_tri_fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
     glShaderSource(pi_color_tri_fragment_shader, 1,
-                   &color_tri_fragment_shader_source, NULL);
+                   &color_tri_fragment_shader_source, nullptr);
     glCompileShader(pi_color_tri_fragment_shader);
     glGetShaderiv(pi_color_tri_fragment_shader, GL_COMPILE_STATUS, &success);
     if (!success) {
-      glGetShaderInfoLog(pi_color_tri_fragment_shader, INFOLOG_LEN, NULL,
+      glGetShaderInfoLog(pi_color_tri_fragment_shader, INFOLOG_LEN, nullptr,
                          infoLog);
       printf("ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n%s\n", infoLog);
       ret_val = false;
@@ -259,7 +259,7 @@ bool pi_loadShaders() {
     glLinkProgram(pi_color_tri_shader_program);
     glGetProgramiv(pi_color_tri_shader_program, GL_LINK_STATUS, &success);
     if (!success) {
-      glGetProgramInfoLog(pi_color_tri_shader_program, INFOLOG_LEN, NULL,
+      glGetProgramInfoLog(pi_color_tri_shader_program, INFOLOG_LEN, nullptr,
                           infoLog);
       printf("ERROR::SHADER::PROGRAM::LINKING_FAILED\n%s\n", infoLog);
       ret_val = false;
@@ -285,11 +285,11 @@ bool pi_loadShaders() {
     /* Vertex shader */
     pi_colorv_tri_vertex_shader = glCreateShader(GL_VERTEX_SHADER);
     glShaderSource(pi_colorv_tri_vertex_shader, 1,
-                   &colorv_tri_vertex_shader_source, NULL);
+                   &colorv_tri_vertex_shader_source, nullptr);
     glCompileShader(pi_colorv_tri_vertex_shader);
     glGetShaderiv(pi_colorv_tri_vertex_shader, GL_COMPILE_STATUS, &success);
     if (!success) {
-      glGetShaderInfoLog(pi_colorv_tri_vertex_shader, INFOLOG_LEN, NULL,
+      glGetShaderInfoLog(pi_colorv_tri_vertex_shader, INFOLOG_LEN, nullptr,
                          infoLog);
       printf("ERROR::SHADER::VERTEX::COMPILATION_FAILED\n%s\n", infoLog);
       ret_val = false;
@@ -300,11 +300,11 @@ bool pi_loadShaders() {
     /* Fragment shader */
     pi_colorv_tri_fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
     glShaderSource(pi_colorv_tri_fragment_shader, 1,
-                   &colorv_tri_fragment_shader_source, NULL);
+                   &colorv_tri_fragment_shader_source, nullptr);
     glCompileShader(pi_colorv_tri_fragment_shader);
     glGetShaderiv(pi_colorv_tri_fragment_shader, GL_COMPILE_STATUS, &success);
     if (!success) {
-      glGetShaderInfoLog(pi_colorv_tri_fragment_shader, INFOLOG_LEN, NULL,
+      glGetShaderInfoLog(pi_colorv_tri_fragment_shader, INFOLOG_LEN, nullptr,
                          infoLog);
       printf("ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n%s\n", infoLog);
       ret_val = false;
@@ -319,7 +319,7 @@ bool pi_loadShaders() {
     glLinkProgram(pi_colorv_tri_shader_program);
     glGetProgramiv(pi_colorv_tri_shader_program, GL_LINK_STATUS, &success);
     if (!success) {
-      glGetProgramInfoLog(pi_colorv_tri_shader_program, INFOLOG_LEN, NULL,
+      glGetProgramInfoLog(pi_colorv_tri_shader_program, INFOLOG_LEN, nullptr,
                           infoLog);
       printf("ERROR::SHADER::PROGRAM::LINKING_FAILED\n%s\n", infoLog);
       ret_val = false;
@@ -345,11 +345,11 @@ bool pi_loadShaders() {
     /* Vertex shader */
     pi_texture_2D_vertex_shader = glCreateShader(GL_VERTEX_SHADER);
     glShaderSource(pi_texture_2D_vertex_shader, 1,
-                   &texture_2D_vertex_shader_source, NULL);
+                   &texture_2D_vertex_shader_source, nullptr);
     glCompileShader(pi_texture_2D_vertex_shader);
     glGetShaderiv(pi_texture_2D_vertex_shader, GL_COMPILE_STATUS, &success);
     if (!success) {
-      glGetShaderInfoLog(pi_texture_2D_vertex_shader, INFOLOG_LEN, NULL,
+      glGetShaderInfoLog(pi_texture_2D_vertex_shader, INFOLOG_LEN, nullptr,
                          infoLog);
       printf("ERROR::SHADER::VERTEX::COMPILATION_FAILED\n%s\n", infoLog);
       ret_val = false;
@@ -360,11 +360,11 @@ bool pi_loadShaders() {
     /* Fragment shader */
     pi_texture_2D_fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
     glShaderSource(pi_texture_2D_fragment_shader, 1,
-                   &texture_2D_fragment_shader_source, NULL);
+                   &texture_2D_fragment_shader_source, nullptr);
     glCompileShader(pi_texture_2D_fragment_shader);
     glGetShaderiv(pi_texture_2D_fragment_shader, GL_COMPILE_STATUS, &success);
     if (!success) {
-      glGetShaderInfoLog(pi_texture_2D_fragment_shader, INFOLOG_LEN, NULL,
+      glGetShaderInfoLog(pi_texture_2D_fragment_shader, INFOLOG_LEN, nullptr,
                          infoLog);
       printf("ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n%s\n", infoLog);
       ret_val = false;
@@ -379,7 +379,7 @@ bool pi_loadShaders() {
     glLinkProgram(pi_texture_2D_shader_program);
     glGetProgramiv(pi_texture_2D_shader_program, GL_LINK_STATUS, &success);
     if (!success) {
-      glGetProgramInfoLog(pi_texture_2D_shader_program, INFOLOG_LEN, NULL,
+      glGetProgramInfoLog(pi_texture_2D_shader_program, INFOLOG_LEN, nullptr,
                           infoLog);
       printf("ERROR::SHADER::PROGRAM::LINKING_FAILED\n%s\n", infoLog);
       ret_val = false;
@@ -393,11 +393,11 @@ bool pi_loadShaders() {
     if(!fade_texture_2D_vertex_shader){
         /* Vertex shader */
         fade_texture_2D_vertex_shader = glCreateShader(GL_VERTEX_SHADER);
-        glShaderSource(fade_texture_2D_vertex_shader, 1, &fade_texture_2D_vertex_shader_source, NULL);
+        glShaderSource(fade_texture_2D_vertex_shader, 1, &fade_texture_2D_vertex_shader_source, nullptr);
         glCompileShader(fade_texture_2D_vertex_shader);
         glGetShaderiv(fade_texture_2D_vertex_shader, GL_COMPILE_STATUS, &success);
         if (!success) {
-            glGetShaderInfoLog(fade_texture_2D_vertex_shader, INFOLOG_LEN, NULL, infoLog);
+            glGetShaderInfoLog(fade_texture_2D_vertex_shader, INFOLOG_LEN, nullptr, infoLog);
             printf("ERROR::SHADER::VERTEX::COMPILATION_FAILED\n%s\n", infoLog);
             ret_val = false;
         }
@@ -406,11 +406,11 @@ bool pi_loadShaders() {
     if(!fade_texture_2D_fragment_shader){
         /* Fragment shader */
         fade_texture_2D_fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
-        glShaderSource(fade_texture_2D_fragment_shader, 1, &fade_texture_2D_fragment_shader_source, NULL);
+        glShaderSource(fade_texture_2D_fragment_shader, 1, &fade_texture_2D_fragment_shader_source, nullptr);
         glCompileShader(fade_texture_2D_fragment_shader);
         glGetShaderiv(fade_texture_2D_fragment_shader, GL_COMPILE_STATUS, &success);
         if (!success) {
-            glGetShaderInfoLog(fade_texture_2D_fragment_shader, INFOLOG_LEN, NULL, infoLog);
+            glGetShaderInfoLog(fade_texture_2D_fragment_shader, INFOLOG_LEN, nullptr, infoLog);
             printf("ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n%s\n", infoLog);
             ret_val = false;
         }
@@ -424,7 +424,7 @@ bool pi_loadShaders() {
         glLinkProgram(fade_texture_2D_shader_program);
         glGetProgramiv(fade_texture_2D_shader_program, GL_LINK_STATUS, &success);
         if (!success) {
-            glGetProgramInfoLog(fade_texture_2D_shader_program, INFOLOG_LEN, NULL, infoLog);
+            glGetProgramInfoLog(fade_texture_2D_shader_program, INFOLOG_LEN, nullptr, infoLog);
             printf("ERROR::SHADER::PROGRAM::LINKING_FAILED\n%s\n", infoLog);
             ret_val = false;
         }
@@ -450,11 +450,11 @@ bool pi_loadShaders() {
     /* Vertex shader */
     pi_circle_filled_vertex_shader = glCreateShader(GL_VERTEX_SHADER);
     glShaderSource(pi_circle_filled_vertex_shader, 1,
-                   &circle_filled_vertex_shader_source, NULL);
+                   &circle_filled_vertex_shader_source, nullptr);
     glCompileShader(pi_circle_filled_vertex_shader);
     glGetShaderiv(pi_circle_filled_vertex_shader, GL_COMPILE_STATUS, &success);
     if (!success) {
-      glGetShaderInfoLog(pi_circle_filled_vertex_shader, INFOLOG_LEN, NULL,
+      glGetShaderInfoLog(pi_circle_filled_vertex_shader, INFOLOG_LEN, nullptr,
                          infoLog);
       printf("ERROR::SHADER::VERTEX::COMPILATION_FAILED\n%s\n", infoLog);
       //qDebug() << infoLog;
@@ -466,12 +466,12 @@ bool pi_loadShaders() {
     /* Fragment shader */
     pi_circle_filled_fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
     glShaderSource(pi_circle_filled_fragment_shader, 1,
-                   &circle_filled_fragment_shader_source, NULL);
+                   &circle_filled_fragment_shader_source, nullptr);
     glCompileShader(pi_circle_filled_fragment_shader);
     glGetShaderiv(pi_circle_filled_fragment_shader, GL_COMPILE_STATUS,
                   &success);
     if (!success) {
-      glGetShaderInfoLog(pi_circle_filled_fragment_shader, INFOLOG_LEN, NULL,
+      glGetShaderInfoLog(pi_circle_filled_fragment_shader, INFOLOG_LEN, nullptr,
                          infoLog);
       printf("ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n%s\n", infoLog);
       //qDebug() << infoLog;
@@ -489,7 +489,7 @@ bool pi_loadShaders() {
     glLinkProgram(pi_circle_filled_shader_program);
     glGetProgramiv(pi_circle_filled_shader_program, GL_LINK_STATUS, &success);
     if (!success) {
-      glGetProgramInfoLog(pi_circle_filled_shader_program, INFOLOG_LEN, NULL,
+      glGetProgramInfoLog(pi_circle_filled_shader_program, INFOLOG_LEN, nullptr,
                           infoLog);
       printf("ERROR::SHADER::PROGRAM::LINKING_FAILED\n%s\n", infoLog);
       //qDebug() << infoLog;
@@ -504,11 +504,11 @@ bool pi_loadShaders() {
     if(!FBO_texture_2D_vertex_shader){
         /* Vertex shader */
         FBO_texture_2D_vertex_shader = glCreateShader(GL_VERTEX_SHADER);
-        glShaderSource(FBO_texture_2D_vertex_shader, 1, &FBO_texture_2D_vertex_shader_source, NULL);
+        glShaderSource(FBO_texture_2D_vertex_shader, 1, &FBO_texture_2D_vertex_shader_source, nullptr);
         glCompileShader(FBO_texture_2D_vertex_shader);
         glGetShaderiv(FBO_texture_2D_vertex_shader, GL_COMPILE_STATUS, &success);
         if (!success) {
-            glGetShaderInfoLog(FBO_texture_2D_vertex_shader, INFOLOG_LEN, NULL, infoLog);
+            glGetShaderInfoLog(FBO_texture_2D_vertex_shader, INFOLOG_LEN, nullptr, infoLog);
             printf("ERROR::SHADER::VERTEX::COMPILATION_FAILED\n%s\n", infoLog);
             ret_val = false;
         }
@@ -517,11 +517,11 @@ bool pi_loadShaders() {
     if(!FBO_texture_2D_fragment_shader){
         /* Fragment shader */
         FBO_texture_2D_fragment_shader = glCreateShader(GL_FRAGMENT_SHADER);
-        glShaderSource(FBO_texture_2D_fragment_shader, 1, &FBO_texture_2D_fragment_shader_source, NULL);
+        glShaderSource(FBO_texture_2D_fragment_shader, 1, &FBO_texture_2D_fragment_shader_source, nullptr);
         glCompileShader(FBO_texture_2D_fragment_shader);
         glGetShaderiv(FBO_texture_2D_fragment_shader, GL_COMPILE_STATUS, &success);
         if (!success) {
-            glGetShaderInfoLog(FBO_texture_2D_fragment_shader, INFOLOG_LEN, NULL, infoLog);
+            glGetShaderInfoLog(FBO_texture_2D_fragment_shader, INFOLOG_LEN, nullptr, infoLog);
             printf("ERROR::SHADER::FRAGMENT::COMPILATION_FAILED\n%s\n", infoLog);
             ret_val = false;
         }
@@ -535,7 +535,7 @@ bool pi_loadShaders() {
         glLinkProgram(FBO_texture_2D_shader_program);
         glGetProgramiv(FBO_texture_2D_shader_program, GL_LINK_STATUS, &success);
         if (!success) {
-            glGetProgramInfoLog(FBO_texture_2D_shader_program, INFOLOG_LEN, NULL, infoLog);
+            glGetProgramInfoLog(FBO_texture_2D_shader_program, INFOLOG_LEN, nullptr, infoLog);
             printf("ERROR::SHADER::PROGRAM::LINKING_FAILED\n%s\n", infoLog);
             ret_val = false;
         }

--- a/plugins/grib_pi/src/pi_shaders.h
+++ b/plugins/grib_pi/src/pi_shaders.h
@@ -64,7 +64,7 @@ public:
       glCompileShader(shaderId);
       glGetShaderiv(shaderId, GL_COMPILE_STATUS, &success);
       if (!success) {
-        glGetShaderInfoLog(shaderId, INFOLOG_LEN, NULL, infoLog);
+        glGetShaderInfoLog(shaderId, INFOLOG_LEN, nullptr, infoLog);
         printf("ERROR::SHADER::COMPILATION_FAILED\n%s\n", infoLog);
         // ret_val = false;
       }
@@ -86,7 +86,7 @@ public:
       glGetProgramiv(programId_, GL_LINK_STATUS,
                      &linkSuccess);  // requesting the status
       if (linkSuccess == GL_FALSE) {
-        glGetProgramInfoLog(programId_, INFOLOG_LEN, NULL, infoLog);
+        glGetProgramInfoLog(programId_, INFOLOG_LEN, nullptr, infoLog);
         printf("ERROR::SHADER::LINK_FAILED\n%s\n", infoLog);
       }
 

--- a/plugins/grib_pi/src/smapi.cpp
+++ b/plugins/grib_pi/src/smapi.cpp
@@ -42,12 +42,12 @@ public:
   wxMapiData() {
     m_hSession = 0;
     m_nLastError = 0;
-    m_hMapi = NULL;
-    m_lpfnMAPILogon = NULL;
-    m_lpfnMAPILogoff = NULL;
-    m_lpfnMAPISendMail = NULL;
-    m_lpfnMAPIResolveName = NULL;
-    m_lpfnMAPIFreeBuffer = NULL;
+    m_hMapi = nullptr;
+    m_lpfnMAPILogon = nullptr;
+    m_lpfnMAPILogoff = nullptr;
+    m_lpfnMAPISendMail = nullptr;
+    m_lpfnMAPIResolveName = nullptr;
+    m_lpfnMAPIFreeBuffer = nullptr;
   }
 
   // Data
@@ -84,7 +84,7 @@ void wxMapiSession::Initialise() {
   // as the MAPI32 dll being present on the system
   bool bMapiInstalled =
       (GetProfileInt(_T("MAIL"), _T("MAPI"), 0) != 0) &&
-      (SearchPath(NULL, _T("MAPI32.DLL"), NULL, 0, NULL, NULL) != 0);
+      (SearchPath(nullptr, _T("MAPI32.DLL"), nullptr, 0, nullptr, nullptr) != 0);
 
   if (bMapiInstalled) {
     // Load up the MAPI dll and get the function pointers we are interested in
@@ -102,10 +102,10 @@ void wxMapiSession::Initialise() {
           (LPMAPIFREEBUFFER)GetProcAddress(m_data->m_hMapi, "MAPIFreeBuffer");
 
       // If any of the functions are not installed then fail the load
-      if (m_data->m_lpfnMAPILogon == NULL || m_data->m_lpfnMAPILogoff == NULL ||
-          m_data->m_lpfnMAPISendMail == NULL ||
-          m_data->m_lpfnMAPIResolveName == NULL ||
-          m_data->m_lpfnMAPIFreeBuffer == NULL) {
+      if (m_data->m_lpfnMAPILogon == nullptr || m_data->m_lpfnMAPILogoff == nullptr ||
+          m_data->m_lpfnMAPISendMail == nullptr ||
+          m_data->m_lpfnMAPIResolveName == nullptr ||
+          m_data->m_lpfnMAPIFreeBuffer == nullptr) {
         wxLogMessage(
             _T("MAIL Error: Failed to get one of the functions pointer in ")
             _T("MAPI32.DLL\n"));
@@ -121,14 +121,14 @@ void wxMapiSession::Initialise() {
 
 void wxMapiSession::Deinitialise() {
   if (m_data->m_hMapi) {
-    // Unload the MAPI dll and reset the function pointers to NULL
+    // Unload the MAPI dll and reset the function pointers to nullptr
     FreeLibrary(m_data->m_hMapi);
-    m_data->m_hMapi = NULL;
-    m_data->m_lpfnMAPILogon = NULL;
-    m_data->m_lpfnMAPILogoff = NULL;
-    m_data->m_lpfnMAPISendMail = NULL;
-    m_data->m_lpfnMAPIResolveName = NULL;
-    m_data->m_lpfnMAPIFreeBuffer = NULL;
+    m_data->m_hMapi = nullptr;
+    m_data->m_lpfnMAPILogon = nullptr;
+    m_data->m_lpfnMAPILogoff = nullptr;
+    m_data->m_lpfnMAPISendMail = nullptr;
+    m_data->m_lpfnMAPIResolveName = nullptr;
+    m_data->m_lpfnMAPIFreeBuffer = nullptr;
   }
 }
 
@@ -146,8 +146,8 @@ bool wxMapiSession::Logon(const wxString& sProfileName,
   // Setup the ascii versions of the profile name and password
   int nProfileLength = sProfileName.Length();
 
-  LPSTR pszProfileName = NULL;
-  LPSTR pszPassword = NULL;
+  LPSTR pszProfileName = nullptr;
+  LPSTR pszPassword = nullptr;
   wxCharBuffer cbProfile(1), cbPassword(1);
   if (nProfileLength) {
 #ifndef UNICODE
@@ -188,7 +188,7 @@ bool wxMapiSession::Logon(const wxString& sProfileName,
     // Failed to create a create mapi session, try to acquire a shared mapi
     // session wxLogDebug(_T("Failed to logon to MAPI using a new session,
     // trying to acquire a shared one\n"));
-    nError = m_data->m_lpfnMAPILogon(nUIParam, NULL, NULL, 0, 0,
+    nError = m_data->m_lpfnMAPILogon(nUIParam, nullptr, nullptr, 0, 0,
                                      &m_data->m_hSession);
     if (nError == SUCCESS_SUCCESS) {
       m_data->m_nLastError = SUCCESS_SUCCESS;
@@ -210,7 +210,7 @@ bool wxMapiSession::Logon(const wxString& sProfileName,
 
 bool wxMapiSession::LoggedOn() const { return (m_data->m_hSession != 0); }
 
-bool wxMapiSession::MapiInstalled() const { return (m_data->m_hMapi != NULL); }
+bool wxMapiSession::MapiInstalled() const { return (m_data->m_hMapi != nullptr); }
 
 bool wxMapiSession::Logoff() {
   wxASSERT(MapiInstalled());           // MAPI must be installed
@@ -420,7 +420,7 @@ bool wxMapiSession::Send(wxMailMessage& message) {
              file.lpszPathName = sFilename.mb_str().release();
  #endif
              //file.lpszFileName = file.lpszPathName;
-             file.lpszFileName = NULL;
+             file.lpszFileName = nullptr;
 
              if (nTitleSize && !message.m_attachmentTitles[i].IsEmpty())
              {

--- a/plugins/grib_pi/src/smapi.h
+++ b/plugins/grib_pi/src/smapi.h
@@ -26,7 +26,7 @@ public:
   // Logon / Logoff Methods
   bool Logon(const wxString& sProfileName,
              const wxString& sPassword = wxEmptyString,
-             wxWindow* pParentWnd = NULL);
+             wxWindow* pParentWnd = nullptr);
   bool LoggedOn() const;
   bool Logoff();
 

--- a/plugins/grib_pi/src/zuFile.cpp
+++ b/plugins/grib_pi/src/zuFile.cpp
@@ -22,7 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 int zu_can_read_file(const char *fname) {
   ZUFILE *f;
   f = zu_open(fname, "rb");
-  if (f == NULL) {
+  if (f == nullptr) {
     return 0;
   } else {
     zu_close(f);
@@ -35,11 +35,11 @@ ZUFILE *zu_open(const char *fname, const char *mode, int type) {
   ZUFILE *f;
   char buf[16];
   if (!fname || strlen(fname) == 0) {
-    return NULL;
+    return nullptr;
   }
   f = (ZUFILE *)malloc(sizeof(ZUFILE));
   if (!f) {
-    return NULL;
+    return nullptr;
   }
 
   f->ok = 1;
@@ -49,7 +49,7 @@ ZUFILE *zu_open(const char *fname, const char *mode, int type) {
   if (type == ZU_COMPRESS_AUTO) {
     char *p = strrchr(f->fname, '.');
     int i = 0;
-    while (p != NULL && *p != '\0' && i < 4) {
+    while (p != nullptr && *p != '\0' && i < 4) {
       buf[i] = tolower(*p);
       i++;
       p++;
@@ -80,24 +80,24 @@ ZUFILE *zu_open(const char *fname, const char *mode, int type) {
       f->faux = fopen(f->fname, mode);
       if (f->faux) {
         int bzerror = BZ_OK;
-        f->zfile = (void *)BZ2_bzReadOpen(&bzerror, f->faux, 0, 0, NULL, 0);
+        f->zfile = (void *)BZ2_bzReadOpen(&bzerror, f->faux, 0, 0, nullptr, 0);
         if (bzerror != BZ_OK) {
           BZ2_bzReadClose(&bzerror, (BZFILE *)(f->zfile));
           fclose(f->faux);
-          f->zfile = NULL;
+          f->zfile = nullptr;
         }
       } else {
-        f->zfile = NULL;
+        f->zfile = nullptr;
       }
       break;
     default:
-      f->zfile = NULL;
+      f->zfile = nullptr;
   }
 
-  if (f->zfile == NULL) {
+  if (f->zfile == nullptr) {
     free(f->fname);
     free(f);
-    f = NULL;
+    f = nullptr;
   }
 
   return f;
@@ -197,11 +197,11 @@ int zu_seek(ZUFILE *f, long offset, int whence) {
         bzerror = BZ_OK;
         rewind(f->faux);
         f->pos = 0;
-        f->zfile = (void *)BZ2_bzReadOpen(&bzerror, f->faux, 0, 0, NULL, 0);
+        f->zfile = (void *)BZ2_bzReadOpen(&bzerror, f->faux, 0, 0, nullptr, 0);
         if (bzerror != BZ_OK) {
           BZ2_bzReadClose(&bzerror, (BZFILE *)(f->zfile));
           fclose(f->faux);
-          f->zfile = NULL;
+          f->zfile = nullptr;
           f->ok = 0;
         }
         res = zu_bzSeekForward(f, offset);


### PR DESCRIPTION
Modernize code to use `nullptr` instead of `NULL` and `0`.

1. Replace all instances of `NULL` and `0` with `nullptr`, except in bzlib2 dependent library.
2. Use `nullptr` to initialize pointers. Previously some statements were using the int value `0` to initialize the pointers.

```diff
-  if (writeBuff == 0) {
+  if (writeBuff == nullptr) {
```

**Context:**
I started investigating a memory leak in the grib plugin, for which I will submit a PR later. Meanwhile, I thought it would be helpful to document the code, do some cleanup and modernize the code with modern C++ constructs.