### PR TITLE
Prevent asserts on Signal K server originated disconnection when security settings change

### DIFF
--- a/model/src/comm_drv_signalk_net.cpp
+++ b/model/src/comm_drv_signalk_net.cpp
@@ -400,6 +400,13 @@ void CommDriverSignalKNet::handle_SK_sentence(
     return;
   }
 
+  if (!root.IsObject()) {
+    wxLogMessage(wxString::Format(
+        _T("SignalKDataStream ERROR: Message is not a JSON Object: %s"),
+        msg->c_str()));
+    return;
+  }
+
   // Decode just enough of string to extract some identifiers
   // such as the sK version, "self" context, and target context
   if (root.HasMember("version")) {


### PR DESCRIPTION
When Signal K server terminates the connection after changing it's security settings, a message like `{message: \"Connection disconnected by security constraint\"}` is received, which is not a JSON object and leads to an assertion in RapidJSON while calling `HasMember` on it. Closes #4394