### PR TITLE
Move user datetime func to navutils

### DIFF
--- a/gui/include/gui/RoutePropDlgImpl.h
+++ b/gui/include/gui/RoutePropDlgImpl.h
@@ -131,26 +131,6 @@ private:
 
   bool IsThisRouteExtendable();
 
-  /**
-   * Convert the date/time in UTC to the given format.
-   * @param ts The input timestamp in UTC.
-   * @param format The desired output format:
-   *        0 = UTC, 1 = Local@PC, 2 = LMT@Location.
-   * @param lon The longitude for LMT calculation. Default is NaN.
-   * @return wxDateTime The converted timestamp in the specified format.
-   */
-  wxDateTime toUsrDateTime(const wxDateTime ts, const int format,
-                           const double lon = INFINITY - INFINITY);
-  /**
-   * Convert a date/time from a given input format to UTC.
-   * @param ts The input timestamp in the specified format.
-   * @param format The input timestamp format:
-   *        0 = UTC, 1 = Local@PC, 2 = LMT@Location.
-   * @param lon The longitude for LMT calculation. Default is NaN.
-   * @return wxDateTime The converted timestamp in UTC.
-   */
-  wxDateTime fromUsrDateTime(const wxDateTime ts, const int format,
-                             const double lon = INFINITY - INFINITY);
   wxString MakeTideInfo(wxString stationName, double lat, double lon,
                         wxDateTime utcTime);
 };

--- a/gui/include/gui/navutil.h
+++ b/gui/include/gui/navutil.h
@@ -53,6 +53,32 @@ extern double fromUsrTemp(double usr_temp, int unit = -1);
 extern wxString getUsrTempUnit();
 extern wxString formatAngle(double angle);
 
+// User date formats
+#define UTCINPUT 0  //!< Date/time in UTC.
+#define LTINPUT 1   //!< Date/time using PC local timezone.
+#define LMTINPUT 2  //!< Date/time using the remote location LMT time.
+
+/**
+ * Convert the date/time in UTC to the given format.
+ * @param ts The input timestamp in UTC.
+ * @param format The desired output format:
+ *        0 = UTC, 1 = Local@PC, 2 = LMT@Location.
+ * @param lon The longitude for LMT calculation. Default is NaN.
+ * @return wxDateTime The converted timestamp in the specified format.
+ */
+wxDateTime toUsrDateTime(const wxDateTime ts, const int format,
+                         const double lon = INFINITY - INFINITY);
+/**
+ * Convert a date/time from a given input format to UTC.
+ * @param ts The input timestamp in the specified format.
+ * @param format The input timestamp format:
+ *        0 = UTC, 1 = Local@PC, 2 = LMT@Location.
+ * @param lon The longitude for LMT calculation. Default is NaN.
+ * @return wxDateTime The converted timestamp in UTC.
+ */
+wxDateTime fromUsrDateTime(const wxDateTime ts, const int format,
+                           const double lon = INFINITY - INFINITY);
+
 extern void AlphaBlending(ocpnDC &dc, int x, int y, int size_x, int size_y,
                           float radius, wxColour color,
                           unsigned char transparency);

--- a/gui/src/RoutePropDlgImpl.cpp
+++ b/gui/src/RoutePropDlgImpl.cpp
@@ -39,10 +39,6 @@
 #include "RoutePropDlgImpl.h"
 #include "tcmgr.h"
 
-#define UTCINPUT 0  //!< Format date/time in UTC.
-#define LTINPUT 1   //!< Format date/time using PC local timezone.
-#define LMTINPUT 2  //!< Format date/time using the remote location LMT time.
-
 #define ID_RCLK_MENU_COPY_TEXT 7013
 #define ID_RCLK_MENU_EDIT_WP 7014
 #define ID_RCLK_MENU_DELETE 7015
@@ -451,59 +447,6 @@ void RoutePropDlgImpl::UpdatePoints() {
     m_dvlcWaypoints->SelectRow(selected_row);
     m_dvlcWaypoints->EnsureVisible(selection);
   }
-}
-
-wxDateTime RoutePropDlgImpl::toUsrDateTime(const wxDateTime ts,
-                                           const int format, const double lon) {
-  if (!ts.IsValid()) {
-    return ts;
-  }
-  wxDateTime dt;
-  switch (m_tz_selection) {
-    case LMTINPUT:  // LMT@Location
-      if (std::isnan(lon)) {
-        dt = wxInvalidDateTime;
-      } else {
-        dt =
-            ts.Add(wxTimeSpan(wxTimeSpan(0, 0, wxLongLong(lon * 3600. / 15.))));
-      }
-      break;
-    case LTINPUT:  // Local@PC
-      // Convert date/time from UTC to local time.
-      dt = ts.FromUTC();
-      break;
-    case UTCINPUT:  // UTC
-      // The date/time is already in UTC.
-      dt = ts;
-      break;
-  }
-  return dt;
-}
-
-wxDateTime RoutePropDlgImpl::fromUsrDateTime(const wxDateTime ts,
-                                             const int format,
-                                             const double lon) {
-  if (!ts.IsValid()) {
-    return ts;
-  }
-  wxDateTime dt;
-  switch (m_tz_selection) {
-    case LMTINPUT:  // LMT@Location
-      if (std::isnan(lon)) {
-        dt = wxInvalidDateTime;
-      } else {
-        dt = ts.Subtract(wxTimeSpan(0, 0, wxLongLong(lon * 3600. / 15.)));
-      }
-      break;
-    case LTINPUT:  // Local@PC
-      // The input date/time is in local time, so convert it to UTC.
-      dt = ts.ToUTC();
-      break;
-    case UTCINPUT:  // UTC
-      dt = ts;
-      break;
-  }
-  return dt;
 }
 
 void RoutePropDlgImpl::SetRouteAndUpdate(Route* pR, bool only_points) {

--- a/gui/src/TrackPropDlg.cpp
+++ b/gui/src/TrackPropDlg.cpp
@@ -49,9 +49,6 @@
 #include "androidUTIL.h"
 #endif
 
-#define UTCINPUT 0  //!< Format date/time in UTC.
-#define LTINPUT 1   //!< Format date/time using PC local timezone.
-#define LMTINPUT 2  //!< Format date/time using the remote location LMT time.
 #define INPUT_FORMAT 1
 #define DISPLAY_FORMAT 2
 #define TIMESTAMP_FORMAT 3

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -3380,6 +3380,58 @@ bool LogMessageOnce(const wxString &msg) {
 /*          Some assorted utilities                                       */
 /**************************************************************************/
 
+wxDateTime toUsrDateTime(const wxDateTime ts, const int format,
+                         const double lon) {
+  if (!ts.IsValid()) {
+    return ts;
+  }
+  wxDateTime dt;
+  switch (format) {
+    case LMTINPUT:  // LMT@Location
+      if (std::isnan(lon)) {
+        dt = wxInvalidDateTime;
+      } else {
+        dt =
+            ts.Add(wxTimeSpan(wxTimeSpan(0, 0, wxLongLong(lon * 3600. / 15.))));
+      }
+      break;
+    case LTINPUT:  // Local@PC
+      // Convert date/time from UTC to local time.
+      dt = ts.FromUTC();
+      break;
+    case UTCINPUT:  // UTC
+      // The date/time is already in UTC.
+      dt = ts;
+      break;
+  }
+  return dt;
+}
+
+wxDateTime fromUsrDateTime(const wxDateTime ts, const int format,
+                           const double lon) {
+  if (!ts.IsValid()) {
+    return ts;
+  }
+  wxDateTime dt;
+  switch (format) {
+    case LMTINPUT:  // LMT@Location
+      if (std::isnan(lon)) {
+        dt = wxInvalidDateTime;
+      } else {
+        dt = ts.Subtract(wxTimeSpan(0, 0, wxLongLong(lon * 3600. / 15.)));
+      }
+      break;
+    case LTINPUT:  // Local@PC
+      // The input date/time is in local time, so convert it to UTC.
+      dt = ts.ToUTC();
+      break;
+    case UTCINPUT:  // UTC
+      dt = ts;
+      break;
+  }
+  return dt;
+}
+
 /**************************************************************************/
 /*          Converts the distance from the units selected by user to NMi  */
 /**************************************************************************/


### PR DESCRIPTION
Move user datetime conversion functions to `navutils` to be available for re-use. This PR resolves #4352.

The format definitions are included in the header and a duplicate format definition is removed.

The refactoring revealed a bug that the input parameter `format` was not used, but the code used the selection in the dialog instead.