### PR TITLE
UI component AlertDialog.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -869,6 +869,7 @@ set(GUI_HDRS
     ${GUI_HDR_DIR}/WindowDestroyListener.h
     ${GUI_HDR_DIR}/WindowDestroyListener.h
 )
+
 set(GUI_SRC_DIR ${CMAKE_SOURCE_DIR}/gui/src)
 set(GUI_SRC
     ${GUI_SRC_DIR}/about.cpp
@@ -1024,10 +1025,8 @@ if (NOT MSVC AND NOT APPLE)
   list(APPEND GUI_SRC ${GUI_SRC_DIR}/ocpn_fontdlg.cpp)
 endif ()
 
-
 set(SRCS ${GUI_SRC})
 set(HDRS ${GUI_HDRS})
-
 if (APPLE)
   add_executable(${PACKAGE_NAME} MACOSX_BUNDLE ${HDRS} ${SRCS})
 elseif (WIN32)
@@ -1115,6 +1114,10 @@ if (APPLE)
 endif ()
 
 find_package(Gettext REQUIRED)
+
+# UI components
+add_subdirectory(libs/gui)
+target_link_libraries(${PACKAGE_NAME} PRIVATE ocpn::guilib)
 
 add_subdirectory(libs/ssl_sha1)
 target_link_libraries(${PACKAGE_NAME} PRIVATE ssl::sha1)

--- a/gui/include/gui/gui_lib.h
+++ b/gui/include/gui/gui_lib.h
@@ -162,20 +162,4 @@ private:
   DECLARE_EVENT_TABLE()
 };
 
-//-----------------------------------------------------------------------
-//          Dummy Text Control for global key events
-//-----------------------------------------------------------------------
-class DummyTextCtrl : public wxTextCtrl {
-public:
-  DummyTextCtrl(wxWindow* parent, wxWindowID id);
-  void OnChar(wxKeyEvent& event);
-  void OnMouseEvent(wxMouseEvent& event);
-
-  wxTimer m_MouseWheelTimer;
-  int m_mouse_wheel_oneshot;
-  int m_last_wheel_dir;
-
-  DECLARE_EVENT_TABLE()
-};
-
 #endif  // GUI_LIB_H__

--- a/gui/include/gui/route_gui.h
+++ b/gui/include/gui/route_gui.h
@@ -7,6 +7,7 @@
  *
  ***************************************************************************
  *   Copyright (C) 2022 by David Register, Alec Leamas                     *
+ *   Copyright (C) 2025 by NoCodeHummel                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -56,6 +57,7 @@ public:
                              ViewPort &vp);
   int SendToGPS(const wxString &com_name, bool bsend_waypoints,
                 SendToGpsDlg *dialog);
+  static bool OnDelete(wxWindow *parent, const int count = 0);
 
 private:
   Route &m_route;

--- a/gui/src/canvasMenu.cpp
+++ b/gui/src/canvasMenu.cpp
@@ -1562,15 +1562,9 @@ void CanvasMenuHandler::PopupMenuHandler(wxCommandEvent &event) {
     }
 
     case ID_RT_MENU_DELETE: {
-      int dlg_return = wxID_YES;
-      if (g_bConfirmObjectDelete) {
-        dlg_return = OCPNMessageBox(
-            parent, _("Are you sure you want to delete this route?"),
-            _("OpenCPN Route Delete"),
-            (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
-      }
+      bool confirmed = RouteGui::OnDelete(parent);
 
-      if (dlg_return == wxID_YES) {
+      if (confirmed) {
         if (g_pRouteMan->GetpActiveRoute() == m_pSelectedRoute)
           g_pRouteMan->DeactivateRoute();
 

--- a/gui/src/route_gui.cpp
+++ b/gui/src/route_gui.cpp
@@ -1,3 +1,28 @@
+/***************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  Route UI stuff
+ * Author:   David Register, Alec Leamas, NoCodeHummel
+ *
+ ***************************************************************************
+ *   Copyright (C) 2022 by David Register, Alec Leamas                     *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+
 #include <string>
 
 #include <wx/colour.h>
@@ -5,6 +30,8 @@
 #include <wx/pen.h>
 #include <wx/string.h>
 #include <wx/utils.h>
+
+#include "dialog_alert.h"
 
 #include "color_handler.h"
 #include "chartbase.h"
@@ -610,4 +637,23 @@ int RouteGui::SendToGPS(const wxString &com_name, bool bsend_waypoints,
   OCPNMessageBox(NULL, msg, _("OpenCPN Info"), wxOK | wxICON_INFORMATION);
 
   return (result == 0);
+}
+
+// Delete the route.
+bool RouteGui::OnDelete(wxWindow *parent, const int count) {
+  std::string title = _("Route Delete").utf8_string();
+  std::string action = _("Delete").utf8_string();
+  std::string msg;
+  if (count > 1) {
+    wxString str = wxString::Format(
+        _("Are you sure you want to delete %d routes?"), count);
+    msg = str.c_str();
+  } else {
+    msg = _("Are you sure you want to delete this route?").utf8_string();
+  }
+
+  AlertDialog *dialog = new AlertDialog(parent, title, action);
+  dialog->SetMessage(msg);
+  int result = dialog->ShowModal();
+  return result == wxID_YES;
 }

--- a/gui/src/routemanagerdialog.cpp
+++ b/gui/src/routemanagerdialog.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 
 #include "routemanagerdialog.h"
+#include "route_gui.h"
 
 // For compilers that support precompilation, includes "wx/wx.h".
 #include <wx/wxprec.h>
@@ -1392,33 +1393,27 @@ void RouteManagerDialog::ZoomtoRoute(Route *route) {
 
 // BEGIN Event handlers
 void RouteManagerDialog::OnRteDeleteClick(wxCommandEvent &event) {
-  RouteList list;
+  int count = m_pRouteListCtrl->GetSelectedItemCount();
+  bool confirmed = RouteGui::OnDelete(this, count);
 
-  int answer = OCPNMessageBox(
-      this, _("Are you sure you want to delete the selected object(s)"),
-      wxString(_("OpenCPN Alert")), wxYES_NO);
-  if (answer != wxID_YES) return;
-
-  bool busy = false;
-  if (m_pRouteListCtrl->GetSelectedItemCount()) {
+  if (confirmed && count > 0) {
     ::wxBeginBusyCursor();
+    RouteList list;
+
     gFrame->CancelAllMouseRoute();
     m_bNeedConfigFlush = true;
-    busy = true;
-  }
 
-  long item = -1;
-  for (;;) {
-    item = m_pRouteListCtrl->GetNextItem(item, wxLIST_NEXT_ALL,
-                                         wxLIST_STATE_SELECTED);
-    if (item == -1) break;
+    long item = -1;
+    for (;;) {
+      item = m_pRouteListCtrl->GetNextItem(item, wxLIST_NEXT_ALL,
+                                           wxLIST_STATE_SELECTED);
+      if (item == -1) break;
 
-    Route *proute_to_delete = (Route *)m_pRouteListCtrl->GetItemData(item);
+      Route *proute_to_delete = (Route *)m_pRouteListCtrl->GetItemData(item);
 
-    if (proute_to_delete) list.Append(proute_to_delete);
-  }
+      if (proute_to_delete) list.Append(proute_to_delete);
+    }
 
-  if (busy) {
     for (unsigned int i = 0; i < list.GetCount(); i++) {
       Route *route = list.Item(i)->GetData();
       if (route) {

--- a/libs/gui/CMakeLists.txt
+++ b/libs/gui/CMakeLists.txt
@@ -1,0 +1,51 @@
+#[[
+Copyright (C) 2025 by NoCodeHummel
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the
+Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.
+#]]
+
+# OpenCPN UI components library
+# with dependency on Android utils.
+cmake_minimum_required(VERSION 3.10.0)
+
+if (TARGET ocpn::guilib)
+    return ()
+endif ()
+
+# Sources
+set(SRC
+    include/dialog_alert.h
+    include/dialog_base.h
+    include/dialog_footer.h
+    src/dialog_alert.cpp
+    src/dialog_base.cpp
+)
+
+add_library(GUILIB STATIC ${SRC})
+add_library(ocpn::guilib ALIAS GUILIB)
+
+if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang|GNU")  # Apple is AppleClang
+  target_compile_options(
+    GUILIB PRIVATE
+      -fvisibility=default -Wno-unknown-pragmas -fPIC
+  )
+endif ()
+
+target_include_directories(GUILIB PRIVATE ${wxWidgets_INCLUDE_DIRS})
+target_link_libraries(GUILIB PRIVATE ${wxWidgets_LIBRARIES})
+
+target_include_directories(
+  GUILIB PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
+)

--- a/libs/gui/include/dialog_alert.h
+++ b/libs/gui/include/dialog_alert.h
@@ -1,0 +1,86 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by NoCodeHummel                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ */
+#ifndef DIALOG_ALERT_H
+#define DIALOG_ALERT_H
+
+#include <string>
+
+#include "dialog_base.h"
+#include "dialog_footer.h"
+
+/**
+ * Alert confirmation listener interface.
+ */
+class IAlertConfirmation {
+public:
+  /**
+   * Handle confirmation response.
+   * @param result User response.
+   */
+  virtual void OnConfirm(const bool result) = 0;
+};
+
+/**
+ * A modal message dialog with a cancel and confirmation button.
+ * Can be used with a listener to handle the response.
+ * Alternatively the static GetConfirmation function can be used without
+ * listener.
+ */
+class AlertDialog : public BaseDialog {
+private:
+  std::string m_action;  // confirmation button label
+
+public:
+  AlertDialog(wxWindow* parent, const std::string& title,
+              const std::string& action);
+  ~AlertDialog();
+
+  /**
+   * Listen for response.
+   * @param listener Confirmation listener.
+   */
+  void SetListener(IAlertConfirmation* listener);
+
+  /**
+   * Set alert message.
+   * @param msg Alert message.
+   */
+  void SetMessage(const std::string& msg);
+
+  /**
+   * Show dialog and return response.
+   * @return YES/NO response.
+   */
+  int ShowModal() override;
+
+  /**
+   * Helper that returns the dialog response.
+   * @return YES/NO response.
+   */
+  static int GetConfirmation(wxWindow* parent, const std::string& title,
+                             const std::string& action, const std::string& msg);
+
+private:
+  IAlertConfirmation* m_listener;
+  void OnCancel(wxCommandEvent& event);
+  void OnConfirm(wxCommandEvent& event);
+};
+
+#endif  // DIALOG_ALERT_H

--- a/libs/gui/include/dialog_base.h
+++ b/libs/gui/include/dialog_base.h
@@ -1,0 +1,44 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by NoCodeHummel                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ */
+#ifndef DIALOG_BASE_H
+#define DIALOG_BASE_H
+
+#include <wx/dialog.h>
+
+/**
+ * OpenCPN standard dialog layout with content sizer.
+ */
+class BaseDialog : public wxDialog {
+public:
+  static const int kScaling = 6;  // UI guideline default
+
+  BaseDialog(wxWindow* parent, const std::string& title,
+             long style = wxDEFAULT_DIALOG_STYLE);
+
+  void AddHtmlContent(const wxString& html);
+
+protected:
+  wxBoxSizer* m_layout;
+  wxBoxSizer* m_content;
+
+  static const int kDialogPadding = 12;
+};
+
+#endif  // DIALOG_BASE_H

--- a/libs/gui/include/dialog_footer.h
+++ b/libs/gui/include/dialog_footer.h
@@ -1,0 +1,33 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by NoCodeHummel                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ */
+#ifndef DIALOG_FOOTER_H
+#define DIALOG_FOOTER_H
+
+#include <wx/wx.h>
+
+/**
+ * Footer sizer adjusts the button layout for the target platform.
+ */
+class DialogFooter : public wxStdDialogButtonSizer {
+public:
+  DialogFooter() : wxStdDialogButtonSizer() {};
+};
+
+#endif  // DIALOG_FOOTER_H

--- a/libs/gui/src/dialog_alert.cpp
+++ b/libs/gui/src/dialog_alert.cpp
@@ -1,0 +1,108 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by NoCodeHummel                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ */
+#include <wx/event.h>
+#include <wx/button.h>
+#include <wx/dialog.h>
+#include <wx/sizer.h>
+
+#include "dialog_alert.h"
+
+#ifdef __ANDROID__
+#include "androidUTIL.h"
+#endif
+
+AlertDialog::AlertDialog(wxWindow* parent, const std::string& title,
+                         const std::string& action)
+    : BaseDialog(parent, title, wxSTAY_ON_TOP | wxCAPTION),
+      m_action(action),
+      m_listener(nullptr) {
+  DialogFooter* footer = new DialogFooter();
+  wxButton* ok_button = new wxButton(this, wxID_OK, m_action);
+  wxButton* cancel_button = new wxButton(this, wxID_CANCEL, _("Cancel"));
+  footer->AddButton(cancel_button);
+  footer->AddButton(ok_button);
+  footer->Realize();
+
+  Bind(wxEVT_BUTTON, &AlertDialog::OnConfirm, this, wxID_OK);
+  Bind(wxEVT_BUTTON, &AlertDialog::OnCancel, this, wxID_CANCEL);
+
+  wxSizerFlags flags = wxSizerFlags();
+  flags.Border(wxALL, FromDIP(kDialogPadding));
+  m_layout->Add(footer, flags);
+}
+
+AlertDialog::~AlertDialog() {
+#ifdef __OCPN__ANDROID__
+  androidEnableRotation();
+#endif
+}
+
+void AlertDialog::SetListener(IAlertConfirmation* listener) {
+  m_listener = listener;
+}
+
+void AlertDialog::SetMessage(const std::string& msg) {
+  m_content->Add(new wxStaticText(this, wxID_ANY, msg));
+  m_content->SetSizeHints(this);
+}
+
+int AlertDialog::ShowModal() {
+#ifdef __OCPN__ANDROID__
+  androidDisableRotation();
+#endif
+
+  // Adjust the dialog size.
+  m_layout->Fit(this);
+  wxSize size(GetSize());
+  if (size.x < size.y * 3 / 2) {
+    size.x = size.y * 3 / 2;
+    SetSize(size);
+  }
+  Centre(wxBOTH | wxCENTER_FRAME);
+  return wxDialog::ShowModal();
+}
+
+int AlertDialog::GetConfirmation(wxWindow* parent, const std::string& title,
+                                 const std::string& action,
+                                 const std::string& msg) {
+  AlertDialog* dialog = new AlertDialog(parent, title, action);
+  dialog->SetMessage(msg);
+  return dialog->Show();
+}
+
+void AlertDialog::OnCancel(wxCommandEvent& event) {
+  SetReturnCode(wxID_NO);
+  if (m_listener != nullptr) {
+    m_listener->OnConfirm(false);
+    this->Destroy();
+  } else {
+    EndModal(wxID_NO);
+  }
+}
+
+void AlertDialog::OnConfirm(wxCommandEvent& event) {
+  SetReturnCode(wxID_YES);
+  if (m_listener != nullptr) {
+    m_listener->OnConfirm(true);
+    this->Destroy();
+  } else {
+    EndModal(wxID_YES);
+  }
+}

--- a/libs/gui/src/dialog_base.cpp
+++ b/libs/gui/src/dialog_base.cpp
@@ -1,0 +1,37 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by NoCodeHummel                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ */
+#include <wx/dialog.h>
+#include <wx/sizer.h>
+
+#include "dialog_base.h"
+
+/**
+ * Base dialog constructor implements the layout with vertical sizer.
+ */
+BaseDialog::BaseDialog(wxWindow* parent, const std::string& title, long style)
+    : wxDialog(parent, wxID_ANY, title, wxDefaultPosition, wxDefaultSize,
+               style) {
+  m_layout = new wxBoxSizer(wxVERTICAL);
+  m_content = new wxBoxSizer(wxVERTICAL);
+  wxSizerFlags flags = wxSizerFlags();
+  flags.Border(wxALL, FromDIP(kDialogPadding));
+  m_layout->Add(m_content, flags);
+  SetSizer(m_layout);
+}


### PR DESCRIPTION
Implement AlertDialog UI component following Gnome HIG standards (#4329).

This is a PoC UI component following the introduction of UI guidelines (Gnome HIG). By using re-usable UI component from a library it will be easier to adhere to the standard. The UI component implements and encapsulates the UI specifications.

AlertDialog is implemented with `wxStdDialogButtonSizer` to handle the button placement for the target platforms. The dialog padding is set as recommended in the [Layout guidelines](https://wiki.gnome.org/Design(2f)HIG(2f)Planning(2f)Layout.html), with density-independant pixels (DIP). 

This PR adds a `CMakeList` for UI library in folder `/lib/gui`. 