### PR TITLE
Fix missing words in route print.

### DIFF
--- a/gui/src/printtable.cpp
+++ b/gui/src/printtable.cpp
@@ -109,7 +109,7 @@ void PrintCell::Adjust() {
     if ((w < width - 2 * cellpadding) || words_number == 1) {
       list[list.size() - 1] = tmp2;
     } else {
-      list.push_back(wxString());
+      list.push_back(token);
     }
   }
 


### PR DESCRIPTION
Fix tokenizer to adjust the output line. It was skipping each word when the line gets too long.