### PR TITLE
Add code comments for font manager, locale, and font APIs for plugins.

### DIFF
--- a/gui/include/gui/FontMgr.h
+++ b/gui/include/gui/FontMgr.h
@@ -1,8 +1,4 @@
 /***************************************************************************
- *
- * Project:  OpenCPN
- *
- ***************************************************************************
  *   Copyright (C) 2013 by David S. Register                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -43,26 +39,195 @@ public:
   static FontMgr &Get();
 
   void SetLocale(wxString &newLocale);
-  wxFont *GetFont(const wxString &TextElement, int default_size = 0);
+  /**
+   * Gets a font object for a UI element.
+   *
+   * Each UI element (like "AISTargetAlert", "StatusBar") has a font
+   * configuration. Returns existing font if found, otherwise creates a new one
+   * using system defaults or user preferences.
+   *
+   * Supported TextElements: AISTargetAlert, AISTargetQuery, StatusBar, AIS
+   * Target Name, ObjectQuery, RouteLegInfoRollover, ExtendedTideIcon,
+   * CurrentValue, Console Legend, Console Value, AISRollover,
+   * TideCurrentGraphRollover, Marks, ChartTexts, ToolTips, Dialog, Menu,
+   * GridText
+   *
+   * @param TextElement UI element identifier (e.g., "AISTargetAlert",
+   * "StatusBar")
+   * @param requested_font_size Requested font size in points, 0 to use
+   * system/user default
+   * @return Pointer to the font to use
+   */
+  wxFont *GetFont(const wxString &TextElement, int requested_font_size = 0);
+  /**
+   * Gets the text color for a UI element.
+   *
+   * Looks up stored color for the element. Returns black if not found.
+   *
+   * @param TextElement UI element identifier
+   * @return Text color to use, defaults to black if not found
+   * @see [GetFont]
+   */
   wxColour GetFontColor(const wxString &TextElement) const;
+  /**
+   * Gets the default text color for a UI element.
+   *
+   * Returns predefined defaults for certain elements like Console Legend
+   * (green), Marks (black). Falls back to system window text color if no
+   * special default. On macOS, always returns black to support light/dark mode.
+   *
+   * @param TextElement UI element identifier
+   * @return Default text color for this element
+   * @see [GetFont]
+   */
   wxColour GetDefaultFontColor(const wxString &TextElement);
+  /**
+   * Sets the text color for a UI element.
+   *
+   * Updates stored color for the element in the current locale.
+   *
+   * @param TextElement UI element identifier
+   * @param color New text color to set
+   * @return True if element was found and color was set, false if not found
+   * @see [GetFont]
+   */
   bool SetFontColor(const wxString &TextElement, const wxColour color) const;
 
+  /**
+   * Gets the total number of font configurations currently loaded.
+   * Each configuration defines the font and color for a specific UI element
+   * like "AISTargetAlert" in a specific locale.
+   * @return Number of font configurations
+   * @see [m_fontlist]
+   */
   int GetNumFonts(void) const;
+  /**
+   * Gets the locale-specific configuration key for a font at index i.
+   *
+   * Used to store and retrieve font configurations by combining the current
+   * locale with a hash of the font's text element name (e.g. "AISTargetAlert",
+   * "StatusBar").
+   *
+   * For example, given a text element "Dialog" in French locale "fr_FR", the
+   * returned key might be "fr_FR-a7b9c123" where a7b9c123 is the hash of
+   * "Dialog".
+   *
+   * @param i Font index between 0 and GetNumFonts()-1
+   * @return Configuration string in format "locale-hash" used for storage
+   * @see GetFontConfigKey() for the hash generation
+   * @see s_locale for current locale tracking
+   */
   const wxString &GetConfigString(int i) const;
+  /**
+   * Gets the UI element identifier string for the font at index i.
+   *
+   * Returns the human-readable identifier like "AISTargetAlert" or "StatusBar"
+   * used to reference this font in the UI.
+   *
+   * @param i Font index between 0 and GetNumFonts()-1
+   * @return UI element name for this font configuration
+   */
   const wxString &GetDialogString(int i) const;
+  /**
+   * Gets the native font descriptor string for the font at index i.
+   *
+   * Returns platform-specific complete font specification string that can be
+   * used to recreate the exact font. Contains size, family, style, weight and
+   * other attributes. Format varies by platform.
+   *
+   * @param i Font index between 0 and GetNumFonts()-1
+   * @return Native font description string
+   */
   const wxString &GetNativeDesc(int i) const;
+  /**
+   * Gets description of font at index i.
+   * @param i Font index between 0 and GetNumFonts()-1
+   * @return String in format "elementname:nativedesc:color"
+   */
   wxString GetFullConfigDesc(int i) const;
+  /**
+   * Creates configuration key from UI element name by combining locale with
+   * hash.
+   *
+   * @param description UI element name to hash (e.g. "AISTargetAlert")
+   * @return String in format "locale-hash" for storage.
+   */
   static wxString GetFontConfigKey(const wxString &description);
 
+  /**
+   * Gets array of plugin-defined font configuration keys.
+   *
+   * Plugins can add their own UI elements requiring font configuration beyond
+   * the standard elements defined in FontCandidates[] (like "AISTargetAlert",
+   * "StatusBar"). These plugin-specific keys allow plugins to participate in
+   * OpenCPN's font management system.
+   *
+   * @return Reference to array containing plugin-defined font element
+   * identifiers
+   */
   wxArrayString &GetAuxKeyArray() { return m_AuxKeyArray; }
+  /**
+   * Adds new plugin-defined font configuration key.
+   *
+   * Allows plugins to register their UI elements for font configuration.
+   * Each element must have a unique identifier.
+   *
+   * @param key New plugin UI element identifier to add
+   * @return True if key was added, false if already exists
+   */
   bool AddAuxKey(wxString key);
 
+  /**
+   * Loads font settings from a string descriptor.
+   *
+   * @param[in] pConfigString Lookup key in "locale-hash" format to find font
+   * config
+   * @param[in] pNativeDesc Font settings to load, format:
+   * "TextElement:NativeFontString:rgb(r,g,b)" where:
+   *                        - TextElement: UI element identifier (e.g.
+   * "AISTargetAlert")
+   *                        - NativeFontString: Platform-specific font
+   * description
+   *                        - rgb(r,g,b): Text color in CSS RGB
+   *
+   * Updates the font configuration in m_fontlist matching pConfigString with
+   * the settings from pNativeDesc. Creates new entry if not found.
+   */
   void LoadFontNative(wxString *pConfigString, wxString *pNativeDesc);
+  /**
+   * Updates font and color for a UI element.
+   *
+   * @param TextElement UI element identifier (e.g. "AISTargetAlert")
+   * @param pFont New font to use
+   * @param color New text color
+   * @return True if element found and updated, false if not found
+   */
   bool SetFont(const wxString &TextElement, wxFont *pFont, wxColour color);
   void ScrubList();
+  /**
+   * Finds font descriptor by its configuration key.
+   *
+   * @param pConfigString Key in "locale-hash" format
+   * @return Matching font descriptor or NULL if not found
+   */
   MyFontDesc *FindFontByConfigString(wxString pConfigString);
 
+  /**
+   * Creates or finds a matching font in the font cache.
+   *
+   * If a font with the specified characteristics exists in the cache, returns
+   * that font. Otherwise, creates a new font, adds it to the cache and returns
+   * it.
+   *
+   * @param point_size Font size in points.
+   * @param family Font family like wxFONTFAMILY_SWISS.
+   * @param style Font style like wxFONTSTYLE_NORMAL.
+   * @param weight Font weight like wxFONTWEIGHT_NORMAL.
+   * @param underline True to underline the font.
+   * @param facename Name of the font face, empty for default.
+   * @param encoding Font encoding, wxFONTENCODING_DEFAULT for default.
+   * @return Pointer to the cached wxFont object.
+   */
   wxFont *FindOrCreateFont(int point_size, wxFontFamily family,
                            wxFontStyle style, wxFontWeight weight,
                            bool underline = false,
@@ -90,9 +255,30 @@ private:
 
   static FontMgr *instance;
 
+  /**
+   * Cache mapping font specifications to wxFont objects.
+   *
+   * Cache keyed by combined font properties (size, family, style etc).
+   * Reuses identical wxFont instances to reduce memory usage.
+   * Internal cache for FindOrCreateFont(), does not handle text element
+   * mapping.
+   */
   OCPNwxFontList *m_wxFontCache;
+  /**
+   * High-level list mapping text elements to font configurations.
+   *
+   * Maps text element IDs (e.g. "AISTargetAlert") to complete font settings:
+   * - Font (via font description string)
+   * - Text color
+   * - Locale binding
+   * Used by GetFont() to provide configured fonts for UI elements.
+   */
   FontList *m_fontlist;
+  /** Default wxFont used when no specific font is found. System default in
+   * normal weight */
   wxFont *pDefFont;
+  /** Array of plugin-registered UI element identifiers that supplement standard
+   * elements */
   wxArrayString m_AuxKeyArray;
 };
 

--- a/gui/include/gui/concanv.h
+++ b/gui/include/gui/concanv.h
@@ -102,14 +102,45 @@ private:
 };
 
 /**
- * Main console display canvas. Primary class for the navigation console
- * in OpenCPN. Manages and displays various navigation data points and controls.
+ * Primary navigation console display for route and vessel tracking.
+ *
+ * Manages a dynamic interface that presents real-time navigation metrics
+ * during active route tracking. Provides detailed route information and
+ * interaction capabilities for maritime navigation.
+ *
+ * Key Responsibilities:
+ * - Display current leg and total route navigation data
+ * - Render route-related information like XTE, bearing, range, TTG
+ * - Support user interactions for route display modes
+ * - Manage color scheme and font rendering
+ *
+ * Navigation Display Modes:
+ * - Single Leg Mode: Focuses on current route segment
+ * - Total Route Mode: Displays cumulative route statistics
+ * - Speed Calculation: Supports VMG and SOG calculations
+ *
+ * Interaction Features:
+ * - Context menu for route and display configuration
+ * - Toggleable route total/leg display
+ * - Dynamic font and color scheme adaptation
  */
 class ConsoleCanvas : public wxFrame {
 public:
   ConsoleCanvas(wxWindow *frame);
   ~ConsoleCanvas();
+  /**
+   * Updates route-related data displays.
+   *
+   * Calculates and refreshes navigation metrics based on current
+   * route state, vessel position, and selected display mode.
+   */
   void UpdateRouteData();
+  /**
+   * Recomputes and applies new fonts to console elements.
+   *
+   * Ensures consistent font rendering across different platforms
+   * and display configurations. Triggers layout recalculation.
+   */
   void ShowWithFreshFonts(void);
   void UpdateFonts(void);
   void SetColorScheme(ColorScheme cs);
@@ -117,6 +148,14 @@ public:
   void OnContextMenu(wxContextMenuEvent &event);
   void OnContextMenuSelection(wxCommandEvent &event);
   void RefreshConsoleData(void);
+  /**
+   * Toggles between route total and current leg display modes.
+   *
+   * Switches speed calculation method and route information
+   * presentation between:
+   * - Current leg metrics
+   * - Total route statistics
+   */
   void ToggleRouteTotalDisplay();
 
   wxWindow *m_pParent;

--- a/gui/include/gui/gui_lib.h
+++ b/gui/include/gui/gui_lib.h
@@ -39,7 +39,34 @@ public:
   CopyableText(wxWindow* parent, const char* text);
 };
 
+/**
+ * Retrieves a font from FontMgr, optionally scaled for physical readability.
+ *
+ * Returns a font configured for a specific UI context, scaling based on
+ * system settings and preserving readability across different displays.
+ *
+ * @param item UI element identifier (e.g., "AISTargetAlert", "StatusBar")
+ * @param default_size Optional base font size in points. 0 uses platform default.
+ *
+ * @return Pointer to a dynamically scaled wxFont
+ *
+ * @note Font is managed by OpenCPN's central font cache
+ * @note Pointer is shared and should not be deleted by caller
+ */
 wxFont* GetOCPNScaledFont(wxString item, int default_size = 0);
+/**
+ * Retrieves a font optimized for touch and high-resolution interfaces.
+ *
+ * Generates a font specifically tuned for responsive and touch-friendly
+ * interfaces, with more aggressive scaling than standard font methods.
+ *
+ * @param item UI element identifier (e.g., "AISTargetAlert", "StatusBar")
+ *
+ * @return A wxFont object scaled for touch and high-resolution interfaces
+ *
+ * @note Ensures minimum physical font size for improved readability
+ * @note Particularly suitable for toolbars, buttons, and touch controls
+ */
 wxFont GetOCPNGUIScaledFont(wxString item);
 
 extern int OCPNMessageBox(wxWindow* parent, const wxString& message,

--- a/gui/src/FontMgr.cpp
+++ b/gui/src/FontMgr.cpp
@@ -58,6 +58,14 @@ private:
 
 extern wxString g_locale;
 
+/**
+ * Static copy of effective UI locale.
+ *
+ * Used by FontMgr to support locale-specific font configurations. Allows for
+ * different fonts per language.
+ * Updated whenever UI locale changes via platform ChangeLocale().
+ * @see g_locale for main locale setting
+ */
 wxString s_locale;
 int g_default_font_size;
 wxString g_default_font_facename;
@@ -158,7 +166,7 @@ wxString FontMgr::GetFontConfigKey(const wxString &description) {
   return configkey;
 }
 
-wxFont *FontMgr::GetFont(const wxString &TextElement, int user_default_size) {
+wxFont *FontMgr::GetFont(const wxString &TextElement, int requested_font_size) {
   //    Look thru the font list for a match
   MyFontDesc *pmfd;
   auto node = m_fontlist->GetFirst();
@@ -183,13 +191,13 @@ wxFont *FontMgr::GetFont(const wxString &TextElement, int user_default_size) {
   wxString FaceName = sys_font.GetFaceName();
 
   int new_size;
-  if (0 == user_default_size) {
+  if (0 == requested_font_size) {
     if (g_default_font_size)
       new_size = g_default_font_size;
     else
       new_size = sys_font_size;
   } else
-    new_size = user_default_size;
+    new_size = requested_font_size;
 
   if (g_default_font_facename.Length()) FaceName = g_default_font_facename;
 

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -563,6 +563,14 @@ about *g_pAboutDlgLegacy;
 wxLocale *plocale_def_lang = 0;
 #endif
 
+/**
+ * Global locale setting for OpenCPN UI.
+ *
+ * If not set in config (empty string), uses system default locale.
+ * Stores the language/locale name in format "en_US", "fr_FR", etc.
+ * A valid setting triggers loading the corresponding .mo translation files
+ * from the appropriate locale directory.
+ */
 wxString g_locale;
 wxString g_localeOverride;
 bool g_b_assume_azerty;
@@ -621,7 +629,20 @@ wxString g_config_version_string;
 
 wxString g_CmdSoundString;
 
+/**
+ * Flag to control adaptive UI scaling.
+ *
+ * When true, OpenCPN will automatically maximize the application window
+ * if the pixel density suggests a touch-friendly device.
+ *
+ * This helps ensure better usability on mobile and tablet devices by
+ * providing a full-screen interface optimized for touch interaction.
+ *
+ * @note For the most part, the use of this feature is conditionally compiled
+ * for Android builds only.
+ */
 bool g_bresponsive;
+/** Flag to enable or disable mouse rollover effects in the user interface. */
 bool g_bRollover;
 
 bool b_inCompressAllCharts;
@@ -1400,7 +1421,7 @@ bool MyApp::OnInit() {
   if (!g_Platform->GetLargeLogMessage().IsEmpty())
     wxLogMessage(g_Platform->GetLargeLogMessage());
 
-    //  Validate OpenGL functionality, if selected
+    // Validate OpenGL functionality, if selected
 #ifndef ocpnUSE_GL
   g_bdisable_opengl = true;
   ;
@@ -2039,7 +2060,7 @@ int MyApp::OnExit() {
 #endif
 #endif
 
-    //      Restore any changed system colors
+    // Restore any changed system colors
 
 #ifdef __WXMSW__
   void RestoreSystemColors(void);

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -838,6 +838,44 @@ extern "C" DECL_EXP void GetCanvasLLPix(PlugIn_ViewPort *vp, wxPoint p,
 
 extern "C" DECL_EXP wxWindow *GetOCPNCanvasWindow();
 
+/**
+ * Gets a font for UI elements.
+ *
+ * Plugins can use this to access OpenCPN's font management system which
+ * supports locale-dependent fonts and colors. Font configurations are cached
+ * and shared to minimize memory usage.
+ *
+ * @param TextElement UI element identifier. Supported values:
+ *   - "AISTargetAlert": AIS alert messages
+ *   - "AISTargetQuery": AIS information dialogs
+ *   - "StatusBar": Main status bar text
+ *   - "AIS Target Name": Labels for AIS targets
+ *   - "ObjectQuery": Chart object information text
+ *   - "RouteLegInfoRollover": Route information hover windows
+ *   - "ExtendedTideIcon": Text on extended tide icons
+ *   - "CurrentValue": Current measurement values
+ *   - "Console Legend": Console text labels (e.g. "XTE", "BRG")
+ *   - "Console Value": Console numeric values
+ *   - "AISRollover": AIS target rollover text
+ *   - "TideCurrentGraphRollover": Tide and current graph hover text
+ *   - "Marks": Waypoint label text
+ *   - "ChartTexts": Text rendered directly on charts
+ *   - "ToolTips": Tooltip text
+ *   - "Dialog": Dialog box and control panel text
+ *   - "Menu": Menu item text
+ *   - "GridText": Grid annotation text
+ *
+ * @param default_size Font size in points, 0 to use system default size
+ * @return Pointer to configured wxFont, do not delete it
+ *
+ * @note Each UI element can have different fonts per locale to support
+ * language-specific fonts. Color is also managed - use OCPNGetFontColor()
+ * to get the configured color.
+ * @note The "console" in OpenCPN displays key navigation data such as Cross Track
+ * Error (XTE), Bearing (BRG), Velocity Made Good (VMG), Range (RNG), and Time
+ * to Go (TTG). By default, the text is large and green, optimized for
+ * visibility.
+ */
 extern "C" DECL_EXP wxFont *OCPNGetFont(wxString TextElement, int default_size);
 
 extern "C" DECL_EXP wxString *GetpSharedDataLocation();
@@ -1311,12 +1349,67 @@ extern DECL_EXP bool CheckEdgePan_PlugIn(int x, int y, bool dragging,
                                          int margin, int delta);
 extern DECL_EXP wxBitmap GetIcon_PlugIn(const wxString &name);
 extern DECL_EXP void SetCursor_PlugIn(wxCursor *pPlugin_Cursor = NULL);
+/**
+ * Retrieves a platform-normalized font scaled for consistent physical size.
+ *
+ * Provides a font that maintains perceptually consistent size across different
+ * platforms, screen densities, and display characteristics. The scaling ensures
+ * that a specified font size appears similar in physical dimensions regardless
+ * of:
+ * - Screen DPI
+ * - Operating system
+ * - Display resolution
+ * - Physical screen size
+ *
+ * @param TextElement Identifies the UI context (e.g., "AISTargetAlert",
+ * "StatusBar")
+ * @param default_size Base font size in points. When 0, uses system default.
+ *                     When non-zero (e.g., 12), applies cross-platform scaling
+ *                     to maintain consistent physical font size.
+ *
+ * @return Pointer to a wxFont with platform-normalized scaling
+ *
+ * @note Scaling mechanism:
+ *       - Adjusts point size based on system DPI
+ *       - Applies platform-specific scaling factors
+ *       - Ensures readable text across diverse display environments
+ *
+ * @note Returned font is managed by OpenCPN's font cache
+ * @note Pointer should not be deleted by the caller
+ *
+ * @example
+ * // A 12-point font will look similar on:
+ * // - Windows laptop
+ * // - MacBook Retina display
+ * // - Android tablet
+ * wxFont* font = GetOCPNScaledFont_PlugIn("StatusBar", 12);
+ */
 extern DECL_EXP wxFont *GetOCPNScaledFont_PlugIn(wxString TextElement,
                                                  int default_size = 0);
+/**
+ * Gets a uniquely scaled font copy for responsive UI elements.
+ *
+ * Like GetOCPNScaledFont_PlugIn() but scales font size more aggressively based
+ * on OpenCPN's responsive/touchscreen mode settings. Used by GUI tools and
+ * windows that need larger fonts for touch usability. Always ensures minimum
+ * 3mm physical size regardless of configured point size.
+ *
+ * @param item UI element name to get font for
+ * @return Scaled wxFont object
+ * @see OCPNGetFont() for supported TextElement values
+ * @see GetOCPNScaledFont_PlugIn()
+ */
 extern DECL_EXP wxFont GetOCPNGUIScaledFont_PlugIn(wxString item);
 extern DECL_EXP double GetOCPNGUIToolScaleFactor_PlugIn(int GUIScaledFactor);
 extern DECL_EXP double GetOCPNGUIToolScaleFactor_PlugIn();
 extern DECL_EXP float GetOCPNChartScaleFactor_Plugin();
+/**
+ * Gets color configured for a UI text element.
+ *
+ * @param TextElement UI element ID like "AISTargetAlert"
+ * @return Color configured for element, defaults to system window text color
+ * @see OCPNGetFont() for supported TextElement values
+ */
 extern DECL_EXP wxColour GetFontColour_PlugIn(wxString TextElement);
 
 extern DECL_EXP double GetCanvasTilt();
@@ -1338,6 +1431,16 @@ extern DECL_EXP wxDialog *GetActiveOptionsDialog();
 extern DECL_EXP wxArrayString GetWaypointGUIDArray(void);
 extern DECL_EXP wxArrayString GetIconNameArray(void);
 
+/**
+ * Registers a new font configuration element.
+ *
+ * Allows plugins to define custom UI elements needing font configuration,
+ * beyond the standard elements defined in OCPNGetFont().
+ *
+ * @param TextElement New UI element identifier to register
+ * @return True if element was registered, false if already exists
+ * @see OCPNGetFont()
+ */
 extern DECL_EXP bool AddPersistentFontKey(wxString TextElement);
 extern DECL_EXP wxString GetActiveStyleName();
 
@@ -1518,13 +1621,33 @@ bool LaunchDefaultBrowser_Plugin(wxString url);
 /* Allow drawing of objects onto other OpenGL canvases */
 extern DECL_EXP void PlugInAISDrawGL(wxGLCanvas *glcanvas,
                                      const PlugIn_ViewPort &vp);
+/**
+ * Sets text color for a UI element.
+ *
+ * @param TextElement UI element ID. See OCPNGetFont()
+ * @param color New text color to use
+ * @return True if element found and color was set, false if not found
+ * @note Changes are held in memory only and not persisted to config
+ * @see OCPNGetFont()
+ */
 extern DECL_EXP bool PlugInSetFontColor(const wxString TextElement,
                                         const wxColour color);
 
 // API 1.15
 extern DECL_EXP double PlugInGetDisplaySizeMM();
 
-//
+/**
+ * Creates or finds a font in the font cache.
+ *
+ * @param point_size Font size in points
+ * @param family Font family (wxFONTFAMILY_SWISS etc)
+ * @param style Style flags (wxFONTSTYLE_NORMAL etc)
+ * @param weight Weight flags (wxFONTWEIGHT_NORMAL etc)
+ * @param underline True for underlined font
+ * @param facename Font face name, empty for default
+ * @param encoding Font encoding, wxFONTENCODING_DEFAULT for default
+ * @return Pointer to cached wxFont, do not delete
+ */
 extern DECL_EXP wxFont *FindOrCreateFont_PlugIn(
     int point_size, wxFontFamily family, wxFontStyle style, wxFontWeight weight,
     bool underline = false, const wxString &facename = wxEmptyString,


### PR DESCRIPTION
# Changes in this PR

Document APIs for fonts:
1. Plugin font APIs (ocpn_plugin.h)
2. Internal APIs

The proposed code comments could be improved with feedback from the original authors. it would be helpful to clearly document the specific use cases for each of the 4 plugin functions that return a `wxFont` or `wxFont*`. It's not very obvious which function should be used for what purpose.
- `wxFont* OCPNGetFont`
- `wxFont* GetOCPNScaledFont_PlugIn`
- `wxFont GetOCPNGUIScaledFont_PlugIn`
- `wxFont* FindOrCreateFont_PlugIn`

It seems new code should always use `GetOCPNScaledFont_PlugIn` rather than `OCPNGetFont`, but I'm not sure.

# Additional Context

I'm working on https://github.com/rgleason/vdr_pi/pull/67, and I find it's not very clear what is the best plugin API to invoke.

Is it intentional that `GetOCPNGUIScaledFont_PlugIn` returns a new `wxFont` every time it's invoked? Why are we not caching these fonts? https://github.com/OpenCPN/OpenCPN/commit/6bb13c094a4e582a55b5b6d73512746859f21ac6 is not part of a PR, so there is no context.