### PR TITLE
Netmask setting (#4197)

### DIFF
--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -833,6 +833,8 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   Read("CatalogCustomURL", &g_catalog_custom_url);
   Read("CatalogChannel", &g_catalog_channel);
 
+  Read("NetmaskBits", &g_netmask_bits);
+
   //  NMEA connection options.
   if (!bAsTemplate) {
     Read(_T ( "FilterNMEA_Avg" ), &g_bfilter_cogsog);
@@ -2415,6 +2417,7 @@ void MyConfig::UpdateSettings() {
   Write(_T( "CatalogCustomURL"), g_catalog_custom_url);
   Write(_T( "CatalogChannel"), g_catalog_channel);
 
+  Write("NetmaskBits", g_netmask_bits);
   Write(_T ( "FilterNMEA_Avg" ), g_bfilter_cogsog);
   Write(_T ( "FilterNMEA_Sec" ), g_COGFilterSec);
 

--- a/model/include/model/config_vars.h
+++ b/model/include/model/config_vars.h
@@ -75,6 +75,7 @@ extern int g_maxWPNameLength;
 extern int g_mbtilesMaxLayers;
 extern int g_nCOMPortCheck;
 extern int g_nDepthUnitDisplay;
+extern int g_netmask_bits;
 extern int g_nNMEADebug;
 extern int g_nTrackPrecision;
 extern int g_route_line_width;

--- a/model/src/config_vars.cpp
+++ b/model/src/config_vars.cpp
@@ -68,6 +68,7 @@ int g_maxWPNameLength;
 int g_mbtilesMaxLayers = 2;
 int g_nCOMPortCheck = 32;
 int g_nDepthUnitDisplay = 0;
+int g_netmask_bits = 24;
 int g_NMEAAPBPrecision = 3;
 int g_nNMEADebug = 0;
 int g_nTrackPrecision = 0;


### PR DESCRIPTION
To handle #4197 a new netmask setting is added to the Connections dialog advanced panel. A better way would be to dig out the actual netmask using platform-specific code. However, considering that the bug is a corner case I consider this too much work.

![image](https://github.com/user-attachments/assets/528cbef0-aebf-432d-b207-61e4ea6d8ea0)

Closes: #4197