### PR TITLE
Grid text

### DIFF
--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -782,15 +782,16 @@ ChartCanvas::ChartCanvas(wxFrame *frame, int canvasIndex)
   if (!g_bdisable_opengl) m_pQuilt->EnableHighDefinitionZoom(true);
 #endif
 
-  int gridFontSize = 8;
-#if defined(__WXOSX__) || defined(__WXGTK3__)
-  // Support scaled HDPI displays.
-  gridFontSize *= GetContentScaleFactor();
-#endif
+  //   int gridFontSize = 8;
+  // #if defined(__WXOSX__) || defined(__WXGTK3__)
+  //   // Support scaled HDPI displays.
+  //   gridFontSize *= GetContentScaleFactor();
+  // #endif
 
-  m_pgridFont = FontMgr::Get().FindOrCreateFont(
-      gridFontSize, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL,
-      FALSE, wxString(_T ( "Arial" )));
+  m_pgridFont = FontMgr::Get().GetFont(_("GridText"));
+  //   FontMgr::Get().FindOrCreateFont(
+  //       gridFontSize, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
+  //       wxFONTWEIGHT_NORMAL, FALSE, wxString(_T ( "Arial" )));
 
   m_Piano = new Piano(this);
 
@@ -6503,7 +6504,7 @@ void ChartCanvas::GridDraw(ocpnDC &dc) {
   wxPen GridPen(GetGlobalColor(_T ( "SNDG1" )), 1, wxPENSTYLE_SOLID);
   dc.SetPen(GridPen);
   dc.SetFont(*m_pgridFont);
-  dc.SetTextForeground(GetGlobalColor(_T ( "SNDG1" )));
+  dc.SetTextForeground(FontMgr::Get().GetFontColor(_("GridText")));
 
   w = m_canvas_width;
   h = m_canvas_height;
@@ -8505,7 +8506,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
       else {
         FindRoutePointsAtCursor(SelectRadius, true);  // Not creating Route
       }
-    }  // !g_btouch
+    }       // !g_btouch
     else {  // g_btouch
 
       if ((m_bMeasure_Active && m_nMeasureState) || (m_routeState)) {

--- a/gui/src/glChartCanvas.cpp
+++ b/gui/src/glChartCanvas.cpp
@@ -2036,6 +2036,8 @@ void glChartCanvas::GridDraw() {
   }
 
   // draw major longitude grid lines
+  int th;
+  m_gridfont.GetTextExtent(_T("0"), 0, &th);
   float lat_step = nlat - slat;
   if (!straight_longitudes) lat_step /= ceil(lat_step / curved_step);
 
@@ -2046,7 +2048,7 @@ void glChartCanvas::GridDraw() {
     for (lat = slat; lat < nlat + lat_step / 2; lat += lat_step) {
       m_pParentCanvas->GetCanvasPointPix(lat, lon, &r);
       if (s.x != INVALID_COORD && s.y != INVALID_COORD) {
-        gldc.DrawLine(s.x, s.y, r.x, r.y, false);
+        gldc.DrawLine(s.x, s.y, r.x, r.y + th, false);
       }
       s = r;
     }
@@ -2072,8 +2074,8 @@ void glChartCanvas::GridDraw() {
 
       wxString st =
           CalcGridText(lat, gridlatMajor, true);  // get text for grid line
-      int iy;
-      m_gridfont.GetTextExtent(st, 0, &iy);
+      int ix, iy;
+      m_gridfont.GetTextExtent(st, &ix, &iy);
 
       if (straight_latitudes) {
         wxPoint r, s;
@@ -2139,8 +2141,8 @@ void glChartCanvas::GridDraw() {
         xlon += 360.0;
 
       wxString st = CalcGridText(xlon, gridlonMajor, false);
-      int ix;
-      m_gridfont.GetTextExtent(st, &ix, 0);
+      int ix, iy;
+      m_gridfont.GetTextExtent(st, &ix, &iy);
 
       if (straight_longitudes) {
         float x = -1, y = 0;
@@ -2150,7 +2152,7 @@ void glChartCanvas::GridDraw() {
           y = (float)(r.y * s.x - s.y * r.x + (s.y - r.y) * x) / (s.x - r.x);
         }
 
-        m_gridfont.RenderString(st, x, y);
+        m_gridfont.RenderString(st, x - ix / 2, y);
       } else {
         // iteratively attempt to find where the latitude line crosses x=0
         wxPoint2DDouble r;

--- a/gui/src/glChartCanvas.cpp
+++ b/gui/src/glChartCanvas.cpp
@@ -1961,8 +1961,9 @@ void glChartCanvas::GridDraw() {
 
     m_gridfont.SetContentScaleFactor(OCPN_GetDisplayContentScaleFactor());
     m_gridfont.Build(font, 1, dpi_factor);
+    wxColour GridTextC = FontMgr::Get().GetFontColor(_("GridText"));
+    m_gridfont.SetColor(GridTextC);
   }
-  m_gridfont.SetColor(GridColor);
 
   w = vp.pix_width;
   h = vp.pix_height;
@@ -3001,7 +3002,7 @@ void glChartCanvas::DrawRegion(ViewPort &vp, const LLRegion &region) {
 
   for (std::list<double *>::iterator i = combine_work_data.begin();
        i != combine_work_data.end(); i++)
-    delete[] *i;
+    delete[] * i;
   combine_work_data.clear();
 }
 
@@ -3819,7 +3820,7 @@ void glChartCanvas::DrawGLTidesInBBox(ocpnDC &dc, LLBBox &BBox) {
           RenderTextures(dc, coords, uv, 4, m_pParentCanvas->GetpVP());
         }
       }  // type 'T"
-    }  // loop
+    }    // loop
 
 #endif
 


### PR DESCRIPTION
Honor the fontmanager settings for grid text. Also honor the DMS / DMM setting, and last but not least make the minor meridian spacing nicer for seconds reading (Divide in 6 instead of 5 parts)
![Screenshot_20250330_183246](https://github.com/user-attachments/assets/1c6698b4-6f6f-47ca-b2da-cf9fd3eb6687)

PS my local run of Clang-format does make changes, that are rejected in the online check. How to avoid this??