### PR TITLE
Data monitor basic updates

### DIFF
--- a/ci/generic-build-debian.sh
+++ b/ci/generic-build-debian.sh
@@ -20,7 +20,7 @@ if [[ $(lsb_release -rs) == 20.04 ]]; then
     sudo apt-get install kitware-archive-keyring
 fi
 pushd "${src_tree_root}"
-if [ -n "$PACKAGE_BRANCH" ]; then
+if [[ -n "$PACKAGE_BRANCH" && -z "$CIRCLE_PR_NUMBER" ]]; then
     # Initiate git environment
     git config --global user.name "OpenCPN auto builds"
     git config --global user.email "opencpn-builds@nowhere.net"

--- a/model/include/model/comm_appmsg_bus.h
+++ b/model/include/model/comm_appmsg_bus.h
@@ -42,7 +42,7 @@
 class AppMsgBus {
 public:
   /** Send message to everyone listening to given message type. */
-  void Notify(std::shared_ptr<const AppMsg> msg);
+  void Notify(const std::shared_ptr<const AppMsg>& msg);
 
   /**
    * Set the priority for a given data source providing data.

--- a/model/include/model/comm_navmsg.h
+++ b/model/include/model/comm_navmsg.h
@@ -148,7 +148,9 @@ public:
   NavAddr(Bus b, const std::string& i) : bus(b), iface(i) {};
   NavAddr() : bus(Bus::Undef), iface("") {};
 
-  std::string to_string() const {
+  virtual ~NavAddr() = default;
+
+  virtual std::string to_string() const {
     return NavAddr::BusToString(bus) + " " + iface;
   }
   static std::string BusToString(Bus b);
@@ -336,7 +338,7 @@ public:
 
   std::string key() const { return std::string("plug.json-") + name; };
 
-  std::string to_string() const { return name + ": " + message; }
+  std::string to_string() const;
 };
 
 /** A parsed SignalK message over ipv4 */

--- a/model/include/model/comm_navmsg_bus.h
+++ b/model/include/model/comm_navmsg_bus.h
@@ -49,6 +49,9 @@ public:
   void SendMessage(std::shared_ptr<const NavMsg> message,
                    std::shared_ptr<const NavAddr> address);
 
+  /** Register a message type in list the GetActiveMessages() list. */
+  void RegisterKey(const std::string& key);
+
   /** Accept message received by driver, make it available for upper layers. */
   void Notify(std::shared_ptr<const NavMsg> message);
 

--- a/model/include/model/ocpn_utils.h
+++ b/model/include/model/ocpn_utils.h
@@ -1,8 +1,4 @@
-/******************************************************************************
- *
- * Project:  OpenCPN
- *
- ***************************************************************************
+/**************************************************************************
  *   Copyright (C) 2019 Alec Leamas                                        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
@@ -19,7 +15,11 @@
  *   along with this program; if not, write to the                         *
  *   Free Software Foundation, Inc.,                                       *
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
- ***************************************************************************
+ **************************************************************************/
+
+/**
+ * \file
+ * Miscellaneous utilities, many of which string related.
  */
 
 #ifndef _OCPN_UTILS_H__
@@ -32,30 +32,59 @@
 
 namespace ocpn {
 
+/** Return true if s ends with given suffix */
 bool endswith(const std::string& s, const std::string& suffix);
 
+/** Return true if s starts with given prefix. */
 bool startswith(const std::string& s, const std::string& prefix);
 
-std::string ltrim(std::string s);
+/**
+ * Strip possibly leading space characters in s
+ * @return new string with leading  non-printable characters removed
+ */
+std::string ltrim(const std::string& s);
 
-std::string rtrim(std::string s);
+/**
+ * Strip possibly trailing  space characters in s
+ * @return string with trailing non-printable characters removed
+ */
+std::string rtrim(const std::string& s);
 
+/**
+ * Strip possibly trailing  and/or leading space characters in s
+ * @return string with trailing and leading non-printable characters removed
+ */
 std::string trim(std::string s);
 
+/**
+ * Return a single string being the concatenation of all elements in v with
+ * character c in between.
+ */
 std::string join(std::vector<std::string> v, char c);
 
+/** Return copy of s with all characters converted to lower case. */
 std::string tolower(const std::string& s);
 
+/** Return vector of items in s separated by delimiter*/
 std::vector<std::string> split(const char* s, const std::string& delimiter);
+
+/** Return vector of items in s separated by delimiter*/
 std::vector<std::string> split(const std::string& s,
                                const std::string& delimiter);
 
+/** @deprecated Using std::filesystem instead. */
 bool exists(const std::string& path);
 
+/** @deprecated Using std::filesystem instead. */
 void mkdir(const std::string path);
 
+/**
+ * Perform in place substitution in str, replacing "from" with "to"
+ * @return true if any replacement is done.
+ */
 bool replace(std::string& str, const std::string& from, const std::string& to);
 
+/** Copy file contents in path src_path to dest_path. */
 void copy_file(const std::string& src_path, const std::string& dest_path);
 
 /**
@@ -66,7 +95,7 @@ void copy_file(const std::string& src_path, const std::string& dest_path);
 bool N0183CheckSumOk(const std::string& sentence);
 
 /** Return copy of str with non-printable chars replaced by hex like "<0D>" */
-std::string printable(const std::string str);
+std::string printable(const std::string& str);
 
 }  // namespace ocpn
 

--- a/model/src/comm_appmsg.cpp
+++ b/model/src/comm_appmsg.cpp
@@ -36,6 +36,8 @@
 #include "model/comm_appmsg.h"
 #include "model/ocpn_utils.h"
 
+static const auto kUtfDegrees = wxString::FromUTF8(u8"\u00B0");
+
 /* Free functions. */
 
 std::string TimeToString(const time_t t) {
@@ -54,7 +56,7 @@ std::string TimeToString(const time_t t) {
 std::string DegreesToString(double degrees) {
   using namespace std;
   std::stringstream buf;
-  buf << setw(2) << static_cast<int>(trunc(degrees)) << "\u00B0"
+  buf << setw(2) << static_cast<int>(trunc(degrees)) << kUtfDegrees
       << static_cast<int>(trunc(degrees * 100)) % 100 << "," << setw(2)
       << (static_cast<int>(trunc(degrees * 10000)) % 10000) % 100;
   return buf.str();
@@ -175,4 +177,22 @@ std::string AppMsg::TypeToString(const AppMsg::Type t) const {
       break;
   }
   return "????";  // Not reached, for the compiler.
+}
+
+std::string BasicNavDataMsg::to_string() const {
+  std::stringstream ss;
+  ss << AppMsg::to_string() << " pos: " << pos.to_string() << " sog: " << sog
+     << " cog: " << cog << " var: " << var << " hdt: " << hdt
+     << "  vflag: " << vflag << " set_time: " << TimeToString(set_time.tv_sec);
+  return ss.str();
+}
+std::string AisData::to_string() const {
+  std::stringstream ss;
+  ss << TimeToString(time) << " " << pos.to_string() << " sog: " << sog
+     << " cog: " << cog << " heading: " << heading
+     << " rate of turn: " << rate_of_turn << "type: 0x" << std::hex << type
+     << " name " << name << " callsign " << callsign << " dest: " << dest
+     << " length " << std::dec << length << " beam: " << beam
+     << " draft: " << draft << " status: 0x" << std::hex << status;
+  return ss.str();
 }

--- a/model/src/comm_appmsg_bus.cpp
+++ b/model/src/comm_appmsg_bus.cpp
@@ -31,8 +31,11 @@
 #endif  // precompiled headers
 
 #include "model/comm_appmsg_bus.h"
+#include "model/comm_navmsg_bus.h"
 
-void AppMsgBus::Notify(std::shared_ptr<const AppMsg> msg) {
+void AppMsgBus::Notify(const std::shared_ptr<const AppMsg>& msg) {
+  std::string key = "Internal::" + msg->GetKey();
+  NavMsgBus::GetInstance().RegisterKey(key);
   Observable(*msg).Notify(msg);
 }
 

--- a/model/src/comm_navmsg.cpp
+++ b/model/src/comm_navmsg.cpp
@@ -95,3 +95,7 @@ std::string Nmea0183Msg::to_string() const {
      << " " << ocpn::printable(payload);
   return ss.str();
 }
+
+std::string PluginMsg::to_string() const {
+  return name + ": " + ocpn::rtrim(message);
+}

--- a/model/src/comm_navmsg_bus.cpp
+++ b/model/src/comm_navmsg_bus.cpp
@@ -26,14 +26,18 @@
 #include "model/comm_navmsg_bus.h"
 
 void NavMsgBus::Notify(std::shared_ptr<const NavMsg> msg) {
-  auto key = NavAddr::BusToString(msg->bus) + "::" + msg->GetKey();
+  std::string key = NavAddr::BusToString(msg->bus) + "::" + msg->GetKey();
+  RegisterKey(key);
+  Observable(*msg).Notify(msg);
+}
+
+void NavMsgBus::RegisterKey(const std::string& key) {
   {
     std::lock_guard lock(m_mutex);
     if (m_active_messages.find(key) == m_active_messages.end())
       new_msg_event.Notify();
     m_active_messages.insert(key);
   }
-  Observable(*msg).Notify(msg);
 }
 
 NavMsgBus& NavMsgBus::GetInstance() {

--- a/model/src/ocpn_utils.cpp
+++ b/model/src/ocpn_utils.cpp
@@ -80,6 +80,7 @@ bool exists(const std::string& name) {
 #endif
 }
 
+/** @deprecated Using std::filesystem instead. */
 void mkdir(const std::string path) {
 #if defined(_WIN32) && !defined(__MINGW32__)
   _mkdir(path.c_str());
@@ -90,17 +91,19 @@ void mkdir(const std::string path) {
 #endif
 }
 
-std::string ltrim(std::string s) {
+std::string ltrim(const std::string& arg) {
   using namespace std;
 
+  string s(arg);
   s.erase(s.begin(),
           find_if(s.begin(), s.end(), [](int ch) { return !isspace(ch); }));
   return s;
 }
 
-std::string rtrim(std::string s) {
+std::string rtrim(const std::string& arg) {
   using namespace std;
 
+  string s(arg);
   s.erase(
       find_if(s.rbegin(), s.rend(), [](int ch) { return !isspace(ch); }).base(),
       s.end());
@@ -164,7 +167,7 @@ bool N0183CheckSumOk(const std::string& sentence) {
   return calculated_checksum == checksum;
 }
 
-std::string printable(const std::string str) {
+std::string printable(const std::string& str) {
   std::stringstream ss;
   for (auto it = str.begin(); it != str.end(); it++) {
     if (std::isprint(*it) && *it != '\r' && *it != '\n') {

--- a/model/src/win_usb_watch.cpp
+++ b/model/src/win_usb_watch.cpp
@@ -22,6 +22,7 @@
  * Implement win_watch_daemon.h
  */
 
+#include <winsock2.h>
 #include <windows.h>
 #include <Dbt.h>
 

--- a/plugins/demo_pi_sample/CMakeLists.txt
+++ b/plugins/demo_pi_sample/CMakeLists.txt
@@ -19,14 +19,17 @@
 # ***************************************************************************
 
 # define minimum cmake version
-cmake_minimum_required(VERSION 3.1.1)
+cmake_minimum_required(VERSION 3.5)
+cmake_policy(SET CMP0003 NEW)
+cmake_policy(SET CMP0005 NEW)
+cmake_policy(SET CMP0011 NEW)
 
 project(demo_pi)
 
 set(PACKAGE_NAME demo_pi)
 set(VERBOSE_NAME demo)
 set(TITLE_NAME demo)
-set(CPACK_PACKAGE_CONTARCT "Pavel Kalian")
+set(CPACK_PACKAGE_CONTACT "Pavel Kalian")
 
 message(STATUS "*** Building ${PACKAGE_NAME} ***")
 

--- a/plugins/demo_pi_sample/cmake/PluginConfigure.cmake
+++ b/plugins/demo_pi_sample/cmake/PluginConfigure.cmake
@@ -6,13 +6,6 @@
 
 SET(PLUGIN_SOURCE_DIR .)
 
-# This should be 2.8.0 to have FindGTK2 module
-IF (COMMAND cmake_policy)
-  CMAKE_POLICY(SET CMP0003 OLD)
-  CMAKE_POLICY(SET CMP0005 OLD)
-  CMAKE_POLICY(SET CMP0011 OLD)
-ENDIF (COMMAND cmake_policy)
-
 MESSAGE (STATUS "*** Staging to build ${PACKAGE_NAME} ***")
 
 #configure_file(cmake/version.h.in ${PROJECT_SOURCE_DIR}/src/version.h)
@@ -172,4 +165,3 @@ ENDIF(QT_ANDROID)
 SET(BUILD_SHARED_LIBS TRUE)
 
 FIND_PACKAGE(Gettext REQUIRED)
-

--- a/plugins/demo_pi_sample/cmake/PluginPackage.cmake
+++ b/plugins/demo_pi_sample/cmake/PluginPackage.cmake
@@ -7,10 +7,6 @@
 # build a CPack driven installer package
 #include (InstallRequiredSystemLibraries)
 
-IF (COMMAND cmake_policy)
-  CMAKE_POLICY(SET CMP0002 OLD)
-ENDIF (COMMAND cmake_policy)
-
 SET(CPACK_PACKAGE_NAME "${PACKAGE_NAME}")
 SET(CPACK_PACKAGE_VENDOR "opencpn.org")
 SET(CPACK_PACKAGE_DESCRIPTION_SUMMARY ${CPACK_PACKAGE_NAME} ${PACKAGE_VERSION})

--- a/test/dbus_tests.cpp
+++ b/test/dbus_tests.cpp
@@ -2,6 +2,9 @@
 
 #include <chrono>
 
+#include <stdio.h>
+#include <stdlib.h>
+
 #include <wx/app.h>
 #include <wx/fileconf.h>
 #include <wx/event.h>
@@ -20,16 +23,65 @@ using namespace std::literals::chrono_literals;
 
 static bool bool_result0;
 static std::string s_result;
+static std::string s_pid;
+
+static std::string StartDbusSession() {
+  if (!s_pid.empty()) {
+    int num_pid = std::stoi(s_pid);
+    int r = kill(num_pid, 0);
+    if (r == 0) return s_pid;  // the daemon is already running
+  }
+  FILE* pipe = popen("dbus-launch --sh-syntax", "r");
+  assert(pipe != NULL);
+
+  char* line = NULL;
+  size_t len = 0;
+  std::stringstream ss;
+  int r = getline(&line, &len, pipe);
+  assert(r != -1);
+  ss << line;
+  r = getline(&line, &len, pipe);
+  assert(r != -1);
+  r = getline(&line, &len, pipe);
+  pclose(pipe);
+  auto pid_words = ocpn::split(line, "=");
+  ocpn::replace(pid_words[1], ";", "");
+
+  auto equals_pos = ss.str().find("=");
+  auto var = ss.str().substr(0, equals_pos);
+  auto value = ss.str().substr(equals_pos + 1);
+  while (ocpn::replace(value, "'", ""));
+  while (ocpn::replace(value, "\"", ""));
+  while (ocpn::replace(value, ";", ""));
+  value = ocpn::rtrim(value);
+
+  assert(var == "DBUS_SESSION_BUS_ADDRESS");
+  std::cout << "Setting DBUS_SESSION_BUS_ADDRESS to: \"" << value << "\"\n";
+  unsetenv(var.c_str());
+  setenv(var.c_str(), value.c_str(), true);
+  std::cout << "Starting dbus server: " << pid_words[1];
+  return pid_words[1];
+}
+
+void CloseDbusSession(const std::string& pid) {
+  std::string s("kill ");
+  s += pid;
+  FILE* pipe = popen(s.c_str(), "r");
+  char* line = NULL;
+  size_t len = 0;
+  getline(&line, &len, pipe);
+  pclose(pipe);
+  unsetenv("DBUS_SESSION_BUS_ADDRESS");
+}
 
 class DbusRaise : public wxAppConsole {
 public:
-
   class ObsListener : public wxEvtHandler {
   public:
-    ObsListener(const KeyProvider& kp): wxEvtHandler() {
+    ObsListener(const KeyProvider& kp) : wxEvtHandler() {
       wxDEFINE_EVENT(EVT_OBS_RAISE, ObservedEvt);
       m_listener.Listen(kp.GetKey(), this, EVT_OBS_RAISE);
-      Bind(EVT_OBS_RAISE, [&](ObservedEvt& o) { bool_result0 = true;});
+      Bind(EVT_OBS_RAISE, [&](ObservedEvt& o) { bool_result0 = true; });
     }
     ObservableListener m_listener;
   };
@@ -43,10 +95,12 @@ public:
         "dbus-send --type=method_call --print-reply --dest=org.opencpn.OpenCPN"
         " /org/opencpn/OpenCPN opencpn.desktop.Raise";
     FILE* f = popen(kDbusSendCmd, "r");
-    std::this_thread::sleep_for(50ms);    // Need some time to settle input
+    std::this_thread::sleep_for(50ms);  // Need some time to settle input
     char buff[1024];
     char* line;
-    do { line = fgets(buff, sizeof(buff), f); } while (line);
+    do {
+      line = fgets(buff, sizeof(buff), f);
+    } while (line);
     int r = pclose(f);
     EXPECT_EQ(r, 0);
     EXPECT_TRUE(HasPendingEvents());
@@ -58,7 +112,7 @@ class DbusQuit : public wxAppConsole {
 public:
   class ObsListener : public wxEvtHandler {
   public:
-    ObsListener(DbusServer& dh): wxEvtHandler() {
+    ObsListener(DbusServer& dh) : wxEvtHandler() {
       wxDEFINE_EVENT(EVT_OBS_QUIT, ObservedEvt);
       m_listener.Listen(dh.on_quit, this, EVT_OBS_QUIT);
       Bind(EVT_OBS_QUIT, [&](ObservedEvt&) { bool_result0 = true; });
@@ -73,15 +127,17 @@ public:
     DbusServer& dbus_server = DbusServer::GetInstance();
     ObsListener listener(dbus_server);
     constexpr const char* const kDbusSendCmd =
-       "dbus-send --type=method_call --dest=org.opencpn.OpenCPN --print-reply"
-       " /org/opencpn/OpenCPN opencpn.desktop.Quit";
+        "dbus-send --type=method_call --dest=org.opencpn.OpenCPN --print-reply"
+        " /org/opencpn/OpenCPN opencpn.desktop.Quit";
     FILE* f = popen(kDbusSendCmd, "r");
     char buff[1024];
     char* line;
-    do { line = fgets(buff, sizeof(buff), f); } while (line);
+    do {
+      line = fgets(buff, sizeof(buff), f);
+    } while (line);
     int r = pclose(f);
     EXPECT_EQ(r, 0);
-    std::this_thread::sleep_for(25ms);    // Need some time to settle input
+    std::this_thread::sleep_for(25ms);  // Need some time to settle input
     EXPECT_TRUE(HasPendingEvents());
     ProcessPendingEvents();
     EXPECT_TRUE(bool_result0);
@@ -89,17 +145,18 @@ public:
 };
 
 TEST(DbusServer, Ping) {
-  auto  main_loop = g_main_loop_new(0, false);
+  s_pid = StartDbusSession();
+  auto main_loop = g_main_loop_new(0, false);
   std::thread t(g_main_loop_run, main_loop);
   DbusServer& dbus_server = DbusServer::GetInstance();
 
   constexpr const char* const kDbusSendCmd =
-     "dbus-send --type=method_call --print-reply --dest=org.opencpn.OpenCPN"
-     " /org/opencpn/OpenCPN opencpn.desktop.Ping";
+      "dbus-send --type=method_call --print-reply --dest=org.opencpn.OpenCPN"
+      " /org/opencpn/OpenCPN opencpn.desktop.Ping";
   FILE* f = popen(kDbusSendCmd, "r");
   char buff[1024];
   std::this_thread::sleep_for(100ms);
-  char* line = fgets(buff, sizeof(buff), f);   // initial line, throw.
+  char* line = fgets(buff, sizeof(buff), f);  // initial line, throw.
   EXPECT_TRUE(line);
 
   line = fgets(buff, sizeof(buff), f);  //  "   uint32 21614"
@@ -124,7 +181,10 @@ TEST(DbusServer, Ping) {
 }
 
 TEST(DbusServer, Raise) {
-  auto  main_loop = g_main_loop_new(0, false);
+  std::this_thread::sleep_for(200ms);
+  s_pid = StartDbusSession();
+  std::this_thread::sleep_for(200ms);
+  auto main_loop = g_main_loop_new(0, false);
   std::thread t(g_main_loop_run, main_loop);
   auto logfile = std::string(CMAKE_BINARY_DIR) + "/unittests.log";
   wxLog::SetActiveTarget(new OcpnLog(logfile.c_str()));
@@ -133,6 +193,7 @@ TEST(DbusServer, Raise) {
   wxLog::FlushActive();
 
   bool_result0 = false;
+  std::this_thread::sleep_for(200ms);
   DbusRaise dbus_raise;
   std::this_thread::sleep_for(100ms);
   EXPECT_TRUE(bool_result0);
@@ -140,10 +201,10 @@ TEST(DbusServer, Raise) {
   g_main_loop_quit(main_loop);
   t.join();
   DbusServer::Disconnect();
-}
+};
 
 TEST(DbusServer, Quit) {
-  auto  main_loop = g_main_loop_new(0, false);
+  auto main_loop = g_main_loop_new(0, false);
   std::thread t(g_main_loop_run, main_loop);
   bool_result0 = false;
   DbusQuit dbus_quit;
@@ -158,22 +219,23 @@ TEST(DbusServer, Quit) {
 TEST(DbusServer, Open) {
   s_result = "";
   bool_result0 = false;
-  auto  main_loop = g_main_loop_new(0, false);
+  auto main_loop = g_main_loop_new(0, false);
   std::thread t(g_main_loop_run, main_loop);
 
   DbusServer& dbus_server = DbusServer::GetInstance();
   dbus_server.open_file_cb = [](const std::string& s) {
-      s_result = s;
-      bool_result0 = true;
-      return true; };
+    s_result = s;
+    bool_result0 = true;
+    return true;
+  };
 
   constexpr const char* const kDbusSendCmd =
-     "dbus-send --type=method_call --print-reply --dest=org.opencpn.OpenCPN"
-     " /org/opencpn/OpenCPN opencpn.desktop.Open string:/foo/bar.gpx";
+      "dbus-send --type=method_call --print-reply --dest=org.opencpn.OpenCPN"
+      " /org/opencpn/OpenCPN opencpn.desktop.Open string:/foo/bar.gpx";
   FILE* f = popen(kDbusSendCmd, "r");
   std::this_thread::sleep_for(100ms);
   char buff[1024];
-  char* line = fgets(buff, sizeof(buff), f);   // initial line, throw.
+  char* line = fgets(buff, sizeof(buff), f);  // initial line, throw.
   EXPECT_TRUE(line);
 
   line = fgets(buff, sizeof(buff), f);  //  "   boolean true"
@@ -199,7 +261,7 @@ TEST(DbusServer, Open) {
 TEST(DbusServer, GetRestEndpoint) {
   s_result = "";
   bool_result0 = false;
-  auto  main_loop = g_main_loop_new(0, false);
+  auto main_loop = g_main_loop_new(0, false);
   std::thread t(g_main_loop_run, main_loop);
 
   DbusServer& dbus_server = DbusServer::GetInstance();
@@ -207,11 +269,11 @@ TEST(DbusServer, GetRestEndpoint) {
   dbus_server.get_rest_api_endpoint_cb = []() { return "2.2.2.2/3333"; };
 
   constexpr const char* const kDbusSendCmd =
-     "dbus-send --type=method_call --print-reply --dest=org.opencpn.OpenCPN"
-     " /org/opencpn/OpenCPN opencpn.desktop.GetRestEndpoint";
+      "dbus-send --type=method_call --print-reply --dest=org.opencpn.OpenCPN"
+      " /org/opencpn/OpenCPN opencpn.desktop.GetRestEndpoint";
   FILE* f = popen(kDbusSendCmd, "r");
   char buff[1024];
-  char* line = fgets(buff, sizeof(buff), f);   // initial line, throw.
+  char* line = fgets(buff, sizeof(buff), f);  // initial line, throw.
   EXPECT_TRUE(line);
 
   line = fgets(buff, sizeof(buff), f);  //  "   string 2.2.2.2/3333"
@@ -230,6 +292,7 @@ TEST(DbusServer, GetRestEndpoint) {
   DbusServer::Disconnect();
 }
 
+#if 0
 TEST(Instance, DbusServer) {
   auto  main_loop = g_main_loop_new(0, false);
   std::thread t(g_main_loop_run, main_loop);
@@ -245,8 +308,9 @@ TEST(Instance, DbusServer) {
   delete dbus_server2;
 }
 
+
 TEST(DbusClient, Raise) {
-  DbusServer::Disconnect();
+  //DbusServer::Disconnect();
   std::string server_cmd(TEST_ROOT);
   server_cmd += "/test_server.py 1";
   FILE* p = popen(server_cmd.c_str(), "r");
@@ -299,3 +363,7 @@ TEST(DbusClient, GetEndpoint) {
   EXPECT_TRUE(result.first);
   EXPECT_EQ(std::string("0.0.0.0/1025"), result.second);
 }
+
+#endif  // 0
+
+TEST(DbusServer, Exit) { CloseDbusSession(s_pid); }


### PR DESCRIPTION
Some general updates of build and com_navmsg_bus required and used by  #4400 but also useful as in their own right.  Part of making #4400 somewhat smaller and more manageable.

Not expected to change anything in current behaviour.