### PR TITLE
Chart font size

### DIFF
--- a/android/androidUTIL.cpp
+++ b/android/androidUTIL.cpp
@@ -4594,7 +4594,7 @@ MigrateAssistantDialog::MigrateAssistantDialog(wxWindow *parent, bool bskipScan,
 
   m_statusTimer.SetOwner(this, MIGRATION_STATUS_TIMER);
 
-  wxFont *qFont = OCPNGetFont(_("Dialog"), 0);
+  wxFont *qFont = OCPNGetFont(_("Dialog"));
   SetFont(*qFont);
 
   CreateControls();

--- a/gui/include/gui/FontMgr.h
+++ b/gui/include/gui/FontMgr.h
@@ -56,6 +56,10 @@ public:
    * "StatusBar")
    * @param requested_font_size Requested font size in points, 0 to use
    * system/user default
+   * @deprecated requested_font_size This parameter is deprecated as it
+   * overrides user font customization settings. Hard-coded font sizes make it
+   * impossible for OpenCPN to honor user font preferences. Always use 0 to
+   * respect user's font customization choices.
    * @return Pointer to the font to use
    */
   wxFont *GetFont(const wxString &TextElement, int requested_font_size = 0);

--- a/gui/src/FontMgr.cpp
+++ b/gui/src/FontMgr.cpp
@@ -659,8 +659,7 @@ void FontMgr::ScrubList() {
       break;
     }
 
-    GetFont(wxGetTranslation(candidate), g_default_font_size);
-
+    GetFont(wxGetTranslation(candidate));
     i++;
   }
 }

--- a/gui/src/RoutePropDlgImpl.cpp
+++ b/gui/src/RoutePropDlgImpl.cpp
@@ -882,7 +882,7 @@ void RoutePropDlgImpl::WaypointsOnDataViewListCtrlItemContextMenu(
     wxMenuItem* delItem =
         new wxMenuItem(&menu, ID_RCLK_MENU_DELETE, _("Remove Selected"));
 #ifdef __ANDROID__
-    wxFont* pf = OCPNGetFont(_("Menu"), 0);
+    wxFont* pf = OCPNGetFont(_("Menu"));
     editItem->SetFont(*pf);
     moveUpItem->SetFont(*pf);
     moveDownItem->SetFont(*pf);

--- a/gui/src/SendToPeerDlg.cpp
+++ b/gui/src/SendToPeerDlg.cpp
@@ -193,7 +193,7 @@ bool SendToPeerDlg::Create(wxWindow* parent, wxWindowID id,
                            const wxString& caption, const wxString& hint,
                            const wxPoint& pos, const wxSize& size, long style) {
   SetExtraStyle(GetExtraStyle() | wxWS_EX_BLOCK_EVENTS);
-  wxFont* pF = OCPNGetFont(_("Dialog"), 0);
+  wxFont* pF = OCPNGetFont(_("Dialog"));
   SetFont(*pF);
 
   wxDialog::Create(parent, id, caption, pos, size, style);

--- a/gui/src/priority_gui.cpp
+++ b/gui/src/priority_gui.cpp
@@ -77,7 +77,7 @@ PriorityDlg::PriorityDlg(wxWindow* parent)
 
   m_prioTree = new wxTreeCtrl(this, wxID_ANY, wxDefaultPosition, wxDefaultSize);
   stcSizer->Add(m_prioTree, 1, wxALL | wxEXPAND, 5);
-  wxFont* pF = OCPNGetFont(_("Dialog"), 0);
+  wxFont* pF = OCPNGetFont(_("Dialog"));
   m_pF = pF;
   m_prioTree->SetFont(*pF);
 #ifdef __ANDROID__

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -2278,7 +2278,7 @@ extern "C" DECL_EXP wxWindow *GetOCPNCanvasWindow();
  * Time to Go (TTG). By default, the text is large and green, optimized for
  * visibility.
  */
-extern "C" DECL_EXP wxFont *OCPNGetFont(wxString TextElement, int default_size);
+extern "C" DECL_EXP wxFont *OCPNGetFont(wxString TextElement, int default_size = 0);
 
 /**
  * Gets shared application data location.

--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -569,7 +569,7 @@ void ChartDldrPanelImpl::OnContextMenu(wxMouseEvent &event) {
   wxPoint mouseClient = ScreenToClient(mouseScreen);
 
 #ifdef __OCPN__ANDROID__
-  wxFont *pf = OCPNGetFont(_("Menu"), 0);
+  wxFont *pf = OCPNGetFont(_("Menu"));
 
   // add stuff
   wxMenuItem *item1 = new wxMenuItem(&menu, ID_MNU_SELALL, _("Select all"));
@@ -2216,7 +2216,7 @@ bool ChartDldrGuiAddSourceDlg::LoadSection(const wxTreeItemId &root,
       item = m_treeCtrlPredefSrcs->AppendItem(
           root, wxString::FromUTF8(element.first_child().value()), 0, 0);
 
-      wxFont *pFont = OCPNGetFont(_("Dialog"), 0);
+      wxFont *pFont = OCPNGetFont(_("Dialog"));
       if (pFont) m_treeCtrlPredefSrcs->SetItemFont(item, *pFont);
     }
     if (!strcmp(element.name(), "sections")) LoadSections(item, element);
@@ -2253,7 +2253,7 @@ bool ChartDldrGuiAddSourceDlg::LoadCatalog(const wxTreeItemId &root,
   ChartSource *cs = new ChartSource(name, location, dir);
   wxTreeItemId id = m_treeCtrlPredefSrcs->AppendItem(root, name, 1, 1, cs);
 
-  wxFont *pFont = OCPNGetFont(_("Dialog"), 0);
+  wxFont *pFont = OCPNGetFont(_("Dialog"));
   if (pFont) m_treeCtrlPredefSrcs->SetItemFont(id, *pFont);
 
   return true;

--- a/plugins/chartdldr_pi/src/chartdldrgui.cpp
+++ b/plugins/chartdldr_pi/src/chartdldrgui.cpp
@@ -887,7 +887,7 @@ ChartDldrPrefsDlg::ChartDldrPrefsDlg(wxWindow* parent, wxWindowID id,
                                      const wxString& title, const wxPoint& pos,
                                      const wxSize& size, long style)
     : wxDialog(parent, id, title, pos, size, style) {
-  wxFont* pFont = OCPNGetFont(_("Dialog"), 0);
+  wxFont* pFont = OCPNGetFont(_("Dialog"));
   if (pFont) SetFont(*pFont);
 
   this->SetSizeHints(wxDefaultSize, wxDefaultSize);

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -4099,7 +4099,7 @@ DashboardPreferencesDialog::DashboardPreferencesDialog(
     : wxDialog(parent, id, _("Dashboard preferences"), wxDefaultPosition,
                wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
 #ifdef __WXQT__
-  wxFont *pF = OCPNGetFont(_("Dialog"), 0);
+  wxFont *pF = OCPNGetFont(_("Dialog"));
   SetFont(*pF);
 #endif
 
@@ -4890,7 +4890,7 @@ void DashboardPreferencesDialog::OnInstrumentAdd(wxCommandEvent &event) {
   AddInstrumentDlg pdlg((wxWindow *)event.GetEventObject(), wxID_ANY);
 
 #ifdef __OCPN__ANDROID__
-  wxFont *pF = OCPNGetFont(_("Dialog"), 0);
+  wxFont *pF = OCPNGetFont(_("Dialog"));
   pdlg.SetFont(*pF);
 
   wxSize esize;
@@ -5181,7 +5181,7 @@ AddInstrumentDlg::AddInstrumentDlg(wxWindow *pparent, wxWindowID id)
   m_pListCtrlInstruments->AssignImageList(imglist, wxIMAGE_LIST_SMALL);
   m_pListCtrlInstruments->InsertColumn(0, _("Instruments"));
 
-  wxFont *pF = OCPNGetFont(_("Dialog"), 0);
+  wxFont *pF = OCPNGetFont(_("Dialog"));
   m_pListCtrlInstruments->SetFont(*pF);
 
 #ifdef __OCPN__ANDROID__
@@ -5551,7 +5551,7 @@ void DashboardWindow::OnContextMenu(wxContextMenuEvent &event) {
   wxMenu *contextMenu = new wxMenu();
 
 #ifdef __WXQT__
-  wxFont *pf = OCPNGetFont(_("Menu"), 0);
+  wxFont *pf = OCPNGetFont(_("Menu"));
 
   // add stuff
   wxMenuItem *item1 =
@@ -6185,7 +6185,7 @@ bool OCPNFontButton::Create(wxWindow *parent, wxWindowID id,
 void OCPNFontButton::OnButtonClick(wxCommandEvent &WXUNUSED(ev)) {
   // update the wxFontData to be shown in the dialog
   m_data.SetInitialFont(m_selectedFont);
-  wxFont *pF = OCPNGetFont(_("Dialog"), 0);
+  wxFont *pF = OCPNGetFont(_("Dialog"));
 
 #ifdef __WXGTK__
   // Use a smaller font picker dialog (ocpnGenericFontDialog) for small displays

--- a/plugins/grib_pi/src/CursorData.cpp
+++ b/plugins/grib_pi/src/CursorData.cpp
@@ -142,7 +142,7 @@ void CursorData::PopulateTrackingControls(bool vertical) {
 
   this->Fit();
   // Get text controls sizing data
-  wxFont *font = OCPNGetFont(_("Dialog"), 0);
+  wxFont *font = OCPNGetFont(_("Dialog"));
   int wn, wd, ws, wl;
   GetTextExtent(_T("abcdefghihjk"), &wn, nullptr, 0, 0,
                 font);  // normal width text control size
@@ -742,7 +742,7 @@ void CursorData::MenuAppend(wxMenu *menu, int id, wxString label, int setting) {
   wxMenuItem *item = new wxMenuItem(menu, id, label, _T(""), wxITEM_CHECK);
 
 #ifdef __WXMSW__
-  wxFont *qFont = OCPNGetFont(_("Menu"), 0);
+  wxFont *qFont = OCPNGetFont(_("Menu"));
   item->SetFont(*qFont);
 #endif
 

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -377,7 +377,7 @@ void GRIBOverlayFactory::SetMessageFont() {
 #ifdef __WXQT__
   fo = GetOCPNGUIScaledFont_PlugIn(_("Dialog"));
 #else
-  fo = *OCPNGetFont(_("Dialog"), 0);
+  fo = *OCPNGetFont(_("Dialog"));
   fo.SetPointSize(
       (fo.GetPointSize() * g_ContentScaleFactor / OCPN_GetWinDIPScaleFactor()));
 #endif

--- a/plugins/grib_pi/src/GribRequestDialog.cpp
+++ b/plugins/grib_pi/src/GribRequestDialog.cpp
@@ -222,7 +222,7 @@ void GribRequestSetting::InitRequestConfig() {
   // Set wxSpinCtrl sizing
   int w, h;
   GetTextExtent(_T("-360"), &w, &h, 0, 0,
-                OCPNGetFont(_("Dialog"), 0));  // optimal text control size
+                OCPNGetFont(_("Dialog")));  // optimal text control size
   w += 30;
   h += 4;
   m_sMovingSpeed->SetMinSize(wxSize(w, h));
@@ -311,7 +311,7 @@ void GribRequestSetting::OnClose(wxCloseEvent &event) {
 void GribRequestSetting::SetRequestDialogSize() {
   int y;
   /*first let's size the mail display space*/
-  GetTextExtent(_T("abc"), nullptr, &y, 0, 0, OCPNGetFont(_("Dialog"), 0));
+  GetTextExtent(_T("abc"), nullptr, &y, 0, 0, OCPNGetFont(_("Dialog")));
   m_MailImage->SetMinSize(
       wxSize(-1, ((y * m_MailImage->GetNumberOfLines()) + 10)));
 
@@ -1177,7 +1177,7 @@ bool GribRequestSetting::DoRenderZoneOverlay() {
   center.x = x + (zw / 2);
   center.y = y + (zh / 2);
 
-  wxFont fo = *OCPNGetFont(_("Dialog"), 0);
+  wxFont fo = *OCPNGetFont(_("Dialog"));
   fo.SetPointSize(
       (fo.GetPointSize() * m_displayScale / OCPN_GetWinDIPScaleFactor()));
   wxFont *font = &fo;

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -951,7 +951,7 @@ void GRIBUICtrlBar::MenuAppend(wxMenu *menu, int id, wxString label,
 
     /* Menu font do not work properly for MSW (wxWidgets 3.2.1)
     #ifdef __WXMSW__
-      wxFont *qFont = OCPNGetFont(_("Menu"), 0);
+      wxFont *qFont = OCPNGetFont(_("Menu"));
       item->SetFont(*qFont);
     #endif
     */

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -450,7 +450,7 @@ void grib_pi::OnToolbarToolCallback(int id) {
                        wxEmptyString, wxITEM_NORMAL);
     /* Menu font do not work properly for MSW (wxWidgets 3.2.1)
     #ifdef __WXMSW__
-        wxFont *qFont = OCPNGetFont(_("Menu"), 0);
+        wxFont *qFont = OCPNGetFont(_("Menu"));
         table->SetFont(*qFont);
     #endif
     */
@@ -479,8 +479,7 @@ void grib_pi::OnToolbarToolCallback(int id) {
       starting = true;
     }
     // the dialog font could have been changed since grib plugin opened
-    if (m_pGribCtrlBar->GetFont() != *OCPNGetFont(_("Dialog"), 0))
-      starting = true;
+    if (m_pGribCtrlBar->GetFont() != *OCPNGetFont(_("Dialog"))) starting = true;
     if (starting) {
       m_pGRIBOverlayFactory->SetMessageFont();
       SetDialogFont(m_pGribCtrlBar);

--- a/plugins/grib_pi/src/grib_pi.h
+++ b/plugins/grib_pi/src/grib_pi.h
@@ -127,8 +127,7 @@ public:
   void SetCursorDataXY(wxPoint p) { m_CursorDataxy = p; }
   void SetCtrlBarSizeXY(wxSize p) { m_CtrlBar_Sizexy = p; }
   void SetColorScheme(PI_ColorScheme cs);
-  void SetDialogFont(wxWindow *window,
-                     wxFont *font = OCPNGetFont(_("Dialog"), 0));
+  void SetDialogFont(wxWindow *window, wxFont *font = OCPNGetFont(_("Dialog")));
   void SetCurrentViewPort(PlugIn_ViewPort &vp) { m_current_vp = vp; }
   PlugIn_ViewPort &GetCurrentViewPort() { return m_current_vp; }
 

--- a/plugins/wmm_pi/src/wmm_pi.cpp
+++ b/plugins/wmm_pi/src/wmm_pi.cpp
@@ -161,7 +161,7 @@ int wmm_pi::Init(void) {
 
   // pFontSmall = new wxFont( 10, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
   // wxFONTWEIGHT_BOLD );
-  pFontSmall = OCPNGetFont(_("WMM_Live_Overlay"), 0);
+  pFontSmall = OCPNGetFont(_("WMM_Live_Overlay"));
 
   m_shareLocn = *GetpSharedDataLocation() + _T("plugins") +
                 wxFileName::GetPathSeparator() + _T("wmm_pi") +
@@ -363,7 +363,7 @@ void wmm_pi::OnToolbarToolCallback(int id) {
   if (!m_buseable) return;
   if (NULL == m_pWmmDialog) {
     m_pWmmDialog = new WmmUIDialog(*this, m_parent_window);
-    wxFont *pFont = OCPNGetFont(_("Dialog"), 0);
+    wxFont *pFont = OCPNGetFont(_("Dialog"));
     m_pWmmDialog->SetFont(*pFont);
 
     m_pWmmDialog->Move(wxPoint(m_wmm_dialog_x, m_wmm_dialog_y));
@@ -906,7 +906,7 @@ void wmm_pi::ShowPreferencesDialog(wxWindow *parent) {
 
 void wmm_pi::ShowPlotSettings() {
   WmmPlotSettingsDialog *dialog = new WmmPlotSettingsDialog(m_parent_window);
-  wxFont *pFont = OCPNGetFont(_("Dialog"), 0);
+  wxFont *pFont = OCPNGetFont(_("Dialog"));
   dialog->SetFont(*pFont);
 
   dialog->Fit();


### PR DESCRIPTION
Improve chart text sizing with monotonic font transformation.

Replace non-monotonic piecewise font size adjustment with a linear transformation that maps S52 chart text sizes to a consistent range. This ensures larger input values always result in proportionally larger output sizes while still preventing 
excessively large fonts from NOAA ENC files.

- Map input font sizes [0-20] to a normalized range [0-4]
- Add normalized value to user's configured font size
- Maintain minimum readable size of 10 points
- Improve code readability with clear comments and constants

In addition, respect the user font customization (font color, face and font size). For example, if the user selects a font size of 12, then this is considered to be the base font size. The normalized value in the range [0, 4] is added to the base font size.

If the user customizes the font size to a very small value like "2" (not sure it's even possible), then the font size is clamped to 10.

With Default system font:

<img width="1048" alt="image" src="https://github.com/user-attachments/assets/bd3c06f6-118d-47ea-89db-233acf1c4fd4" />

With custom font face and color:

<img width="1093" alt="image" src="https://github.com/user-attachments/assets/d8f10d97-4402-4270-ae3c-aa59e6b0af3a" />

Increase the font size in Options -> User Interface:

<img width="1018" alt="image" src="https://github.com/user-attachments/assets/7ae51c28-0170-46ca-b050-774b9553ae43" />

