### PR TITLE
ChartText font changing and saving issue

### DIFF
--- a/gui/src/FontMgr.cpp
+++ b/gui/src/FontMgr.cpp
@@ -201,7 +201,12 @@ wxFont *FontMgr::GetFont(const wxString &TextElement, int requested_font_size) {
       } else if (requested_font_size != 0 &&
                  pmfd->m_font->GetPointSize() == requested_font_size) {
         return pmfd->m_font;
-      }
+      } else
+        // There is a list entry, but no font found, so create one
+        return FindOrCreateFont(
+            requested_font_size, pmfd->m_font->GetFamily(),
+            pmfd->m_font->GetStyle(), pmfd->m_font->GetWeight(), false,
+            pmfd->m_font->GetFaceName(), pmfd->m_font->GetEncoding());
     }
     node = node->GetNext();
   }


### PR DESCRIPTION
On my box (Debian12) I can't change the chart text font. (Chang color is fine) 
This is caused by the font manager. If the code is requesting a non default pointsize in FontMgr::GetFont (FontMrg.cpp 186) the code is adding a new entry to the Fontdescription list. However the font is always of the system native default type!
When quiting O this list is iterated over and saved to the config file. The last added entry is then saved, and therefore is always the standard system font.

My solution is to not add the newly requested fontsize to the Fontdescription list, but only to the font 'pool'. Not sure if this is the best option possible but it works(for me).

PS I did try to find a way to update the charttext font after clicking the 'apply' btn in the options dlg. I know it is possible as the font IS updated if shifting the ENC text size slider and also if changing together with the dialog font. Up to now I didn't find the right part of code doing this, so the chart font is only updated after restart of O.