### PR TITLE
Fix compiler warning: add missing override keyword

### DIFF
--- a/model/include/model/comm_drv_n0183_serial.h
+++ b/model/include/model/comm_drv_n0183_serial.h
@@ -58,7 +58,9 @@ public:
   bool SendMessage(std::shared_ptr<const NavMsg> msg,
                    std::shared_ptr<const NavAddr> addr) override;
 
-  DriverStats GetDriverStats() const { return m_serial_io->GetStats(); }
+  DriverStats GetDriverStats() const override {
+    return m_serial_io->GetStats();
+  }
 
 private:
   std::string m_portstring;


### PR DESCRIPTION
Fix following compilation warnings:
```bash
ttype.cpp
In file included from /Users/serosset/git/OpenCPN/model/src/comm_drv_factory.cpp:41:
/Users/serosset/git/OpenCPN/model/include/model/comm_drv_n0183_serial.h:61:15: warning: 'GetDriverStats' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   61 |   DriverStats GetDriverStats() const { return m_serial_io->GetStats(); }
      |               ^
/Users/serosset/git/OpenCPN/model/include/model/comm_drv_stats.h:56:23: note: overridden virtual function is here
   56 |   virtual DriverStats GetDriverStats() const = 0;
      |                       ^
In file included from /Users/serosset/git/OpenCPN/model/src/comm_drv_n0183_serial.cpp:42:
/Users/serosset/git/OpenCPN/model/include/model/comm_drv_n0183_serial.h:61:15: warning: 'GetDriverStats' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
   61 |   DriverStats GetDriverStats() const { return m_serial_io->GetStats(); }
      |               ^
/Users/serosset/git/OpenCPN/model/include/model/comm_drv_stats.h:56:23: note: overridden virtual function is here
   56 |   virtual DriverStats GetDriverStats() const = 0;
      |                       ^

```