### PR TITLE
Updated build instructions for MacOS

### DIFF
--- a/manual/modules/ROOT/pages/mac-osx.adoc
+++ b/manual/modules/ROOT/pages/mac-osx.adoc
@@ -137,6 +137,17 @@ Open the `OpenCPN.xcodeproj` file in Xcode, and use the “Build”, “Run”,
 “Debug”, etc features as normal. To use the “Run” action you need to
 build the “OpenCPN” target rather than the default “ALL_BUILD” target.
 
+=== Code Signing
+
+When building OpenCPN on Apple Silicon Macs, additional configuration
+may be needed to handle code signing and architecture.
+After building, sign the application with an ad-hoc signature:
+
+ $ codesign --force --deep --sign - /path/bin/OpenCPN.app
+
+Note: These settings create a build that can run locally but
+isn't suitable for distribution through the App Store.
+
 === Creating the installer package
 
 WARNING - Do The Following:


### PR DESCRIPTION
# Issue

1. After getting a Macbook M4 with Apple Silicon, I followed the usual [MacOS build instructions](https://opencpn-manuals.github.io/development/ocpn-dev-manual/5.3.1/compile_mac_osx.html)
2. When I try to run the application, it fails with a code signing issue. The program is stopped immediately after launching OpenCPN.

I applied this workaround:
```bash
codesign --force --deep --sign - ~/OpenCPN/bin/OpenCPN.app
```

# Changes in this PR

I have updated the manual to show the `codesign` command. It's also what the `ci/generic-build-macos.sh` script does, but it wasn't documented in the build instructions.