### PR TITLE
Improve the DEPARE color for bad chartdata

### DIFF
--- a/libs/s52plib/src/s52cnsy.cpp
+++ b/libs/s52plib/src/s52cnsy.cpp
@@ -625,8 +625,10 @@ static void *DEPARE01(void *param) {
 
   drval1 = -1.0;  // default values
   drval1_found = GetDoubleAttr(obj, "DRVAL1", drval1);
-  drval2 = drval1 + 0.01;
+  // drval2 = drval1 + 0.01;
   GetDoubleAttr(obj, "DRVAL2", drval2);
+  //make sure drval2 is higher then drval1, always even in bad charts
+  if (drval2 <= drval1) drval1 + 0.01;
 
   //   Create a string of the proper color reference
 


### PR DESCRIPTION
Some (inland) ENC come with DRVAL1 and DRVAL2 both programmed 0.0. The result is a green filled area.
The difference for and after this commit.
![Screenshot_20250124_203132](https://github.com/user-attachments/assets/67471adc-5787-4ad7-9eb3-7beebc2be85e)
