### PR TITLE
Communications clean up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -858,7 +858,7 @@ set(GUI_HDRS
     ${GUI_HDR_DIR}/track_gui.h
     ${GUI_HDR_DIR}/trackprintout.h
     ${GUI_HDR_DIR}/TrackPropDlg.h
-    ${GUI_HDR_DIR}/TTYScroll.h
+    ${GUI_HDR_DIR}/tty_scroll.h
     ${GUI_HDR_DIR}/TTYWindow.h
     ${GUI_HDR_DIR}/udev_rule_mgr.h
     ${GUI_HDR_DIR}/undo.h
@@ -978,7 +978,7 @@ set(GUI_SRC
     ${GUI_SRC_DIR}/track_gui.cpp
     ${GUI_SRC_DIR}/trackprintout.cpp
     ${GUI_SRC_DIR}/TrackPropDlg.cpp
-    ${GUI_SRC_DIR}/TTYScroll.cpp
+    ${GUI_SRC_DIR}/tty_scroll.cpp
     ${GUI_SRC_DIR}/TTYWindow.cpp
     ${GUI_SRC_DIR}/udev_rule_mgr.cpp
     ${GUI_SRC_DIR}/undo.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -358,7 +358,7 @@ if (NOT WIN32 AND NOT APPLE)
   if (NOT OCPN_PEDANTIC)
     add_compile_options(
       "-Wno-unused" "-fexceptions" "-rdynamic" "-fno-strict-aliasing"
-      "-Wno-deprecated-declarations"
+      "-Wno-deprecated-declarations" "-Wno-unknown-pragmas"
     )
   endif ()
   if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang|GNU")

--- a/gui/include/gui/TTYWindow.h
+++ b/gui/include/gui/TTYWindow.h
@@ -30,7 +30,7 @@
 
 class wxButton;
 class wxTextCtrl;
-class TTYScroll;
+class TtyScroll;
 class WindowDestroyListener;
 
 class TTYWindow : public wxFrame {
@@ -52,7 +52,7 @@ public:
 protected:
   void CreateLegendBitmap();
   WindowDestroyListener *m_window_destroy_listener;
-  TTYScroll *m_tty_scroll;
+  TtyScroll *m_tty_scroll;
   wxButton *m_btn_pause;
   wxButton *m_btn_copy;
   wxButton *m_btn_copy_N0183;

--- a/gui/include/gui/tty_scroll.h
+++ b/gui/include/gui/tty_scroll.h
@@ -21,6 +21,8 @@
 #ifndef __TTYSCROLL_H__
 #define __TTYSCROLL_H__
 
+#include <deque>
+
 #include <wx/scrolwin.h>
 #include <wx/textctrl.h>
 
@@ -32,21 +34,44 @@
 /** Scrolled TTY-like window for logging, etc. */
 class TtyScroll : public wxScrolledWindow {
 public:
-  TtyScroll(wxWindow *parent, int n_lines, wxTextCtrl &tFilter);
-  virtual ~TtyScroll();
-  virtual void OnDraw(wxDC &dc);
-  virtual void Add(const wxString &line);
-  void OnSize(wxSizeEvent &event);
-  void Pause(bool pause) { bpause = pause; }
-  void Copy(bool);
+  /**
+   * Create a TtyScroll instance
+   * @param parent Parent window
+   * @param n_lines Number of visible lines i. e., window height.
+   * @param filter Used by Add() to discard lines. If filter is empty
+   * or added lines contains filter.GetValue() lines are used; otherwise
+   * lines are discarded.
+   */
+  TtyScroll(wxWindow* parent, int n_lines, wxTextCtrl& filter);
+
+  virtual ~TtyScroll() = default;
+
+  /**
+   * Add a line to bottom of window, typically discarding top-most line.
+   * Subject to checks with respect to paused state and filter possibly
+   * discarding argument line.
+   */
+  virtual void Add(const wxString& line);
+
+  /** Set the window to ignore Add() or not depending on pause. */
+  void Pause(bool pause) { m_is_paused = pause; }
+
+  /**
+   *  Copy visible content to clipboard.
+   *  @param n0183 If true, copy cleaned up data excluding time stamps etc.
+   */
+  void Copy(bool n183);
 
 protected:
-  wxCoord m_hLine;  // the height of one line on screen
-  size_t m_nLines;  // the number of lines we draw
+  wxCoord m_line_height;  // the height of one line on screen
+  size_t m_n_lines;       // the number of lines we draw
 
-  wxArrayString *m_plineArray;
-  wxTextCtrl &m_tFilter;
-  bool bpause;
+  std::deque<wxString> m_lines;
+  wxTextCtrl& m_filter;
+  bool m_is_paused;
+
+  virtual void OnDraw(wxDC& dc);
+  void OnSize(wxSizeEvent& event);
 };
 
 #endif

--- a/gui/include/gui/tty_scroll.h
+++ b/gui/include/gui/tty_scroll.h
@@ -1,8 +1,4 @@
-/******************************************************************************
- *
- * Project:  OpenCPN
- *
- ***************************************************************************
+/***************************************************************************
  *   Copyright (C) 2013 by David S. Register                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -28,11 +24,16 @@
 #include <wx/scrolwin.h>
 #include <wx/textctrl.h>
 
-//    Scrolled TTY-like window for logging, etc....
-class TTYScroll : public wxScrolledWindow {
+/**
+ * \file
+ * Scrolled TTY-like window for logging, etc....
+ */
+
+/** Scrolled TTY-like window for logging, etc. */
+class TtyScroll : public wxScrolledWindow {
 public:
-  TTYScroll(wxWindow *parent, int n_lines, wxTextCtrl &tFilter);
-  virtual ~TTYScroll();
+  TtyScroll(wxWindow *parent, int n_lines, wxTextCtrl &tFilter);
+  virtual ~TtyScroll();
   virtual void OnDraw(wxDC &dc);
   virtual void Add(const wxString &line);
   void OnSize(wxSizeEvent &event);

--- a/gui/src/TTYWindow.cpp
+++ b/gui/src/TTYWindow.cpp
@@ -31,7 +31,7 @@
 #include <wx/dcscreen.h>
 
 #include "TTYWindow.h"
-#include "TTYScroll.h"
+#include "tty_scroll.h"
 #include "WindowDestroyListener.h"
 #include "color_handler.h"
 #include "ocpn_plugin.h"
@@ -56,7 +56,7 @@ TTYWindow::TTYWindow(wxWindow* parent, int n_lines,
 
   m_filter = new wxTextCtrl(this, wxID_ANY);
 
-  m_tty_scroll = new TTYScroll(this, n_lines, *m_filter);
+  m_tty_scroll = new TtyScroll(this, n_lines, *m_filter);
   m_tty_scroll->Scroll(-1, 1000);  // start with full scroll down
 
   bSizerOuterContainer->Add(m_tty_scroll, 1, wxEXPAND, 5);

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -1,10 +1,4 @@
-/***************************************************************************
- *
- * Project:  OpenCPN
- * Purpose:  PlugIn GUI API Functions
- * Author:   David Register
- *
- ***************************************************************************
+/**************************************************************************
  *   Copyright (C) 2024 by David S. Register                               *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -23,7 +17,12 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
  **************************************************************************/
 
-#include "dychart.h"
+/**
+ * \file
+ * PlugIn GUI API Functions
+ */
+
+#include "dychart.h"  // Must be ahead due to buggy GL includes handling
 
 #include <wx/wx.h>
 #include <wx/arrstr.h>
@@ -35,38 +34,39 @@
 #include <wx/string.h>
 #include <wx/window.h>
 
-#include "ocpn_plugin.h"
-#include "pluginmanager.h"
-#include "toolbar.h"
-#include "options.h"
-#include "s52plib.h"
+#include "model/ais_decoder.h"
+#include "model/comm_navmsg_bus.h"
+#include "model/idents.h"
+#include "model/multiplexer.h"
+#include "model/own_ship.h"
 #include "model/plugin_comm.h"
 #include "model/route.h"
 #include "model/track.h"
-#include "routemanagerdialog.h"
-#include "model/idents.h"
-#include "model/multiplexer.h"
-#include "chartdb.h"
-#include "OCPNPlatform.h"
-#include "OCPN_AUIManager.h"
-#include "FontMgr.h"
-#include "gui_lib.h"
-#include "model/ais_decoder.h"
-#include "model/comm_navmsg_bus.h"
-#include "model/own_ship.h"
-#include "ocpn_app.h"
-#include "ocpn_frame.h"
-#include "svg_utils.h"
-#include "navutil.h"
-#include "chcanv.h"
-#include "piano.h"
-#include "waypointman_gui.h"
-#include "routeman_gui.h"
-#include "glChartCanvas.h"
-#include "SoundFactory.h"
-#include "SystemCmdSound.h"
+
 #include "ais.h"
+#include "chartdb.h"
+#include "chcanv.h"
 #include "ConfigMgr.h"
+#include "FontMgr.h"
+#include "glChartCanvas.h"
+#include "gui_lib.h"
+#include "navutil.h"
+#include "ocpn_app.h"
+#include "OCPN_AUIManager.h"
+#include "ocpn_frame.h"
+#include "OCPNPlatform.h"
+#include "ocpn_plugin.h"
+#include "options.h"
+#include "piano.h"
+#include "pluginmanager.h"
+#include "routemanagerdialog.h"
+#include "routeman_gui.h"
+#include "s52plib.h"
+#include "SoundFactory.h"
+#include "svg_utils.h"
+#include "SystemCmdSound.h"
+#include "toolbar.h"
+#include "waypointman_gui.h"
 
 extern PlugInManager* s_ppim;
 extern MyConfig* pConfig;

--- a/gui/src/tty_scroll.cpp
+++ b/gui/src/tty_scroll.cpp
@@ -26,9 +26,9 @@
 #include <wx/dcclient.h>
 #include <wx/clipbrd.h>
 
-#include "TTYScroll.h"
+#include "tty_scroll.h"
 
-TTYScroll::TTYScroll(wxWindow *parent, int n_lines, wxTextCtrl &tFilter)
+TtyScroll::TtyScroll(wxWindow *parent, int n_lines, wxTextCtrl &tFilter)
     : wxScrolledWindow(parent), m_nLines(n_lines), m_tFilter(tFilter) {
   bpause = false;
   wxClientDC dc(this);
@@ -40,9 +40,9 @@ TTYScroll::TTYScroll(wxWindow *parent, int n_lines, wxTextCtrl &tFilter)
   for (unsigned int i = 0; i < m_nLines; i++) m_plineArray->Add(_T(""));
 }
 
-TTYScroll::~TTYScroll() { delete m_plineArray; }
+TtyScroll::~TtyScroll() { delete m_plineArray; }
 
-void TTYScroll::Add(const wxString &line) {
+void TtyScroll::Add(const wxString &line) {
   wxString filter = m_tFilter.GetValue();
   if (!bpause && (filter.IsEmpty() || line.Contains(filter))) {
     if (m_plineArray->GetCount() > m_nLines - 1) {  // shuffle the arraystring
@@ -60,7 +60,7 @@ void TTYScroll::Add(const wxString &line) {
   }
 }
 
-void TTYScroll::OnDraw(wxDC &dc) {
+void TtyScroll::OnDraw(wxDC &dc) {
   // update region is always in device coords, translate to logical ones
   wxRect rectUpdate = GetUpdateRegion().GetBox();
   CalcUnscrolledPosition(rectUpdate.x, rectUpdate.y, &rectUpdate.x,
@@ -99,7 +99,7 @@ void TTYScroll::OnDraw(wxDC &dc) {
   }
 }
 
-void TTYScroll::Copy(bool n0183) {
+void TtyScroll::Copy(bool n0183) {
   wxString theText;
   for (unsigned int i = 0; i < m_plineArray->GetCount(); i++) {
     wxString s = m_plineArray->Item(i);

--- a/model/include/model/comm_drv_n2k.h
+++ b/model/include/model/comm_drv_n2k.h
@@ -38,7 +38,7 @@ public:
   virtual bool SendMessage(std::shared_ptr<const NavMsg> msg,
                            std::shared_ptr<const NavAddr> addr) override = 0;
   virtual void SetListener(DriverListener& l) override;
-  virtual std::shared_ptr<NavAddr> GetAddress(const N2kName& name);
+  virtual std::shared_ptr<NavAddr2000> GetAddress(const N2kName& name);
   virtual int SetTXPGN(int pgn) { return 0; }
 };
 

--- a/model/include/model/comm_navmsg.h
+++ b/model/include/model/comm_navmsg.h
@@ -163,6 +163,9 @@ class NavAddr0183 : public NavAddr {
 public:
   NavAddr0183(const std::string iface) : NavAddr(NavAddr::Bus::N0183, iface) {};
 
+  // An empty, illegal N0183 address
+  NavAddr0183() : NavAddr() {}
+
   std::string to_string() const { return iface; }
 };
 
@@ -173,6 +176,9 @@ public:
 
   NavAddr2000(const std::string& iface, unsigned char _address)
       : NavAddr(NavAddr::Bus::N2000, iface), name(0), address(_address) {};
+
+  // An empty, illegal N2000 address
+  NavAddr2000() : NavAddr() {}
 
   std::string to_string() const { return name.to_string(); }
 
@@ -207,16 +213,22 @@ class NavMsg : public KeyProvider {
 public:
   NavMsg() = delete;
 
+  /** Return unique key used by observable to notify/listen. */
   virtual std::string key() const = 0;
 
   virtual std::string to_string() const {
     return NavAddr::BusToString(bus) + " " + key();
   }
 
+  /** Alias for key(). */
   std::string GetKey() const { return key(); }
 
   const NavAddr::Bus bus;
 
+  /**
+   * Source address is set by drivers when receiving, unused and should be
+   * empty when sending.
+   */
   std::shared_ptr<const NavAddr> source;
 
 protected:

--- a/model/include/model/comm_navmsg.h
+++ b/model/include/model/comm_navmsg.h
@@ -216,6 +216,7 @@ public:
   /** Return unique key used by observable to notify/listen. */
   virtual std::string key() const = 0;
 
+  /** Return printable string for logging etc without trailing nl */
   virtual std::string to_string() const {
     return NavAddr::BusToString(bus) + " " + key();
   }
@@ -297,9 +298,7 @@ public:
 
   std::string key() const { return Nmea0183Msg::MessageKey(type.c_str()); };
 
-  std::string to_string() const {
-    return NavMsg::to_string() + " " + talker + type + " " + payload;
-  }
+  std::string to_string() const;
 
   /** Return key which should be used to listen to given message type. */
   static std::string MessageKey(const char* type = "ALL") {
@@ -336,6 +335,8 @@ public:
   const std::string dest_host;  ///< hostname, ip address or 'localhost'
 
   std::string key() const { return std::string("plug.json-") + name; };
+
+  std::string to_string() const { return name + ": " + message; }
 };
 
 /** A parsed SignalK message over ipv4 */

--- a/model/include/model/comm_navmsg.h
+++ b/model/include/model/comm_navmsg.h
@@ -43,6 +43,10 @@ struct N2kPGN {
 
   N2kPGN(uint64_t _pgn) { pgn = _pgn; }
 
+  friend bool operator<(const N2kPGN& lhs, const N2kPGN& rhs) {
+    return lhs.pgn < rhs.pgn;
+  }
+
   std::string to_string() const {
     std::stringstream ss;
     ss << pgn;
@@ -62,6 +66,10 @@ struct N2kPGN {
 struct N2kName {
   N2kName() {};
   N2kName(uint64_t name) { value.Name = name; }
+
+  friend bool operator<(const N2kName& lhs, const N2kName& rhs) {
+    return lhs.value.Name < rhs.value.Name;
+  }
 
   std::string to_string() const {
     std::stringstream ss;

--- a/model/include/model/comm_navmsg.h
+++ b/model/include/model/comm_navmsg.h
@@ -245,15 +245,15 @@ public:
   Nmea2000Msg(const uint64_t _pgn)
       : NavMsg(NavAddr::Bus::N2000, std::make_shared<NavAddr>()), PGN(_pgn) {}
 
-  Nmea2000Msg(const uint64_t _pgn, std::shared_ptr<const NavAddr> src)
+  Nmea2000Msg(const uint64_t _pgn, std::shared_ptr<const NavAddr2000> src)
       : NavMsg(NavAddr::Bus::N2000, src), PGN(_pgn) {}
 
   Nmea2000Msg(const uint64_t _pgn, const std::vector<unsigned char>& _payload,
-              std::shared_ptr<const NavAddr> src)
+              std::shared_ptr<const NavAddr2000> src)
       : NavMsg(NavAddr::Bus::N2000, src), PGN(_pgn), payload(_payload) {}
 
   Nmea2000Msg(const uint64_t _pgn, const std::vector<unsigned char>& _payload,
-              std::shared_ptr<const NavAddr> src, int _priority)
+              std::shared_ptr<const NavAddr2000> src, int _priority)
       : NavMsg(NavAddr::Bus::N2000, src),
         PGN(_pgn),
         payload(_payload),

--- a/model/include/model/ocpn_utils.h
+++ b/model/include/model/ocpn_utils.h
@@ -65,6 +65,9 @@ void copy_file(const std::string& src_path, const std::string& dest_path);
  */
 bool N0183CheckSumOk(const std::string& sentence);
 
+/** Return copy of str with non-printable chars replaced by hex like "<0D>" */
+std::string printable(const std::string str);
+
 }  // namespace ocpn
 
 #endif  //  _OCPN_UTILS_H__

--- a/model/src/comm_drv_n2k.cpp
+++ b/model/src/comm_drv_n2k.cpp
@@ -47,6 +47,6 @@ bool CommDriverN2K::SendMessage(std::shared_ptr<const NavMsg> msg,
 
 void CommDriverN2K::SetListener(DriverListener& l) {};
 
-std::shared_ptr<NavAddr> CommDriverN2K::GetAddress(const N2kName& name) {
-  return std::make_shared<NavAddr>(NavAddr2000(iface, name));
+std::shared_ptr<NavAddr2000> CommDriverN2K::GetAddress(const N2kName& name) {
+  return std::make_shared<NavAddr2000>(NavAddr2000(iface, name));
 }

--- a/model/src/comm_n0183_output.cpp
+++ b/model/src/comm_n0183_output.cpp
@@ -126,11 +126,10 @@ void BroadcastNMEA0183Message(const wxString& msg, NmeaLog& nmea_log,
         if (bout_filter) {
           std::string id = msg.ToStdString().substr(1, 5);
           auto msg_out = std::make_shared<Nmea0183Msg>(
-              id, msg.ToStdString(),
-              std::make_shared<NavAddr0183>(driver->iface));
+              id, msg.ToStdString(), std::make_shared<NavAddr>());
 
-          bool bxmit_ok = driver->SendMessage(
-              msg_out, std::make_shared<NavAddr0183>(driver->iface));
+          bool bxmit_ok =
+              driver->SendMessage(msg_out, std::make_shared<NavAddr>());
 
           if (bxmit_ok)
             LogBroadcastOutputMessageColor(msg, params.GetDSPort(), "<BLUE>",
@@ -536,7 +535,7 @@ int SendRouteToGPS_N0183(Route* pr, const wxString& com_name,
   } else
 
   {
-    auto address = std::make_shared<NavAddr0183>(drv_n0183->iface);
+    auto address = std::make_shared<NavAddr>();
     SENTENCE snt;
     NMEA0183 oNMEA0183(NmeaCtxFactory());
     oNMEA0183.TalkerID = _T ( "EC" );
@@ -614,11 +613,11 @@ int SendRouteToGPS_N0183(Route* pr, const wxString& com_name,
         //  We need only send once for FurunoGP3X models
 
         auto msg_out = std::make_shared<Nmea0183Msg>(
-            std::string("ECWPL"), snt.Sentence.ToStdString(), address);
+            "ECWPL", snt.Sentence.ToStdString(), address);
 
-        drv_n0183->SendMessage(msg_out, address);
+        drv_n0183->SendMessage(msg_out, std::make_shared<NavAddr>());
         if (g_GPS_Ident != "FurunoGP3X")
-          drv_n0183->SendMessage(msg_out, address);
+          drv_n0183->SendMessage(msg_out, std::make_shared<NavAddr>());
 
         multiplexer.LogOutputMessage(snt.Sentence, com_name.ToStdString(),
                                      false);
@@ -824,7 +823,7 @@ int SendRouteToGPS_N0183(Route* pr, const wxString& com_name,
         wxString sentence = sentence_array[ii];
 
         auto msg_out = std::make_shared<Nmea0183Msg>(
-            std::string("ECRTE"), sentence.ToStdString(), address);
+            "ECRTE", sentence.ToStdString(), std::make_shared<NavAddr>());
         drv_n0183->SendMessage(msg_out, address);
 
         wxString fmsg = FormatPrintableMessage(sentence);
@@ -842,7 +841,7 @@ int SendRouteToGPS_N0183(Route* pr, const wxString& com_name,
 
     } else {
       auto msg_out = std::make_shared<Nmea0183Msg>(
-          std::string("ECRTE"), snt.Sentence.ToStdString(), address);
+          "ECRTE", snt.Sentence.ToStdString(), address);
       drv_n0183->SendMessage(msg_out, address);
 
       wxString fmsg = FormatPrintableMessage(snt.Sentence);
@@ -865,8 +864,8 @@ int SendRouteToGPS_N0183(Route* pr, const wxString& com_name,
       rtep.Printf(",%c%c", 0x0d, 0x0a);
       rte += rtep;
 
-      auto msg_out = std::make_shared<Nmea0183Msg>(std::string("GPRTC"),
-                                                   rte.ToStdString(), address);
+      auto msg_out =
+          std::make_shared<Nmea0183Msg>("GPRTC", rte.ToStdString(), address);
       drv_n0183->SendMessage(msg_out, address);
       multiplexer.LogOutputMessage(rte, com_name.ToStdString(), false);
 
@@ -877,8 +876,8 @@ int SendRouteToGPS_N0183(Route* pr, const wxString& com_name,
       wxString term;
       term.Printf("$PFEC,GPxfr,CTL,E%c%c", 0x0d, 0x0a);
 
-      auto msg_outf = std::make_shared<Nmea0183Msg>(
-          std::string("GPRTC"), term.ToStdString(), address);
+      auto msg_outf =
+          std::make_shared<Nmea0183Msg>("GPRTC", term.ToStdString(), address);
       drv_n0183->SendMessage(msg_outf, address);
 
       multiplexer.LogOutputMessage(term, com_name.ToStdString(), false);
@@ -1031,7 +1030,7 @@ int SendWaypointToGPS_N0183(RoutePoint* prp, const wxString& com_name,
   {  // Standard NMEA mode
     auto drv_n0183 = dynamic_cast<CommDriverN0183*>(target_driver.get());
 
-    auto address = std::make_shared<NavAddr0183>(drv_n0183->iface);
+    auto address = std::make_shared<NavAddr>();
     SENTENCE snt;
     NMEA0183 oNMEA0183(NmeaCtxFactory());
     oNMEA0183.TalkerID = "EC";
@@ -1073,7 +1072,7 @@ int SendWaypointToGPS_N0183(RoutePoint* prp, const wxString& com_name,
     }
 
     auto msg_out = std::make_shared<Nmea0183Msg>(
-        std::string("ECWPL"), snt.Sentence.ToStdString(), address);
+        "ECWPL", snt.Sentence.ToStdString(), address);
     drv_n0183->SendMessage(msg_out, address);
 
     multiplexer.LogOutputMessage(snt.Sentence, com_name, false);

--- a/model/src/comm_navmsg.cpp
+++ b/model/src/comm_navmsg.cpp
@@ -69,6 +69,7 @@ NavAddr::Bus NavAddr::StringToBus(const std::string& s) {
   if (s == "nmea2000") return NavAddr::Bus::N2000;
   if (s == "SignalK") return NavAddr::Bus::Signalk;
   if (s == "Onenet") return NavAddr::Bus::Onenet;
+  if (s == "Plugin") return NavAddr::Bus::Plugin;
   if (s == "TestBus") return NavAddr::Bus::TestBus;
   return NavAddr::Bus::Undef;
 }

--- a/model/src/comm_navmsg.cpp
+++ b/model/src/comm_navmsg.cpp
@@ -35,6 +35,7 @@
 #include <iomanip>
 
 #include "model/comm_driver.h"
+#include "model/ocpn_utils.h"
 
 std::string NavAddr::BusToString(NavAddr::Bus b) {
   switch (b) {
@@ -85,4 +86,11 @@ std::string Nmea2000Msg::to_string() const {
                 [&s](unsigned char c) { s.append(CharToString(c)); });
 
   return NavMsg::to_string() + " " + PGN.to_string() + " " + s;
+}
+
+std::string Nmea0183Msg::to_string() const {
+  std::stringstream ss;
+  ss << NavAddr::BusToString(bus) << " " << key() << " " << talker << type
+     << " " << ocpn::printable(payload);
+  return ss.str();
 }

--- a/model/src/multiplexer.cpp
+++ b/model/src/multiplexer.cpp
@@ -318,8 +318,15 @@ void Multiplexer::HandleN0183(std::shared_ptr<const Nmea0183Msg> n0183_msg) {
             bool bxmit_ok = true;
             if (params.SentencePassesFilter(n0183_msg->payload.c_str(),
                                             FILTER_OUTPUT)) {
-              bxmit_ok = driver->SendMessage(
-                  n0183_msg, std::make_shared<NavAddr0183>(driver->iface));
+              // Reset source address. It's const, so make a modified copy
+              std::string id("XXXXX");
+              unsigned comma_pos = n0183_msg->payload.find(",");
+              if (comma_pos != std::string::npos && comma_pos > 5)
+                id = n0183_msg->payload.substr(1, comma_pos - 1);
+              auto null_addr = std::make_shared<NavAddr>();
+              auto msg = std::make_shared<Nmea0183Msg>(id, n0183_msg->payload,
+                                                       null_addr);
+              bxmit_ok = driver->SendMessage(msg, null_addr);
               bout_filter = false;
             }
 

--- a/model/src/ocpn_utils.cpp
+++ b/model/src/ocpn_utils.cpp
@@ -23,8 +23,10 @@
  */
 #include <algorithm>
 #include <cstdio>
+#include <iomanip>
 #include <iostream>
 #include <fstream>
+#include <sstream>
 #include <string.h>
 #include <sys/stat.h>
 
@@ -160,6 +162,21 @@ bool N0183CheckSumOk(const std::string& sentence) {
     calculated_checksum ^= static_cast<unsigned char>(*i);
 
   return calculated_checksum == checksum;
+}
+
+std::string printable(const std::string str) {
+  std::stringstream ss;
+  for (auto it = str.begin(); it != str.end(); it++) {
+    if (std::isprint(*it) && *it != '\r' && *it != '\n') {
+      ss << *it;
+    } else {
+      std::stringstream ss2;
+      ss2 << std::setw(2) << std::setfill('0') << std::uppercase << std::hex
+          << static_cast<int>(*it);
+      ss << "<" << ss2.str() << ">";
+    }
+  }
+  return ss.str();
 }
 
 }  // namespace ocpn

--- a/model/src/plugin_api.cpp
+++ b/model/src/plugin_api.cpp
@@ -177,7 +177,7 @@ CommDriverResult WriteCommDriver(
 
     std::string msg(payload->begin(), payload->end());
     std::string id = msg.substr(1, 5);
-    auto address = std::make_shared<NavAddr0183>(d0183->iface);
+    auto address = std::make_shared<NavAddr>();
     auto msg_out = std::make_shared<Nmea0183Msg>(id, msg, address);
     bool xmit_ok = d0183->SendMessage(msg_out, address);
     return xmit_ok ? RESULT_COMM_NO_ERROR : RESULT_COMM_TX_ERROR;

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -294,7 +294,7 @@ gui/include/gui/toolbar.h
 gui/include/gui/track_gui.h
 gui/include/gui/trackprintout.h
 gui/include/gui/TrackPropDlg.h
-gui/include/gui/TTYScroll.h
+gui/include/gui/TtyScroll.h
 gui/include/gui/TTYWindow.h
 gui/include/gui/udev_rule_mgr.h
 gui/include/gui/undo.h
@@ -403,7 +403,7 @@ gui/src/toolbar.cpp
 gui/src/track_gui.cpp
 gui/src/trackprintout.cpp
 gui/src/TrackPropDlg.cpp
-gui/src/TTYScroll.cpp
+gui/src/TtyScroll.cpp
 gui/src/TTYWindow.cpp
 gui/src/udev_rule_mgr.cpp
 gui/src/undo.cpp

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -80,6 +80,7 @@ NavAddr::Bus s_bus;
 AppMsg::Type s_apptype;
 
 auto shared_navaddr_none = std::make_shared<NavAddr>();
+auto shared_navaddr_none2000 = std::make_shared<NavAddr2000>();
 
 wxLogStderr defaultLog;
 
@@ -189,8 +190,8 @@ public:
       std::string s("payload data");
       auto payload = std::vector<unsigned char>(s.begin(), s.end());
       auto id = static_cast<uint64_t>(1234);
-      auto n2k_msg =
-          std::make_shared<const Nmea2000Msg>(id, payload, shared_navaddr_none);
+      auto n2k_msg = std::make_shared<const Nmea2000Msg>(
+          id, payload, shared_navaddr_none2000);
       Observable observable("1234");
       observable.Notify(n2k_msg);
     }
@@ -313,7 +314,7 @@ public:
       auto payload = std::vector<unsigned char>(s.begin(), s.end());
       auto id = static_cast<uint64_t>(1234);
       auto msg =
-          std::make_unique<Nmea2000Msg>(id, payload, shared_navaddr_none);
+          std::make_unique<Nmea2000Msg>(id, payload, shared_navaddr_none2000);
       NavMsgBus::GetInstance().Notify(std::move(msg));
     }
   };
@@ -401,7 +402,7 @@ public:
       auto payload = std::vector<unsigned char>(s.begin(), s.end());
       auto id = static_cast<uint64_t>(1234);
       auto msg =
-          std::make_unique<Nmea2000Msg>(id, payload, shared_navaddr_none);
+          std::make_unique<Nmea2000Msg>(id, payload, shared_navaddr_none2000);
       NavMsgBus::GetInstance().Notify(std::move(msg));
     }
   };
@@ -956,7 +957,8 @@ TEST(Navmsg2000, to_string) {
   std::string s("payload data");
   auto payload = std::vector<unsigned char>(s.begin(), s.end());
   auto id = static_cast<uint64_t>(1234);
-  auto msg = std::make_shared<Nmea2000Msg>(id, payload, shared_navaddr_none);
+  auto msg =
+      std::make_shared<Nmea2000Msg>(id, payload, shared_navaddr_none2000);
   EXPECT_EQ(string("nmea2000 n2000-1234 1234 7061796c6f61642064617461"),
             msg->to_string());
 }
@@ -977,7 +979,7 @@ TEST(FileDriver, output) {
   std::string s("payload data");
   auto payload = std::vector<unsigned char>(s.begin(), s.end());
   auto id = static_cast<uint64_t>(1234);
-  Nmea2000Msg msg(id, payload, shared_navaddr_none);
+  Nmea2000Msg msg(id, payload, shared_navaddr_none2000);
   remove("test-output.txt");
 
   driver->SendMessage(std::make_shared<const Nmea2000Msg>(msg),


### PR DESCRIPTION
Various preparatory works related to #4324 but useful for it's own sake.

The PR does not contain any user visible changes. Under the hood:
 
  - navmsg: Add missing constructors and operators required by standard STL containers.
  - navmsg: Fix to_string() so it does the right thing for all message types.
  - navmsg: Clean up source address. This is (should be) unused when sending, made available when receiving data.
  - observable: Add missing ObsListener std::move assignment semantics. 
  - ocpn_plugin_gui.cpp: Sort header mess, file level comments
  - TTYScroll: Rename (Google GL), clean up, optimize.