### PR TITLE
Fix UTF-8 character

### DIFF
--- a/plugins/grib_pi/src/pi_TexFont.cpp
+++ b/plugins/grib_pi/src/pi_TexFont.cpp
@@ -62,7 +62,7 @@ void TexFont::Build(wxFont &font, bool blur) {
     wxCoord gw, gh;
     wxString text;
     if (i == DEGREE_GLYPH)
-      text = wxString::Format(_T("%c"), 0x00B0);  //_T("�");
+      text = wxString::Format(_T("%c"), 0x00B0);  //_T("°");
     else
       text = wxString::Format(_T("%c"), i);
     wxCoord descent, exlead;
@@ -122,7 +122,7 @@ void TexFont::Build(wxFont &font, bool blur) {
 
     wxString text;
     if (i == DEGREE_GLYPH)
-      text = wxString::Format(_T("%c"), 0x00B0);  //_T("�");
+      text = wxString::Format(_T("%c"), 0x00B0);  //_T("°");
     else
       text = wxString::Format(_T("%c"), i);
 


### PR DESCRIPTION
Fix regression that was introduced in #4278. The degree character `°` was somehow changed to `�` while saving the file or running clang-format.