### PR TITLE
Route bearing reverse

### DIFF
--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -10900,6 +10900,7 @@ void ChartCanvas::RenderRouteLegs(ocpnDC &dc) {
   }
 
   wxString routeInfo;
+  double varBrg;
   if (g_bShowTrue)
     routeInfo << wxString::Format(wxString("%03d%c(T) ", wxConvUTF8), (int)brg,
                                   0x00B0);
@@ -10907,13 +10908,24 @@ void ChartCanvas::RenderRouteLegs(ocpnDC &dc) {
   if (g_bShowMag) {
     double latAverage = (m_cursor_lat + render_lat) / 2;
     double lonAverage = (m_cursor_lon + render_lon) / 2;
-    double varBrg = gFrame->GetMag(brg, latAverage, lonAverage);
+    varBrg = gFrame->GetMag(brg, latAverage, lonAverage);
 
     routeInfo << wxString::Format(wxString("%03d%c(M) ", wxConvUTF8),
                                   (int)varBrg, 0x00B0);
   }
-
   routeInfo << _T(" ") << FormatDistanceAdaptive(dist);
+
+  if (np==1){
+   routeInfo << "\nReverse: ";
+   if (g_bShowTrue)
+    routeInfo << wxString::Format(wxString("%03d%c(T) ", wxConvUTF8), (int)(brg+180)%360,
+                                  0x00B0);
+
+    if (g_bShowMag) {
+      routeInfo << wxString::Format(wxString("%03d%c(M) ", wxConvUTF8),
+                                    (int)(varBrg+180)%360, 0x00B0);
+    }
+  }
 
   wxString s0;
   if (!route->m_bIsInLayer)

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -10915,7 +10915,7 @@ void ChartCanvas::RenderRouteLegs(ocpnDC &dc) {
   }
   routeInfo << _T(" ") << FormatDistanceAdaptive(dist);
 
-  //To make it easier to misuse a route as a bearing on a charted object add for (only)
+  //To make it easier to use a route as a bearing on a charted object add for
   //the first leg also the reverse bearing.
   if (np==1){
     routeInfo << "\nReverse: ";

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -8264,7 +8264,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
       else {
         FindRoutePointsAtCursor(SelectRadius, true);  // Not creating Route
       }
-    }       // !g_btouch
+    }  // !g_btouch
     else {  // g_btouch
 
       if ((m_bMeasure_Active && m_nMeasureState) || (m_routeState)) {

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -8264,7 +8264,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
       else {
         FindRoutePointsAtCursor(SelectRadius, true);  // Not creating Route
       }
-    }  // !g_btouch
+    }       // !g_btouch
     else {  // g_btouch
 
       if ((m_bMeasure_Active && m_nMeasureState) || (m_routeState)) {
@@ -10915,16 +10915,16 @@ void ChartCanvas::RenderRouteLegs(ocpnDC &dc) {
   }
   routeInfo << _T(" ") << FormatDistanceAdaptive(dist);
 
-  //To make it easier to use a route as a bearing on a charted object add for
-  //the first leg also the reverse bearing.
-  if (np==1){
+  // To make it easier to use a route as a bearing on a charted object add for
+  // the first leg also the reverse bearing.
+  if (np == 1) {
     routeInfo << "\nReverse: ";
     if (g_bShowTrue)
-    routeInfo << wxString::Format(wxString("%03d%c(T) ", wxConvUTF8), (int)(brg+180.)%360,
-                                  0x00B0);
+      routeInfo << wxString::Format(wxString("%03d%c(T) ", wxConvUTF8),
+                                    (int)(brg + 180.) % 360, 0x00B0);
     if (g_bShowMag)
       routeInfo << wxString::Format(wxString("%03d%c(M) ", wxConvUTF8),
-                                    (int)(varBrg+180.)%360, 0x00B0);
+                                    (int)(varBrg + 180.) % 360, 0x00B0);
   }
 
   wxString s0;

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -10915,16 +10915,16 @@ void ChartCanvas::RenderRouteLegs(ocpnDC &dc) {
   }
   routeInfo << _T(" ") << FormatDistanceAdaptive(dist);
 
+  //To make it easier to misuse a route as a bearing on a charted object add for (only)
+  //the first leg also the reverse bearing.
   if (np==1){
-   routeInfo << "\nReverse: ";
-   if (g_bShowTrue)
-    routeInfo << wxString::Format(wxString("%03d%c(T) ", wxConvUTF8), (int)(brg+180)%360,
+    routeInfo << "\nReverse: ";
+    if (g_bShowTrue)
+    routeInfo << wxString::Format(wxString("%03d%c(T) ", wxConvUTF8), (int)(brg+180.)%360,
                                   0x00B0);
-
-    if (g_bShowMag) {
+    if (g_bShowMag)
       routeInfo << wxString::Format(wxString("%03d%c(M) ", wxConvUTF8),
-                                    (int)(varBrg+180)%360, 0x00B0);
-    }
+                                    (int)(varBrg+180.)%360, 0x00B0);
   }
 
   wxString s0;


### PR DESCRIPTION
A route can also be used to draw a bearing on the chart. But you have to start drawing from the object and draw towards your own position. This means the bearing shown in the popup are opposite from your actual bearing towards the object.
This commit also add the opposite bearing. For the first leg of a route only, and only during start of a new 'route'.
Picture as is now.
![Screenshot_20250216_153226](https://github.com/user-attachments/assets/68d313c6-0774-4dfa-aa60-4ff1421c7ae4)
and a screenshot as proposed.
![Screenshot_20250216_153405](https://github.com/user-attachments/assets/92c144c6-0bd2-4ae5-bb4d-8cc2411dcec4)
