### PR TITLE
Fix wind barbs and elements not moving with chart when panning

### DIFF
--- a/gui/include/gui/viewport.h
+++ b/gui/include/gui/viewport.h
@@ -155,6 +155,35 @@ public:
   wxRect GetVPRectIntersect(size_t n, float *llpoints);
   ViewPort BuildExpandedVP(int width, int height);
 
+  /**
+   * Computes the bounding box coordinates for the current viewport.
+   * This function is responsible for determining the lat/lon boundaries of the
+   * current viewport, which are used for various purposes including plugin
+   * rendering.
+   *
+   * The function calculates a larger "virtual" pixel window size when rotation
+   * is applied to ensure that enough chart data is fetched to fill the rotated
+   * screen. It then computes the viewport lat/lon reference points based on
+   * screen coordinates.
+   *
+   * Different algorithms are used depending on the projection type (POLAR,
+   * ORTHOGRAPHIC, STEREOGRAPHIC, GNOMONIC, MERCATOR, EQUIRECTANGULAR).
+   *
+   * Edge cases are handled such as:
+   * - IDL (International Date Line) crossings
+   * - Poles being visible on screen
+   * - Non-rectangular mappings between screen space and geographical
+   * coordinates
+   *
+   * The computed bounding box is stored in vpBBox and is used by various parts
+   * of the program to determine which chart features should be rendered and
+   * which are outside the visible area.
+   *
+   * @note When rotation or skew is applied, the function creates a larger
+   * rectangle that encompasses the rotated viewport, which can lead to data
+   * being fetched and rendered for areas that may be just outside the visible
+   * part of the screen.
+   */
   void SetBoxes(void);
   /**
    * Set the physical to logical pixel ratio for the display.
@@ -245,8 +274,9 @@ public:
   }
 
 private:
-  LLBBox vpBBox;  // An un-skewed rectangular lat/lon bounding box
-                  // which contains the entire vieport
+  /** An un-skewed rectangular lat/lon bounding box which contains the entire
+   * viewport. */
+  LLBBox vpBBox;
 
   bool bValid;  // This VP is valid
 

--- a/gui/src/viewport.cpp
+++ b/gui/src/viewport.cpp
@@ -819,9 +819,9 @@ wxRect ViewPort::GetVPRectIntersect(size_t n, float *llpoints) {
 }
 
 void ViewPort::SetBoxes(void) {
-  //  In the case where canvas rotation is applied, we need to define a larger
-  //  "virtual" pixel window size to ensure that enough chart data is fatched
-  //  and available to fill the rotated screen.
+  // In the case where canvas rotation is applied, we need to define a larger
+  // "virtual" pixel window size to ensure that enough chart data is fatched
+  // and available to fill the rotated screen.
   rv_rect = wxRect(0, 0, pix_width, pix_height);
 
   //  Specify the minimum required rectangle in unrotated screen space which

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -2260,24 +2260,26 @@ extern "C" DECL_EXP void RequestRefresh(wxWindow *);
 extern "C" DECL_EXP bool GetGlobalColor(wxString colorName, wxColour *pcolour);
 
 /**
- * Converts lat/lon to canvas pixel coordinates.
+ * Converts lat/lon to canvas physical pixel coordinates.
  *
- * Transforms geographic coordinates to screen pixels for the given viewport.
+ * Transforms geographic coordinates to screen physical pixels for the given
+ * viewport.
  *
  * @param vp Current viewport
- * @param pp Will receive pixel coordinates
+ * @param pp Will receive physical pixel coordinates
  * @param lat Latitude in decimal degrees
  * @param lon Longitude in decimal degrees
  */
 extern "C" DECL_EXP void GetCanvasPixLL(PlugIn_ViewPort *vp, wxPoint *pp,
                                         double lat, double lon);
 /**
- * Converts canvas pixel coordinates to lat/lon.
+ * Converts canvas physical pixel coordinates to lat/lon.
  *
- * Transforms screen pixels to geographic coordinates for the given viewport.
+ * Transforms screen physical pixels to geographic coordinates for the given
+ * viewport.
  *
  * @param vp Current viewport
- * @param p Pixel coordinates
+ * @param p Physical pixel coordinates
  * @param plat Will receive latitude in decimal degrees
  * @param plon Will receive longitude in decimal degrees
  */

--- a/plugins/grib_pi/src/GribOverlayFactory.h
+++ b/plugins/grib_pi/src/GribOverlayFactory.h
@@ -221,14 +221,92 @@ private:
 
   void SettingsIdToGribId(int i, int &idx, int &idy, bool &polar);
   bool DoRenderGribOverlay(PlugIn_ViewPort *vp);
+  /**
+   * Renders wind or current barbed arrows on the chart.
+   *
+   * This function draws barbed arrows representing wind or current directions
+   * and magnitudes. The barbs change appearance based on speed (more barbs for
+   * higher speed). The arrows can be drawn using fixed spacing (grid) or
+   * minimum spacing modes.
+   *
+   * @param settings The settings index identifying the data type (WIND,
+   * CURRENT, etc.)
+   * @param pGR Array of GribRecord pointers containing the data
+   * @param vp Current viewport for rendering
+   */
   void RenderGribBarbedArrows(int config, GribRecord **pGR,
                               PlugIn_ViewPort *vp);
+  /**
+   * Renders isobars (lines of equal value) for pressure or other scalar fields.
+   *
+   * This function draws isobar lines at specific intervals defined in the
+   * settings. It also handles label placement along the isobars. For pressure,
+   * the function supports different unit conversions. The implementation caches
+   * isobar calculations to improve performance.
+   *
+   * @param settings The settings index identifying the data type (PRESSURE,
+   * etc.)
+   * @param pGR Array of GribRecord pointers containing the data
+   * @param pIsobarArray Array of cached isobar objects for reuse
+   * @param vp Current viewport for rendering
+   */
   void RenderGribIsobar(int config, GribRecord **pGR,
                         wxArrayPtrVoid **pIsobarArray, PlugIn_ViewPort *vp);
+  /**
+   * Renders direction arrows for vector fields like wind or current.
+   *
+   * This function draws arrows showing flow direction for vector data. The
+   * arrows can be single, double, or width-varied based on settings. Supports
+   * both fixed spacing (grid) mode and minimum spacing mode.
+   *
+   * @param settings The settings index identifying the data type (WIND,
+   * CURRENT, etc.)
+   * @param pGR Array of GribRecord pointers containing the data
+   * @param vp Current viewport for rendering
+   */
   void RenderGribDirectionArrows(int config, GribRecord **pGR,
                                  PlugIn_ViewPort *vp);
+  /**
+   * Renders color-coded overlay maps showing data distribution.
+   *
+   * This function creates and draws bitmap or OpenGL texture overlays showing
+   * geographic distribution of data using color gradients. It handles both
+   * scalar and vector magnitude fields, and manages appropriate color mapping
+   * based on data range. Includes transparency support for certain data types.
+   *
+   * @param settings The settings index identifying the data type
+   * @param pGR Array of GribRecord pointers containing the data
+   * @param vp Current viewport for rendering
+   */
   void RenderGribOverlayMap(int config, GribRecord **pGR, PlugIn_ViewPort *vp);
+  /**
+   * Renders numeric values at fixed or minimum-spaced grid points.
+   *
+   * This function displays actual data values at locations across the chart.
+   * Values are drawn with background colors matching the data scale.
+   * Supports both fixed spacing (grid) mode and minimum spacing mode.
+   * Grid placement is aligned to geographic coordinates to maintain proper
+   * positioning during panning.
+   *
+   * @param settings The settings index identifying the data type
+   * @param pGR Array of GribRecord pointers containing the data
+   * @param vp Current viewport for rendering
+   */
   void RenderGribNumbers(int config, GribRecord **pGR, PlugIn_ViewPort *vp);
+  /**
+   * Renders animated particles showing flow patterns.
+   *
+   * This function creates and updates flowing particles that visualize vector
+   * fields like wind or current. Particles have position history, move based on
+   * field strength and direction, and are color-coded by magnitude. The
+   * implementation manages particle lifecycle, trajectory calculation, and
+   * efficient rendering for potentially thousands of particles.
+   *
+   * @param settings The settings index identifying the data type (WIND,
+   * CURRENT)
+   * @param pGR Array of GribRecord pointers containing the data
+   * @param vp Current viewport for rendering
+   */
   void RenderGribParticles(int settings, GribRecord **pGR, PlugIn_ViewPort *vp);
   void DrawLineBuffer(LineBuffer &buffer);
   void OnParticleTimer(wxTimerEvent &event);

--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -1197,7 +1197,7 @@ GribSettingsDialogBase::GribSettingsDialogBase(wxWindow* parent, wxWindowID id,
 
   wxStaticText* m_staticText41;
   m_staticText41 =
-      new wxStaticText(m_scSetDataPanel, wxID_ANY, _("Spacing(pixels)"),
+      new wxStaticText(m_scSetDataPanel, wxID_ANY, _("Spacing (pixels)"),
                        wxDefaultPosition, wxDefaultSize, 0);
   m_staticText41->Wrap(-1);
   fgSizer42->Add(m_staticText41, 0, wxALL, 5);
@@ -1301,7 +1301,7 @@ GribSettingsDialogBase::GribSettingsDialogBase(wxWindow* parent, wxWindowID id,
 
   wxStaticText* m_staticText42;
   m_staticText42 =
-      new wxStaticText(m_scSetDataPanel, wxID_ANY, _("Spacing(pixels)"),
+      new wxStaticText(m_scSetDataPanel, wxID_ANY, _("Spacing (pixels)"),
                        wxDefaultPosition, wxDefaultSize, 0);
   m_staticText42->Wrap(-1);
   fgSizer43->Add(m_staticText42, 0, wxALL, 5);
@@ -1374,7 +1374,7 @@ GribSettingsDialogBase::GribSettingsDialogBase(wxWindow* parent, wxWindowID id,
 
   wxStaticText* m_staticText43;
   m_staticText43 =
-      new wxStaticText(m_scSetDataPanel, wxID_ANY, _("Spacing(pixels)"),
+      new wxStaticText(m_scSetDataPanel, wxID_ANY, _("Spacing (pixels)"),
                        wxDefaultPosition, wxDefaultSize, 0);
   m_staticText43->Wrap(-1);
   m_fgNumData1->Add(m_staticText43, 0, wxALL, 5);

--- a/plugins/grib_pi/src/GribUIDialogBase.h
+++ b/plugins/grib_pi/src/GribUIDialogBase.h
@@ -304,10 +304,29 @@ protected:
   wxCheckBox* m_cbBarbedArrows;
   wxFlexGridSizer* m_fgBarbedData1;
   wxChoice* m_cBarbedColours;
+  /**
+   * Flag to determine barbed arrow layout mode.
+   *
+   * When true, wind/current barbs are drawn using a fixed spacing grid where
+   * arrows are evenly distributed across the screen at intervals specified
+   * by m_iBarbArrSpacing. This mode creates a regular pattern of barbs.
+   */
   wxCheckBox* m_cBarbArrFixSpac;
   wxCheckBox* m_cBarbArrMinSpac;
   wxFlexGridSizer* m_fgBarbedData2;
   wxCheckBox* m_cBarbedVisibility;
+  /**
+   * Spacing between barbed arrows in fixed spacing mode.
+   *
+   * This value defines the pixel distance between adjacent wind/current barbs
+   * when using fixed spacing mode (m_bBarbArrFixSpac = true). The spacing
+   * is measured in screen pixels, but is converted to geographic coordinates
+   * during rendering to ensure proper movement when panning.
+   *
+   * Higher values create a sparser grid with fewer barbs, while lower values
+   * create a denser grid with more barbs. The actual on-screen distance
+   * includes this spacing plus the size of the barbed arrow itself.
+   */
   wxSpinCtrl* m_sBarbArrSpacing;
   wxCheckBox* m_cbIsoBars;
   wxFlexGridSizer* m_fIsoBarSpacing;


### PR DESCRIPTION
Fix for #4405

# Problem

When panning charts with the GRIB plugin enabled, wind barbs and other graphical elements (direction arrows and numbers) do not move with the chart. Instead, they remain fixed at their screen positions, creating a confusing visualization where the chart moves but the weather elements stay in place.

# Solution

This PR changes how the fixed-spacing grids for GRIB elements (wind barbs, direction arrows, and numerical values) are calculated and rendered:

1. Instead of creating a layout grid in screen coordinates, we now:
   - Convert the user-configured pixel spacing to geographic spacing based on the current zoom level
   - Create a grid of elements in geographic coordinates (lat/lon)
   - Convert these geographic positions to screen coordinates only during rendering
2. With this approach, GRIB visualization elements:
   - Are properly anchored to geographic positions
   - Move correctly with the chart during panning operations
   - Maintain their proper geographic relationships with the underlying chart

The recording below shows barbed arrows have a pan effect following the chart panning movement.

https://github.com/user-attachments/assets/c6e9d94c-fc5a-4d30-832c-9f31b307f597


