### PR TITLE
Improve route printing: include missing information.

### DIFF
--- a/gui/include/gui/route_printout.h
+++ b/gui/include/gui/route_printout.h
@@ -42,7 +42,11 @@ enum class RoutePrintOptions {
   kWaypointPosition,
   kWaypointCourse,
   kWaypointDistance,
-  kWaypointDescription
+  kWaypointDescription,
+  kWaypointSpeed,
+  kWaypointETA,
+  kWaypointETD,
+  kWaypointTideEvent
 };
 
 /**
@@ -60,6 +64,14 @@ public:
                  _("Print Waypoint Course to Next").ToStdString());
     AddSelection(options, RoutePrintOptions::kWaypointDistance,
                  _("Print Waypoint Distance to Next").ToStdString());
+    AddSelection(options, RoutePrintOptions::kWaypointSpeed,
+                 _("Waypoint Leg Speed").ToStdString());
+    AddSelection(options, RoutePrintOptions::kWaypointETA,
+                 _("Waypoint Estimated Time Arrival").ToStdString());
+    AddSelection(options, RoutePrintOptions::kWaypointETD,
+                 _("Waypoint Estimated Time Departure").ToStdString());
+    AddSelection(options, RoutePrintOptions::kWaypointTideEvent,
+                 _("Waypoint Next Tide Event").ToStdString());
     AddSelection(options, RoutePrintOptions::kWaypointDescription,
                  _("Print Waypoint Description").ToStdString());
   };
@@ -75,8 +87,10 @@ public:
    * Create route prinout.
    * @param route Route to print.
    * @param options Selected print options.
+   * @param tz_selection Timezone selection.
    */
-  RoutePrintout(Route* route, const std::set<int>& options);
+  RoutePrintout(Route* route, const std::set<int>& options,
+                const int tz_selection);
 
   void OnPreparePrinting() override;
 

--- a/gui/include/gui/tcmgr.h
+++ b/gui/include/gui/tcmgr.h
@@ -30,6 +30,8 @@
 #include <map>
 #include <vector>
 
+#include <wx/datetime.h>
+
 #include "Station_Data.h"
 #include "IDX_entry.h"
 #include "TC_Error_Code.h"
@@ -104,6 +106,8 @@ public:
 
   int GetStationTimeOffset(IDX_entry *pIDX);
   int GetNextBigEvent(time_t *tm, int idx);
+  std::wstring GetTidalEventStr(int station_id, wxDateTime ref_dt, double lat,
+                                double lon, int dt_type);
   double GetStationLat(IDX_entry *pIDX);
   double GetStationLon(IDX_entry *pIDX);
 

--- a/gui/src/RoutePropDlgImpl.cpp
+++ b/gui/src/RoutePropDlgImpl.cpp
@@ -1060,7 +1060,7 @@ void RoutePropDlgImpl::PrintOnButtonClick(wxCommandEvent& event) {
 
   if (result == wxID_OK) {
     dlg.GetSelected(s_options);
-    RoutePrintout printout(m_pRoute, s_options);
+    RoutePrintout printout(m_pRoute, s_options, m_tz_selection);
     auto& printer = PrintDialog::GetInstance();
     printer.Initialize(wxPORTRAIT);
     printer.EnablePageNumbers(true);

--- a/gui/src/route_printout.cpp
+++ b/gui/src/route_printout.cpp
@@ -64,10 +64,14 @@
 #include "print_dialog.h"
 #include "printtable.h"
 #include "route_printout.h"
+#include "tcmgr.h"
 
 using namespace std;
 
-RoutePrintout::RoutePrintout(Route* route, const std::set<int>& options)
+extern TCMgr* ptcmgr;
+
+RoutePrintout::RoutePrintout(Route* route, const std::set<int>& options,
+                             const int tz_selection)
     : BasePrintout(_("Route Print").ToStdString()), m_route(route) {
   // Offset text from the edge of the cell (Needed on Linux)
   m_text_offset_x = 5;
@@ -78,7 +82,7 @@ RoutePrintout::RoutePrintout(Route* route, const std::set<int>& options)
   m_table << _("Leg");
 
   if (GUI::HasKey(options, RoutePrintOptions::kWaypointName)) {
-    m_table << _("To Waypoint");
+    m_table << _("Waypoint");
   }
   if (GUI::HasKey(options, RoutePrintOptions::kWaypointPosition)) {
     m_table << _("Position");
@@ -89,6 +93,18 @@ RoutePrintout::RoutePrintout(Route* route, const std::set<int>& options)
   if (GUI::HasKey(options, RoutePrintOptions::kWaypointDistance)) {
     m_table << _("Distance");
   }
+  if (GUI::HasKey(options, RoutePrintOptions::kWaypointSpeed)) {
+    m_table << _("Speed");
+  }
+  if (GUI::HasKey(options, RoutePrintOptions::kWaypointETA)) {
+    m_table << _("ETA");
+  }
+  if (GUI::HasKey(options, RoutePrintOptions::kWaypointETD)) {
+    m_table << _("ETD");
+  }
+  if (GUI::HasKey(options, RoutePrintOptions::kWaypointTideEvent)) {
+    m_table << _("Next tide event");
+  }
   if (GUI::HasKey(options, RoutePrintOptions::kWaypointDescription)) {
     m_table << _("Description");
   }
@@ -98,19 +114,31 @@ RoutePrintout::RoutePrintout(Route* route, const std::set<int>& options)
   m_table << 20;
 
   if (GUI::HasKey(options, RoutePrintOptions::kWaypointName)) {
-    m_table << 40;
+    m_table << 60;
   }
   if (GUI::HasKey(options, RoutePrintOptions::kWaypointPosition)) {
-    m_table << 40;
+    m_table << 60;
   }
   if (GUI::HasKey(options, RoutePrintOptions::kWaypointCourse)) {
     m_table << 40;
   }
   if (GUI::HasKey(options, RoutePrintOptions::kWaypointDistance)) {
+    m_table << 40;
+  }
+  if (GUI::HasKey(options, RoutePrintOptions::kWaypointSpeed)) {
+    m_table << 40;
+  }
+  if (GUI::HasKey(options, RoutePrintOptions::kWaypointETA)) {
     m_table << 80;
   }
+  if (GUI::HasKey(options, RoutePrintOptions::kWaypointETD)) {
+    m_table << 80;
+  }
+  if (GUI::HasKey(options, RoutePrintOptions::kWaypointTideEvent)) {
+    m_table << 120;
+  }
   if (GUI::HasKey(options, RoutePrintOptions::kWaypointDescription)) {
-    m_table << 100;
+    m_table << 120;
   }
 
   m_table.StartFillData();
@@ -148,6 +176,52 @@ RoutePrintout::RoutePrintout(Route* route, const std::set<int>& options)
                        << toUsrDistance(point->GetDistance())
                        << getUsrDistanceUnit();
         m_table << point_distance.str();
+      } else {
+        m_table << "---";
+      }
+    }
+    if (GUI::HasKey(options, RoutePrintOptions::kWaypointSpeed)) {
+      std::wostringstream point_speed;
+      if (n > 1) {
+        point_speed << std::fixed << std::setprecision(1);
+        if (point->GetPlannedSpeed() < .1) {
+          point_speed << toUsrSpeed(m_route->m_PlannedSpeed);
+        } else {
+          point_speed << toUsrSpeed(point->GetPlannedSpeed());
+        }
+        point_speed << getUsrSpeedUnit().ToStdString();
+        m_table << point_speed.str();
+      } else {
+        m_table << "---";
+      }
+    }
+    if (GUI::HasKey(options, RoutePrintOptions::kWaypointETA)) {
+      m_table << toUsrDateTime(point->GetETA(), tz_selection, point->m_lon)
+                     .FormatISOCombined(' ');
+    }
+    if (GUI::HasKey(options, RoutePrintOptions::kWaypointETD)) {
+      if (point->GetManualETD().IsValid()) {
+        m_table << toUsrDateTime(point->GetManualETD(), tz_selection,
+                                 point->m_lon)
+                       .FormatISOCombined(' ');
+      } else {
+        m_table << "---";
+      }
+    }
+    if (GUI::HasKey(options, RoutePrintOptions::kWaypointTideEvent)) {
+      std::wostringstream point_tide;
+      if (point->m_TideStation.Len() > 0 && point->GetETA().IsValid()) {
+        int station_id = ptcmgr->GetStationIDXbyName(
+            point->m_TideStation, point->m_lat, point->m_lon);
+        if (station_id > 0) {
+          point_tide << ptcmgr->GetTidalEventStr(station_id, point->GetETA(),
+                                                 point->m_lat, point->m_lon,
+                                                 tz_selection);
+          point_tide << "\n@" << point->m_TideStation;
+          m_table << point_tide.str();
+        } else {
+          m_table << "---";
+        }
       } else {
         m_table << "---";
       }
@@ -191,26 +265,83 @@ void RoutePrintout::OnPreparePrinting() {
 }
 
 void RoutePrintout::DrawPage(wxDC* dc, int page) {
-  wxFont routePrintFont_bold(10, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL,
-                             wxFONTWEIGHT_BOLD);
-  dc->SetFont(routePrintFont_bold);
+  wxFont title_font(16, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL,
+                    wxFONTWEIGHT_BOLD);
+  wxFont subtitle_font(12, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL,
+                       wxFONTWEIGHT_NORMAL);
+  wxFont header_font(10, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL,
+                     wxFONTWEIGHT_BOLD);
+  wxFont normal_font(10, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL,
+                     wxFONTWEIGHT_NORMAL);
+
   wxBrush brush(wxColour(255, 255, 255), wxBRUSHSTYLE_TRANSPARENT);
   dc->SetBrush(brush);
 
-  int header_text_offset_x = 2;
-  int header_text_offset_y = 2;
-
-  dc->DrawText(m_route->m_RouteNameString, 150, 20);
-
   int current_x = m_margin_x;
   int current_y = m_margin_y;
+
+  std::wostringstream title;
+  std::wostringstream subtitle;
+  std::wostringstream distance;
+
+  distance << std::fixed << std::setprecision(1)
+           << toUsrDistance(m_route->m_route_length)
+           << getUsrDistanceUnit().ToStdString();
+
+  if (m_route->m_RouteNameString.Trim().Len() > 0) {
+    title << m_route->m_RouteNameString.ToStdString();
+    title << " (" << distance.str() << ")";
+  } else {
+    title << _("Total distance ").ToStdString() << distance.str();
+  }
+
+  if (m_route->m_RouteStartString.Trim().Len() > 0) {
+    subtitle << _("From").ToStdString() << " "
+             << m_route->m_RouteStartString.ToStdString();
+    if (m_route->m_RouteEndString.Trim().Len() > 0) {
+      subtitle << " " << _("To").ToStdString() << " "
+               << m_route->m_RouteEndString.ToStdString();
+    }
+  } else if (m_route->m_RouteEndString.Trim().Len() > 0) {
+    subtitle << _("Destination").ToStdString() << " "
+             << m_route->m_RouteEndString.ToStdString();
+  }
+
+  int title_width, title_height;
+  dc->SetFont(title_font);
+  dc->GetTextExtent(title.str(), &title_width, &title_height);
+  dc->DrawText(title.str(), current_x, current_y);
+  current_y += title_height + m_text_offset_y;
+
+  if (subtitle.str().length() > 0) {
+    int subtitle_width, subtitle_height;
+    dc->SetFont(subtitle_font);
+    dc->GetTextExtent(subtitle.str(), &subtitle_width, &subtitle_height);
+    dc->DrawText(subtitle.str(), current_x, current_y);
+    current_y += subtitle_height + m_text_offset_y;
+  }
+
+  dc->SetFont(normal_font);
+
+  // Route description on page 1.
+  if (page == 1 && m_route->m_RouteDescription.Trim().Len() > 0) {
+    int page_size_x, page_size_y;
+    dc->GetSize(&page_size_x, &page_size_y);
+
+    PrintCell cell_desc;
+    cell_desc.Init(m_route->m_RouteDescription, dc, page_size_x, m_margin_x);
+    dc->DrawText(cell_desc.GetText(), current_x, current_y);
+    current_y += cell_desc.GetHeight() + m_text_offset_y;
+  }
+
   vector<PrintCell>& header_content = m_table.GetHeader();
   for (size_t j = 0; j < header_content.size(); j++) {
     PrintCell& cell = header_content[j];
-    dc->DrawRectangle(current_x, current_y, cell.GetWidth(), cell.GetHeight());
-    dc->DrawText(cell.GetText(), current_x + header_text_offset_x,
-                 current_y + header_text_offset_y);
-    current_x += cell.GetWidth();
+    dc->DrawRectangle(current_x, current_y, cell.GetWidth() + m_text_offset_x,
+                      cell.GetHeight() + m_text_offset_y);
+    dc->DrawText(cell.GetText(), current_x + m_text_offset_x,
+                 current_y + m_text_offset_y);
+    current_x += cell.GetWidth() + m_text_offset_x;
   }
 
   wxFont routePrintFont_normal(10, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL,
@@ -218,7 +349,7 @@ void RoutePrintout::DrawPage(wxDC* dc, int page) {
   dc->SetFont(routePrintFont_normal);
 
   vector<vector<PrintCell> >& cells = m_table.GetContent();
-  current_y = m_margin_y + m_table.GetHeaderHeight();
+  current_y += m_table.GetHeaderHeight() + m_text_offset_y;
   int current_height = 0;
   for (size_t i = 0; i < cells.size(); i++) {
     vector<PrintCell>& content_row = cells[i];
@@ -226,12 +357,13 @@ void RoutePrintout::DrawPage(wxDC* dc, int page) {
     for (size_t j = 0; j < content_row.size(); j++) {
       PrintCell& cell = content_row[j];
       if (cell.GetPage() == page) {
-        wxRect r(current_x, current_y, cell.GetWidth(), cell.GetHeight());
+        wxRect r(current_x, current_y, cell.GetWidth() + m_text_offset_x,
+                 cell.GetHeight() + m_text_offset_y);
         dc->DrawRectangle(r);
         r.Offset(m_text_offset_x, m_text_offset_y);
         dc->DrawLabel(cell.GetText(), r);
-        current_x += cell.GetWidth();
-        current_height = cell.GetHeight();
+        current_x += cell.GetWidth() + m_text_offset_x;
+        current_height = cell.GetHeight() + m_text_offset_y;
       }
     }
     current_y += current_height;

--- a/gui/src/tcmgr.cpp
+++ b/gui/src/tcmgr.cpp
@@ -27,7 +27,6 @@
 #ifndef WX_PRECOMP
 #include <wx/wx.h>
 #endif  // precompiled headers
-#include <wx/datetime.h>
 #include <wx/hashmap.h>
 
 #include <stdlib.h>
@@ -36,6 +35,7 @@
 
 #include "gui_lib.h"
 #include "dychart.h"
+#include "navutil.h"
 #include "tcmgr.h"
 #include "model/georef.h"
 #include "model/logger.h"
@@ -991,6 +991,31 @@ int TCMgr::GetNextBigEvent(time_t *tm, int idx) {
     q = tcvalue[0];
     *tm += 60;
   }
+}
+
+std::wstring TCMgr::GetTidalEventStr(int station_id, wxDateTime ref_dt,
+                                     double lat, double lon, int dt_type) {
+  IDX_entry *idx = (IDX_entry *)GetIDX_entry(station_id);
+  time_t dtmtt = ref_dt.FromUTC().GetTicks();
+  int event = GetNextBigEvent(&dtmtt, station_id);
+  wxDateTime event_dt = wxDateTime(dtmtt).MakeUTC();
+
+  std::wstring event_str;
+  if (event == 1) {
+    event_str = _("LW").ToStdWstring();
+  } else if (event == 2) {
+    event_str = _("HW").ToStdWstring();
+  } else {
+    event_str = _("Unavailable").ToStdWstring();
+  }
+
+  if (event > 0) {
+    event_str.append(L": ");
+    event_str.append(
+        toUsrDateTime(event_dt, dt_type, lon).FormatISOCombined(' '));
+  }
+
+  return event_str;
 }
 
 std::map<double, const IDX_entry *> TCMgr::GetStationsForLL(double xlat,


### PR DESCRIPTION
Fix #4294 to improve route printing for passage planning and briefing. The main purpose is to include currently missing information in the printout.

Changes to improve route printing:
- Added way-point elements to print selection.
- Increased font size of title with route name and distance.
- Added subtitle with route start and destination.
- Added route description.
- Added speed to the way-points table.
- Added ETA and ETD to the way-point table.
- Added tide information to the way-point table.
