### PR TITLE
Improve route waypoint resequencing

### DIFF
--- a/gui/src/MarkInfo.cpp
+++ b/gui/src/MarkInfo.cpp
@@ -1753,28 +1753,33 @@ bool MarkInfoDlg::SaveChanges() {
       } else {
         m_pRoutePoint->SetETD(wxEmptyString);
       }
+
       // Here is some logic....
-      // If the Markname is completely numeric, and is part of a route,
+      // If the name has 3 numeric characters, and is part of a route,
       // Then declare it to be of attribute m_bDynamicName = true
       // This is later used for re-numbering points on actions like
       // Insert Point, Delete Point, Append Point, etc
-
       if (m_pRoutePoint->m_bIsInRoute) {
         bool b_name_is_numeric = true;
-        for (unsigned int i = 0; i < m_pRoutePoint->GetName().Len(); i++) {
-          if (i < 2 && wxChar('N') == m_pRoutePoint->GetName()[0] &&
-              wxChar('M') == m_pRoutePoint->GetName()[1] &&
-              m_pRoutePoint->GetName().Len() > 2)
-            continue;
-          if (wxChar('0') > m_pRoutePoint->GetName()[i])
-            b_name_is_numeric = false;
-          if (wxChar('9') < m_pRoutePoint->GetName()[i])
-            b_name_is_numeric = false;
+        if (m_pRoutePoint->GetName().Len() >= 2) {
+          wxString substring = m_pRoutePoint->GetName().Left(2);
+          if (substring == "NM") {
+            substring = m_pRoutePoint->GetName().substr(2, 3);
+          } else {
+            substring = m_pRoutePoint->GetName().Left(3);
+          }
+          for (unsigned int i = 0; i < substring.Len(); i++) {
+            if (b_name_is_numeric == true) {
+              b_name_is_numeric = wxIsdigit(substring[i]);
+            }
+          }
+          m_pRoutePoint->m_bDynamicName = b_name_is_numeric;
+        } else {
+          m_pRoutePoint->m_bDynamicName = false;
         }
-
-        m_pRoutePoint->m_bDynamicName = b_name_is_numeric;
-      } else
+      } else {
         m_pRoutePoint->m_bDynamicName = false;
+      }
 
       if (m_pRoutePoint->m_bIsInRoute) {
         // Update the route segment selectables

--- a/model/src/route.cpp
+++ b/model/src/route.cpp
@@ -666,8 +666,18 @@ void Route::RenameRoutePoints(void) {
   while (node) {
     RoutePoint *prp = node->GetData();
     if (prp->m_bDynamicName) {
-      wxString name;
-      name.Printf(_T ( "%03d" ), i);
+      wxString name = prp->GetName();
+      if (name.Len() == 3) {
+        name.Printf(_T ( "%03d" ), i);
+      } else if (name.Left(2) == "NM") {
+        name.Printf(_T ( "%03d" ), i);
+        if (prp->GetName().Len() >= 5) {
+          name.Append(prp->GetName().Mid(5));
+        }
+      } else {
+        name.Printf(_T ( "%03d" ), i);
+        name.Append(prp->GetName().Mid(3));
+      }
       prp->SetName(name);
     }
 


### PR DESCRIPTION
Improve route way-point re-sequencing to renumber all way-points that start with a dynamic sub-string. Also including way-point names that have a longer customized name (e.g. 004-Dover). The custom part of the name is appended to the new sequence number.