### PR TITLE
FontMgr::GetFont should honor the requested font size

### DIFF
--- a/gui/include/gui/FontDesc.h
+++ b/gui/include/gui/FontDesc.h
@@ -36,10 +36,29 @@ public:
              wxColour color);
   ~MyFontDesc();
 
+  /**
+   * UI element identifier, e.g., "AISTargetAlert", "StatusBar".
+   *
+   * Used to identify the font configuration in the list.
+   *
+   * @see [GetFont]
+   */
   wxString m_dialogstring;
+  /**
+   * Configuration key in "locale-hash" format.
+   */
   wxString m_configstring;
+  /**
+   * Platform-specific font descriptor string.
+   */
   wxString m_nativeInfo;
+  /**
+   * Font object.
+   */
   wxFont *m_font;
+  /**
+   * Text color.
+   */
   wxColour m_color;
 };
 


### PR DESCRIPTION
This is a fix for #4288 

Font Matching Logic Improvements:
Added explicit size matching logic with four scenarios:
1. Default font size (when requested_font_size is 0)
2. User-customized default font size (g_default_font_size)
3. System default font size
4. Exact requested font size matching