### PR TITLE
Implement TextField in UI library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -786,7 +786,6 @@ set(GUI_HDRS
     ${GUI_HDR_DIR}/FlexHash.h
     ${GUI_HDR_DIR}/FontDesc.h
     ${GUI_HDR_DIR}/FontMgr.h
-    ${GUI_HDR_DIR}/dialog_cntrl.h
     ${GUI_HDR_DIR}/GoToPositionDialog.h
     ${GUI_HDR_DIR}/gshhs.h
     ${GUI_HDR_DIR}/gui_lib.h
@@ -905,7 +904,6 @@ set(GUI_SRC
     ${GUI_SRC_DIR}/FlexHash.cpp
     ${GUI_SRC_DIR}/FontDesc.cpp
     ${GUI_SRC_DIR}/FontMgr.cpp
-    ${GUI_SRC_DIR}/dialog_cntrl.cpp
     ${GUI_SRC_DIR}/GoToPositionDialog.cpp
     ${GUI_SRC_DIR}/gshhs.cpp
     ${GUI_SRC_DIR}/gui_lib.cpp

--- a/gui/include/gui/MarkInfo.h
+++ b/gui/include/gui/MarkInfo.h
@@ -356,6 +356,7 @@ protected:
   void OnRightClickLatLon(wxCommandEvent& event);
   void OnHtmlLinkClicked(wxHtmlLinkEvent& event);
   void OnHyperLinkClick(wxHyperlinkEvent& event);
+  void OnLayoutResize(wxCommandEvent& event);
 
   void On_html_link_popupmenu_Click(wxCommandEvent& event);
   void DefautlBtnClicked(wxCommandEvent& event);

--- a/gui/include/gui/MarkInfo.h
+++ b/gui/include/gui/MarkInfo.h
@@ -53,7 +53,7 @@
 #include <wx/combobox.h>
 
 #include <wx/dialog.h>
-#include "dialog_cntrl.h"
+#include "field_text.h"
 
 #include "route_validator.h"
 

--- a/gui/include/gui/MarkInfo.h
+++ b/gui/include/gui/MarkInfo.h
@@ -54,6 +54,7 @@
 
 #include <wx/dialog.h>
 #include "field_text.h"
+#include "form_grid.h"
 
 #include "route_validator.h"
 
@@ -255,7 +256,7 @@ protected:
   wxColourPickerCtrl* m_PickColor;
   wxCheckBox* m_cbEtaPresent;
   wxBoxSizer* bMainSizer;
-  wxFlexGridSizer* fSizerBasicProperties;
+  FormGrid* fSizerBasicProperties;
   wxFlexGridSizer* waypointradarGrid;
   wxFlexGridSizer* waypointrrSelect;
   wxGridBagSizer* bGB_SizerProperties;

--- a/gui/include/gui/route_validator.h
+++ b/gui/include/gui/route_validator.h
@@ -25,7 +25,7 @@
 #ifndef ROUTE_VALIDATOR_H
 #define ROUTE_VALIDATOR_H
 
-#include "dialog_cntrl.h"
+#include "field_text.h"
 #include "model/route_point.h"
 
 /**

--- a/gui/src/MarkInfo.cpp
+++ b/gui/src/MarkInfo.cpp
@@ -59,6 +59,7 @@
 #include "styles.h"
 #include "svg_utils.h"
 #include "TCWin.h"
+#include "ui_utils.h"
 
 #ifdef __ANDROID__
 #include "androidUTIL.h"
@@ -210,6 +211,7 @@ EVT_TEXT(ID_LONCTRL, MarkInfoDlg::OnPositionCtlUpdated)
 EVT_CHOICE(ID_WPT_RANGERINGS_NO, MarkInfoDlg::OnWptRangeRingsNoChange)
 // the HTML listbox's events
 EVT_HTML_LINK_CLICKED(wxID_ANY, MarkInfoDlg::OnHtmlLinkClicked)
+EVT_COMMAND(wxID_ANY, EVT_LAYOUT_RESIZE, MarkInfoDlg::OnLayoutResize)
 EVT_CLOSE(MarkInfoDlg::OnClose)
 
 // EVT_CHOICE( ID_WAYPOINTRANGERINGS, MarkInfoDef::OnWaypointRangeRingSelect )
@@ -313,9 +315,9 @@ void MarkInfoDlg::Create() {
 
   // Basic panel
   m_panelBasicProperties->SetScrollRate(0, 2);
+  m_notebookProperties->AddPage(m_panelBasicProperties, _("Basic"), true);
   bSizerBasicProperties = new wxBoxSizer(wxVERTICAL);
   m_panelBasicProperties->SetSizer(bSizerBasicProperties);
-  m_notebookProperties->AddPage(m_panelBasicProperties, _("Basic"), true);
 
   // Layer notification
   m_staticTextLayer = new wxStaticText(
@@ -333,10 +335,7 @@ void MarkInfoDlg::Create() {
   int label_size = m_sizeMetric * 4;
 
   // Name property
-  wxStaticText* name_label = new wxStaticText(props_panel, wxID_ANY, _("Name"));
-  m_textName = new TextField(props_panel, wxID_ANY, wxEmptyString);
-  props_sizer->Add(name_label, 0, wxALIGN_TOP);
-  props_sizer->Add(m_textName->GetParent(), 0, wxEXPAND);
+  m_textName = new TextField(props_panel, _("Name"));
 
   // Show name checkbox
   wxStaticText* name_cb_label =
@@ -363,21 +362,10 @@ void MarkInfoDlg::Create() {
   props_sizer->Add(icon_label, 0, wxALIGN_CENTER_VERTICAL);
   props_sizer->Add(m_bcomboBoxIcon, 0, wxEXPAND);
 
-  // Latitude property
-  wxStaticText* latitude_label =
-      new wxStaticText(props_panel, wxID_ANY, _("Latitude"));
-  latitude_label->SetMinSize(wxSize(label_size, -1));
-  m_textLatitude = new TextField(props_panel, wxID_ANY, wxEmptyString);
-  props_sizer->Add(latitude_label, 0, wxALIGN_TOP);
-  props_sizer->Add(m_textLatitude->GetParent(), 0, wxEXPAND);
-
-  // Longitude property
-  wxStaticText* longitude_label =
-      new wxStaticText(props_panel, wxID_ANY, _("Longitude"));
-  longitude_label->SetMinSize(wxSize(label_size, -1));
-  m_textLongitude = new TextField(props_panel, wxID_ANY, wxEmptyString);
-  props_sizer->Add(longitude_label, 0, wxALIGN_TOP);
-  props_sizer->Add(m_textLongitude->GetParent(), 0, wxEXPAND);
+  // Lat/lon properties
+  m_textLatitude = new TextField(props_panel, _("Latitude"));
+  m_textLongitude = new TextField(props_panel, _("Longitude"));
+  props_sizer->Fit(props_panel);
 
   // Description box
   wxStaticBox* desc_box =
@@ -1011,6 +999,11 @@ void MarkInfoDlg::OnHtmlLinkClicked(wxHtmlLinkEvent& event) {
 
   event.Skip();
 #endif
+}
+
+void MarkInfoDlg::OnLayoutResize(wxCommandEvent& event) {
+  m_panelBasicProperties->Layout();
+  this->Layout();
 }
 
 void MarkInfoDlg::OnDescChangedExt(wxCommandEvent& event) {

--- a/gui/src/MarkInfo.cpp
+++ b/gui/src/MarkInfo.cpp
@@ -40,7 +40,6 @@
 #include <wx/bmpbuttn.h>
 
 #include "chcanv.h"
-#include "dialog_cntrl.h"
 #include "gui_lib.h"
 #include "MarkInfo.h"
 #include "model/georef.h"

--- a/gui/src/MarkInfo.cpp
+++ b/gui/src/MarkInfo.cpp
@@ -327,10 +327,7 @@ void MarkInfoDlg::Create() {
 
   // Basic properties grid layout
   wxPanel* props_panel = new wxPanel(m_panelBasicProperties);
-  wxFlexGridSizer* props_sizer =
-      new wxFlexGridSizer(2, m_sizeMetric / 2, m_sizeMetric * 2);
-  props_sizer->AddGrowableCol(0, 0);  // first column grows
-  props_sizer->AddGrowableCol(1, 1);  // second column grows
+  FormGrid* props_sizer = new FormGrid(this);
   props_panel->SetSizer(props_sizer);
   bSizerBasicProperties->Add(props_panel, 0, wxALL | wxEXPAND, 16);
   int label_size = m_sizeMetric * 4;

--- a/libs/gui/CMakeLists.txt
+++ b/libs/gui/CMakeLists.txt
@@ -29,8 +29,12 @@ set(SRC
     include/dialog_alert.h
     include/dialog_base.h
     include/dialog_footer.h
+    include/field_text.h
+    include/ui_utils.h
     src/dialog_alert.cpp
     src/dialog_base.cpp
+    src/field_text.cpp
+    src/ui_utils.cpp
 )
 
 add_library(GUILIB STATIC ${SRC})

--- a/libs/gui/CMakeLists.txt
+++ b/libs/gui/CMakeLists.txt
@@ -30,10 +30,12 @@ set(SRC
     include/dialog_base.h
     include/dialog_footer.h
     include/field_text.h
+    include/form_grid.h
     include/ui_utils.h
     src/dialog_alert.cpp
     src/dialog_base.cpp
     src/field_text.cpp
+    src/form_grid.cpp
     src/ui_utils.cpp
 )
 

--- a/libs/gui/include/dialog_base.h
+++ b/libs/gui/include/dialog_base.h
@@ -22,23 +22,22 @@
 
 #include <wx/dialog.h>
 
+#include "ui_utils.h"
+
 /**
  * OpenCPN standard dialog layout with content sizer.
  */
 class BaseDialog : public wxDialog {
 public:
-  static const int kScaling = 6;  // UI guideline default
-
   BaseDialog(wxWindow* parent, const std::string& title,
              long style = wxDEFAULT_DIALOG_STYLE);
-
-  void AddHtmlContent(const wxString& html);
 
 protected:
   wxBoxSizer* m_layout;
   wxBoxSizer* m_content;
 
-  static const int kDialogPadding = 12;
+  // padding scaling factor
+  static const int kDialogPadding = 2;
 };
 
 #endif  // DIALOG_BASE_H

--- a/libs/gui/include/field_text.h
+++ b/libs/gui/include/field_text.h
@@ -20,10 +20,10 @@
 
 /**
  * \file
- * Dialog control classes and validator base classes.
+ * Text field classes and text validator base classes.
  */
-#ifndef DIALOG_CNTRL_H
-#define DIALOG_CNTRL_H
+#ifndef TEXT_FIELD_H
+#define TEXT_FIELD_H
 
 #include <wx/wx.h>
 #include <wx/string.h>
@@ -78,4 +78,4 @@ public:
   virtual wxString IsValid(const wxString& val) const override = 0;
 };
 
-#endif  // DIALOG_CNTRL_H
+#endif  // TEXT_FIELD_H

--- a/libs/gui/include/field_text.h
+++ b/libs/gui/include/field_text.h
@@ -37,9 +37,17 @@
  */
 class TextField : public wxTextCtrl {
 public:
-  TextField(wxWindow* parent, wxWindowID id = wxID_ANY,
-            const wxString& value = "", const wxPoint& pos = wxDefaultPosition,
-            const wxSize& size = wxDefaultSize, long style = 0);
+  /**
+   * Add new text field to the form grid.
+   * It requires a parent window with form grid,
+   * to layout label and field in the grid columns.
+   * @param parent Parent window.
+   * @param label Field label.
+   * @param value Field value.
+   * @param id Window identifier.
+   */
+  TextField(wxWindow* parent, const wxString& label, const wxString& value = "",
+            wxWindowID id = wxID_ANY);
 
   /**
    * Shows an error below the text field.

--- a/libs/gui/include/field_text.h
+++ b/libs/gui/include/field_text.h
@@ -56,7 +56,6 @@ public:
   void OnTextChanged(wxCommandEvent& event);
 
 private:
-  wxSizer* m_sizer;
   wxStaticText* m_error_text;
 };
 

--- a/libs/gui/include/form_grid.h
+++ b/libs/gui/include/form_grid.h
@@ -1,0 +1,33 @@
+/***************************************************************************
+ *   Copyright (C) 2025 by NoCodeHummel                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+#ifndef FORM_GRID_H
+#define FORM_GRID_H
+
+#include <wx/wx.h>
+
+/**
+ * Grid layout with 2 columns for form labels and fields.
+ * The flexible grid aligns the form elements with spacing.
+ */
+class FormGrid : public wxFlexGridSizer {
+public:
+  FormGrid(wxWindow* parent);
+};
+
+#endif  // FORM_GRID_H

--- a/libs/gui/include/ui_utils.h
+++ b/libs/gui/include/ui_utils.h
@@ -42,5 +42,5 @@ static const int kSpacing = 6;
  */
 int GetSpacing(wxWindow* window, int factor);
 
-void PropagateResize(wxWindow* window);
+void PropagateLayout(wxWindow* window);
 }  // namespace GUI

--- a/libs/gui/include/ui_utils.h
+++ b/libs/gui/include/ui_utils.h
@@ -1,5 +1,5 @@
-/**************************************************************************
- *   Copyright (C) 2024 Alec Leamas                                        *
+/***************************************************************************
+ *   Copyright (C) 2025 NoCodeHummel                                       *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,16 +18,14 @@
  **************************************************************************/
 
 /**
- *  \file
- *  Implement gui.h.
+ * \file
+ * GUI library related utils.
  */
-#include <wx/dialog.h>
-#include <wx/frame.h>
+#include <wx/window.h>
 
-#include "model/gui.h"
-
-wxWindow* GetTopWindow() {
-  auto top_window = wxWindow::FindWindowByName(kTopLevelWindowName);
-  assert(top_window && "Cannot find MainWindow a k a gFrame");
-  return top_window;
-}
+/**
+ * Organizes constant variables and methods.
+ */
+namespace GUI {
+void PropagateResize(wxWindow* window);
+}  // namespace GUI

--- a/libs/gui/include/ui_utils.h
+++ b/libs/gui/include/ui_utils.h
@@ -27,5 +27,20 @@
  * Organizes constant variables and methods.
  */
 namespace GUI {
+
+/**
+ * Default spacing in pixels.
+ */
+static const int kSpacing = 6;
+
+/**
+ * Multiply default spacing with a factor,
+ * and calculate device independent pixels.
+ * @param window Owner class.
+ * @param int Scaling factor.
+ * @return Scaling in DIP.
+ */
+int GetSpacing(wxWindow* window, int factor);
+
 void PropagateResize(wxWindow* window);
 }  // namespace GUI

--- a/libs/gui/include/ui_utils.h
+++ b/libs/gui/include/ui_utils.h
@@ -30,6 +30,7 @@ namespace GUI {
 
 /**
  * Default spacing in pixels.
+ * Use GetSpacing() for DIP.
  */
 static const int kSpacing = 6;
 

--- a/libs/gui/include/ui_utils.h
+++ b/libs/gui/include/ui_utils.h
@@ -19,9 +19,14 @@
 
 /**
  * \file
- * GUI library related utils.
+ * GUI library utils and events.
  */
 #include <wx/window.h>
+#include <wx/scrolwin.h>
+#include <wx/event.h>
+
+// Declare custom events
+wxDECLARE_EVENT(EVT_LAYOUT_RESIZE, wxCommandEvent);
 
 /**
  * Organizes constant variables and methods.
@@ -29,7 +34,7 @@
 namespace GUI {
 
 /**
- * Default spacing in pixels.
+ * UI guideline default spacing in pixels.
  * Use GetSpacing() for DIP.
  */
 static const int kSpacing = 6;
@@ -43,5 +48,9 @@ static const int kSpacing = 6;
  */
 int GetSpacing(wxWindow* window, int factor);
 
-void PropagateLayout(wxWindow* window);
+/**
+ * Trigger window layout event.
+ * @param ctx Window context.
+ */
+void LayoutResizeEvent(wxWindow* ctx);
 }  // namespace GUI

--- a/libs/gui/src/dialog_alert.cpp
+++ b/libs/gui/src/dialog_alert.cpp
@@ -38,16 +38,11 @@ AlertDialog::AlertDialog(wxWindow* parent, const std::string& title,
 
   Bind(wxEVT_BUTTON, &AlertDialog::OnConfirm, this, wxID_OK);
   Bind(wxEVT_BUTTON, &AlertDialog::OnCancel, this, wxID_CANCEL);
-#if wxCHECK_VERSION(3, 2, 0)
-  auto flags = wxSizerFlags().Border(wxALL, FromDIP(kDialogPadding));
-#else
-  auto flags = wxSizerFlags().Border();
-#endif
-  m_layout->Add(footer, flags);
+  m_layout->Add(footer, wxSizerFlags().Border(
+                            wxALL, GUI::GetSpacing(this, kDialogPadding)));
 }
 
-AlertDialog::~AlertDialog() {
-}
+AlertDialog::~AlertDialog() {}
 
 void AlertDialog::SetListener(IAlertConfirmation* listener) {
   m_listener = listener;
@@ -59,7 +54,6 @@ void AlertDialog::SetMessage(const std::string& msg) {
 }
 
 int AlertDialog::ShowModal() {
-
   // Adjust the dialog size.
   m_layout->Fit(this);
   wxSize size(GetSize());

--- a/libs/gui/src/dialog_base.cpp
+++ b/libs/gui/src/dialog_base.cpp
@@ -30,11 +30,7 @@ BaseDialog::BaseDialog(wxWindow* parent, const std::string& title, long style)
                style) {
   m_layout = new wxBoxSizer(wxVERTICAL);
   m_content = new wxBoxSizer(wxVERTICAL);
-#if wxCHECK_VERSION(3, 1, 2)
-  auto flags = wxSizerFlags().Border(wxALL, FromDIP(kDialogPadding));
-#else
-  auto flags = wxSizerFlags().Border();
-#endif
-  m_layout->Add(m_content, flags);
+  m_layout->Add(m_content, wxSizerFlags().Border(
+                               wxALL, GUI::GetSpacing(this, kDialogPadding)));
   SetSizer(m_layout);
 }

--- a/libs/gui/src/dialog_base.cpp
+++ b/libs/gui/src/dialog_base.cpp
@@ -33,4 +33,7 @@ BaseDialog::BaseDialog(wxWindow* parent, const std::string& title, long style)
   m_layout->Add(m_content, wxSizerFlags().Border(
                                wxALL, GUI::GetSpacing(this, kDialogPadding)));
   SetSizer(m_layout);
+
+  // Handle layout resize event
+  Bind(EVT_LAYOUT_RESIZE, [&](wxCommandEvent&) { Layout(); });
 }

--- a/libs/gui/src/field_text.cpp
+++ b/libs/gui/src/field_text.cpp
@@ -24,35 +24,36 @@
 TextField::TextField(wxWindow* parent, wxWindowID id, const wxString& value,
                      const wxPoint& pos, const wxSize& size, long style)
     : wxTextCtrl(new wxPanel(parent), id, value, pos, size, style) {
-  m_sizer = new wxBoxSizer(wxVERTICAL);
-  m_sizer->Add(this, 0, wxEXPAND);
-
   auto* panel = dynamic_cast<wxPanel*>(GetParent());
   assert(panel && "Textfield: Wrong parent type");
-  panel->SetSizer(m_sizer);
+
+  // Sizer for field with error text.
   m_error_text = new wxStaticText(panel, wxID_ANY, "");
+  wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
+  sizer->Add(this, 0, wxEXPAND);
+  sizer->Add(m_error_text, 0, wxEXPAND);
+  m_error_text->Hide();
+  panel->SetSizer(sizer);
+  sizer->Fit(panel);
 }
 
 void TextField::OnError(const wxString& msg = "") {
   bool has_error = m_error_text->GetLabel().Len() > 0;
+  m_error_text->ClearBackground();
   m_error_text->SetLabel(msg);
+  m_error_text->SetForegroundColour(*wxRED);
+  m_error_text->Show(msg.Len() > 0);
+  m_error_text->Refresh();
 
-  if (msg.IsEmpty()) {
-    m_sizer->Detach(m_error_text);
-    GUI::PropagateResize(this);
-  } else if (has_error) {
-    m_error_text->ClearBackground();
-    m_error_text->Refresh();
-  } else {
-    m_error_text->SetForegroundColour(*wxRED);
-    m_sizer->Insert(1, m_error_text, 0, wxALL | wxEXPAND, 4);
-    GUI::PropagateResize(this);
+  // Update layout when error status changed.
+  if (msg.Len() > 0 != has_error) {
+    GUI::PropagateLayout(this);
   }
 }
 
 void TextField::SetValidator(const wxValidator& validator) {
   wxTextCtrl::SetValidator(validator);
-  OnError("");
+  OnError();
 }
 
 void TextField::OnTextChanged(wxCommandEvent& event) {

--- a/libs/gui/src/field_text.cpp
+++ b/libs/gui/src/field_text.cpp
@@ -18,20 +18,31 @@
  ***************************************************************************
  */
 
+#include <wx/notebook.h>
+
 #include "field_text.h"
+#include "form_grid.h"
 #include "ui_utils.h"
 
-TextField::TextField(wxWindow* parent, wxWindowID id, const wxString& value,
-                     const wxPoint& pos, const wxSize& size, long style)
-    : wxTextCtrl(new wxPanel(parent), id, value, pos, size, style) {
+TextField::TextField(wxWindow* parent, const wxString& label,
+                     const wxString& value, wxWindowID id)
+    : wxTextCtrl(new wxPanel(parent), id, value, wxDefaultPosition,
+                 wxDefaultSize, 0) {
   auto* panel = dynamic_cast<wxPanel*>(GetParent());
   assert(panel && "Textfield: Wrong parent type");
+
+  // Add field panel and label
+  auto* grid = dynamic_cast<FormGrid*>(parent->GetSizer());
+  assert(grid && "Textfield: Wrong parent sizer");
+  wxStaticText* text_label = new wxStaticText(parent, wxID_ANY, label);
+  grid->Add(text_label, wxSizerFlags(0).Align(wxALIGN_TOP));
+  grid->Add(panel, wxSizerFlags(0).Expand());
 
   // Sizer for field with error text.
   m_error_text = new wxStaticText(panel, wxID_ANY, "");
   wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
-  sizer->Add(this, 0, wxEXPAND);
-  sizer->Add(m_error_text, 0, wxEXPAND);
+  sizer->Add(this, wxSizerFlags(0).Expand());
+  sizer->Add(m_error_text, wxSizerFlags(0).Expand());
   m_error_text->Hide();
   panel->SetSizer(sizer);
   sizer->Fit(panel);
@@ -46,8 +57,8 @@ void TextField::OnError(const wxString& msg = "") {
   m_error_text->Refresh();
 
   // Update layout when error status changed.
-  if (msg.Len() > 0 != has_error) {
-    GUI::PropagateLayout(this);
+  if ((msg.Len() > 0) != has_error) {
+    GUI::LayoutResizeEvent(this);
   }
 }
 

--- a/libs/gui/src/field_text.cpp
+++ b/libs/gui/src/field_text.cpp
@@ -18,8 +18,8 @@
  ***************************************************************************
  */
 
-#include "dialog_cntrl.h"
-#include "model/gui.h"
+#include "field_text.h"
+#include "ui_utils.h"
 
 TextField::TextField(wxWindow* parent, wxWindowID id, const wxString& value,
                      const wxPoint& pos, const wxSize& size, long style)
@@ -39,14 +39,14 @@ void TextField::OnError(const wxString& msg = "") {
 
   if (msg.IsEmpty()) {
     m_sizer->Detach(m_error_text);
-    PropagateResize(this);
+    GUI::PropagateResize(this);
   } else if (has_error) {
     m_error_text->ClearBackground();
     m_error_text->Refresh();
   } else {
     m_error_text->SetForegroundColour(*wxRED);
     m_sizer->Insert(1, m_error_text, 0, wxALL | wxEXPAND, 4);
-    PropagateResize(this);
+    GUI::PropagateResize(this);
   }
 }
 

--- a/libs/gui/src/form_grid.cpp
+++ b/libs/gui/src/form_grid.cpp
@@ -1,0 +1,28 @@
+
+/***************************************************************************
+ *   Copyright (C) 2025 by NoCodeHummel                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ **************************************************************************/
+#include "form_grid.h"
+#include "ui_utils.h"
+
+FormGrid::FormGrid(wxWindow* parent)
+    : wxFlexGridSizer(2, GUI::GetSpacing(parent, 1),
+                      GUI::GetSpacing(parent, 1)) {
+  AddGrowableCol(0, 0);
+  AddGrowableCol(1, 1);
+}

--- a/libs/gui/src/ui_utils.cpp
+++ b/libs/gui/src/ui_utils.cpp
@@ -17,10 +17,10 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 
-#include <wx/frame.h>
-#include <wx/window.h>
-
 #include "ui_utils.h"
+
+// Define custom events
+wxDEFINE_EVENT(EVT_LAYOUT_RESIZE, wxCommandEvent);
 
 int GUI::GetSpacing(wxWindow* window, int factor) {
 #if wxCHECK_VERSION(3, 2, 0)
@@ -30,9 +30,7 @@ int GUI::GetSpacing(wxWindow* window, int factor) {
 #endif
 }
 
-void GUI::PropagateLayout(wxWindow* window) {
-  wxWindow* parent = window->GetParent();
-  parent->Layout();
-  if (parent->IsTopLevel()) return;
-  PropagateLayout(parent);
+void GUI::LayoutResizeEvent(wxWindow* ctx) {
+  wxCommandEvent event(EVT_LAYOUT_RESIZE, ctx->GetId());
+  wxPostEvent(ctx, event);
 }

--- a/libs/gui/src/ui_utils.cpp
+++ b/libs/gui/src/ui_utils.cpp
@@ -1,5 +1,5 @@
-/**************************************************************************
- *   Copyright (C) 2024 Alec Leamas                                        *
+/***************************************************************************
+ *   Copyright (C) 2025 by NoCodeHummel                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -17,17 +17,16 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 
-/**
- *  \file
- *  Implement gui.h.
- */
-#include <wx/dialog.h>
 #include <wx/frame.h>
+#include "ui_utils.h"
 
-#include "model/gui.h"
-
-wxWindow* GetTopWindow() {
-  auto top_window = wxWindow::FindWindowByName(kTopLevelWindowName);
-  assert(top_window && "Cannot find MainWindow a k a gFrame");
-  return top_window;
+void GUI::PropagateResize(wxWindow* window) {
+  wxWindow* parent = window->GetParent();
+  while (parent) {
+    parent->Layout();
+    parent = parent->GetParent();
+    if (wxTopLevelWindow* topLevel = wxDynamicCast(parent, wxTopLevelWindow)) {
+      break;
+    }
+  }
 }

--- a/libs/gui/src/ui_utils.cpp
+++ b/libs/gui/src/ui_utils.cpp
@@ -18,7 +18,17 @@
  **************************************************************************/
 
 #include <wx/frame.h>
+#include <wx/window.h>
+
 #include "ui_utils.h"
+
+int GUI::GetSpacing(wxWindow* window, int factor) {
+#if wxCHECK_VERSION(3, 2, 0)
+  return window->FromDIP(kSpacing * factor);
+#else
+  return kScaling * factor;
+#endif
+}
 
 void GUI::PropagateResize(wxWindow* window) {
   wxWindow* parent = window->GetParent();

--- a/libs/gui/src/ui_utils.cpp
+++ b/libs/gui/src/ui_utils.cpp
@@ -30,13 +30,9 @@ int GUI::GetSpacing(wxWindow* window, int factor) {
 #endif
 }
 
-void GUI::PropagateResize(wxWindow* window) {
+void GUI::PropagateLayout(wxWindow* window) {
   wxWindow* parent = window->GetParent();
-  while (parent) {
-    parent->Layout();
-    parent = parent->GetParent();
-    if (wxTopLevelWindow* topLevel = wxDynamicCast(parent, wxTopLevelWindow)) {
-      break;
-    }
-  }
+  parent->Layout();
+  if (parent->IsTopLevel()) return;
+  PropagateLayout(parent);
 }

--- a/libs/gui/src/ui_utils.cpp
+++ b/libs/gui/src/ui_utils.cpp
@@ -26,7 +26,7 @@ int GUI::GetSpacing(wxWindow* window, int factor) {
 #if wxCHECK_VERSION(3, 2, 0)
   return window->FromDIP(kSpacing * factor);
 #else
-  return kScaling * factor;
+  return kSpacing * factor;
 #endif
 }
 

--- a/model/include/model/gui.h
+++ b/model/include/model/gui.h
@@ -28,4 +28,3 @@ static const char* const kTopLevelWindowName = "MainWindow";
 
 /** Return the top level window a k a gFrame. */
 wxWindow* GetTopWindow();
-void PropagateResize(wxWindow* window);


### PR DESCRIPTION
UI library TextField implementation (#4338).

The PR first moves the existing code to the UI library. Secondly spacing variable and method are refactored from the `BaseDialog` to the UI library utils to also support spacing with DIP in other classes. In compliance with the UI guidelines using 6px as base for spacing.

The PR introduces a `FormGrid` class in the UI library to layout multiple `TextField`s in a form with proper spacing. The grid has two columns; one for the label and one for the actual field.

The text field class interface is simplified to encapsulate layout and spacing within the class, including error handling. This simplifies the usage of this UI component.
