### PR TITLE
Add code comments for chart panning

### DIFF
--- a/gui/include/gui/chcanv.h
+++ b/gui/include/gui/chcanv.h
@@ -157,6 +157,21 @@ public:
 
   bool MouseEventSetup(wxMouseEvent &event, bool b_handle_dclick = true);
   bool MouseEventProcessObjects(wxMouseEvent &event);
+  /**
+   * Processes mouse events for core chart panning and zooming operations.
+   *
+   * This method handles the main chart navigation interactions:
+   * - Mouse wheel zooming with configurable sensitivity and optional smoothing.
+   * - Left-click chart centering. Centers chart on click point in non-drag
+   * scenarios.
+   * - Click-and-drag panning. Updates chart position continuously during drag.
+   *
+   * @param event The mouse event to process
+   * @return true if event was processed, false to allow focus shifting between
+   * canvases.
+   *
+   * @note Interacts with route creation and measurement tools active states
+   */
   bool MouseEventProcessCanvas(wxMouseEvent &event);
   void SetCanvasCursor(wxMouseEvent &event);
   void OnKillFocus(wxFocusEvent &WXUNUSED(event));

--- a/gui/include/gui/glChartCanvas.h
+++ b/gui/include/gui/glChartCanvas.h
@@ -99,6 +99,19 @@ GLboolean QueryExtension(const char *extName);
 class ocpnGLOptions {
 public:
   bool m_bUseAcceleratedPanning;
+  /**
+   * Controls OpenGL canvas hardware-accelerated panning mode.
+   *
+   * When true, uses an OpenGL optimization where the chart is rendered to a
+   * texture (via FBO - Frame Buffer Object) during panning operations.
+   * This texture is then translated/moved using GPU operations rather than
+   * redrawing the entire chart for each pan event, significantly improving
+   * performance during chart panning.
+   *
+   * This is separate from standard chart panning which is enabled by default
+   * and uses left-click + drag. This flag only controls whether that panning
+   * uses hardware acceleration.
+   */
   bool m_bUseCanvasPanning;
 
   bool m_bTextureCompression;

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -480,6 +480,24 @@ bool g_bLookAhead;
 bool g_bskew_comp;
 bool g_bopengl;
 bool g_bSoftwareGL;
+/**
+ * Controls how the chart panning and zooming smoothing is done during user
+ * interactions.
+ *
+ * When enabled (true):
+ * - Chart panning has inertia, with smooth acceleration and deceleration
+ * - Mouse wheel zooming is smoothly animated between zoom levels
+ * - Chart overscaled rendering is optimized for smooth transitions
+ * - Chart quilting transitions may be smoother
+ *
+ * When disabled (false):
+ * - Chart panning stops immediately when mouse is released
+ * - Mouse wheel zooming jumps directly between zoom levels without animation
+ * - Rendering may be slightly faster but less visually polished
+ *
+ * Changed through the Display > Advanced > "Smooth Panning/Zooming" checkbox.
+ * Saved to config as user preference.
+ */
 bool g_bsmoothpanzoom;
 bool g_fog_overzoom;
 double g_overzoom_emphasis_base;
@@ -1128,13 +1146,15 @@ bool MyApp::OnInit() {
   temp_font.SetDefaultEncoding(wxFONTENCODING_SYSTEM);
 
   //      Establish Log File location
-  if (!g_Platform->InitializeLogFile()) return false;
+  if (!g_Platform->InitializeLogFile()) {
+    return false;
+  };
 
 #ifdef __WXMSW__
 
-    //  Un-comment the following to establish a separate console window as a
-    //  target for printf() in Windows
-    //     RedirectIOToConsole();
+  //  Un-comment the following to establish a separate console window as a
+  //  target for printf() in Windows
+  //     RedirectIOToConsole();
 
 #endif
 
@@ -1354,10 +1374,12 @@ bool MyApp::OnInit() {
   }
 
   //  Is this the first run after a clean installation?
-  if (!n_NavMessageShown) g_bFirstRun = true;
+  if (!n_NavMessageShown) {
+    g_bFirstRun = true;
+  }
 
-    //  Now we can set the locale
-    //    using wxWidgets/gettext methodology....
+  //  Now we can set the locale
+  //    using wxWidgets/gettext methodology....
 
 #if wxUSE_XLOCALE || !wxCHECK_VERSION(3, 0, 0)
 
@@ -1420,10 +1442,11 @@ bool MyApp::OnInit() {
   g_Platform->SetUpgradeOptions(vs, g_config_version_string);
 
   //  log deferred log restart message, if it exists.
-  if (!g_Platform->GetLargeLogMessage().IsEmpty())
+  if (!g_Platform->GetLargeLogMessage().IsEmpty()) {
     wxLogMessage(g_Platform->GetLargeLogMessage());
+  }
 
-    // Validate OpenGL functionality, if selected
+  // Validate OpenGL functionality, if selected
 #ifndef ocpnUSE_GL
   g_bdisable_opengl = true;
   ;
@@ -1432,17 +1455,19 @@ bool MyApp::OnInit() {
   if (g_bdisable_opengl) g_bopengl = false;
 
 #if defined(__linux__) && !defined(__ANDROID__)
-  if (g_bSoftwareGL) setenv("LIBGL_ALWAYS_SOFTWARE", "1", 1);
+  if (g_bSoftwareGL) {
+    setenv("LIBGL_ALWAYS_SOFTWARE", "1", 1);
+  }
 #endif
 
-    // FIXMW (dave) move to frame
-    // g_bTransparentToolbarInOpenGLOK = isTransparentToolbarInOpenGLOK();
+  // FIXMW (dave) move to frame
+  // g_bTransparentToolbarInOpenGLOK = isTransparentToolbarInOpenGLOK();
 
-    // On Windows platforms, establish a default cache managment policy
-    // as allowing OpenCPN a percentage of available physical memory,
-    // not to exceed 1 GB
-    // Note that this logic implies that Windows platforms always use
-    // the memCacheLimit policy, and never use the fallback nCacheLimit policy
+  // On Windows platforms, establish a default cache managment policy
+  // as allowing OpenCPN a percentage of available physical memory,
+  // not to exceed 1 GB
+  // Note that this logic implies that Windows platforms always use
+  // the memCacheLimit policy, and never use the fallback nCacheLimit policy
 #ifdef __WXMSW__
   if (0 == g_memCacheLimit) g_memCacheLimit = (int)(g_mem_total * 0.5);
   g_memCacheLimit =
@@ -2060,12 +2085,14 @@ int MyApp::OnExit() {
 #ifdef __WXMSW__
 #ifdef USE_GLU_TESS
 #ifdef USE_GLU_DLL
-  if (s_glu_dll_ready) FreeLibrary(s_hGLU_DLL);  // free the glu32.dll
+  if (s_glu_dll_ready) {
+    FreeLibrary(s_hGLU_DLL);
+  }  // free the glu32.dll
 #endif
 #endif
 #endif
 
-    // Restore any changed system colors
+  // Restore any changed system colors
 
 #ifdef __WXMSW__
   void RestoreSystemColors(void);


### PR DESCRIPTION
1. Add code comments for chart panning fields and functions. I'm looking at improvements of mouse click and drag selection in the GRIB plugin, and I wanted to understand better how OpenCPN core does panning.
2. Add a few curly braces to ensure code comments in `gui/src/ocpn_app.cpp` are properly indented. The CI uses a slightly older version of `clang-format` that incorrectly indents code comments. Specifically this happens after a `if` statement followed by a single statement without curly braces. For example:

```c++
   if (!g_Platform->GetLargeLogMessage().IsEmpty())
     wxLogMessage(g_Platform->GetLargeLogMessage());
 
-  // Validate OpenGL functionality, if selected
+    // Validate OpenGL functionality, if selected
```

A more recent version of clang-format (e.g. 19.1.7) properly indents code in that case.