### PR TITLE
Fix bugs in route and waypoint properties

### DIFF
--- a/gui/include/gui/RoutePropDlg.h
+++ b/gui/include/gui/RoutePropDlg.h
@@ -78,10 +78,12 @@ protected:
   wxStaticText* m_stEnroute;
   wxTextCtrl* m_tcEnroute;
   wxStaticText* m_stDeparture;
+  /** The date picker for the departure date of the route. */
   wxDatePickerCtrl* m_dpDepartureDate;
 #ifdef __WXGTK__
   TimeCtrl* m_tpDepartureTime;
 #else
+  /** The time picker for the departure time of the route. */
   wxTimePickerCtrl* m_tpDepartureTime;
 #endif
   wxStaticText* m_stTimeZone;

--- a/gui/include/gui/RoutePropDlgImpl.h
+++ b/gui/include/gui/RoutePropDlgImpl.h
@@ -86,7 +86,7 @@ protected:
   void OnHyperlinkClick(wxHyperlinkEvent& event);
   void HyperlinkContextMenu(wxMouseEvent& event);
   void m_scrolledWindowLinksOnContextMenu(wxMouseEvent& event);
-
+  /** Returns the departure time of the route, in UTC. */
   wxDateTime GetDepartureTS();
   void SaveChanges();
   void ResetChanges();
@@ -104,13 +104,56 @@ private:
   static bool instanceFlag;
   static RoutePropDlgImpl* single;
 
+  /**
+   * Pointer to the route being edited or displayed.
+   * This is the route currently shown in the dialog. Changes are made directly
+   * to this route.
+   */
   Route* m_pRoute;
+  /**
+   * Original route state, stored when dialog opens.
+   * Used to restore original route properties if changes are canceled.
+   * Only selected properties are preserved (speed and departure time).
+   */
   Route m_OrigRoute;
-  Route* m_pHead;  // for route splitting
+  /**
+   * First segment when splitting a route.
+   * Created when the Split button is clicked and the user confirms. Contains
+   * the first portion of the original route, from start up to the selected
+   * waypoint.
+   */
+  Route* m_pHead;
+  /**
+   * Second segment when splitting a route.
+   * Created when the Split button is clicked and the user confirms. Contains
+   * the second portion of the original route, from the selected waypoint to the
+   * end.
+   */
   Route* m_pTail;
+  /**
+   * Waypoint to start the extension from when extending a route.
+   * This is typically the last point of the current route, or a point from
+   * another route that is near the last point of the current route.
+   */
   RoutePoint* m_pExtendPoint;
+  /**
+   * Route to extend from when extending the current route.
+   * This route contains m_pExtendPoint and is used as the source for
+   * extending the current route.
+   */
   Route* m_pExtendRoute;
+  /**
+   * Currently selected waypoint when navigating the route.
+   * This is the active waypoint when the route is being navigated.
+   * Used to highlight the active leg in the route display.
+   */
   RoutePoint* m_pEnroutePoint;
+  /**
+   * Flag indicating whether the route should start navigation immediately.
+   * When true, the route will be activated for navigation as soon as the dialog
+   * is closed with OK. This is typically set when a route is newly created and
+   * the user chooses to start navigating it right away.
+   */
   bool m_bStartNow;
 
   /**

--- a/gui/include/gui/navutil.h
+++ b/gui/include/gui/navutil.h
@@ -61,17 +61,30 @@ extern wxString formatAngle(double angle);
   3  //!< Date/time according to global OpenCPN settings.
 
 /**
- * Convert the date/time in UTC to the given format.
- * @param ts The input timestamp in UTC.
+ * Converts a timestamp from UTC to the user's preferred time format.
+ *
+ * This function transforms a timestamp based on the specified format or the
+ * global application setting. It supports Universal Time (UTC), Local Mean Time
+ * (LMT) based on longitude, and Local time based on the user's system timezone.
+ *
+ * @param ts The timestamp to convert, must be in UTC.
  * @param format The desired output format:
  *        0 = UTC, 1 = Local@PC, 2 = LMT@Location, 3 = Global settings.
- * @param lon The longitude for LMT calculation. Default is NaN.
- * @return wxDateTime The converted timestamp in the specified format.
+ * @param lon The longitude in degrees for LMT calculation (positive for east,
+ * negative for west). Default is NaN.
+ * @return wxDateTime The converted timestamp in the specified format, or
+ * wxInvalidDateTime if conversion fails.
  */
 wxDateTime toUsrDateTime(const wxDateTime ts, const int format,
                          const double lon = INFINITY - INFINITY);
 /**
- * Convert a date/time from a given input format to UTC.
+ * Converts a timestamp from a user's preferred time format to UTC.
+ *
+ * This function is the inverse of toUsrDateTime, transforming a timestamp from
+ * the specified format back to UTC. It handles Universal Time (UTC), Local Mean
+ * Time (LMT) based on longitude, and Local time based on the user's system
+ * timezone.
+ *
  * @param ts The input timestamp in the specified format.
  * @param format The input timestamp format:
  *        0 = UTC, 1 = Local@PC, 2 = LMT@Location, 3 = Global settings.

--- a/gui/src/RoutePropDlg.cpp
+++ b/gui/src/RoutePropDlg.cpp
@@ -540,6 +540,12 @@ RoutePropDlg::RoutePropDlg(wxWindow* parent, wxWindowID id,
 
   m_btnExtend = new wxButton(this, wxID_ANY, _("Extend"), wxDefaultPosition,
                              wxDefaultSize, 0);
+  m_btnExtend->SetToolTip(_(
+      "Extend this route by connecting it to another route. The button is "
+      "disabled when: the route is active, is part of a layer, or there is no "
+      "suitable route to connect to. A suitable route must be visible, "
+      "different from this route, and share a common waypoint with this route "
+      "(or have a waypoint very close to the last point of this route)."));
   wSizerCustomBtns->Add(m_btnExtend, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
   m_btnSplit = new wxButton(this, wxID_ANY, _("Split"), wxDefaultPosition,

--- a/gui/src/TCWin.cpp
+++ b/gui/src/TCWin.cpp
@@ -151,6 +151,9 @@ TCWin::TCWin(ChartCanvas *parent, int x, int y, void *pvIDX) {
       this, wxID_ANY, wxPoint((sx - (bsx * 2)) / 2, sy - (m_tsy * 12 / 10)),
       wxSize(2 * bsx, bsy), m_choiceTimezoneNChoices, m_choiceTimezoneChoices,
       0);
+  m_choiceTimezone->SetToolTip(
+      _("Select whether tide times are shown in UTC or "
+        "Local Mean Time (LMT) at the station"));
   m_choiceSize_x = bsx * 2;
 
   m_choiceTimezone->SetSelection(m_tzoneDisplay);
@@ -303,11 +306,13 @@ void TCWin::SetTimeFactors() {
   int station_offset = ptcmgr->GetStationTimeOffset(pIDX);
 
   m_stationOffset_mins = station_offset;
-  if (this_now.IsDST()) m_stationOffset_mins += 60;
+  if (this_now.IsDST()) {
+    m_stationOffset_mins += 60;
+  }
 
-    //  Correct a bug in wx3.0.2
-    //  If the system TZ happens to be GMT, with DST active (e.g.summer in
-    //  London), then wxDateTime returns incorrect results for toGMT() method
+  //  Correct a bug in wx3.0.2
+  //  If the system TZ happens to be GMT, with DST active (e.g.summer in
+  //  London), then wxDateTime returns incorrect results for toGMT() method
 #if wxCHECK_VERSION(3, 0, 2)
 //    if(  this_now.IsDST() )
 //        m_corr_mins +=60;

--- a/gui/src/TrackPropDlg.cpp
+++ b/gui/src/TrackPropDlg.cpp
@@ -597,6 +597,13 @@ void TrackPropDlg::CreateControlsCompact() {
 
   m_sdbBtmBtnsSizerExtend = new wxButton(this, wxID_ANY, _("Extend"),
                                          wxDefaultPosition, wxDefaultSize, 0);
+  m_sdbBtmBtnsSizerExtend->SetToolTip(
+      _("Extends this track by connecting it to another track.\n"
+        "Disabled when the track is active, the track is in a layer, or no "
+        "suitable track to connect to exists.\n"
+        "A suitable track is one that is visible, is different from this "
+        "track, and has its last point's timestamp earlier than or equal to "
+        "this track's first point's timestamp."));
   itemBoxSizerAux->Add(m_sdbBtmBtnsSizerExtend, 0,
                        wxALIGN_LEFT | wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
@@ -1875,7 +1882,7 @@ wxString OCPNTrackListCtrl::OnGetItemText(long item, long column) const {
             DateTimeFormatOptions()
                 .SetTimezone(getDatetimeTimezoneSelector(m_tz_selection))
                 .SetLongitude(getStartPointLongitude());
-        ret = ocpn::toUsrDateTimeFormat(timestamp, opts);
+        ret = ocpn::toUsrDateTimeFormat(timestamp.FromUTC(), opts);
       } else
         ret = _T("----");
     } break;

--- a/gui/src/canvasMenu.cpp
+++ b/gui/src/canvasMenu.cpp
@@ -1330,6 +1330,7 @@ void CanvasMenuHandler::PopupMenuHandler(wxCommandEvent &event) {
             g_pRouteMan->GetRouteArrayContaining(m_pFoundRoutePoint);
         if (proute_array) {
           pWayPointMan->DestroyWaypoint(m_pFoundRoutePoint);
+          delete proute_array;
         } else {
           parent->undo->BeforeUndoableAction(
               Undo_DeleteWaypoint, m_pFoundRoutePoint, Undo_IsOrphanded,

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -7369,6 +7369,7 @@ void ChartCanvas::FindRoutePointsAtCursor(float selectRadius,
 
     //    Get an array of all routes using this point
     m_pEditRouteArray = g_pRouteMan->GetRouteArrayContaining(frp);
+    // TODO: delete m_pEditRouteArray after use?
 
     // Use route array to determine actual visibility for the point
     bool brp_viz = false;
@@ -8116,6 +8117,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                 break;
               }
             }
+            delete proute_array;
             if (!brp_viz &&
                 frp->IsShared())  // is not visible as part of route, but still
                                   // exists as a waypoint
@@ -8217,6 +8219,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                 break;
               }
             }
+            delete proute_array;
             if (!brp_viz &&
                 pNearbyPoint->IsShared())  // is not visible as part of route,
                                            // but still exists as a waypoint
@@ -9179,6 +9182,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                     pr->m_bIsBeingEdited = false;
                   }
                 }
+                delete lastEditRouteArray;
               }
             }
           }

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -3113,8 +3113,6 @@ void MyFrame::TrackOn(void) {
   }
 
   wxJSONValue v;
-  wxDateTime now;
-  now = now.Now().ToUTC();
   wxString name = g_pActiveTrack->GetName();
   if (name.IsEmpty()) {
     TrackPoint *tp = g_pActiveTrack->GetPoint(0);

--- a/gui/src/route_point_gui.cpp
+++ b/gui/src/route_point_gui.cpp
@@ -952,6 +952,7 @@ int RoutePointGui::GetIconImageIndex() {
           break;
         }
       }
+      delete proute_array;
     }
 
     if (brp_viz)

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -2970,19 +2970,21 @@ struct DateTimeFormatOptions {
 };
 
 /**
- * Format a wxDateTime to a localized string representation, conforming to the
+ * Format a date/time to a localized string representation, conforming to the
  * global date/time format and timezone settings.
  *
- * The function uses the timezone configuration to format the date/time either
- * in UTC, local time, or local mean time (LMT) based on the longitude.
+ * The function expects date_time to be in local time and formats it according to the 
+ * timezone configuration either in:
+ * - UTC: Coordinated Universal Time (default)
+ * - Local Time: System's configured timezone with proper DST handling
+ * - LMT: Local Mean Time calculated based on the longitude specified in options
  *
  * @note This function should be used instead of wxDateTime.Format() to ensure
  * consistent date/time formatting across the entire application.
  *
- * @param date_time The date/time to format.
- * @param options The date/time format options.
- * @return wxString The formatted date/time string.
- *
+ * @param date_time The date/time to format, must be in local time.
+ * @param options The date/time format options including target timezone and formatting preferences.
+ * @return wxString The formatted date/time string with appropriate timezone indicator.
  */
 extern DECL_EXP wxString toUsrDateTimeFormat_Plugin(
     const wxDateTime date_time,

--- a/model/include/model/datetime.h
+++ b/model/include/model/datetime.h
@@ -29,12 +29,24 @@ extern wxString g_datetime_format;
 namespace ocpn {
 
 /**
- * Format a date/time to a localized string representation, conforming to the
- * formatting options.
+ * Return the date/time format to use when formatting date/time strings.
+ * This is a global setting that affects all date/time formatting in OpenCPN.
  *
- * @param date_time The date/time to format.
+ * @details Supported values are:
+ * - "UTC": Format date/time in Coordinated Universal Time (UTC).
+ * - "Local Time": Format date/time using the operating system timezone
+ *   configuration.
+ */
+wxString getUsrDateTimeFormat();
+
+/**
+ * Format a date/time to a localized string representation, conforming to
+ * the formatting options.
+ *
+ * @param date_time The date/time to format, must be local time.
  * @param options The date/time format options.
- * @return wxString The formatted date/time string.
+ * @return wxString The formatted date/time string with appropriate timezone
+ * indicator.
  *
  * @note This function should be used instead of wxDateTime.Format() to ensure
  * consistent date/time formatting across the entire application, including

--- a/model/include/model/navutil_base.h
+++ b/model/include/model/navutil_base.h
@@ -75,6 +75,19 @@ extern double toUsrDepth(double cel_depth, int unit = -1);
 extern double fromUsrDepth(double usr_depth, int unit = -1);
 extern wxString getUsrDepthUnit(int unit = -1);
 
+/**
+ * This function parses a string containing a GPX time representation
+ * and returns a wxDateTime containing the UTC corresponding to the
+ * input. The function return value is a pointer past the last valid
+ * character parsed (if successful) or NULL (if the string is invalid).
+ *
+ * Valid GPX time strings are in ISO 8601 format as follows:
+ *
+ *   [-]<YYYY>-<MM>-<DD>T<hh>:<mm>:<ss>Z|(+|-<hh>:<mm>)
+ *
+ * For example, 2010-10-30T14:34:56Z and 2010-10-30T14:34:56-04:00
+ * are the same time. The first is UTC and the second is EDT.
+ */
 const wxChar *ParseGPXDateTime(wxDateTime &dt, const wxChar *datetime);
 
 extern wxString formatTimeDelta(wxTimeSpan span);

--- a/model/include/model/route.h
+++ b/model/include/model/route.h
@@ -124,6 +124,25 @@ public:
   void RemovePoint(RoutePoint *rp, bool bRenamePoints = false);
   void DeSelectRoute();
   void FinalizeForRendering();
+  /**
+   * Updates the navigation data for a single route segment between two
+   * waypoints.
+   *
+   * This function calculates and updates the following data for a route
+   * segment:
+   * - Distance between the two waypoints (stored in the destination waypoint)
+   * - Course from the source to destination waypoint
+   * - Contribution to the total route length
+   * - Segment VMG (Velocity Made Good) based on planned speed
+   * - ETE (Estimated Time Enroute) for the segment
+   * - ETD (Estimated Time of Departure) from the source waypoint
+   * - ETA (Estimated Time of Arrival) at the destination waypoint
+   *
+   * @param prp0 Pointer to the source waypoint (departure point)
+   * @param prp Pointer to the destination waypoint (arrival point)
+   * @param planspeed Default planned speed in knots, used if the destination
+   * waypoint doesn't specify its own speed
+   */
   void UpdateSegmentDistance(RoutePoint *prp0, RoutePoint *prp,
                              double planspeed = -1.0);
   void UpdateSegmentDistances(double planspeed = -1.0);
@@ -154,6 +173,11 @@ public:
 
   double GetRouteArrivalRadius(void) { return m_ArrivalRadius; }
   void SetRouteArrivalRadius(double radius) { m_ArrivalRadius = radius; }
+  /**
+   * Set the departure time of the route.
+   *
+   * @param dt The departure date and time to set, in UTC.
+   */
   void SetDepartureDate(const wxDateTime &dt) {
     if (dt.IsValid()) m_PlannedDeparture = dt;
   }
@@ -185,6 +209,7 @@ public:
   int m_lastMousePointIndex;
   bool m_NextLegGreatCircle;
   double m_PlannedSpeed;
+  /** The departure time of the route, in UTC. */
   wxDateTime m_PlannedDeparture;
   wxString m_TimeDisplayFormat;
 

--- a/model/include/model/route_point.h
+++ b/model/include/model/route_point.h
@@ -167,21 +167,188 @@ public:
   bool IsDragHandleEnabled() { return m_bDrawDragHandle; }
   void SetPlannedSpeed(double spd);
   double GetPlannedSpeed();
+  /**
+   * Retrieves the Estimated Time of Departure for this waypoint, in UTC.
+   *
+   * This function returns the waypoint's ETD (Estimated Time of Departure),
+   * considering both explicitly set ETD values and values embedded in the
+   * waypoint description.
+   *
+   * @return The estimated time of departure as a wxDateTime object, or
+   * wxInvalidDateTime if no valid ETD information exists.
+   */
   wxDateTime GetETD();
+  /**
+   * Retrieves the manually set Estimated Time of Departure for this waypoint,
+   * in UTC.
+   *
+   * This function returns the manually set ETD (Estimated Time of Departure)
+   * value only if the ETD was explicitly set by a user rather than calculated
+   * automatically. If the ETD is not manually set or if the ETD is invalid, the
+   * function returns an invalid datetime value.
+   *
+   * The function checks two conditions:
+   * 1. The m_manual_etd flag must be true, indicating the ETD was manually set
+   * 2. The m_seg_etd value must be valid
+   *
+   * @return The manually set ETD as a wxDateTime object if available, or
+   *         wxInvalidDateTime if no manual ETD has been set.
+   */
   wxDateTime GetManualETD();
+  /**
+   * Sets the Estimated Time of Departure for this waypoint, in UTC.
+   *
+   * This function sets the ETD (Estimated Time of Departure) for the waypoint
+   * and marks it as manually set by setting the m_manual_etd flag to true.
+   *
+   * @param etd The wxDateTime object representing the estimated time of
+   * departure.
+   */
   void SetETD(const wxDateTime &etd);
+  /**
+   * Sets the Estimated Time of Departure from a string.
+   *
+   * This function attempts to parse a datetime string and set it as the ETD
+   * value. If successful, it marks the ETD as manually set. If the input string
+   * is empty, it clears the ETD value and resets the manual flag.
+   *
+   * The function tries two parsing methods:
+   * 1. ISO combined format (YYYY-MM-DDThh:mm:ss)
+   * 2. Generic datetime parsing
+   *
+   * @param ts String containing the datetime to set as ETD.
+   * @return True if parsing was successful or the string was empty, false if
+   * parsing failed.
+   *
+   * @note The input string is assumed to be in UTC format. No timezone
+   * conversion is performed.
+   * @todo: add support to parse timezone information from the string.
+   */
   bool SetETD(const wxString &ts);
+  /**
+   * Retrieves the Estimated Time of Arrival for this waypoint, in UTC.
+   *
+   * This function returns the stored Estimated Time of Arrival (ETA) if it's
+   * valid. The ETA is typically calculated based on route planning data such as
+   * distances and planned speeds.
+   *
+   * For the first waypoint in a route, the ETA represents when the vessel is
+   * expected to reach this waypoint from its current position or a designated
+   * starting point. It is calculated based on:
+   *   - The current vessel position
+   *   - The distance to the first waypoint
+   *   - The vessel's current or planned speed
+   *
+   * For subsequent waypoints, it represents when the vessel is expected to
+   * arrive after leaving the previous waypoint.
+   *
+   * The relationship between waypoints creates a timing chain:
+   * The ETA at one waypoint determines the default ETD from that waypoint,
+   * which then affects the ETA at the next waypoint, and so on through the
+   * route.
+   *
+   * @return The estimated time of arrival as a wxDateTime object, or
+   * wxInvalidDateTime if no valid ETA information exists.
+   */
   wxDateTime GetETA();
+  /**
+   * Retrieves the Estimated Time En route as a formatted string.
+   *
+   * This function returns the Estimated Time En route (ETE) for this waypoint
+   * as a formatted time delta string. The ETE represents the expected travel
+   * time to reach this waypoint from the previous point in a route.
+   *
+   * @return Formatted string representation of the time en route, or an empty
+   * string if no ETE value is available.
+   */
   wxString GetETE();
   void SetETE(wxLongLong secs);
 
   double m_lat, m_lon;
   double m_seg_len;  // length in NMI to this point
                      // undefined for starting point
+
+  /**
+   * Planned speed for traveling FROM this waypoint TO the next waypoint.
+   *
+   * This value represents the Velocity Made Good (VMG) expected when traveling
+   * from this waypoint to the next waypoint in a route. It is used to calculate
+   * the ETE (Estimated Time Enroute) for this leg, and consequently the ETA
+   * (Estimated Time of Arrival) at the next waypoint.
+   *
+   * If this value is not explicitly set (or is less than 0.1), the route's
+   * default planned speed will be used instead. The unit is knots (nautical
+   * miles per hour).
+   *
+   * For the last waypoint in a route, this value has no navigational
+   * significance.
+   */
   double m_seg_vmg;
+  /**
+   * Estimated Time of Departure from this waypoint, in UTC.
+   *
+   * For normal waypoints in a route, this represents when the vessel is
+   * expected to depart from this waypoint toward the next waypoint. By default,
+   * it is set to the same value as the ETA (m_seg_eta) to this waypoint,
+   * creating a continuous timing chain through the route.
+   *
+   * For the first waypoint in a route:
+   * - During route planning, it is initially set to the route's planned
+   * departure time
+   * - During active navigation, it represents the time when the route was
+   * activated
+   *
+   * This value can be manually set by the user (indicated by m_manual_etd
+   * flag), in which case it takes precedence over the automatically calculated
+   * value.
+   */
   wxDateTime m_seg_etd;
+
+  /**
+   * Estimated Time of Arrival at this waypoint, in UTC.
+   *
+   * For waypoints in a route, this represents when the vessel is expected to
+   * arrive at this waypoint based on the ETD and planned speed from the
+   * previous waypoint.
+   *
+   * For the first waypoint in a route:
+   * - During route planning, it is initially set to the route's planned
+   * departure time
+   * - During active navigation, it is calculated based on:
+   *   * The current vessel position
+   *   * The distance to the first waypoint
+   *   * The vessel's current or planned speed
+   *
+   * The relationship between waypoints creates a timing chain:
+   * The ETA at one waypoint determines the default ETD from that waypoint,
+   * which then affects the ETA at the next waypoint, and so on through the
+   * route.
+   */
   wxDateTime m_seg_eta;
+  /**
+   * Estimated Time Enroute for the leg leading to this waypoint.
+   *
+   * This value represents the expected travel time (in seconds) from the
+   * previous waypoint to this one. It is calculated based on:
+   * - The distance between the previous waypoint and this one (m_seg_len)
+   * - The planned speed for this leg (m_seg_vmg)
+   *
+   * For the first waypoint in a route during active navigation, this represents
+   * the estimated time from the vessel's current position to the first
+   * waypoint.
+   *
+   * The formula used is: ETE = (distance in nautical miles / speed in knots) *
+   * 3600
+   */
   wxLongLong m_seg_ete = 0;
+  /**
+   * Flag indicating whether the ETD has been manually set by the user.
+   *
+   * When true, this flag indicates that the m_seg_etd value was explicitly set
+   * by the user rather than being calculated automatically by the navigation
+   * system. This affects how the ETD is treated in route calculations and UI
+   * display.
+   */
   bool m_manual_etd{false};
 
   bool m_bPtIsSelected;
@@ -262,6 +429,20 @@ private:
   bool b_UseScamin;
   long m_ScaMin;
   long m_ScaMax;
+  /**
+   * The planned speed associated with this waypoint.
+   *
+   * For a waypoint within a route, this represents the speed to be used when
+   * traveling FROM this waypoint TO the next waypoint in the route. For the
+   * last waypoint in a route, this value has no navigational significance.
+   *
+   * This value is used for:
+   * - Calculating the ETA at the next waypoint
+   * - Determining the total time to complete a route segment
+   * - Route planning and navigation displays
+   *
+   * The speed is stored in knots (nautical miles per hour).
+   */
   double m_PlannedSpeed;
 
   bool m_bsharedMark /*m_bKeepXRoute*/;  // This is an isolated mark which is

--- a/model/include/model/routeman.h
+++ b/model/include/model/routeman.h
@@ -129,12 +129,82 @@ public:
   Track *FindTrackByGUID(const wxString &guid);
   Route *FindRouteContainingWaypoint(RoutePoint *pWP);
   Route *FindVisibleRouteContainingWaypoint(RoutePoint *pWP);
+  /**
+   * Find all routes that contain the given waypoint.
+   *
+   * This function searches through all routes in the route list
+   * and returns an array of route pointers for each route that
+   * contains the specified waypoint.
+   *
+   * @param pWP Pointer to the waypoint to search for.
+   * @return Pointer to wxArrayPtrVoid containing routes, or nullptr if no
+   * routes contain the waypoint. The caller is responsible for deleting the
+   * returned array when done with it.
+   */
   wxArrayPtrVoid *GetRouteArrayContaining(RoutePoint *pWP);
   bool DoesRouteContainSharedPoints(Route *pRoute);
   void RemovePointFromRoute(RoutePoint *point, Route *route, int route_state);
 
+  /**
+   * Activates a route for navigation.
+   *
+   * This function sets up a route for active navigation by:
+   * 1. Setting up the route for plugin notifications
+   * 2. Configuring output drivers for navigation data
+   * 3. Creating a "virtual" waypoint at the vessel's current position if
+   * starting at the beginning of the route
+   * 4. Activating the first/selected waypoint as the active navigation target
+   * 5. Initializing arrival detection parameters
+   *
+   * When a route is activated, OpenCPN starts providing navigation data to
+   * autopilot systems and plugins, updating the display to show the active
+   * route, and monitoring for waypoint arrivals.
+   *
+   * @param pRouteToActivate Pointer to the Route object to activate
+   * @param pStartPoint Optional pointer to a specific RoutePoint to start from
+   *                    (if NULL, starts from the first point in the route)
+   * @return true if route was successfully activated
+   */
   bool ActivateRoute(Route *pRouteToActivate, RoutePoint *pStartPoint = NULL);
+  /**
+   * Activates a specific waypoint within a route for navigation.
+   *
+   * This function sets up navigation to a specific waypoint by:
+   * 1. Setting up waypoint plugin notifications
+   * 2. Establishing the active waypoint and its preceding segment
+   * 3. Creating a "virtual" waypoint at the vessel's current position if this
+   * is the first point in the route
+   * 4. Setting up visual indicators (making the active point blink)
+   * 5. Initializing arrival detection parameters
+   *
+   * This function is called by ActivateRoute() and is also used when manually
+   * changing the active waypoint during navigation.
+   *
+   * @param pA Pointer to the route containing the waypoint
+   * @param pRP_target Pointer to the RoutePoint to set as the active target
+   * @return true if waypoint was successfully activated
+   */
   bool ActivateRoutePoint(Route *pA, RoutePoint *pRP);
+  /**
+   * Activates the next waypoint in a route when the current waypoint is
+   * reached.
+   *
+   * This function handles the transition between waypoints by:
+   * 1. Deactivating the current waypoint
+   * 2. Sending arrival notifications to plugins
+   * 3. Finding and activating the next waypoint in sequence
+   * 4. Setting up visual indicators for the new active waypoint
+   * 5. Resetting arrival detection parameters
+   *
+   * This function is called automatically when a waypoint arrival is detected,
+   * or manually when skipping a waypoint.
+   *
+   * @param pr Pointer to the active route
+   * @param skipped Boolean indicating if this is a manual skip (true) or normal
+   * arrival (false)
+   * @return true if successfully activated the next waypoint, false if at the
+   * end of the route
+   */
   bool ActivateNextPoint(Route *pr, bool skipped);
   RoutePoint *FindBestActivatePoint(Route *pR, double lat, double lon,
                                     double cog, double sog);

--- a/model/include/model/track.h
+++ b/model/include/model/track.h
@@ -57,7 +57,26 @@ public:
   TrackPoint(TrackPoint *orig);
   ~TrackPoint();
 
+  /**
+   * Retrieves the creation timestamp of a track point as a wxDateTime object.
+   *
+   * @return wxDateTime object representing the creation time in UTC.
+   *         If the internal timestamp string is invalid or empty, the
+   *         returned wxDateTime may be invalid.
+   */
   wxDateTime GetCreateTime(void);
+  /**
+   * Sets the creation timestamp for a track point.
+   *
+   * @param dt The wxDateTime object containing the timestamp to set.
+   *           Should be in UTC time already, as no time zone conversion is
+   * performed. The time is directly formatted and marked with 'Z' (UTC
+   * indicator). If the provided datetime is invalid, an empty string will be
+   * stored.
+   *
+   * Format: YYYY-MM-DDThh:mm:ssZ
+   * Example: 2023-04-15T14:22:38Z
+   */
   void SetCreateTime(wxDateTime dt);
   const char *GetTimeString() { return m_stimestring.c_str(); }
   bool HasValidTimestamp() {
@@ -69,6 +88,19 @@ public:
   int m_GPXTrkSegNo;
 
 private:
+  /**
+   * Sets the creation timestamp for a track point from a string.
+   *
+   * @param ts The timestamp string to store. Should be in ISO 8601 format.
+   *           If empty, the track point will have no timestamp.
+   *
+   * For example:
+   * - "2023-04-15T14:22:38Z" (UTC)
+   * - "2023-04-15T10:22:38-04:00" (EDT, 4 hours west of UTC)
+   *
+   * Time zone information will be correctly interpreted when the timestamp is
+   * read via GetCreateTime() which will return a wxDateTime object in UTC.
+   */
   void SetCreateTime(wxString ts);
   std::string m_stimestring;
 };

--- a/model/src/datetime.cpp
+++ b/model/src/datetime.cpp
@@ -27,6 +27,8 @@
 
 namespace ocpn {
 
+wxString getUsrDateTimeFormat() { return ::g_datetime_format; }
+
 // date/time in the desired time zone format.
 wxString toUsrDateTimeFormat(const wxDateTime date_time,
                              const DateTimeFormatOptions& options) {
@@ -92,20 +94,22 @@ wxString toUsrDateTimeFormat(const wxDateTime date_time,
     // operating system. For example "2021-10-31 01:30:00 EDT" is unambiguous,
     // while "2021-10-31 01:30:00 LOC" is not.
     wxString tzName = t.Format("%Z");
-    ret = t.Format(format, wxDateTime::Local) + " " + tzName;
+    ret = t.Format(format) + " " + tzName;
   } else if (effective_time_zone == "UTC") {
-    ret = t.Format(format, wxDateTime::UTC) + " " + _("UTC");
+    // Convert to UTC and format date/time.
+    ret = t.ToUTC().Format(format) + " " + _("UTC");
   } else if (effective_time_zone == "LMT") {
     // Local mean solar time at the current location.
+    t = t.ToUTC();
     if (std::isnan(options.longitude)) {
       t = wxInvalidDateTime;
     } else {
       t.Add(wxTimeSpan(0, 0, wxLongLong(options.longitude * 3600. / 15.)));
     }
-    ret = t.Format(format, wxDateTime::UTC) + " " + _("LMT");
+    ret = t.Format(format) + " " + _("LMT");
   } else {
     // Fallback to UTC if the timezone is not recognized.
-    ret = t.Format(format, wxDateTime::UTC) + " " + _("UTC");
+    ret = t.ToUTC().Format(format) + " " + _("UTC");
   }
   return ret;
 }

--- a/model/src/navutil_base.cpp
+++ b/model/src/navutil_base.cpp
@@ -563,18 +563,6 @@ double vVectorMagnitude(pVector2D v0) {
   return (dMagnitude);
 }
 
-// This function parses a string containing a GPX time representation
-// and returns a wxDateTime containing the UTC corresponding to the
-// input. The function return value is a pointer past the last valid
-// character parsed (if successful) or NULL (if the string is invalid).
-//
-// Valid GPX time strings are in ISO 8601 format as follows:
-//
-//   [-]<YYYY>-<MM>-<DD>T<hh>:<mm>:<ss>Z|(+|-<hh>:<mm>)
-//
-// For example, 2010-10-30T14:34:56Z and 2010-10-30T14:34:56-04:00
-// are the same time. The first is UTC and the second is EDT.
-
 const wxChar *ParseGPXDateTime(wxDateTime &dt, const wxChar *datetime) {
   long sign, hrs_west, mins_west;
   const wxChar *end;

--- a/model/src/route_point.cpp
+++ b/model/src/route_point.cpp
@@ -336,6 +336,7 @@ bool RoutePoint::IsSharedInVisibleRoute() {
           break;
         }
       }
+      delete proute_array;
     }
 
     return brp_viz;
@@ -477,6 +478,9 @@ wxDateTime RoutePoint::GetETD() {
         wxString tz(parse_return);
 
         if (tz.Find(_T("UT")) != wxNOT_FOUND) {
+          // TODO: This is error-prone. It would match any string containing
+          // these characters, not just time zone codes For example, "UT" would
+          // match "UTC+2".
           m_seg_etd = etd;
         } else {
           if (tz.Find(_T("LMT")) != wxNOT_FOUND) {
@@ -537,6 +541,9 @@ bool RoutePoint::SetETD(const wxString &ts) {
   }
   wxDateTime tmp;
   wxString::const_iterator end;
+  // No timezone conversion is done because the serialized string
+  // does not include timezone information, e.g., "2025-03-26T18:57:01"
+  // The input string is assumed to be in UTC format.
   if (tmp.ParseISOCombined(ts)) {
     SetETD(tmp);
     return TRUE;

--- a/model/src/routeman.cpp
+++ b/model/src/routeman.cpp
@@ -781,6 +781,7 @@ bool Routeman::DoesRouteContainSharedPoints(Route *pRoute) {
           else
             return true;
         }
+        delete pRA;
       }
 
       if (pnode) pnode = pnode->GetNext();

--- a/model/src/track.cpp
+++ b/model/src/track.cpp
@@ -994,7 +994,7 @@ wxString Track::GetDateTime(const wxString label_for_invalid_date) const {
   TrackPoint *rp = NULL;
   if ((int)TrackPoints.size() > 0) rp = TrackPoints[0];
   if (rp && rp->GetCreateTime().IsValid())
-    name = ocpn::toUsrDateTimeFormat(rp->GetCreateTime());
+    name = ocpn::toUsrDateTimeFormat(rp->GetCreateTime().FromUTC());
   else
     name = label_for_invalid_date;
   return name;

--- a/plugins/grib_pi/src/GribRecordSet.h
+++ b/plugins/grib_pi/src/GribRecordSet.h
@@ -139,7 +139,8 @@ public:
     }
   }
 
-  /** Reference time for this set of records. */
+  /** Reference time for this set of records, as the number of seconds since the
+   * epoch. */
   time_t m_Reference_Time;
   /** Unique identifier for this record set. */
   unsigned int m_ID;

--- a/plugins/grib_pi/src/GribTable.cpp
+++ b/plugins/grib_pi/src/GribTable.cpp
@@ -74,7 +74,8 @@ void GRIBTable::InitGribTable(const wxString zone, ArrayOfGribRecordSets *rsa,
         DateTimeFormatOptions()
             .SetFormatString("$short_date\n$hour_minutes")
             .SetTimezone(zone);
-    m_pGribTable->SetColLabelValue(i, toUsrDateTimeFormat_Plugin(time, opts));
+    m_pGribTable->SetColLabelValue(
+        i, toUsrDateTimeFormat_Plugin(wxDateTime(time), opts));
     nrows = -1;
     GribTimelineRecordSet *pTimeset = m_pGDialog->GetTimeLineRecordSet(time);
     if (pTimeset == 0) continue;

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -456,7 +456,7 @@ void GRIBUICtrlBar::OpenFile(bool newestFile) {
           DateTimeFormatOptions().SetTimezone(pPlugIn->GetTimezoneSelector());
       title.append(" (" +
                    toUsrDateTimeFormat_Plugin(
-                       m_bGRIBActiveFile->GetRefDateTime(), opts) +
+                       wxDateTime(m_bGRIBActiveFile->GetRefDateTime()), opts) +
                    ")");
 
       if (rsa->GetCount() > 1) {
@@ -1339,12 +1339,12 @@ void GRIBUICtrlBar::TimelineChanged() {
     SaveSelectionString();  // memorize index and label
     DateTimeFormatOptions opts =
         DateTimeFormatOptions().SetTimezone(pPlugIn->GetTimezoneSelector());
-    m_cRecordForecast->SetString(
-        m_Selection_index,
-        toUsrDateTimeFormat_Plugin(time, opts));  // replace it by the
+    wxString formattedTime = toUsrDateTimeFormat_Plugin(time, opts);
+    m_cRecordForecast->SetString(m_Selection_index,
+                                 formattedTime);  // replace it by the
                                                   // interpolated time label
-    m_cRecordForecast->SetStringSelection(toUsrDateTimeFormat_Plugin(
-        time, opts));  // ensure it's visible in the box
+    m_cRecordForecast->SetStringSelection(
+        formattedTime);  // ensure it's visible in the box
   }
 
   UpdateTrackingControl();
@@ -1401,7 +1401,7 @@ wxDateTime GRIBUICtrlBar::GetNow() {
 
   ArrayOfGribRecordSets *rsa = m_bGRIBActiveFile->GetRecordSetArrayPtr();
 
-  // verifie if we are outside of the file time range
+  // Verify if we are outside of the file time range
   now = (now > rsa->Item(rsa->GetCount() - 1).m_Reference_Time)
             ? rsa->Item(rsa->GetCount() - 1).m_Reference_Time
         : (now < rsa->Item(0).m_Reference_Time) ? rsa->Item(0).m_Reference_Time
@@ -1911,12 +1911,11 @@ void GRIBUICtrlBar::ComputeBestForecastForNow() {
   SaveSelectionString();  // memorize the new selected wxChoice date time label
   DateTimeFormatOptions opts =
       DateTimeFormatOptions().SetTimezone(pPlugIn->GetTimezoneSelector());
-  m_cRecordForecast->SetString(
-      m_Selection_index,
-      toUsrDateTimeFormat_Plugin(now, opts));  // write the now date time label
-                                               // in the right place in wxChoice
-  m_cRecordForecast->SetStringSelection(
-      toUsrDateTimeFormat_Plugin(now, opts));  // put it in the box
+  wxString nowTime = toUsrDateTimeFormat_Plugin(now, opts);
+  m_cRecordForecast->SetString(m_Selection_index,
+                               nowTime);  // write the now date time label
+                                          // in the right place in wxChoice
+  m_cRecordForecast->SetStringSelection(nowTime);  // put it in the box
 
   UpdateTrackingControl();
 

--- a/plugins/grib_pi/src/GribUIDialog.h
+++ b/plugins/grib_pi/src/GribUIDialog.h
@@ -189,6 +189,7 @@ public:
   void ContextMenuItemCallback(int id);
   void SetFactoryOptions();
 
+  /** Returns the selected time in the GRIB timeline widget. */
   wxDateTime TimelineTime();
   /**
    * Retrieves or creates a temporally interpolated GRIB record set for a
@@ -459,7 +460,8 @@ public:
     return &m_GribRecordSetArray;
   }
   /**
-   * Gets reference datetime of the GRIB data.
+   * Returns the reference datetime of the GRIB data, as the number of seconds
+   * since the epoch.
    *
    * The reference time is when the model run started (analysis time).
    * This differs from the forecast time of individual records which is


### PR DESCRIPTION
# Overview

This PR:
1. Addresses issues related to centralized configuration of date/time format. Because of a regression introduced by #4052, the ETD/ETA fields in route properties were incorrect, and the tide events were also incorrect.
2. Fix inconsistencies in the `toUsrDateTimeFormat` function and `toUsrDateTimeFormat_Plugin` API: The implementation did not properly handle conversion from input date/time argument to target timezone (local time, LMT, UTC).
3. Fix crashes when removing waypoints from routes
4. Fix memory leaks in GetRouteArrayContaining calls.
5. Disable ETD for final waypoints
6. Add tooltips
7. Add/improve code comments

# Problems
1. In the "Waypoint properties" dialog, the speed units (e.g. "knts") are not updated after the user changes the speed units in global Options.
   1. Click "Waypoint properties", which invokes the constructor for the waypoint dialog. This is where `getUsrSpeedUnit()` is invoked. The units are not refreshed after the dialog has been created.
   2. Go to "Options" and change the speed units
   4. Go back to the waypoint properties. Notice that a) the value has been updated, but the units did not. For example, if the speed value was 1 knot, and then Options -> Units -> Speed is changed to km/h, then in the waypoint properties the value was set to 1.852, but the unit still shows "kts"
2. OpenCPN crashes after a waypoint has been removed from a route.
   1. Create a route with at least 3 waypoints.
   2. Click "remove from route" then "Delete waypoint".
   3. Go to "route properties" click on a waypoint.
   8. Notice OpenCPN crashes.
3. Analyzed #4431 , but IMHO, there is nothing to change. The existing behavior is correct.
4. Some of the callers to `GetRouteArrayContaining` do not delete the returned array, which causes a memory leak.
9. Issue reported in #4432

## Problems Introduced by #4052

The #4052 PR introduced a regression:

1. I introduced a `toUsrDateTimeFormat()` function and documented the input `wxDateTime` argument should be in UTC, which was the intent.
2. However, the implementation worked when the input argument was specified in local time, not in UTC.
3. Some of the `toUsrDateTimeFormat()`  callers were passing local time, and others were passing UTC time.
   1. The manual MOB and AIS functions were working because it was passing local time, which was what the `toUsrDateTimeFormat()` expected.
   2. In the routing dialog, the ETA, ETD, and tide date/time objects were not formatted correctly because the code passing a UTC time as documented in `toUsrDateTimeFormat()`, but the implementation was assuming local time.

The fix is to:
1. Make the `toUsrDateTimeFormat()` function work correctly when the input argument is in UTC.
3. Check all callers and ensure they all pass a `wxDateTime` in UTC format.

# Changes

- Add code comments.
- Add tooltips in waypoint and route properties.
- Refresh speed units to handle the case when user changes units in global options.
- Fix OpenCPN crash when waypoint is removed from route and user clicks "route properties'.
- Setting an ETD (Estimated Time of Departure) for the very last waypoint in a route doesn't make logical sense since there are no subsequent waypoints to navigate to - there's no "departure" from the final destination.
- Rename `m_EtaDatePickerCtrl` to `m_EtdDatePickerCtrl` as it is used to indicate **ETD**, not ETA. Same for `m_EtdTimePickerCtrl `
- If a waypoint is part of a route, and this is the last waypoint, the ETD is meaningless. So:
   1. Uncheck "set ETD"
   5. Reset "ETD" to empty value.
- Fix memory leaks for the calls to `GetRouteArrayContaining`. The caller should should delete the return value after use.
- In the "waypoint property" dialog, the ETD inherit the global configuration for the date/time settings (UTC or Local Time). See screenshot example below.

# Screenshots

The waypoint dialog now honors the date/time format settings that are specified in "Options":

<img width="1194" alt="image" src="https://github.com/user-attachments/assets/01bccaf1-7a2e-4de6-a2aa-b1703d75ade9" />

Added multiple tooltips. For example:

<img width="480" alt="image" src="https://github.com/user-attachments/assets/99f4a0ba-a8bc-49c4-9192-70720dfcc209" />

# Tests

- [x] Waypoint Dialog Properties
   - [x] Confirm tooltip texts for waypoint properties accurately explain their functionality: Tide station, arrival radius, planned speed, ETD
   - [x] Check that date/time format display of the ETD property adapts based on user settings (UTC vs. Local Time) - The "ETD" static label should indicate the date/time format based on the global setting in Options -> Display -> Date and Time
   - [x] Test creating a waypoint with manual ETD set and verify it persists when saved
   - [x] Confirm ETD controls are disabled for the last waypoint in a route - It does not make sense to set an ETD for the last waypoint in a route.
   - [x] Confirm ETD controls are enabled when the waypoint in a route is not the last waypoint.
   - [x] Test ETD time conversion between UTC and local time based on user settings

- [x] Waypoint ETD persistence with "Local Time". In Options -> Display, set "Date/time" format to "Local Time"
   - [x] Set the ETD in a waypoint. Click OK, then close OpenCPN. Restart OpenCPN, go to the waypoint, and check the ETD is still the same value in Local Time.
   - [x] After the above, go to Options -> Display, set "Date/time" format to "UTC". Verify the ETD date is now formatted using UTC with the proper conversion.

- [x] Waypoint ETD persistence with "Local Time". In Options -> Display, set "Date/time" format to "UTC"
   - [x] Set the ETD in a waypoint. Click OK, then close OpenCPN. Restart OpenCPN, go to the waypoint, and check the ETD is still the same value in UTC.
   - [x] After the above, go to Options -> Display, set "Date/time" format to "Local Time". Verify the ETD date is formatted using "Local Time" with the proper conversion.

- [x] Route properties
   - [x] Confirm tooltip texts for route properties accurately explain their functionality: "Extend" button
   - [x] Verify that when setting the ETD in the waypoint dialog property, the same ETD value is shown in the table format in the route widget.
   - [x] Verify that when you change the "Time" settings in the route widget ("Local Time", "UTC", "LMT@Location", "Honor Global Settings", the value of the ETD is reformatted accordingly
 
- [x] Date/time format for `toUsrDateTimeFormat` callers
   - [x] Anchorage name based on date/time for Android - Unable to test, but confident it works correctly based on code analysis. 
   - [x] Manual MOB - Click MOB button, verify date/time is properly formatted according to the global date/time options.
   - [x] AIS MOB - Same logic as Manual MOB, but activated from AIS message
   - [x] Navigate to MOB - Validate the route name includes the date/time, formatted according to global date/time options.
   - [x] Route properties
      - [x] Validate the route ETA in the first leg is the same as the route departure date/time, prefixed with "Start:". Verify date/time format is updated based on the "Time" setting (local, UTC, LMT, honor global options)
      - [x] Validate that for each leg in the route table, the daylight (daytime, night time, mo twilight, sunset) is not affected by the timezone selection
      - [x] Validate that if you change the route Departure date/time, then close/restart OpenCPN, the route departure has been saved as expected. Try changing the date with different time settings (local, LMT, UTC, global options)
      - [x] Verify you can set a departure date/time (ETD) for each leg.
      - [x] Verify the ETD date/time is formatted according to the "Time" setting (local, UTC, LMT, honor global options)
      - [x] If the departure date/time is **after** the ETA, then the ETD is not displayed with the "!!" prefix
      - [x] If the departure date/time is **before** the ETA, then the ETD is displayed with the "!!" prefix
      - [x] Verify the presence of the "!!" ETD prefix is not affected when the user changes the "Time" setting (local, UTC, LMT, honor global options)
      - [x] Validate the “!!” prefix is updated after a change of the route departure date/time. Change the leg ETD are before the leg ETA.
      - [x] Validate the route legs ETAs are updated when the user changes the route departure date/time.
      - [x] Verify the time of the next tide event (high water, low water) at the station is printed. The “Next tide event” column should display the time according to the “Time” setting (local, UTC, LMT, honor global settings) and in the timezone at the station.
      - [x] Verify the UTC offset for the tide station if formatted as +/-HH:MM
   - [x] “Route & Mark > Tracks” manager
      - [x] Verify the “Start Date” of the track is formatted according to the global options (local, UTC).
      - [x] Verity the “Timestamp” of each track leg is formatted according to the global options (local, UTC).
      - [x] Verity the “Timestamp” of the first track leg is the same as the “Start Date” of the track.
      - [x] Verify the “Start Date” of the track is the same as the trkpt/time elements in the navobj.xml file
   - [x] GRIB Plugin
      - [x] Verify the title of the GRIB dialog is formatted according to the date/format options.
      - [x] Verify the drop-down list of GRIB times is populated and that all dates are formatted according to the date/format options.
      - [x] Verity the timestamps in the drop-down list of GRIB times matches the expected times in the GRIB file.
      - [x] Verify the Date/Time in the GRIB weather table if formatted according to the date/format options.
      - [x] Verity the first date/time in the GRIB weather table matches the expected time from the GRIB file
      - [x] Verify that when you drag the timeline slider, the selected time in the dropdown is updated with the expected time.
      - [x] Verify that when you click the "Now" button, the selected time in the dropdown is updated with the expected time.
      - [x] Verify the GRIB selected time is shown as a vertical red line in the tide station properties. When you move the GRIB timeline slider, the position of the red vertical line is updated. The time of the vertical line matches the time of the selected time in the GRIB plugin.

- [x] Edge Cases
   - [x] Verify user is allowed to configure ETD if a waypoint belongs to two or more routes, and it is the last waypoint in route 1 (which means ETD is not applicable) but it's an intermediate point in at least one other route.