### PR TITLE
Fix crash when exporting route/waypoint to GPS.

### DIFF
--- a/gui/src/route_gui.cpp
+++ b/gui/src/route_gui.cpp
@@ -630,10 +630,18 @@ int RouteGui::SendToGPS(const wxString &com_name, bool bsend_waypoints,
   if (0 == result)
     msg = _("Route Transmitted.");
   else {
-    if (result == ERR_GARMIN_INITIALIZE)
-      msg = _("Error on Route Upload.  Garmin GPS not connected");
-    else
-      msg = _("Error on Route Upload.  Please check logfiles...");
+    switch (result) {
+      case ERR_GARMIN_INITIALIZE:
+        msg = _("Error on Route Upload. Garmin GPS not connected");
+        break;
+      case ERR_GPS_DRIVER_NOT_AVAILAIBLE:
+        msg = _("Error on Route Upload. GPS driver not available");
+        break;
+      case ERR_GARMIN_SEND_MESSAGE:
+      default:
+        msg = _("Error on Route Upload. Please check logfiles...");
+        break;
+    }
   }
   OCPNMessageBox(NULL, msg, _("OpenCPN Info"), wxOK | wxICON_INFORMATION);
 

--- a/gui/src/route_point_gui.cpp
+++ b/gui/src/route_point_gui.cpp
@@ -917,10 +917,18 @@ bool RoutePointGui::SendToGPS(const wxString &com_name, SendToGpsDlg *dialog) {
   if (0 == result)
     msg = _("Waypoint(s) Transmitted.");
   else {
-    if (result == ERR_GARMIN_INITIALIZE)
-      msg = _("Error on Waypoint Upload.  Garmin GPS not connected");
-    else
-      msg = _("Error on Waypoint Upload.  Please check logfiles...");
+    switch (result) {
+      case ERR_GARMIN_INITIALIZE:
+        msg = _("Error on Waypoint Upload. Garmin GPS not connected");
+        break;
+      case ERR_GPS_DRIVER_NOT_AVAILAIBLE:
+        msg = _("Error on Waypoint Upload. GPS driver not available");
+        break;
+      case ERR_GARMIN_SEND_MESSAGE:
+      default:
+        msg = _("Error on Waypoint Upload. Please check logfiles...");
+        break;
+    }
   }
 
   OCPNMessageBox(NULL, msg, _("OpenCPN Info"), wxOK | wxICON_INFORMATION);

--- a/model/include/model/comm_n0183_output.h
+++ b/model/include/model/comm_n0183_output.h
@@ -41,9 +41,18 @@
 class RoutePoint;
 class Route;
 
-//      Garmin interface private error codes
+/**
+ * Failed to initialize Garmin device.
+ */
 #define ERR_GARMIN_INITIALIZE -1
-#define ERR_GARMIN_GENERAL -2
+/**
+ * Failed to send message to Garmin device.
+ */
+#define ERR_GARMIN_SEND_MESSAGE -2
+/**
+ * GPS driver not available.
+ */
+#define ERR_GPS_DRIVER_NOT_AVAILAIBLE -3
 
 void BroadcastNMEA0183Message(const wxString& msg, NmeaLog& nmea_log,
                               EventVar& on_msg_sent);

--- a/model/src/comm_n0183_output.cpp
+++ b/model/src/comm_n0183_output.cpp
@@ -405,7 +405,7 @@ int PrepareOutputChannel(const wxString& com_name, N0183DlgCtx dlg_ctx,
       MESSAGE_LOG << "Error Sending Waypoint to Garmin USB, last error: "
                   << GetLastGarminError();
 
-      ret_val = ERR_GARMIN_GENERAL;
+      ret_val = ERR_GARMIN_SEND_MESSAGE;
     } else
       ret_val = 0;
 
@@ -432,6 +432,9 @@ int SendRouteToGPS_N0183(Route* pr, const wxString& com_name,
                                 b_restoreStream, btempStream);
 
   auto drv_n0183 = dynamic_cast<CommDriverN0183*>(target_driver.get());
+  if (!drv_n0183) {
+    return ERR_GPS_DRIVER_NOT_AVAILAIBLE;
+  }
 
 #ifdef USE_GARMINHOST
 #ifdef __WXMSW__
@@ -464,7 +467,7 @@ int SendRouteToGPS_N0183(Route* pr, const wxString& com_name,
       if (ret1 != 1) {
         MESSAGE_LOG << " Error sending routes, last garmin error: "
                     << GetLastGarminError();
-        ret_val = ERR_GARMIN_GENERAL;
+        ret_val = ERR_GARMIN_SEND_MESSAGE;
       } else
         ret_val = 0;
     }
@@ -519,7 +522,7 @@ int SendRouteToGPS_N0183(Route* pr, const wxString& com_name,
       MESSAGE_LOG << "Error Sending Route to Garmin GPS on port: " << short_com
                   << " Error Code: " << lret_val
                   << " LastGarminError: " << GetLastGarminError();
-      ret_val = ERR_GARMIN_GENERAL;
+      ret_val = ERR_GARMIN_SEND_MESSAGE;
       goto ret_point;
     } else {
       ret_val = 0;
@@ -961,7 +964,7 @@ int SendWaypointToGPS_N0183(RoutePoint* prp, const wxString& com_name,
       MESSAGE_LOG << "Error Sending Waypoint to Garmin USB, last error: "
                   << GetLastGarminError();
 
-      ret_val = ERR_GARMIN_GENERAL;
+      ret_val = ERR_GARMIN_SEND_MESSAGE;
     } else
       ret_val = 0;
 
@@ -1018,7 +1021,7 @@ int SendWaypointToGPS_N0183(RoutePoint* prp, const wxString& com_name,
       MESSAGE_LOG << "Error Sending Waypoint(s) to Garmin GPS on port, "
                   << com_name << " error code: " << ret_val
                   << ", last garmin error: " << GetLastGarminError();
-      ret_val = ERR_GARMIN_GENERAL;
+      ret_val = ERR_GARMIN_SEND_MESSAGE;
       goto ret_point;
     } else
       ret_val = 0;
@@ -1029,6 +1032,10 @@ int SendWaypointToGPS_N0183(RoutePoint* prp, const wxString& com_name,
 
   {  // Standard NMEA mode
     auto drv_n0183 = dynamic_cast<CommDriverN0183*>(target_driver.get());
+    if (!drv_n0183) {
+      ret_val = ERR_GPS_DRIVER_NOT_AVAILAIBLE;
+      goto ret_point;
+    }
 
     auto address = std::make_shared<NavAddr>();
     SENTENCE snt;


### PR DESCRIPTION
Fix #4433

With this change, OpenCPN displays an error message if route/waypoint export fails because no device is connected.

I'm not very familiar with this part of the code. I see the error message states "Garmin". Is this the only supported brand?

@leamas, could you take a look? 