### PR TITLE
Check if own mmsi is recently been set and delete it from target list

### DIFF
--- a/model/src/ais_decoder.cpp
+++ b/model/src/ais_decoder.cpp
@@ -4292,6 +4292,13 @@ void AisDecoder::OnTimerAIS(wxTimerEvent &event) {
       }
     }
 
+    // Check if the target has recently been set as own MMSI
+    if (xtd->MMSI == g_OwnShipmmsi) {
+      remove_array.push_back(xtd->MMSI);  // Add this target to removal list
+      xtd->b_removed = true;
+      plugin_msg.Notify(xtd, "");
+    }
+
     ++it;
   }
 


### PR DESCRIPTION
Handles the case where the user has just entered their own MMSI for an AIS target that already exists in the list. Without this, it takes "remove lost time" before deletion and possible user confusion.