### PR TITLE
Fix regressions in Font Manager, support reset to system font

### DIFF
--- a/gui/include/gui/FontDesc.h
+++ b/gui/include/gui/FontDesc.h
@@ -33,7 +33,7 @@
 class MyFontDesc {
 public:
   MyFontDesc(wxString DialogString, wxString ConfigString, wxFont *pFont,
-             wxColour color);
+             wxColour color, bool is_default = true);
   ~MyFontDesc();
 
   /**
@@ -60,6 +60,8 @@ public:
    * Text color.
    */
   wxColour m_color;
+  /** Indicates if this is the default font entry for the TextElement. */
+  bool m_is_default;
 };
 
 WX_DECLARE_LIST(MyFontDesc, FontList);

--- a/gui/include/gui/options.h
+++ b/gui/include/gui/options.h
@@ -101,6 +101,7 @@ enum {
   ID_BUTTONDELETE,
   ID_BUTTONCOMPRESS,
   ID_BUTTONFONTCHOOSE,
+  ID_BUTTONFONT_RESET,
   ID_BUTTONECDISHELP,
   ID_BUTTONFONTCOLOR,
   ID_BUTTONGROUP,
@@ -648,6 +649,7 @@ private:
 
   void OnAlertEnableButtonClick(wxCommandEvent &event);
   void OnAlertAudioEnableButtonClick(wxCommandEvent &event);
+  void OnResetFont(wxCommandEvent &event);
 
   void UpdateTemplateTitleText();
   void CheckDeviceAccess(wxString &path);

--- a/gui/src/FontDesc.cpp
+++ b/gui/src/FontDesc.cpp
@@ -28,14 +28,12 @@
 WX_DEFINE_LIST(FontList);
 
 MyFontDesc::MyFontDesc(wxString DialogString, wxString ConfigString,
-                       wxFont *pFont, wxColour color) {
-  m_dialogstring = DialogString;
-  m_configstring = ConfigString;
-
-  m_nativeInfo = pFont->GetNativeFontInfoDesc();
-
-  m_font = pFont;
-  m_color = color;
-}
+                       wxFont *pFont, wxColour color, bool is_default)
+    : m_dialogstring(DialogString),
+      m_configstring(ConfigString),
+      m_nativeInfo(pFont->GetNativeFontInfoDesc()),
+      m_font(pFont),
+      m_color(color),
+      m_is_default(is_default) {}
 
 MyFontDesc::~MyFontDesc() { delete m_font; }

--- a/gui/src/FontMgr.cpp
+++ b/gui/src/FontMgr.cpp
@@ -22,6 +22,7 @@
  **************************************************************************/
 
 #include <locale>
+#include <set>
 
 #include <wx/gdicmn.h>
 #include <wx/tokenzr.h>
@@ -114,37 +115,17 @@ FontMgr::~FontMgr() {
 void FontMgr::SetLocale(wxString &newLocale) { s_locale = newLocale; }
 
 wxColour FontMgr::GetFontColor(const wxString &TextElement) const {
-  //    Look thru the font list for a match
-  MyFontDesc *pmfd;
-  auto node = m_fontlist->GetFirst();
-  while (node) {
-    pmfd = node->GetData();
-    if (pmfd->m_dialogstring == TextElement) {
-      if (pmfd->m_configstring.BeforeFirst('-') == s_locale)
-        return pmfd->m_color;
-    }
-    node = node->GetNext();
-  }
-
-  return wxColour(0, 0, 0);
+  MyFontDesc *pmfd = GetFontDesc(TextElement);
+  return pmfd ? pmfd->m_color : wxColour(0, 0, 0);
 }
 
 bool FontMgr::SetFontColor(const wxString &TextElement,
                            const wxColour color) const {
-  //    Look thru the font list for a match
-  MyFontDesc *pmfd;
-  auto node = m_fontlist->GetFirst();
-  while (node) {
-    pmfd = node->GetData();
-    if (pmfd->m_dialogstring == TextElement) {
-      if (pmfd->m_configstring.BeforeFirst('-') == s_locale) {
-        pmfd->m_color = color;
-        return true;
-      }
-    }
-    node = node->GetNext();
+  MyFontDesc *pmfd = GetFontDesc(TextElement);
+  if (pmfd) {
+    pmfd->m_color = color;
+    return true;
   }
-
   return false;
 }
 
@@ -173,15 +154,36 @@ wxString FontMgr::GetFontConfigKey(const wxString &description) {
   return configkey;
 }
 
-wxFont *FontMgr::GetFont(const wxString &TextElement, int requested_font_size) {
+int FontMgr::GetSystemFontSize() {
   static int sys_font_size = 0;
-  static wxString sys_font_facename;
-  // Get the system default font.
   if (!sys_font_size) {
     wxFont sys_font = *wxNORMAL_FONT;
     sys_font_size = sys_font.GetPointSize();
+  }
+  return sys_font_size;
+}
+
+wxString FontMgr::GetSystemFontFaceName() {
+  static wxString sys_font_facename;
+  if (sys_font_facename.IsEmpty()) {
+    wxFont sys_font = *wxNORMAL_FONT;
     sys_font_facename = sys_font.GetFaceName();
   }
+  return sys_font_facename;
+}
+
+bool FontMgr::IsDefaultFontEntry(const MyFontDesc *font_desc) const {
+  return font_desc && font_desc->m_is_default;
+  /*
+  if (!font_desc || !font_desc->m_font) return false;
+
+  int font_size = font_desc->m_font->GetPointSize();
+  return (g_default_font_size && font_size == g_default_font_size) ||
+         (!g_default_font_size && font_size == GetSystemFontSize());
+  */
+}
+
+wxFont *FontMgr::GetFont(const wxString &TextElement, int requested_font_size) {
   // Look thru the font list for a match
   MyFontDesc *pmfd;
   auto node = m_fontlist->GetFirst();
@@ -191,17 +193,13 @@ wxFont *FontMgr::GetFont(const wxString &TextElement, int requested_font_size) {
     // Check if the font matches both the text element and the requested size.
     if (pmfd->m_dialogstring == TextElement &&
         (pmfd->m_configstring.BeforeFirst('-') == s_locale)) {
-      int font_size = pmfd->m_font->GetPointSize();
-      if (requested_font_size == 0) {
+      if (requested_font_size == 0 && IsDefaultFontEntry(pmfd)) {
         // Caller did not specify a font size, so return the default font.
         // The user may have customized the default font in Options->User Fonts,
         // else the system default font is used.
-        if (g_default_font_size && font_size == g_default_font_size) {
-          return pmfd->m_font;
-        } else if (font_size == sys_font_size) {
-          return pmfd->m_font;
-        }
-      } else if (font_size == requested_font_size) {
+        return pmfd->m_font;
+      } else if (requested_font_size != 0 &&
+                 pmfd->m_font->GetPointSize() == requested_font_size) {
         return pmfd->m_font;
       }
     }
@@ -216,25 +214,52 @@ wxFont *FontMgr::GetFont(const wxString &TextElement, int requested_font_size) {
 
   int new_size;
   if (0 == requested_font_size) {
-    if (g_default_font_size)
-      new_size = g_default_font_size;
-    else
-      new_size = sys_font_size;
+    new_size = g_default_font_size ? g_default_font_size : GetSystemFontSize();
   } else
     new_size = requested_font_size;
 
-  if (g_default_font_facename.Length())
-    sys_font_facename = g_default_font_facename;
+  wxString face_name = g_default_font_facename.Length()
+                           ? g_default_font_facename
+                           : GetSystemFontFaceName();
 
-  wxString nativefont = GetSimpleNativeFont(new_size, sys_font_facename);
+  wxString nativefont = GetSimpleNativeFont(new_size, face_name);
   wxFont *nf = wxFont::New(nativefont);
 
   wxColor color = GetDefaultFontColor(TextElement);
 
-  MyFontDesc *pnewfd = new MyFontDesc(TextElement, configkey, nf, color);
+  bool is_default = (requested_font_size == 0);
+  MyFontDesc *pnewfd =
+      new MyFontDesc(TextElement, configkey, nf, color, is_default);
   m_fontlist->Append(pnewfd);
 
   return pnewfd->m_font;
+}
+
+MyFontDesc *FontMgr::GetFontDesc(const wxString &TextElement) const {
+  // First try to find the default font entry
+  MyFontDesc *pmfd;
+  auto node = m_fontlist->GetFirst();
+  while (node) {
+    pmfd = node->GetData();
+    if (pmfd->m_dialogstring == TextElement && pmfd->m_is_default &&
+        pmfd->m_configstring.BeforeFirst('-') == s_locale) {
+      return pmfd;
+    }
+    node = node->GetNext();
+  }
+
+  // No default entry found, fall back to first matching entry
+  node = m_fontlist->GetFirst();
+  while (node) {
+    pmfd = node->GetData();
+    if (pmfd->m_dialogstring == TextElement &&
+        pmfd->m_configstring.BeforeFirst('-') == s_locale) {
+      return pmfd;
+    }
+    node = node->GetNext();
+  }
+
+  return NULL;
 }
 
 wxColour FontMgr::GetDefaultFontColor(const wxString &TextElement) {
@@ -280,31 +305,20 @@ wxString FontMgr::GetSimpleNativeFont(int size, wxString face) {
 bool FontMgr::SetFont(const wxString &TextElement, wxFont *pFont,
                       wxColour color) {
   //    Look thru the font list for a match
-  MyFontDesc *pmfd;
-  auto node = m_fontlist->GetFirst();
-  while (node) {
-    pmfd = node->GetData();
-    if (pmfd->m_dialogstring == TextElement) {
-      if (pmfd->m_configstring.BeforeFirst('-') == s_locale) {
-        // Todo Think about this
-        //
+  MyFontDesc *pmfd = GetFontDesc(TextElement);
+  // Todo Think about this
+  //
+  //      Cannot delete the present font, since it may be in use elsewhere
+  //      This WILL leak....but only on font changes
+  //              delete pmfd->m_font;                            // purge
+  //              any old value
+  if (pmfd) {
+    pmfd->m_font = pFont;
+    pmfd->m_nativeInfo = pFont->GetNativeFontInfoDesc();
+    pmfd->m_color = color;
 
-        //      Cannot delete the present font, since it may be in use elsewhere
-        //      This WILL leak....but only on font changes
-
-        //              delete pmfd->m_font;                            // purge
-        //              any old value
-
-        pmfd->m_font = pFont;
-        pmfd->m_nativeInfo = pFont->GetNativeFontInfoDesc();
-        pmfd->m_color = color;
-
-        return true;
-      }
-    }
-    node = node->GetNext();
+    return true;
   }
-
   return false;
 }
 
@@ -318,6 +332,26 @@ const wxString &FontMgr::GetConfigString(int i) const {
 const wxString &FontMgr::GetDialogString(int i) const {
   MyFontDesc *pfd = m_fontlist->Item(i)->GetData();
   return pfd->m_dialogstring;
+}
+
+wxArrayString FontMgr::GetDialogStrings(const wxString &locale) const {
+  std::set<wxString> uniqueStrings;
+
+  auto node = m_fontlist->GetFirst();
+  while (node) {
+    MyFontDesc *pmfd = node->GetData();
+    if (locale.IsEmpty() || pmfd->m_configstring.BeforeFirst('-') == locale) {
+      uniqueStrings.insert(pmfd->m_dialogstring);
+    }
+    node = node->GetNext();
+  }
+  wxArrayString strings;
+  strings.reserve(uniqueStrings.size());  // Pre-allocate for efficiency
+  for (const auto &str : uniqueStrings) {
+    strings.Add(str);
+  }
+
+  return strings;
 }
 
 const wxString &FontMgr::GetNativeDesc(int i) const {
@@ -637,4 +671,26 @@ bool FontMgr::AddAuxKey(wxString key) {
   }
   m_AuxKeyArray.Add(key);
   return true;
+}
+
+bool FontMgr::ResetFontToDefault(const wxString &TextElement) {
+  // Create default font with system settings
+  int size = g_default_font_size ? g_default_font_size : GetSystemFontSize();
+  wxString face = g_default_font_facename.Length() ? g_default_font_facename
+                                                   : GetSystemFontFaceName();
+  wxString native = GetSimpleNativeFont(size, face);
+  wxFont *defaultFont = wxFont::New(native);
+
+  // Find and update the font descriptor
+  MyFontDesc *desc = GetFontDesc(TextElement);
+  if (desc) {
+    // Update font properties
+    desc->m_font = defaultFont;
+    desc->m_nativeInfo = native;
+    desc->m_color = GetDefaultFontColor(TextElement);
+    desc->m_is_default = true;
+    return true;
+  }
+
+  return false;
 }


### PR DESCRIPTION
This is a follow-up to #4359 and #4296 

Specifically the issue reported by @Hakansv at https://github.com/OpenCPN/OpenCPN/pull/4296#issuecomment-2644203597

# Issue Description

## Issue 1

Two regressions have been introduced by #4359:
   1. Methods that don't take a font size parameter (like `GetFontColor()`) were inconsistently handling default fonts. They would return properties from the first matching font entry in the cache, even if it wasn't the default font entry for that text element.
   2. In the UI, the drop-down list of fonts in Options -> User Interface -> Fonts may have duplicates.

This regression was introduced after attempting to fix this problem: In the font manager, the `GetFont()` function completely ignored `user_default_size`. While it seems to handle `user_default_size`, it actually doesn't use it when searching through existing fonts in `m_fontlist`. The first loop entirely ignored the `user_default_size`, only returning an exact match based on TextElement and locale.
This means if the caller is looking for a font with a specific size, the method may return a font with a different size than requested.

To address this issue, the `GetFont()` method now properly handles font sizes, allowing both default fonts and specific font sizes to coexist for the same text element. This means the same font typeface may be present in the font manager, with different sizes.

## Issue 2

In the UI, the user can customize fonts by selecting a facetype, style and font size. However, the font size selected by the user is ignored.

<img width="464" alt="image" src="https://github.com/user-attachments/assets/d94709cc-5277-42d3-bb1c-0fad8f952e37" />

## Issue 3

After a user has customized a font, e.g., for a particular font category such as "Grid Text", there is no obvious way to reset to system defaults.

<img width="620" alt="image" src="https://github.com/user-attachments/assets/76349426-5f71-4949-b687-40c14ae84082" />


# Changes
1. Added utility functions to consistently identify system font properties.
2. Added a method to determine if a font entry represents the default font.
4. Refactored `GetFont()` to properly handle both default and specific font sizes.
5. Updated methods that don't take a font size parameter (such as `GetFontColor()`) to prioritize returning properties from default font entries.
6. Honor font size selection selected by user.
7. Fix regression where the list of Font categories (e.g. Grid Text, Menu...) had duplicates.
8. Add code comments.
9. Add `ResetFontToDefault()` function to reset font to system defaults for a particular `TextElement`. See screenshot below.

<img width="561" alt="image" src="https://github.com/user-attachments/assets/649cf34c-ef7d-4399-a89f-8c404e6244b5" />


# Tests

- [x] Go to Options -> User Interface -> Fonts. Click the drop-down list. Verify the list has unique names (Menu, Marks, Dialog, AIS Target Name...)
- [x] Validate the Text Elements in the drop-down list are sorted in alphabetical order.
- [x] Verify that customizing a font takes effect.
    1. In the Chart Panel Options, click "Show Grid". 
    2. Go to Options -> User Interface -> Fonts. In the drop-down list, select "GridText". Click "Choose Font..." and select a typeface, style. Click Ok and then Ok again in the Option panel. Verify the typeface of the grid (latitude, longitude) has been changed.
    3. Open `opencpn.ini` to validate the font customization has been saved. On MacOS, the INI section is `[Settings/MacFonts]`.
- [x] After the above test, quit OpenCPN, then restart OpenCPN. Validate the custom font is still configured and applied.
- [x] Validate customizing the font size takes effect. Go to Options -> User Interface -> Fonts. Click the drop-down list.
    1. In the Chart Panel Options, click "Show Grid".
    4. Go to Options -> User Interface -> Fonts. In the drop-down list, select "GridText". Click "Choose Font...". Change the font size. Click "Ok" twice. Validate the font size is changed.
- [x] Validate the "Reset to Default" option is working:
    1. Go to Options -> User Interface -> Fonts. In the drop-down list, select "GridText". Click "Choose Font..." and select a typeface, style. Click Ok and then Ok again in the Option panel. Verify the typeface of the grid (latitude, longitude) has been changed.
    2. Go to Options -> User Interface -> Fonts again. Click "Reset to Default".
    3. Click Ok twice. Verify the font of the grid text has been reset to system default.

# Additional Issues Found

Below are preexisting issues that could be addressed in a future PR.

1. The following font customization options are presented in "Choose Font..." but do not take effect (at least on MacOS):
   1. Font style (regular, bold, italic, condensed...).
   2. Font size (fixed)
   3. Font color
   4. Font underline style
   5. Font strikethrough

On MacOS, there are several font selection options. Only a few of them are relevant to the OpenCPN font customization.

<img width="447" alt="image" src="https://github.com/user-attachments/assets/693bad7a-0eee-4d83-ae36-15a33aaaa5d8" />

2. If the user selects a native font, but does not complete all the fields (such as the "Style" field), then click "ok", no font change takes effect.

<img width="615" alt="image" src="https://github.com/user-attachments/assets/45f66387-3865-4fe4-b3d7-652a0a4784bc" />
