### PR TITLE
Connections; Change words to correct translation

### DIFF
--- a/gui/src/connections_dlg.cpp
+++ b/gui/src/connections_dlg.cpp
@@ -139,7 +139,7 @@ public:
     GetTable()->AppendCols(8);
     HideCol(7);
     static const std::array<wxString, 7> headers = {
-        "", _("Protocol"), _("Direction"), _("Port"), _("Status"), "", ""};
+        "", _("Protocol"), _("In/Out"), _("Data port"), _("Status"), "", ""};
     for (auto hdr = headers.begin(); hdr != headers.end(); hdr++)
       SetColLabelValue(static_cast<int>(hdr - headers.begin()), *hdr);
     if (IsWindows()) {


### PR DESCRIPTION
The word "Port" must not be used lonely as discussed here: https://github.com/OpenCPN/OpenCPN/discussions/4078#discussioncomment-11928018