### PR TITLE
Fix manual selection of download area for GRIB files

### DIFF
--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -5592,12 +5592,14 @@ bool ChartCanvas::SetViewPoint(double lat, double lon, double scale_ppm,
         //  Allow the quilt to adjust the new ViewPort for performance
         //  optimization This will normally be only a fractional (i.e.
         //  sub-pixel) adjustment...
-        if (b_adjust) m_pQuilt->AdjustQuiltVP(last_vp, VPoint);
+        if (b_adjust) {
+          m_pQuilt->AdjustQuiltVP(last_vp, VPoint);
+        }
 
-          //                ChartData->ClearCacheInUseFlags();
-          //                unsigned long hash1 = m_pQuilt->GetXStackHash();
+        //                ChartData->ClearCacheInUseFlags();
+        //                unsigned long hash1 = m_pQuilt->GetXStackHash();
 
-          //                wxStopWatch sw;
+        //                wxStopWatch sw;
 
 #ifdef __ANDROID__
         // This is an optimization for panning on touch screen systems.
@@ -9796,6 +9798,11 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
 bool panleftIsDown;
 
 bool ChartCanvas::MouseEventProcessCanvas(wxMouseEvent &event) {
+  // Skip all mouse processing if shift is held.
+  // This allows plugins to implement shift+drag behaviors.
+  if (event.ShiftDown()) {
+    return false;
+  }
   int x, y;
   event.GetPosition(&x, &y);
 

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -1466,8 +1466,15 @@ public:
   /**
    * Notifies plugin of viewport changes.
    *
-   * This method is called when the chart viewport changes (pan/zoom).
-   * Must be implemented if plugin needs viewport awareness.
+   * This method is called whenever the chart viewport changes on any canvas due
+   * to:
+   * - User pan/zoom operations
+   * - Periodic canvas updates
+   * - Course/heading changes affecting chart orientation
+   *
+   * For multi-canvas configurations (e.g. split screen), this is called
+   * separately for each canvas's viewport changes, regardless of which canvas
+   * has focus or mouse interaction.
    *
    * @param vp New viewport parameters
    *
@@ -4687,9 +4694,23 @@ extern DECL_EXP bool ShuttingDown(void);
  * Gets the currently focused chart canvas.
  *
  * Returns the chart canvas window that currently has input focus in
- * multi-canvas configurations.
+ * multi-canvas configurations. A canvas gains focus when:
+ *
+ * - User clicks within the canvas area
+ * - User uses keyboard shortcuts to switch canvas focus
+ * - Canvas is explicitly given focus programmatically
+ *
+ * Focus determines which canvas:
+ * - Receives keyboard input events
+ * - Is the target for navigation commands
+ * - Shows active canvas indicators
+ * - Gets tool/menu actions by default
  *
  * @return Pointer to focused canvas window, NULL if none focused
+ *
+ * @see GetCanvasIndexUnderMouse() To find canvas under mouse cursor
+ * @see GetCanvasCount() To get total number of canvases
+ * @see GetCanvasByIndex() To get canvas by index number
  */
 extern DECL_EXP wxWindow *PluginGetFocusCanvas();
 /**
@@ -4810,9 +4831,14 @@ extern DECL_EXP wxWindow *GetCanvasUnderMouse();
  * Gets index of chart canvas under mouse cursor.
  *
  * Returns the index of the canvas window that the mouse cursor is currently
- * over in multi-canvas configurations.
+ * positioned over in multi-canvas configurations. Note that having the mouse
+ * over a canvas does not automatically give that canvas focus - it merely
+ * indicates mouse position.
  *
  * @return Canvas index (0-based), -1 if mouse not over any canvas
+ * @note This returns mouse position only - does not affect canvas focus
+ * @see GetFocusCanvas() To determine which canvas has input focus
+ * @see GetCanvasCount() To get total number of canvases
  */
 extern DECL_EXP int GetCanvasIndexUnderMouse();
 // extern DECL_EXP std::vector<wxWindow *> GetCanvasArray();

--- a/plugins/grib_pi/GRIB.fbp
+++ b/plugins/grib_pi/GRIB.fbp
@@ -1026,7 +1026,7 @@
                     <property name="window_extra_style"></property>
                     <property name="window_name"></property>
                     <property name="window_style"></property>
-                    <event name="OnButtonClick">OnRequest</event>
+                    <event name="OnButtonClick">OnRequestForecastData</event>
                     <event name="OnRightDown">OnMouseEvent</event>
                   </object>
                 </object>
@@ -15958,9 +15958,9 @@
                       <property name="Save">0</property>
                       <property name="Yes">1</property>
                       <property name="minimum_size"></property>
-                      <property name="name">m_rButton</property>
+                      <property name="name">m_rEmailButtons</property>
                       <property name="permission">protected</property>
-                      <event name="OnApplyButtonClick">OnSaveMail</event>
+                      <event name="OnApplyButtonClick">OnOK</event>
                       <event name="OnCancelButtonClick">OnCancel</event>
                       <event name="OnYesButtonClick">OnSendMaiL</event>
                     </object>

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -606,7 +606,7 @@ bool GRIBOverlayFactory::DoRenderGribOverlay(PlugIn_ViewPort *vp) {
   }
   if (m_dlg.ProjectionEnabled()) {
     int x, y;
-    m_dlg.GetProjectedLatLon(x, y);
+    m_dlg.GetProjectedLatLon(x, y, vp);
     DrawProjectedPosition(x, y);
   }
   if (!m_Message_Hiden.IsEmpty()) m_Message_Hiden.Append(_T("\n"));

--- a/plugins/grib_pi/src/GribRequestDialog.h
+++ b/plugins/grib_pi/src/GribRequestDialog.h
@@ -71,6 +71,15 @@ const std::string CATALOG_URL =
 #define XYGRIB_MAX_DOWNLOADABLE_GRIB_SIZE_MB 10
 
 /**
+ * Enumeration defining the states of the GRIB zone selection overlay rendering.
+ */
+enum ZoneSelectionRenderState {
+  RENDER_NONE = 0,      // No selection zone to render
+  RENDER_COMPLETE = 1,  // Selection is complete, render the final zone
+  RENDER_DRAWING = 2    // User is actively drawing the selection zone
+};
+
+/**
  * Manages GRIB file request configuration and downloads.
  *
  * This class provides:
@@ -89,25 +98,139 @@ public:
 
   void OnClose(wxCloseEvent &event) override;
   void SetVpSize(PlugIn_ViewPort *vp);
-  void OnVpChange(PlugIn_ViewPort *vp);
+  /**
+   * Callback invoked when the view port under mouse has changed.
+   * This is the viewport where the mouse cursor is currently located.
+   */
+  void OnVpUnderMouseChange(PlugIn_ViewPort *vp);
+  /**
+   * Callback invoked when the focused view port has changed,
+   * such as in multi-chart mode when user switches viewport focus.
+   */
+  void OnVpWithFocusChange(PlugIn_ViewPort *vp);
+  /**
+   * Intercepts mouse events to handle GRIB area selection.
+   *
+   * We only handle mouse events when the Shift key is pressed to avoid
+   * conflicting with OpenCPN core chart panning, which uses normal left-click
+   * drag. This lets users:
+   * - Pan the chart normally with left-click drag.
+   * - Select GRIB download area with Shift + left-click drag.
+   *
+   * The selection states flow:
+   * 1. User holds Shift and left-clicks: Start selection (DRAW_SELECTION)
+   * 2. User drags with Shift still held: Update selection rectangle
+   * 3. User releases left button: Complete selection (COMPLETE_SELECTION)
+   *
+   * @param event The intercepted mouse event.
+   * @return true if event was handled, false to pass event to chart.
+   */
   bool MouseEventHook(wxMouseEvent &event);
+  /**
+   * Renders the GRIB area selection overlay using standard device context.
+   * Called by OpenCPN when in standard graphics mode. Passes the DC to
+   * DoRenderZoneOverlay() for actual rendering.
+   *
+   * @param dc Device context to draw on
+   * @return true if overlay should be rendered, false if nothing to draw
+   */
   bool RenderZoneOverlay(wxDC &dc);
+  /**
+   * Renders the GRIB area selection overlay using OpenGL.
+   * Called by OpenCPN when in OpenGL mode. Sets up OpenGL context
+   * and delegates actual rendering to DoRenderZoneOverlay().
+   *
+   * @return true if overlay should be rendered, false if nothing to draw
+   */
   bool RenderGlZoneOverlay();
+  /**
+   * Draws the GRIB area selection overlay on the chart.
+   * This includes the rectangular selection zone and an information label
+   * showing the coordinates and estimated file size.
+   * Supports both standard wxDC and OpenGL rendering paths.
+   *
+   * @return true if drawing was successful
+   */
   bool DoRenderZoneOverlay();
   void SetRequestDialogSize();
   void StopGraphicalZoneSelection();
+  void UpdateAreaSelectionState();
+  /**
+   * Get the minimum latitude of the bounding box for the download request.
+   *
+   * The bouding box is defined by the user during manual zone selection
+   * or by the visible area of the chart in focus.
+   *
+   * @return The minimum latitude of the bounding box.
+   */
+  double GetMinLat() const;
+  /**
+   * Get the maximum latitude of the bounding box for the download request.
+   *
+   * The bouding box is defined by the user during manual zone selection
+   * or by the visible area of the chart in focus.
+   *
+   * @return The maximum latitude of the bounding box.
+   */
+  double GetMaxLat() const;
+  /**
+   * Get the minimum longitude of the bounding box for the download request.
+   *
+   * The bouding box is defined by the user during manual zone selection
+   * or by the visible area of the chart in focus.
+   *
+   * @return The minimum longitude of the bounding box.
+   */
+  double GetMinLon() const;
+  /**
+   * Get the maximum longitude of the bounding box for the download request.
+   *
+   * The bouding box is defined by the user during manual zone selection
+   * or by the visible area of the chart in focus.
+   *
+   * @return The maximum longitude of the bounding box.
+   */
+  double GetMaxLon() const;
+
+  int GetBoundingBoxCanvasIndex() const { return m_boundingBoxCanvasIndex; }
+
   void Save() {
     wxCommandEvent evt;
-    OnSaveMail(evt);
+    OnOK(evt);
   }
 
   wxString m_RequestConfigBase;
   wxString m_MailToAddresses;
-  int m_RenderZoneOverlay;
+  /**
+   * Current state of the bounding box overlay rendering.
+   * Controls whether and how the selection zone is displayed on the chart.
+   * @see ZoneSelectionRenderState
+   */
+  ZoneSelectionRenderState m_RenderSelectionZoneState;
 
+  /**
+   * Starting point of the bounding box in physical pixels.
+   * Set when user begins dragging to select a bounding box. Acts as the anchor
+   * point for drawing the bounding box rectangle.
+   */
   wxPoint m_StartPoint;
-  PlugIn_ViewPort *m_Vp;
+  /** The latitude at the starting point of the bounding box. */
+  double m_StartLat;
+  /** The longitude at the starting point of the bounding box. */
+  double m_StartLon;
+
+  /**
+   * The viewport currently in focus.
+   *
+   * @note In multi-canvas mode, this may be different from the viewport under
+   * the mouse cursor.
+   */
+  PlugIn_ViewPort *m_VpFocus;
+  /** The viewport under the mouse. */
+  PlugIn_ViewPort *m_VpMouse;
+  /** The latitude at the mouse cursor while drawing a bounding box. */
   double m_Lat;
+  /** The longitude at the mouse cursor while drawing a bounding box. */
   double m_Lon;
 
 private:
@@ -119,6 +242,10 @@ private:
   wxString WriteMail();
   int EstimateFileSize(double *size);
 
+  /** Save the "download" configuration to disk. */
+  void SaveConfig() override;
+  /** Load the "download" configuration from disk and initialize the dialog
+   * widgets based on the configuration that was loaded from disk. */
   void InitRequestConfig();
   void OnExit(wxCommandEvent &event) {
     wxCloseEvent evt;
@@ -136,7 +263,7 @@ private:
   }
   void OnTimeRangeChange(wxCommandEvent &event) override;
   void OnSendMaiL(wxCommandEvent &event) override;
-  void OnSaveMail(wxCommandEvent &event) override;
+  void OnOK(wxCommandEvent &event) override;
   void OnZoneSelectionModeChange(wxCommandEvent &event) override;
   void OnCancel(wxCommandEvent &event) override {
     wxCloseEvent evt;
@@ -200,6 +327,9 @@ private:
   bool m_canceled;
   bool m_bLocal_source_selected;
   GribDownloadType m_downloadType;
+  /** Index of the canvas where the bounding box is drawn during manual zone
+   * selection. */
+  int m_boundingBoxCanvasIndex;
 };
 
 #endif

--- a/plugins/grib_pi/src/GribSettingsDialog.cpp
+++ b/plugins/grib_pi/src/GribSettingsDialog.cpp
@@ -662,25 +662,25 @@ GribSettingsDialog::GribSettingsDialog(GRIBUICtrlBar &parent,
   }
   // Set Bitmap
   m_biAltitude->SetBitmap(parent.GetScaledBitmap(
-      wxBitmap(altitude), _T("altitude"), parent.m_ScaledFactor));
-  m_biNow->SetBitmap(
-      parent.GetScaledBitmap(wxBitmap(now), _T("now"), parent.m_ScaledFactor));
+      wxBitmap(altitude), _T("altitude"), parent.GetScaleFactor()));
+  m_biNow->SetBitmap(parent.GetScaledBitmap(wxBitmap(now), _T("now"),
+                                            parent.GetScaleFactor()));
   m_biZoomToCenter->SetBitmap(parent.GetScaledBitmap(
-      wxBitmap(zoomto), _T("zoomto"), parent.m_ScaledFactor));
+      wxBitmap(zoomto), _T("zoomto"), parent.GetScaleFactor()));
   m_biShowCursorData->SetBitmap(parent.GetScaledBitmap(
       parent.m_CDataIsShown ? wxBitmap(curdata) : wxBitmap(ncurdata),
       parent.m_CDataIsShown ? _T("curdata") : _T("ncurdata"),
-      parent.m_ScaledFactor));
+      parent.GetScaleFactor()));
   m_biPlay->SetBitmap(parent.GetScaledBitmap(wxBitmap(play), _T("play"),
-                                             parent.m_ScaledFactor));
+                                             parent.GetScaleFactor()));
   m_biTimeSlider->SetBitmap(parent.GetScaledBitmap(
-      wxBitmap(slider), _T("slider"), parent.m_ScaledFactor));
+      wxBitmap(slider), _T("slider"), parent.GetScaleFactor()));
   m_biOpenFile->SetBitmap(parent.GetScaledBitmap(
-      wxBitmap(openfile), _T("openfile"), parent.m_ScaledFactor));
+      wxBitmap(openfile), _T("openfile"), parent.GetScaleFactor()));
   m_biSettings->SetBitmap(parent.GetScaledBitmap(
-      wxBitmap(setting), _T("setting"), parent.m_ScaledFactor));
+      wxBitmap(setting), _T("setting"), parent.GetScaleFactor()));
   m_biRequest->SetBitmap(parent.GetScaledBitmap(
-      wxBitmap(request), _T("request"), parent.m_ScaledFactor));
+      wxBitmap(request), _T("request"), parent.GetScaleFactor()));
   // read bookpage
   wxFileConfig *pConf = GetOCPNConfigObject();
   if (pConf) {
@@ -728,7 +728,7 @@ GribSettingsDialog::GribSettingsDialog(GRIBUICtrlBar &parent,
   ReadDataTypeSettings(m_lastdatatype);
   m_sButtonApply->SetLabel(_("Apply"));
 
-  DimeWindow(this);  // aplly global colours scheme
+  DimeWindow(this);  // apply global colours scheme
 
 #ifdef __OCPN__ANDROID__
   GetHandle()->setStyleSheet(qtStyleSheet);

--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -11,14 +11,18 @@
 #include "GribUIDialogBase.h"
 #include "XyGribPanel.h"
 #include "manual.h"
+#include "ocpn_plugin.h"
+#include "folder.xpm"
 
 ///////////////////////////////////////////////////////////////////////////
 
 GRIBUICtrlBarBase::GRIBUICtrlBarBase(wxWindow* parent, wxWindowID id,
                                      const wxString& title, const wxPoint& pos,
-                                     const wxSize& size, long style)
+                                     const wxSize& size, long style,
+                                     double scale_factor)
     : wxDialog(parent, id, title, pos, size, style) {
   m_ProjectBoatPanel = nullptr;
+  m_ScaledFactor = scale_factor;
 
 #ifdef __OCPN__ANDROID__
   const bool m_bcompact = true;
@@ -410,9 +414,10 @@ GRIBUICtrlBarBase::GRIBUICtrlBarBase(wxWindow* parent, wxWindowID id,
 #endif
 
   if (m_bpRequest) {
-    m_bpRequest->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
-                         wxCommandEventHandler(GRIBUICtrlBarBase::OnRequest),
-                         nullptr, this);
+    m_bpRequest->Connect(
+        wxEVT_COMMAND_BUTTON_CLICKED,
+        wxCommandEventHandler(GRIBUICtrlBarBase::OnRequestForecastData),
+        nullptr, this);
     m_bpRequest->Connect(wxEVT_RIGHT_DOWN,
                          wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
                          nullptr, this);
@@ -551,12 +556,41 @@ GRIBUICtrlBarBase::~GRIBUICtrlBarBase() {
                            nullptr, this);
 
   if (m_bpRequest) {
-    m_bpRequest->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED,
-                            wxCommandEventHandler(GRIBUICtrlBarBase::OnRequest),
-                            nullptr, this);
+    m_bpRequest->Disconnect(
+        wxEVT_COMMAND_BUTTON_CLICKED,
+        wxCommandEventHandler(GRIBUICtrlBarBase::OnRequestForecastData),
+        nullptr, this);
     m_bpRequest->Disconnect(
         wxEVT_RIGHT_DOWN, wxMouseEventHandler(GRIBUICtrlBarBase::OnMouseEvent),
         nullptr, this);
+  }
+}
+
+wxBitmap GRIBUICtrlBarBase::GetScaledBitmap(wxBitmap bitmap,
+                                            const wxString svgFileName,
+                                            double scale_factor) {
+  int margin = 4;  // there is a small margin around the bitmap drawn by the
+  // wxBitmapButton
+  int w = bitmap.GetWidth() - margin;
+  int h = bitmap.GetHeight() - margin;
+  w *= scale_factor;
+  h *= scale_factor;
+
+#ifdef ocpnUSE_SVG
+  wxString shareLocn = *GetpSharedDataLocation() + _T("plugins") +
+                       wxFileName::GetPathSeparator() + _T("grib_pi") +
+                       wxFileName::GetPathSeparator() + _T("data") +
+                       wxFileName::GetPathSeparator();
+  wxString filename = shareLocn + svgFileName + _T(".svg");
+
+  wxBitmap svgbm = GetBitmapFromSVGFile(filename, w, h);
+  if (svgbm.GetWidth() > 0 && svgbm.GetHeight() > 0)
+    return svgbm;
+  else
+#endif  // ocpnUSE_SVG
+  {
+    wxImage a = bitmap.ConvertToImage();
+    return wxBitmap(a.Scale(w, h), wxIMAGE_QUALITY_HIGH);
   }
 }
 
@@ -2356,18 +2390,133 @@ void GribPreferencesDialogBase::OnDirSelClick(wxCommandEvent& event) {
   }
 }
 
-GribRequestSettingBase::GribRequestSettingBase(wxWindow* parent, wxWindowID id,
-                                               const wxString& title,
-                                               const wxPoint& pos,
-                                               const wxSize& size, long style)
-    : wxDialog(parent, id, title, pos, size, style) {
-  this->SetSizeHints(wxDefaultSize, wxDefaultSize);
+wxStaticBoxSizer* GribRequestSettingBase::createAreaSelectionSection(
+    wxWindow* parent, GRIBUICtrlBarBase* ctrlBar) {
+  wxStaticBoxSizer* sbSizer81;
+  sbSizer81 = new wxStaticBoxSizer(
+      new wxStaticBox(parent, wxID_ANY, _("Area Selection")), wxVERTICAL);
 
-  wxBoxSizer* bSizerMain;
-  bSizerMain = new wxBoxSizer(wxVERTICAL);
+  wxFlexGridSizer* fgSizer36;
+  fgSizer36 = new wxFlexGridSizer(0, 2, 0, 0);
+  fgSizer36->SetFlexibleDirection(wxBOTH);
+  fgSizer36->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
 
-  m_notebookGetGrib =
-      new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0);
+  wxFlexGridSizer* fgSizer37;
+  fgSizer37 = new wxFlexGridSizer(0, 1, 0, 0);
+  fgSizer37->SetFlexibleDirection(wxBOTH);
+  fgSizer37->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
+
+  wxBoxSizer* zoneSelBoxSizer = new wxBoxSizer(wxVERTICAL);
+  m_rbCurrentView =
+      new wxRadioButton(parent, AUTOSELECT, _("Current View"),
+                        wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+  m_rbManualSelect = new wxRadioButton(parent, MANSELECT, _("Manual Selection"),
+                                       wxDefaultPosition, wxDefaultSize);
+  m_rbCurrentView->SetValue(true);  // Set Current View as default
+
+  zoneSelBoxSizer->Add(m_rbCurrentView, 0, wxALL, 5);
+  zoneSelBoxSizer->Add(m_rbManualSelect, 0, wxALL, 5);
+  fgSizer37->Add(zoneSelBoxSizer, 0, wxLEFT | wxBOTTOM, 5);
+
+  m_bpManualSelection =
+      new wxBitmapToggleButton(this, ID_BTNREQUEST, wxNullBitmap,
+                               wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW);
+  m_bpManualSelection->SetBitmapLabel(GRIBUICtrlBarBase::GetScaledBitmap(
+      wxBitmap(selzone), _T("selzone"), ctrlBar->GetScaleFactor()));
+  // Set the pressed state bitmap - use a darker/highlighted version of the same
+  // bitmap
+  wxBitmap pressedBitmap = GRIBUICtrlBarBase::GetScaledBitmap(
+      wxBitmap(selzone), _T("selzone"), ctrlBar->GetScaleFactor());
+  pressedBitmap =
+      pressedBitmap.ConvertToDisabled();  // Creates a greyed version
+  m_bpManualSelection->SetBitmapPressed(pressedBitmap);
+
+  m_bpManualSelection->SetToolTip(
+      _("Click to select the download area, or Shift + Click + Drag on the "
+        "canvas"));
+  fgSizer37->Add(m_bpManualSelection, 0, wxLEFT, 5);
+
+  fgSizer36->Add(fgSizer37, 1, wxEXPAND | wxLEFT, 5);
+
+  fgZoneCoordinatesSizer = new wxFlexGridSizer(0, 6, 0, 0);
+  fgZoneCoordinatesSizer->SetFlexibleDirection(wxBOTH);
+  fgZoneCoordinatesSizer->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
+
+  wxStaticText* m_staticText34;
+  m_staticText34 = new wxStaticText(parent, wxID_ANY, _("Max Lat"),
+                                    wxDefaultPosition, wxDefaultSize, 0);
+  m_staticText34->Wrap(-1);
+  fgZoneCoordinatesSizer->Add(m_staticText34, 0, wxLEFT | wxRIGHT, 5);
+
+  m_spMaxLat = new wxSpinCtrl(parent, MAXLAT, wxEmptyString, wxDefaultPosition,
+                              wxDefaultSize, wxSP_ARROW_KEYS, -180, 180, 0);
+  fgZoneCoordinatesSizer->Add(m_spMaxLat, 0, wxLEFT | wxRIGHT, 5);
+
+  m_stMaxLatNS = new wxStaticText(parent, wxID_ANY, _("N"), wxDefaultPosition,
+                                  wxDefaultSize, 0);
+  m_stMaxLatNS->Wrap(-1);
+  fgZoneCoordinatesSizer->Add(m_stMaxLatNS, 0, wxRIGHT, 20);
+
+  m_staticText36 = new wxStaticText(parent, wxID_ANY, _("Max Long"),
+                                    wxDefaultPosition, wxDefaultSize, 0);
+  m_staticText36->Wrap(-1);
+  fgZoneCoordinatesSizer->Add(m_staticText36, 0, wxLEFT | wxRIGHT, 5);
+
+  m_spMaxLon = new wxSpinCtrl(parent, MAXLON, wxEmptyString, wxDefaultPosition,
+                              wxDefaultSize, wxSP_ARROW_KEYS, -180, 180, 0);
+  fgZoneCoordinatesSizer->Add(m_spMaxLon, 0, wxLEFT | wxRIGHT, 5);
+
+  m_stMaxLonEW = new wxStaticText(parent, wxID_ANY, _("E"), wxDefaultPosition,
+                                  wxDefaultSize, 0);
+  m_stMaxLonEW->Wrap(-1);
+  fgZoneCoordinatesSizer->Add(m_stMaxLonEW, 0, wxRIGHT, 5);
+
+  wxStaticText* m_staticText38;
+  m_staticText38 = new wxStaticText(parent, wxID_ANY, _("Min Lat"),
+                                    wxDefaultPosition, wxDefaultSize, 0);
+  m_staticText38->Wrap(-1);
+  fgZoneCoordinatesSizer->Add(m_staticText38, 0, wxLEFT | wxRIGHT | wxTOP, 5);
+
+  m_spMinLat = new wxSpinCtrl(parent, MINLAT, wxEmptyString, wxDefaultPosition,
+                              wxDefaultSize, wxSP_ARROW_KEYS, -180, 180, 0);
+  fgZoneCoordinatesSizer->Add(m_spMinLat, 0, wxLEFT | wxRIGHT | wxTOP, 5);
+
+  m_stMinLatNS = new wxStaticText(parent, wxID_ANY, _("S"), wxDefaultPosition,
+                                  wxDefaultSize, 0);
+  m_stMinLatNS->Wrap(-1);
+  fgZoneCoordinatesSizer->Add(m_stMinLatNS, 0, wxRIGHT | wxTOP, 5);
+
+  wxStaticText* m_staticText40;
+  m_staticText40 = new wxStaticText(parent, wxID_ANY, _("Min Long"),
+                                    wxDefaultPosition, wxDefaultSize, 0);
+  m_staticText40->Wrap(-1);
+  fgZoneCoordinatesSizer->Add(m_staticText40, 0, wxLEFT | wxRIGHT | wxTOP, 5);
+
+  m_spMinLon = new wxSpinCtrl(parent, MINLON, wxEmptyString, wxDefaultPosition,
+                              wxDefaultSize, wxSP_ARROW_KEYS, -180, 180, 0);
+  fgZoneCoordinatesSizer->Add(m_spMinLon, 0, wxLEFT | wxRIGHT | wxTOP, 5);
+
+  m_stMinLonEW = new wxStaticText(parent, wxID_ANY, _("W"), wxDefaultPosition,
+                                  wxDefaultSize, 0);
+  m_stMinLonEW->Wrap(-1);
+  fgZoneCoordinatesSizer->Add(m_stMinLonEW, 0, wxRIGHT | wxTOP, 5);
+
+  wxFlexGridSizer* fgSizer38;
+  fgSizer38 = new wxFlexGridSizer(0, 1, 0, 0);
+  fgSizer38->Add(fgZoneCoordinatesSizer, 1, wxEXPAND | wxLEFT | wxTOP, 5);
+
+  m_cUseSavedZone = new wxCheckBox(parent, SAVEDZONE, _("Use Always this Area"),
+                                   wxDefaultPosition, wxDefaultSize, 0);
+  fgSizer38->Add(m_cUseSavedZone, 0, wxLEFT | wxRIGHT | wxTOP, 5);
+
+  fgSizer36->Add(fgSizer38, 1, wxEXPAND | wxLEFT | wxTOP, 5);
+
+  sbSizer81->Add(fgSizer36, 1, wxBOTTOM | wxEXPAND | wxTOP, 5);
+
+  return sbSizer81;
+}
+
+void GribRequestSettingBase::createWorldPanel() {
   m_panelWorld = new wxPanel(m_notebookGetGrib, wxID_ANY, wxDefaultPosition,
                              wxDefaultSize, wxTAB_TRAVERSAL);
   wxBoxSizer* bSizerWorldDownload;
@@ -2430,7 +2579,9 @@ GribRequestSettingBase::GribRequestSettingBase(wxWindow* parent, wxWindowID id,
   m_panelWorld->SetSizer(bSizerWorldDownload);
   m_panelWorld->Layout();
   bSizerWorldDownload->Fit(m_panelWorld);
-  m_notebookGetGrib->AddPage(m_panelWorld, _("World"), true);
+}
+
+void GribRequestSettingBase::createLocalModelsPanel() {
   m_panelLocalModels =
       new wxPanel(m_notebookGetGrib, wxID_ANY, wxDefaultPosition, wxDefaultSize,
                   wxTAB_TRAVERSAL);
@@ -2477,8 +2628,9 @@ GribRequestSettingBase::GribRequestSettingBase(wxWindow* parent, wxWindowID id,
   m_panelLocalModels->SetSizer(bMainSizer);
   m_panelLocalModels->Layout();
   bMainSizer->Fit(m_panelLocalModels);
-  m_notebookGetGrib->AddPage(m_panelLocalModels, _("Local models"), false);
+}
 
+void GribRequestSettingBase::createEmailPanel() {
   m_panelEmail = new wxPanel(m_notebookGetGrib, wxID_ANY, wxDefaultPosition,
                              wxDefaultSize, wxTAB_TRAVERSAL);
 
@@ -2718,105 +2870,9 @@ GribRequestSettingBase::GribRequestSettingBase(wxWindow* parent, wxWindowID id,
 
   m_fgScrollSizer->Add(sbSizer7, 1, wxEXPAND, 5);
 
-  wxStaticBoxSizer* sbSizer81;
-  sbSizer81 = new wxStaticBoxSizer(
-      new wxStaticBox(m_sScrolledDialog, wxID_ANY, _("Area Selection")),
-      wxVERTICAL);
-
-  wxFlexGridSizer* fgSizer36;
-  fgSizer36 = new wxFlexGridSizer(0, 2, 0, 0);
-  fgSizer36->SetFlexibleDirection(wxBOTH);
-  fgSizer36->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
-
-  wxFlexGridSizer* fgSizer37;
-  fgSizer37 = new wxFlexGridSizer(0, 1, 0, 0);
-  fgSizer37->SetFlexibleDirection(wxBOTH);
-  fgSizer37->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
-
-  m_cManualZoneSel =
-      new wxCheckBox(m_sScrolledDialog, MANSELECT, _("Manual Selection"),
-                     wxDefaultPosition, wxDefaultSize, 0);
-  fgSizer37->Add(m_cManualZoneSel, 0, wxLEFT | wxBOTTOM, 5);
-
-  m_cUseSavedZone =
-      new wxCheckBox(m_sScrolledDialog, SAVEDZONE, _("Use Always this Area"),
-                     wxDefaultPosition, wxDefaultSize, 0);
-  fgSizer37->Add(m_cUseSavedZone, 0, wxLEFT | wxRIGHT | wxTOP, 5);
-
-  fgSizer36->Add(fgSizer37, 1, wxEXPAND | wxLEFT, 5);
-
-  fgZoneCoordinatesSizer = new wxFlexGridSizer(0, 6, 0, 0);
-  fgZoneCoordinatesSizer->SetFlexibleDirection(wxBOTH);
-  fgZoneCoordinatesSizer->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
-
-  wxStaticText* m_staticText34;
-  m_staticText34 = new wxStaticText(m_sScrolledDialog, wxID_ANY, _("Max Lat"),
-                                    wxDefaultPosition, wxDefaultSize, 0);
-  m_staticText34->Wrap(-1);
-  fgZoneCoordinatesSizer->Add(m_staticText34, 0, wxLEFT | wxRIGHT, 5);
-
-  m_spMaxLat = new wxSpinCtrl(m_sScrolledDialog, MAXLAT, wxEmptyString,
-                              wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS,
-                              -180, 180, 0);
-  fgZoneCoordinatesSizer->Add(m_spMaxLat, 0, wxLEFT | wxRIGHT, 5);
-
-  m_stMaxLatNS = new wxStaticText(m_sScrolledDialog, wxID_ANY, _("N"),
-                                  wxDefaultPosition, wxDefaultSize, 0);
-  m_stMaxLatNS->Wrap(-1);
-  fgZoneCoordinatesSizer->Add(m_stMaxLatNS, 0, wxRIGHT, 20);
-
-  m_staticText36 = new wxStaticText(m_sScrolledDialog, wxID_ANY, _("Max Long"),
-                                    wxDefaultPosition, wxDefaultSize, 0);
-  m_staticText36->Wrap(-1);
-  fgZoneCoordinatesSizer->Add(m_staticText36, 0, wxLEFT | wxRIGHT, 5);
-
-  m_spMaxLon = new wxSpinCtrl(m_sScrolledDialog, MAXLON, wxEmptyString,
-                              wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS,
-                              -180, 180, 0);
-  fgZoneCoordinatesSizer->Add(m_spMaxLon, 0, wxLEFT | wxRIGHT, 5);
-
-  m_stMaxLonEW = new wxStaticText(m_sScrolledDialog, wxID_ANY, _("E"),
-                                  wxDefaultPosition, wxDefaultSize, 0);
-  m_stMaxLonEW->Wrap(-1);
-  fgZoneCoordinatesSizer->Add(m_stMaxLonEW, 0, wxRIGHT, 5);
-
-  wxStaticText* m_staticText38;
-  m_staticText38 = new wxStaticText(m_sScrolledDialog, wxID_ANY, _("Min Lat"),
-                                    wxDefaultPosition, wxDefaultSize, 0);
-  m_staticText38->Wrap(-1);
-  fgZoneCoordinatesSizer->Add(m_staticText38, 0, wxLEFT | wxRIGHT | wxTOP, 5);
-
-  m_spMinLat = new wxSpinCtrl(m_sScrolledDialog, MINLAT, wxEmptyString,
-                              wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS,
-                              -180, 180, 0);
-  fgZoneCoordinatesSizer->Add(m_spMinLat, 0, wxLEFT | wxRIGHT | wxTOP, 5);
-
-  m_stMinLatNS = new wxStaticText(m_sScrolledDialog, wxID_ANY, _("S"),
-                                  wxDefaultPosition, wxDefaultSize, 0);
-  m_stMinLatNS->Wrap(-1);
-  fgZoneCoordinatesSizer->Add(m_stMinLatNS, 0, wxRIGHT | wxTOP, 5);
-
-  wxStaticText* m_staticText40;
-  m_staticText40 = new wxStaticText(m_sScrolledDialog, wxID_ANY, _("Min Long"),
-                                    wxDefaultPosition, wxDefaultSize, 0);
-  m_staticText40->Wrap(-1);
-  fgZoneCoordinatesSizer->Add(m_staticText40, 0, wxLEFT | wxRIGHT | wxTOP, 5);
-
-  m_spMinLon = new wxSpinCtrl(m_sScrolledDialog, MINLON, wxEmptyString,
-                              wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS,
-                              -180, 180, 0);
-  fgZoneCoordinatesSizer->Add(m_spMinLon, 0, wxLEFT | wxRIGHT | wxTOP, 5);
-
-  m_stMinLonEW = new wxStaticText(m_sScrolledDialog, wxID_ANY, _("W"),
-                                  wxDefaultPosition, wxDefaultSize, 0);
-  m_stMinLonEW->Wrap(-1);
-  fgZoneCoordinatesSizer->Add(m_stMinLonEW, 0, wxRIGHT | wxTOP, 5);
-
-  fgSizer36->Add(fgZoneCoordinatesSizer, 1, wxEXPAND | wxLEFT | wxTOP, 5);
-
-  sbSizer81->Add(fgSizer36, 1, wxBOTTOM | wxEXPAND | wxTOP, 5);
-
-  m_fgScrollSizer->Add(sbSizer81, 1, wxEXPAND, 5);
+  // wxStaticBoxSizer* sbSizer81 =
+  // createAreaSelectionSection(m_sScrolledDialog);
+  // m_fgScrollSizer->Add(sbSizer81, 1, wxEXPAND, 5);
 
   wxStaticBoxSizer* sbSizer8;
   sbSizer8 = new wxStaticBoxSizer(
@@ -2976,30 +3032,69 @@ GribRequestSettingBase::GribRequestSettingBase(wxWindow* parent, wxWindowID id,
 
   fgSizer101->Add(m_fgFixedSizer, 1, wxEXPAND, 5);
 
-  m_rButton = new wxStdDialogButtonSizer();
+  wxBoxSizer* buttonSizer = new wxBoxSizer(wxHORIZONTAL);
   m_rButtonYes = new wxButton(m_panelEmail, wxID_YES);
-  m_rButton->AddButton(m_rButtonYes);
-  m_rButtonApply = new wxButton(m_panelEmail, wxID_APPLY);
-  m_rButton->AddButton(m_rButtonApply);
-  m_rButtonCancel = new wxButton(m_panelEmail, wxID_CANCEL, _("Cancel"));
-  m_rButton->AddButton(m_rButtonCancel);
-  m_rButton->Realize();
-
-  fgSizer101->Add(m_rButton, 1, wxEXPAND, 5);
+  m_rButtonYes->SetLabel(_("Send"));
+  buttonSizer->Add(m_rButtonYes, 0, wxALL, 5);
+  fgSizer101->Add(buttonSizer, 0, wxEXPAND | wxALL, 5);
 
   m_panelEmail->SetSizer(fgSizer101);
   m_panelEmail->Layout();
   fgSizer101->Fit(m_panelEmail);
+}
+
+GribRequestSettingBase::GribRequestSettingBase(GRIBUICtrlBarBase* parent,
+                                               wxWindowID id,
+                                               const wxString& title,
+                                               const wxPoint& pos,
+                                               const wxSize& size, long style)
+    : wxDialog(parent, id, title, pos, size, style) {
+  this->SetSizeHints(wxDefaultSize, wxDefaultSize);
+
+  wxBoxSizer* bSizerMain;
+  bSizerMain = new wxBoxSizer(wxVERTICAL);
+
+  m_notebookGetGrib =
+      new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0);
+
+  // Create "World" tab.
+  createWorldPanel();
+  m_notebookGetGrib->AddPage(m_panelWorld, _("World"), true);
+
+  // Create "Local models" tab.
+  createLocalModelsPanel();
+  m_notebookGetGrib->AddPage(m_panelLocalModels, _("Local models"), false);
+
+  // Create "e-mail" tab.
+  createEmailPanel();
   m_notebookGetGrib->AddPage(m_panelEmail, _("e-mail"), false);
 
-  // Create XyGrib panel object
+  // Create XyGrib panel tab
   m_xygribPanel =
       new XyGribPanel(m_notebookGetGrib, wxID_ANY, wxDefaultPosition,
                       wxDefaultSize, wxTAB_TRAVERSAL);
   // Add the XyGrib panel to the download notebook
   m_notebookGetGrib->AddPage(m_xygribPanel, _("XyGrib"), false);
 
+  // Add area selection panel tab.
+  wxStaticBoxSizer* sbSizer81 = createAreaSelectionSection(this, parent);
+  bSizerMain->Add(sbSizer81, 0, wxEXPAND | wxALL, 5);
+
+  // Add notebook with the tabs (World, Local Models, e-mail, XyGrib) to the
+  // main sizer.
   bSizerMain->Add(m_notebookGetGrib, 1, wxEXPAND | wxALL, 5);
+
+  // Add Save and Cancel buttons.
+  wxBoxSizer* bottomButtonSizer = new wxBoxSizer(wxHORIZONTAL);
+  m_rButtonCancel = new wxButton(this, wxID_CANCEL, _("Cancel"));
+  bottomButtonSizer->Add(m_rButtonCancel, 0, wxALL, 5);
+
+  bottomButtonSizer->AddStretchSpacer();
+
+  m_rButtonApply = new wxButton(this, wxID_APPLY);
+  bottomButtonSizer->Add(m_rButtonApply, 0, wxALL, 5);
+
+  bSizerMain->Add(bottomButtonSizer, 0, wxEXPAND | wxALL, 5);
 
   this->SetSizer(bSizerMain);
   this->Layout();
@@ -3071,8 +3166,12 @@ GribRequestSettingBase::GribRequestSettingBase(wxWindow* parent, wxWindowID id,
       wxEVT_COMMAND_CHOICE_SELECTED,
       wxCommandEventHandler(GribRequestSettingBase::OnTimeRangeChange), nullptr,
       this);
-  m_cManualZoneSel->Connect(
-      wxEVT_COMMAND_CHECKBOX_CLICKED,
+  m_rbCurrentView->Connect(
+      wxEVT_COMMAND_RADIOBUTTON_SELECTED,
+      wxCommandEventHandler(GribRequestSettingBase::OnZoneSelectionModeChange),
+      nullptr, this);
+  m_rbManualSelect->Connect(
+      wxEVT_COMMAND_RADIOBUTTON_SELECTED,
       wxCommandEventHandler(GribRequestSettingBase::OnZoneSelectionModeChange),
       nullptr, this);
   m_cUseSavedZone->Connect(
@@ -3154,9 +3253,9 @@ GribRequestSettingBase::GribRequestSettingBase(wxWindow* parent, wxWindowID id,
   m_p300hpa->Connect(wxEVT_COMMAND_CHECKBOX_CLICKED,
                      wxCommandEventHandler(GribRequestSettingBase::OnAnyChange),
                      nullptr, this);
-  m_rButtonApply->Connect(
-      wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnSaveMail), nullptr, this);
+  m_rButtonApply->Connect(wxEVT_COMMAND_BUTTON_CLICKED,
+                          wxCommandEventHandler(GribRequestSettingBase::OnOK),
+                          nullptr, this);
   m_rButtonCancel->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
       wxCommandEventHandler(GribRequestSettingBase::OnCancel), nullptr, this);
@@ -3299,8 +3398,12 @@ GribRequestSettingBase::~GribRequestSettingBase() {
       wxEVT_COMMAND_CHOICE_SELECTED,
       wxCommandEventHandler(GribRequestSettingBase::OnTimeRangeChange), nullptr,
       this);
-  m_cManualZoneSel->Disconnect(
-      wxEVT_COMMAND_CHECKBOX_CLICKED,
+  m_rbCurrentView->Disconnect(
+      wxEVT_COMMAND_RADIOBUTTON_SELECTED,
+      wxCommandEventHandler(GribRequestSettingBase::OnZoneSelectionModeChange),
+      nullptr, this);
+  m_rbManualSelect->Disconnect(
+      wxEVT_COMMAND_RADIOBUTTON_SELECTED,
       wxCommandEventHandler(GribRequestSettingBase::OnZoneSelectionModeChange),
       nullptr, this);
   m_cUseSavedZone->Disconnect(
@@ -3393,7 +3496,7 @@ GribRequestSettingBase::~GribRequestSettingBase() {
       this);
   m_rButtonApply->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribRequestSettingBase::OnSaveMail), nullptr, this);
+      wxCommandEventHandler(GribRequestSettingBase::OnOK), nullptr, this);
   m_rButtonCancel->Disconnect(
       wxEVT_COMMAND_BUTTON_CLICKED,
       wxCommandEventHandler(GribRequestSettingBase::OnCancel), nullptr, this);

--- a/plugins/grib_pi/src/GribUIDialogBase.h
+++ b/plugins/grib_pi/src/GribUIDialogBase.h
@@ -64,6 +64,7 @@
 #include <wx/notebook.h>
 #include <wx/treectrl.h>
 #include <wx/html/htmlwin.h>
+#include <wx/tglbtn.h>
 #include "CustomGrid.h"
 #include "XyGribPanel.h"
 
@@ -82,7 +83,8 @@
 #define ID_TIMELINE 1009
 #define ID_BTNOPENFILE 1010
 #define ID_BTNSETTING 1011
-#define ID_BTNREQUEST 1012
+#define ID_BTNREQUEST \
+  1012  //!< ID of button for requesting/downloading GRIB data.
 // GRIBUICDataBase
 #define CURSOR_DATA 1013
 #define ID_CB_WIND 1014
@@ -126,8 +128,9 @@
 #define MAXLON 1050
 #define MINLAT 1051
 #define MINLON 1052
-#define MANSELECT 1053
-#define SAVEDZONE 1054
+#define AUTOSELECT 1053  //!< Automatic selection mode.
+#define MANSELECT 1054   //!< Manual selection mode.
+#define SAVEDZONE 1055   //!< Save zone.
 
 ///////////////////////////////////////////////////////////////////////////////
 /// Class ProjectBoatPanel
@@ -186,6 +189,7 @@ protected:
   wxFlexGridSizer* m_fgCDataSizer;
   wxFlexGridSizer* m_fgCtrlGrabberSize;
   ProjectBoatPanel* m_ProjectBoatPanel;
+  double m_ScaledFactor;
 
   // Virtual event handlers, overide them in your derived class
   virtual void OnClose(wxCloseEvent& event) { event.Skip(); }
@@ -203,7 +207,7 @@ protected:
   virtual void OnTimeline(wxScrollEvent& event) { event.Skip(); }
   virtual void OnOpenFile(wxCommandEvent& event) { event.Skip(); }
   virtual void OnSettings(wxCommandEvent& event) { event.Skip(); }
-  virtual void OnRequest(wxCommandEvent& event) { event.Skip(); }
+  virtual void OnRequestForecastData(wxCommandEvent& event) { event.Skip(); }
   virtual void OnCompositeDialog(wxCommandEvent& event) { event.Skip(); }
 
 public:
@@ -214,8 +218,14 @@ public:
                     const wxString& title = wxEmptyString,
                     const wxPoint& pos = wxDefaultPosition,
                     const wxSize& size = wxDefaultSize,
-                    long style = wxDEFAULT_DIALOG_STYLE | wxSYSTEM_MENU);
+                    long style = wxDEFAULT_DIALOG_STYLE | wxSYSTEM_MENU,
+                    double scale_factor = 1.0);
   ~GRIBUICtrlBarBase();
+
+  void SetScaleFactor(double factor) { m_ScaledFactor = factor; }
+  double GetScaleFactor() { return m_ScaledFactor; }
+  static wxBitmap GetScaledBitmap(wxBitmap bitmap, const wxString svgFileName,
+                                  double scale_factor);
 };
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -426,6 +436,12 @@ public:
 ///////////////////////////////////////////////////////////////////////////////
 class GribRequestSettingBase : public wxDialog {
 private:
+  wxStaticBoxSizer* createAreaSelectionSection(wxWindow* parent,
+                                               GRIBUICtrlBarBase* ctrlBar);
+  void createWorldPanel();
+  void createLocalModelsPanel();
+  void createEmailPanel();
+
 protected:
   wxNotebook* m_notebookGetGrib;
   wxPanel* m_panelWorld;
@@ -461,16 +477,31 @@ protected:
   wxChoice* m_pInterval;
   wxChoice* m_pTimeRange;
   wxStaticText* m_staticText21;
-  wxCheckBox* m_cManualZoneSel;
+  /**
+   * Radio button selected to indicate the download area is based on
+   * the visible area of the chart in the canvas which is currently
+   * in focus.
+   */
+  wxRadioButton* m_rbCurrentView;
+  /**
+   * Radio button selected to indicate the download area is based on
+   * the area selected by the user.
+   */
+  wxRadioButton* m_rbManualSelect;
+  wxBitmapToggleButton* m_bpManualSelection;
   wxFlexGridSizer* fgZoneCoordinatesSizer;
   wxCheckBox* m_cUseSavedZone;
+  /** A spinner for the max latitude of the bounding box for downloads. */
   wxSpinCtrl* m_spMaxLat;
   wxStaticText* m_stMaxLatNS;
   wxStaticText* m_staticText36;
+  /** A spinner for the max longitude of the bounding box for downloads. */
   wxSpinCtrl* m_spMaxLon;
   wxStaticText* m_stMaxLonEW;
+  /** A spinner for the min latitude of the bounding box for downloads. */
   wxSpinCtrl* m_spMinLat;
   wxStaticText* m_stMinLatNS;
+  /** A spinner for the min longitude of the bounding box for downloads. */
   wxSpinCtrl* m_spMinLon;
   wxStaticText* m_stMinLonEW;
   wxCheckBox* m_pWind;
@@ -495,13 +526,16 @@ protected:
   wxFlexGridSizer* m_fgFixedSizer;
   wxStaticText* m_tFileSize;
   wxStaticText* m_tLimit;
-  wxStdDialogButtonSizer* m_rButton;
+  /** Button to Send a download request through e-mail. */
   wxButton* m_rButtonYes;
+  /** Button to Save the "download request" configuration. */
   wxButton* m_rButtonApply;
+  /** Button to Cancel a request to download, close the dialog without saving
+   * the configuration. */
   wxButton* m_rButtonCancel;
   XyGribPanel* m_xygribPanel;
 
-  // Virtual event handlers, overide them in your derived class
+  // Virtual event handlers, override them in your derived class
   virtual void OnClose(wxCloseEvent& event) { event.Skip(); }
   virtual void OnNotebookPageChanged(wxNotebookEvent& event) { event.Skip(); }
   virtual void OnWorldLengthChoice(wxCommandEvent& event) { event.Skip(); }
@@ -520,18 +554,32 @@ protected:
     event.Skip();
   }
   virtual void OnCoordinatesChange(wxSpinEvent& event) { event.Skip(); }
-  virtual void OnSaveMail(wxCommandEvent& event) { event.Skip(); }
+  /**
+   * Callback invoked when the user clicks the "OK" button in the "download"
+   * dialog.
+   */
+  virtual void OnOK(wxCommandEvent& event) { event.Skip(); }
+  /**
+   * Callback invoked when the user clicks the "Cancel" button in the "download"
+   * dialog.
+   */
   virtual void OnCancel(wxCommandEvent& event) { event.Skip(); }
+  /**
+   * Callback invoked when the user clicks the "Send" button in the "e-mail"
+   * tab.
+   */
   virtual void OnSendMaiL(wxCommandEvent& event) { event.Skip(); }
   virtual void OnXyGribDownloadButton(wxCommandEvent& event) { event.Skip(); }
   virtual void OnXyGribAtmModelChoice(wxCommandEvent& event) { event.Skip(); }
   virtual void OnXyGribWaveModelChoice(wxCommandEvent& event) { event.Skip(); }
   virtual void OnXyGribConfigChange(wxCommandEvent& event) { event.Skip(); }
+  // Save configuration before closing
+  virtual void SaveConfig() {};
 
 public:
   wxScrolledWindow* m_sScrolledDialog;
 
-  GribRequestSettingBase(wxWindow* parent, wxWindowID id = wxID_ANY,
+  GribRequestSettingBase(GRIBUICtrlBarBase* parent, wxWindowID id = wxID_ANY,
                          const wxString& title = _("Get forecast..."),
                          const wxPoint& pos = wxDefaultPosition,
                          const wxSize& size = wxSize(-1, -1),

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -439,9 +439,9 @@ void grib_pi::OnToolbarToolCallback(int id) {
 #ifdef __WXOSX__
     style |= wxSTAY_ON_TOP;
 #endif
-    m_pGribCtrlBar =
-        new GRIBUICtrlBar(m_parent_window, wxID_ANY, wxEmptyString,
-                          wxDefaultPosition, wxDefaultSize, style, this);
+    m_pGribCtrlBar = new GRIBUICtrlBar(m_parent_window, wxID_ANY, wxEmptyString,
+                                       wxDefaultPosition, wxDefaultSize, style,
+                                       this, scale_factor);
     m_pGribCtrlBar->SetScaledBitmap(scale_factor);
 
     wxMenu *dummy = new wxMenu(_T("Plugin"));
@@ -558,11 +558,17 @@ bool grib_pi::DoRenderOverlay(wxDC &dc, PlugIn_ViewPort *vp, int canvasIndex) {
     return false;
 
   m_pGRIBOverlayFactory->RenderGribOverlay(dc, vp);
+  if (PluginGetFocusCanvas() == GetCanvasByIndex(canvasIndex)) {
+    m_pGribCtrlBar->SetViewPortWithFocus(vp);
+  }
 
   if (GetCanvasByIndex(canvasIndex) == GetCanvasUnderMouse()) {
-    m_pGribCtrlBar->SetViewPort(vp);
-    if (m_pGribCtrlBar->pReq_Dialog)
+    m_pGribCtrlBar->SetViewPortUnderMouse(vp);
+    if (m_pGribCtrlBar->pReq_Dialog &&
+        GetCanvasIndexUnderMouse() ==
+            m_pGribCtrlBar->pReq_Dialog->GetBoundingBoxCanvasIndex()) {
       m_pGribCtrlBar->pReq_Dialog->RenderZoneOverlay(dc);
+    }
   }
   if (::wxIsBusy()) ::wxEndBusyCursor();
   return true;
@@ -578,11 +584,17 @@ bool grib_pi::DoRenderGLOverlay(wxGLContext *pcontext, PlugIn_ViewPort *vp,
     return false;
 
   m_pGRIBOverlayFactory->RenderGLGribOverlay(pcontext, vp);
+  if (PluginGetFocusCanvas() == GetCanvasByIndex(canvasIndex)) {
+    m_pGribCtrlBar->SetViewPortWithFocus(vp);
+  }
 
   if (GetCanvasByIndex(canvasIndex) == GetCanvasUnderMouse()) {
-    m_pGribCtrlBar->SetViewPort(vp);
-    if (m_pGribCtrlBar->pReq_Dialog)
+    m_pGribCtrlBar->SetViewPortUnderMouse(vp);
+    if (m_pGribCtrlBar->pReq_Dialog &&
+        GetCanvasIndexUnderMouse() ==
+            m_pGribCtrlBar->pReq_Dialog->GetBoundingBoxCanvasIndex()) {
       m_pGribCtrlBar->pReq_Dialog->RenderGlZoneOverlay();
+    }
   }
 
   if (::wxIsBusy()) ::wxEndBusyCursor();

--- a/plugins/grib_pi/src/grib_pi.h
+++ b/plugins/grib_pi/src/grib_pi.h
@@ -128,6 +128,12 @@ public:
   void SetCtrlBarSizeXY(wxSize p) { m_CtrlBar_Sizexy = p; }
   void SetColorScheme(PI_ColorScheme cs);
   void SetDialogFont(wxWindow *window, wxFont *font = OCPNGetFont(_("Dialog")));
+  /**
+   * Callback invoked by OpenCPN core whenever the current ViewPort changes or
+   * through periodic updates.
+   *
+   * In multi-canvas configurations, each canvas triggers a viewport update.
+   */
   void SetCurrentViewPort(PlugIn_ViewPort &vp) { m_current_vp = vp; }
   PlugIn_ViewPort &GetCurrentViewPort() { return m_current_vp; }
 
@@ -233,6 +239,12 @@ private:
   bool m_bGRIBShowIcon;
 
   bool m_bShowGrib;
+  /**
+   * Stores current viewport.
+   *
+   * In multi-canvas configurations, each canvas triggers independent viewport
+   * updates.
+   */
   PlugIn_ViewPort m_current_vp;
   wxBitmap m_panelBitmap;
 };


### PR DESCRIPTION
# List of Pre-Existing Issues

1. Manual GRIB area selection is currently broken because it conflicts with OpenCPN's core chart panning behavior, resulting in unintended panning when trying to select a download area with the GRIB plugin. The user is supposed to do left-click and drag. However, this behavior is overridden by the OpenCPN core chart panning, which also uses Left click + drag, so as a result, mouse area selection does not work.
2. Users are required to click "manual" mode before being able to select a download area. This extra step is unintuitive and can be eliminated. It's not intuitive because the user must:
   - Click the download button.
   - Click the "email" tab (which is the third tab)
   - Click "Manual Selection".
   - When the user clicks "Manual Selection", spinners are displayed, making the user believe the bounds have to be entered manually using the spinners (i.e. mouse interaction is not obvious).
3. The "Manual Selection" checkbox is oddly located in "email", as it can and should apply to "World" and "XyGrib" downloads as well.
4. Even in automatic mode (based on what's visible on the view port), it's still useful to see the bounds, though they should be read-only.
5. The e-mail downloads support click-and-drag selection, but the "World" and XyGrib downloads do not (XyGrib bounding box is based on the ViewPort coordinates). This is not intuitive. The user should be able to do manual selection for World, e-mail and XyGrib.
6. This one can be subject to debate, but I find the terminology "World" not very intuitive. Because:
    - Even though it's named "World", the download is based on the zoom level, with what is viewable or selected.
    - If "World" means it's a worldwide model (because it's ECMWF), then it's also confusing because GFS is also another worldwide model.
7. When the user starts dragging a selection area, the top-left corner or the red rectangle does not always start where the first left click was done. Root caused to incorrect assignment of starting point when ViewPort changes.
8. It should be possible to select a zone without first clicking the download button. In practice, the user must select the download button at least once, and then the left click + drag selection becomes possible.
9. Some of the configuration parameters are saved only when the user clicks the "Save" button in the "e-mail" tab. However, some of these parameters apply to more than just e-mail. For example: `ManualRequestZoneSizing`, `ZyGribLogin`, `RequestZoneMaxLat`, etc.
10. It's not consistent which "download" parameters are saved, and which ones are not.
11. The purpose of the "Save" button in the e-mail tab is very unintuitive. The "Save" button is displayed only when the user goes to the "e-mail" tab, and it's unclear what it's supposed to save (save the e-mail? save the configuration?). Even though it is only displayed in the "e-mail" tab, it is used to save the configuration for all parameters related to downloading GRIB files (including the XyGrib configuration).
12. The "e-mail" tab is the only tab that has a "Cancel" button. It's not clear why there is Cancel in e-mail and not in the other tabs (world, local models, XyGrib).
13. If the user selects an area on the second canvas no indication on the first canvas is made. But if you move the cursor from the second, right, canvas to the left the area indication on the right is unlit and a area selection on the left canvas is shown but on a totally different and false selection.
14. In multi-canvas mode, when downloading in automatic mode, it was not very predictable whether the download area was based on the focused canvas or the canvas under the mouse.

<img width="530" alt="image" src="https://github.com/user-attachments/assets/1f555142-e522-4a10-8f8b-2ed64742aa68" />

# Changes

**The main change is that a user can select an area with Shift + Left Click + drag, which creates a download area, and then that area is used to set the bounding box in the "World", "E-mail" and "XyGrib" downloads.**

- [x] Make area selection available via mouse with Shift + Left Click + drag. The reason it's not just "Left Click + Drag" is that it would conflict with chart panning.
    - I considered an alternative where first the user has to specify "enter area selection mode", which would temporarily disable chart panning and instead support area selection with the mouse. I felt this was overly complicated, but any feedback is welcome.
- [x] Prevent chart panning when **Shift** key is held to avoid conflict with GRIB area selection. Chart panning must be done with just **left-click + drag** (without shift).
- [x] Capture the screen and lat/long coordinates of the starting point of bounding zone as soon as user holds shift + left click. This captures the exact location of the starting point. Previously it was based on a dragging event, which could introduce a lot of lag when user was drawing selection quickly.
- [x] Re-arrange the layout in the download panel to show the area selection across tabs. Remove the "area selection" from inside the "e-mail" panel, and expose it for all tabs.
- [x] Add a visual cue to users that Shift+drag is available. Add a tooltip or label to the interface explaining "Shift+drag to select area.
- [x] Make manual area selection available for "World", "e-mail" and XyGrib downloads.
- [x] Always show the coordinates of the download area, even in non-manual mode. The spinners are grayed out, but they show the coordinates of the bounding box. The coordinates are updated if the user resizes the main view port window.
- [x] Update code documentation describing selection modes and behaviors.
- [ ] Handle the special case of "Local Models", where manual area selection is not applicable.
- [x] Fix issue with starting point of zone selection. When the user starts dragging a selection area, the top-left corner or the red rectangle should be where the first left click was done.

<img width="674" alt="image" src="https://github.com/user-attachments/assets/4a97f1a8-ec4f-46f8-9a61-ba9e5044ca87" />

# Screenshot showing Manual Selection with Shift + Click + Drag

<img width="992" alt="image" src="https://github.com/user-attachments/assets/71f4712f-87e2-4dbd-9571-3eb887fd0ce4" />

# Tests

- [x] Validate that user can create a download area by holding Shift then left click + Drag. Start from the top left corner and drag down to the right.
- [x] Create a selection area, Shift + left click + Drag, but start from the bottom corner and move upwards to the left.
- [x] Create a selection area. Keep a mental note where the first left-click was done. Validate that when the red rectangle is displayed, the corner of the rectangle is exactly where the mouse click started.
- [x] Validate it's possible to create a download selection before clicking the "download" button. Launch OpenCPN, click the GRIB button in the toolbar, and do not click the download button. Do Shift + left click + Drag, validate the red rectangle is displayed. Now click the "download" button, validate the coordinates of the selected area have been set.
- [x] Validate it's possible to create a download selection when the "download" dialog is open.
- [x] Validate that starting point of bounding box is set at the exact mouse location when user does left click, including when user moves the mouse quickly.
- [x] Validate that user can still do chart panning with left click + Drag.
- [x] Validate that on Shift + Click + Drag, the setting is automatically changed to "Manual Selection". I.e. the user specifies intent to select an area, so if "Manual Selection" is disabled, it should automatically enabled it.
- [x] Validate that after Click + Drag, the area coordinates are updated based on the mouse selection.
- [x] Validate that if user unchecks "Manual Selection", then the area coordinates are greyed out, and "Use Always this Area" is greyed out.
- [x] Validate that if user checks "Manual Selection", the the area coordinates are enabled, and "Use Always this Area" is enabled.
- [x] Validate that if user has made a manual selection with the mouse (Click + Drag), then:
   - [x] e-mail download uses these coordinates
   - [x] "World" download uses these coordinates
   - [x] "XyGrib" download uses these coordinates.
- [x] Validate that if user has unchecks manual selection (after having done a manual selection):
   - [x] e-mail download uses the ViewPort coordinates.
   - [x] "World" download uses the ViewPort coordinates.
   - [x] "XyGrib" download uses the ViewPort coordinates.
- [x] Validate that when the user clicks "Cancel" at the bottom of the "Get Forecast" dialog, the dialog is closed without saving the configuration. 
- [x] Validate that when the user clicks "OK" at the bottom of the "Get Forecast" dialog, the dialog is closed after saving the configuration.
- [x] Validate that when the user clicks "Download" in the "World" tab, the data is downloaded, then the config is saved, then the dialog is closed.
- [x] Validate that when the user clicks "Download" in the "Local Models" tab, the data is downloaded, then the config is saved, then the dialog is closed.
- [x] Validate that when the user clicks "Download" in the "XyGrib" tab, the data is downloaded, then the config is saved, then the dialog is closed.
- [x] Validate GRIB file size estimate in XyGrib tab. Zoom out to have a ViewPort view which covers a large area. The request dialog should reject the download request because the file is too big (over 10MB). Then make a manual selection using Shift + Left Click + Drag over a small area. Try the Download again. This should succeed because the file size estimate should have been updated based on the manual zone selection instead of the view port.
- [x] Test with two canvas layout. Move the cursor from the second, right, canvas to the left the area. The red bounding box on the right is unlit and a area selection on the left canvas is shown but on a totally different and false selection. TODO figure out what to do.

# Open Items

1. How to handle the special case of "Local Models"? Is it sufficient to just grey out the Area Selection in the "Local Models" tab?
2. The Shift + left click + Drag seems to lag sometimes. It feels like it may take ~200ms before the plugin registers the corner of the bounding box.
3. User is not able to start the bounding box from the lower right corner and dragging up. The user must currently start from the top left corner and move to the right and down.
4. It would be useful to have a means to show the bounding box **after** the user has released the mouse.

# References

Related PR is #4369 
