### PR TITLE
Clicking on the compass widget causes map to pan to the right instead of changing compass mode

### DIFF
--- a/gui/include/gui/chcanv.h
+++ b/gui/include/gui/chcanv.h
@@ -219,6 +219,10 @@ public:
   bool SetVPProjection(int projection);
   /**
    * Set the viewport center point.
+   * Centers the view on a specific lat/lon position.
+   * @param lat Latitude in degrees
+   * @param lon Longitude in degrees
+   * @return true if view was changed successfully
    */
   bool SetViewPoint(double lat, double lon);
   bool SetViewPointByCorners(double latSW, double lonSW, double latNE,

--- a/gui/include/gui/compass.h
+++ b/gui/include/gui/compass.h
@@ -53,7 +53,17 @@ public:
   void SetScaleFactor(float factor);
 
   void Move(const wxPoint &pt) { m_rect.SetPosition(pt); }
+  /**
+   * Return the coordinates of the compass widget, in physical pixels relative
+   * to the canvas window. Beware when comparing with data returned from
+   * wxWidgets APIs, which return logical pixels.
+   */
   wxRect GetRect(void) const { return m_rect; }
+  /**
+   * Return the coordinates of the compass widget, in logical pixels.
+   * This can be compared with data returned from wxWidgets APIs.
+   */
+  wxRect GetLogicalRect(void) const;
 
 private:
   void CreateBmp(bool bnew = false);
@@ -74,6 +84,10 @@ private:
   int m_yoffset;
   float m_scale;
 
+  /**
+   * The coordinates of the compass widget, in physical pixels relative to the
+   * canvas window.
+   */
   wxRect m_rect;
   bool m_shown;
   bool m_bshowGPS;

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -7143,8 +7143,14 @@ bool leftIsDown;
 
 bool ChartCanvas::MouseEventOverlayWindows(wxMouseEvent &event) {
   if (!m_bChartDragging && !m_bDrawingRoute) {
-    if (m_Compass && m_Compass->IsShown() &&
-        m_Compass->GetRect().Contains(event.GetPosition())) {
+    /*
+     * The m_Compass->GetRect() coordinates are in physical pixels, whereas the
+     * mouse event coordinates are in logical pixels.
+     */
+    wxRect logicalRect = m_Compass->GetLogicalRect();
+    bool isInCompass = m_Compass && m_Compass->IsShown() &&
+                       logicalRect.Contains(event.GetPosition());
+    if (isInCompass) {
       if (m_Compass->MouseEvent(event)) {
         cursor_region = CENTER;
         if (!g_btouch) SetCanvasCursor(event);

--- a/model/include/model/comm_vars.h
+++ b/model/include/model/comm_vars.h
@@ -35,6 +35,11 @@ extern int g_priSats;
 extern int g_SatsInView;
 
 extern bool g_bVAR_Rx;
+/**
+ * Indicates valid GNSS reception status based on satellite visibility
+ * and successful parsing of NMEA0183, SignalK, or NMEA2000 data.
+ * Reset to false if no valid signal is received within watchdog timeout period.
+ */
 extern bool g_bSatValid;
 extern wxString g_ownshipMMSI_SK;
 #endif  // COMM_VARS_H__

--- a/model/include/model/own_ship.h
+++ b/model/include/model/own_ship.h
@@ -34,6 +34,12 @@ extern double gHdt;
 extern double gHdm;
 extern double gVar;
 
+// Indicate whether the Global Navigation Satellite System (GNSS) has a valid
+// position. true  = OpenCPN has obtained a current position from a GNSS
+// receiver. false = OpenCPN unable to determine position, or no GNSS receiver
+// is connected. Note: the variable name uses the term "GPS" for historical
+// reasons; modern GNSS receivers can acquire data from GPS and other satellite
+// systems.
 extern bool bGPSValid;
 
 #endif  // OWN_SHIP_H__


### PR DESCRIPTION
Fix for #4211 