### PR TITLE
Add route planned speed and ETD fields in plugin API

### DIFF
--- a/cli/api_shim.cpp
+++ b/cli/api_shim.cpp
@@ -1029,7 +1029,7 @@ DECL_EXP void SetToolbarToolBitmapsSVG(int item, wxString SVGfile,
                                        wxString SVGfileRollover,
                                        wxString SVGfileToggled) {}
 DECL_EXP void RemoveCanvasContextMenuItem(int item) {}
-DECL_EXP void JumpToPosition(double lat, double lon, double scale){};
+DECL_EXP void JumpToPosition(double lat, double lon, double scale) {};
 DECL_EXP void SetCanvasContextMenuItemViz(int item, bool viz) {}
 DECL_EXP void SetCanvasContextMenuItemGrey(int item, bool grey) {}
 DECL_EXP void RequestRefresh(wxWindow *) {}
@@ -1110,7 +1110,7 @@ DECL_EXP bool PlugIn_GSHHS_CrossesLand(double lat1, double lon1, double lat2,
   return true;
 }
 
-DECL_EXP void PlugInPlaySound(wxString &sound_file){};
+DECL_EXP void PlugInPlaySound(wxString &sound_file) {};
 
 // API 1.10 Route and Waypoint Support
 DECL_EXP wxBitmap *FindSystemWaypointIcon(wxString &icon_name) { return 0; }
@@ -1532,7 +1532,7 @@ DECL_EXP void PlugInHandleAutopilotRoute(bool enable) {}
 wxString *GetpSharedDataLocation(void) {
   return g_BasePlatform->GetSharedDataDirPtr();
 }
-DECL_EXP ArrayOfPlugIn_AIS_Targets* GetAISTargetArray() { return 0; }
+DECL_EXP ArrayOfPlugIn_AIS_Targets *GetAISTargetArray() { return 0; }
 DECL_EXP bool ShuttingDown(void) { return true; }
 
 DECL_EXP wxWindow *PluginGetFocusCanvas() { return 0; }
@@ -1579,8 +1579,8 @@ DECL_EXP int GetLatLonFormat(void) { return 0; }
 DECL_EXP void ZeroXTE() {}
 
 DECL_EXP PlugIn_Waypoint::PlugIn_Waypoint() {}
-DECL_EXP PlugIn_Waypoint::PlugIn_Waypoint(double, double, const wxString&,
-                  const wxString&, const wxString&) {}
+DECL_EXP PlugIn_Waypoint::PlugIn_Waypoint(double, double, const wxString &,
+                                          const wxString &, const wxString &) {}
 DECL_EXP PlugIn_Waypoint::~PlugIn_Waypoint() {}
 
 DECL_EXP PlugIn_Waypoint_Ex::PlugIn_Waypoint_Ex() {}
@@ -1594,6 +1594,28 @@ DECL_EXP void PlugIn_Waypoint_Ex::InitDefaults() {}
 DECL_EXP bool PlugIn_Waypoint_Ex::GetFSStatus() { return true; }
 
 DECL_EXP int PlugIn_Waypoint_Ex::GetRouteMembershipCount() { return 0; }
+
+DECL_EXP PlugIn_Waypoint_ExV2::PlugIn_Waypoint_ExV2() : PlugIn_Waypoint_Ex() {
+  InitExV2Defaults();
+}
+
+DECL_EXP PlugIn_Waypoint_ExV2::PlugIn_Waypoint_ExV2(
+    double lat, double lon, const wxString &icon_ident, const wxString &wp_name,
+    const wxString &GUID, const double ScaMin, const bool bNameVisible,
+    const int nRanges, const double RangeDistance, const wxColor RangeColor)
+    : PlugIn_Waypoint_Ex(lat, lon, icon_ident, wp_name, GUID, ScaMin,
+                         bNameVisible, nRanges, RangeDistance, RangeColor) {
+  InitExV2Defaults();
+}
+
+DECL_EXP void PlugIn_Waypoint_ExV2::InitExV2Defaults() {
+  scamax = 1e6;
+  m_PlannedSpeed = 0.0;
+  m_WaypointArrivalRadius = 0.0;
+  m_bShowWaypointRangeRings = false;
+}
+
+DECL_EXP PlugIn_Waypoint_ExV2::~PlugIn_Waypoint_ExV2() {}
 
 DECL_EXP PlugIn_Route::PlugIn_Route(void) {}
 DECL_EXP PlugIn_Route::~PlugIn_Route(void) {}

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -2973,8 +2973,8 @@ struct DateTimeFormatOptions {
  * Format a date/time to a localized string representation, conforming to the
  * global date/time format and timezone settings.
  *
- * The function expects date_time to be in local time and formats it according to the 
- * timezone configuration either in:
+ * The function expects date_time to be in local time and formats it according
+ * to the timezone configuration either in:
  * - UTC: Coordinated Universal Time (default)
  * - Local Time: System's configured timezone with proper DST handling
  * - LMT: Local Mean Time calculated based on the longitude specified in options
@@ -2983,8 +2983,10 @@ struct DateTimeFormatOptions {
  * consistent date/time formatting across the entire application.
  *
  * @param date_time The date/time to format, must be in local time.
- * @param options The date/time format options including target timezone and formatting preferences.
- * @return wxString The formatted date/time string with appropriate timezone indicator.
+ * @param options The date/time format options including target timezone and
+ * formatting preferences.
+ * @return wxString The formatted date/time string with appropriate timezone
+ * indicator.
  */
 extern DECL_EXP wxString toUsrDateTimeFormat_Plugin(
     const wxDateTime date_time,
@@ -5066,7 +5068,7 @@ public:
                      const double ScaMin = 1e9, const bool bNameVisible = false,
                      const int nRanges = 0, const double RangeDistance = 1.0,
                      const wxColor RangeColor = wxColor(255, 0, 0));
-  ~PlugIn_Waypoint_Ex();
+  virtual ~PlugIn_Waypoint_Ex();
   /**
    * Initializes waypoint properties to default values.
    *
@@ -5132,6 +5134,27 @@ public:
 
 WX_DECLARE_LIST(PlugIn_Waypoint_Ex, Plugin_WaypointExList);
 
+class DECL_EXP PlugIn_Waypoint_ExV2 : public PlugIn_Waypoint_Ex {
+public:
+  PlugIn_Waypoint_ExV2();
+  PlugIn_Waypoint_ExV2(double lat, double lon, const wxString &icon_ident,
+                       const wxString &wp_name, const wxString &GUID = "",
+                       const double ScaMin = 1e9,
+                       const bool bNameVisible = false, const int nRanges = 0,
+                       const double RangeDistance = 1.0,
+                       const wxColor RangeColor = wxColor(255, 0, 0));
+  virtual ~PlugIn_Waypoint_ExV2();
+  double scamax;  //!< Maximum display scale (1:X) for waypoint visibility
+  double m_PlannedSpeed;           //!< Planned speed for next leg (knots)
+  bool m_bShowWaypointRangeRings;  //!< True to show range rings on chart
+  double m_WaypointArrivalRadius;  //!< Arrival radius in nautical miles
+  /** Estimated departure time, or wxInvalidDateTime if not set. */
+  wxDateTime m_ETD;
+
+private:
+  void InitExV2Defaults();
+};
+
 /**
  * Extended route class for managing complex route features.
  *
@@ -5157,7 +5180,7 @@ WX_DECLARE_LIST(PlugIn_Waypoint_Ex, Plugin_WaypointExList);
 class DECL_EXP PlugIn_Route_Ex {
 public:
   PlugIn_Route_Ex(void);
-  ~PlugIn_Route_Ex(void);
+  virtual ~PlugIn_Route_Ex(void);
 
   wxString m_NameString;   //!< User-visible name of the route
   wxString m_StartString;  //!< Description of route start point

--- a/manual/modules/ROOT/nav.adoc
+++ b/manual/modules/ROOT/nav.adoc
@@ -10,6 +10,7 @@
 ** xref:create-deb-package.adoc[Create Debian packages]
 * xref:unit-tests.adoc[Unit tests]
 * xref:rest-interface.adoc[REST server]
+* xref:plugin-api.adoc[Plugin API]
 * xref:odraw-messaging.adoc[ODraw Messaging API]
 * xref:plugin-messaging.adoc[New Message Plugin API]
 * xref:messaging-debug.adoc[Data Monitor concepts]

--- a/manual/modules/ROOT/pages/plugin-api.adoc
+++ b/manual/modules/ROOT/pages/plugin-api.adoc
@@ -1,0 +1,128 @@
+= Plugin API
+
+== Introduction for Core Developers
+
+This section provides guidance for OpenCPN core developers who are creating or extending the plugin API. Unlike other parts of the developer manual that focus on plugin developers using the API, this section covers best practices, design principles, and implementation considerations for those maintaining and evolving the API itself.
+
+The plugin API serves as the contract between OpenCPN core and its plugins. Any changes to this API must be carefully considered to maintain backward compatibility while enabling new features. As a core developer, your decisions about the plugin API will affect both the stability of existing plugins and the capabilities available to future plugin authors.
+
+== API Design Principles
+
+=== Maintaining Stable ABI
+
+* Changes to the plugin API must preserve both source (API) and binary (ABI) compatibility.
+* Plugins compiled against an older version of the API should continue to work with newer versions of OpenCPN.
+
+=== API Documentation
+
+* Document all functions, classes, and parameters.
+* Include usage examples for complex features.
+
+=== Sharing Content Between Plugins and Core
+
+*Create dedicated classes for shared content*
+
+* When plugins and the core application need to share data structures (either unidirectionally or bidirectionally), create a specific class to encapsulate this shared content.
+* Example: `PlugIn_Waypoint` for sharing waypoint data between core and plugins.
+* These classes provide clear boundaries and interfaces for data exchange.
+
+=== API Stability and Compatibility
+
+*Never modify published classes*
+
+* Once a new OpenCPN version has been published along with a new version of the plugin API, do not:
+** Add new fields to existing classes
+** Remove fields from existing classes
+** Reorder fields within classes
+** Change the meaning or interpretation of existing fields
+* Any of these changes could break binary compatibility with existing plugins.
+
+*Use virtual destructors in all API classes*
+
+* Always include a virtual destructor in base classes:
++
+[source,cpp]
+----
+virtual ~PlugIn_Waypoint();
+----
+* This ensures that when a derived object is deleted through a base pointer, the correct (derived) destructor will be called.
+* Without a virtual destructor, deleting a derived class through a base pointer will only call the base class destructor, potentially causing memory leaks.
+* This becomes a critical issue when introducing class inheritance in future releases, even if it seems unnecessary in the initial implementation.
+
+*Avoid passing classes by value*
+
+* Do not pass or return API classes by value. Instead, use pointers or references:
++
+[source,cpp]
+----
+// Good
+bool UpdateSingleWaypoint(PlugIn_Waypoint* pwaypoint);
+
+// Bad
+bool UpdateSingleWaypoint(PlugIn_Waypoint pwaypoint);
+----
+* Passing by value may work initially, but becomes a serious problem in future releases when derived classes are added - passing them to a function expecting the base class will cause slicing. This would force developers to create new functions such as `UpdateSingleWaypointV2`, causing the plugin API to be bloated.
+* A key consideration is that new fields cannot be added to the base class after the plugin API has been published. Changing a class would break ABI compatibility.
+* Example of slicing problem:
++
+[source,cpp]
+----
+void ProcessWaypoint(PlugIn_Waypoint wp) { /* uses only base class members */ }
+
+PlugIn_WaypointV2 myPoint;
+myPoint.scamax = 1000000;  // V2-specific field
+ProcessWaypoint(myPoint);  // The scamax value is lost in the function!
+----
+
+=== API Evolution
+
+*Use versioned class names for API evolution*
+
+* Instead of adding "_Ex" or similar suffixes (which don't scale well), use explicit version numbering:
++
+[source,cpp]
+----
+// Good
+class PlugIn_WaypointV1 { ... };
+class PlugIn_WaypointV2 : public PlugIn_WaypointV1 { ... };
+class PlugIn_WaypointV3 : public PlugIn_WaypointV2 { ... };
+
+// Avoid
+class PlugIn_Waypoint { ... };
+class PlugIn_Waypoint_Ex { ... };
+class PlugIn_Waypoint_Ex_Ex { ... };  // Awkward naming!
+----
+* Clear versioning makes the evolution path obvious and reduces confusion
+* For the first version, you can omit the version suffix, but be prepared to introduce explicit versioning in future updates
+
+*Create subclasses for new fields*
+
+* When new fields need to be added in future plugin API versions, create a subclass rather than modifying the existing class:
++
+[source,cpp]
+----
+class PlugIn_WaypointV2 : public PlugIn_Waypoint {
+public:
+  double scamax;
+  double m_PlannedSpeed;
+  // New fields here...
+};
+----
+* This allows for backward compatibility - older plugins continue working with the base class
+* Newer plugins can benefit from the extended functionality
+* Use dynamic casting to detect and utilize the extended classes:
++
+[source,cpp]
+----
+PlugIn_WaypointV2* dst_v2 = dynamic_cast<PlugIn_WaypointV2*>(dst);
+if (dst_v2) {
+  // use extended fields
+}
+----
+
+=== Memory Management
+
+*Clear ownership semantics*
+
+* Define clear ownership rules for every object passed through the API
+* Document whether the receiver takes ownership of passed objects

--- a/manual/modules/ROOT/pages/plugin-messaging.adoc
+++ b/manual/modules/ROOT/pages/plugin-messaging.adoc
@@ -1,13 +1,13 @@
 = Handling Communications Messages in Plugins
 
-Since 5.8.0 opencpn has a new system for handling messages in plugins.
+Since 5.8.0 OpenCPN has a new system for handling messages in plugins.
 The new model is based on that a plugin subscribes to the messages it is
 interested in rather then the old model where plugins get all messages.
 
 The new system is the only way to handle the new NMEA2000 devices.
-For N0183 devices a compatiblity layer is installed which makes things work
+For N0183 devices a compatibility layer is installed which makes things work
 as earlier.
-However, the new system can be used also for nmea0183 where it offers more
+However, the new system can be used also for NMEA0183 where it offers more
 flexibility and performance.
 
 == Receiving messages
@@ -26,7 +26,7 @@ The code handling messages must live in a wxEventClass instance.
 In almost all cases this means that the code should be implemented in a wxWindow.
 If there is a wxWindow available with a suitable lifespan, this could be used.
 If there is no such window, it needs to be created (it can be hidden) or an
-existing one can be modified to alwasy exist, using Show()/Hide() to enable and
+existing one can be modified to always exist, using Show()/Hide() to enable and
 disable.
 
 As an example, the *ShipDrivergui_impl*  class is used.
@@ -185,8 +185,8 @@ Plugins may access comm ports for direct output.
 The general program flow for a plugin may look something like this
 pseudo-code:
 
-.  Plugin will query OCPN core for a list of active comm drivers.
-.  Plugin will inspect the list, and query OCPN core for driver attributes.
+.  Plugin will query OpenCPN core for a list of active comm drivers.
+.  Plugin will inspect the list, and query OpenCPN core for driver attributes.
 .  Plugin will select a comm driver with appropriate attributes for output.
 .  Plugin will register a list of PGNs expected to be transmitted (N2K
    specific)
@@ -195,10 +195,10 @@ pseudo-code:
 
 The mechanism for specifying a particular comm driver uses the notion of
 "handles". Each active comm driver has an associated opaque handle, managed
-by OCPN core. All references by a plugin to a driver are by means of its
+by OpenCPN core. All references by a plugin to a driver are by means of its
 handle. Handles should be considered to be "opaque", meaning that the exact
 contents of the handle are of no specific value to the plugin, and only have
-meaning to the OCPN core management of drivers.
+meaning to the OpenCPN core management of drivers.
 
 Some example code sending `payload_msg` to the */dev/ttyUSB0* port:
 

--- a/model/include/model/route_point.h
+++ b/model/include/model/route_point.h
@@ -168,6 +168,20 @@ public:
   void SetUseSca(bool value) { b_UseScamin = value; };
   bool IsDragHandleEnabled() { return m_bDrawDragHandle; }
   void SetPlannedSpeed(double spd);
+  /**
+   * Return the planned speed associated with this waypoint.
+   *
+   * For a waypoint within a route, this represents the speed to be used when
+   * traveling FROM this waypoint TO the next waypoint in the route. For the
+   * last waypoint in a route, this value has no navigational significance.
+   *
+   * This value is used for:
+   * - Calculating the ETA at the next waypoint
+   * - Determining the total time to complete a route segment
+   * - Route planning and navigation displays
+   *
+   * The speed is stored in knots (nautical miles per hour).
+   */
   double GetPlannedSpeed();
   /**
    * Retrieves the Estimated Time of Departure for this waypoint, in UTC.
@@ -267,8 +281,11 @@ public:
   void SetETE(wxLongLong secs);
 
   double m_lat, m_lon;
-  double m_seg_len;  // length in NMI to this point
-                     // undefined for starting point
+  /**
+   * Length of the leg from previous waypoint to this waypoint in nautical
+   * miles. Undefined for the starting point of a route.
+   */
+  double m_seg_len;
 
   /**
    * Planned speed for traveling FROM this waypoint TO the next waypoint.
@@ -282,8 +299,7 @@ public:
    * default planned speed will be used instead. The unit is knots (nautical
    * miles per hour).
    *
-   * For the last waypoint in a route, this value has no navigational
-   * significance.
+   * Not applicable for the last waypoint in a route.
    */
   double m_seg_vmg;
   /**
@@ -353,66 +369,177 @@ public:
    */
   bool m_manual_etd{false};
 
+  /**
+   * Flag indicating if this waypoint is currently selected.
+   */
   bool m_bPtIsSelected;
+  /**
+   * Flag indicating if this waypoint is currently being edited.
+   */
   bool m_bRPIsBeingEdited;
 
+  /**
+   * Flag indicating if this waypoint is part of a route.
+   */
   bool m_bIsInRoute;
   /** Flag indicating if the waypoint is a standalone mark. */
   bool m_bIsolatedMark;
-
-  bool m_bIsVisible;  // true if should be drawn, false if invisible
+  /**
+   * Flag indicating if the waypoint should be drawn on the chart.
+   * When false, the waypoint is invisible.
+   */
+  bool m_bIsVisible;
+  /**
+   * Flag indicating if the waypoint should be included in lists.
+   */
   bool m_bIsListed;
+  /**
+   * Flag indicating if this waypoint is active for navigation.
+   */
   bool m_bIsActive;
+  /**
+   * Flag indicating if the waypoint icon needs to be reloaded or redrawn.
+   */
   bool m_IconIsDirty;
+  /**
+   * Description text for the waypoint.
+   * May contain encoded information like ETD or planned speed.
+   */
   wxString m_MarkDescription;
+  /**
+   * Globally Unique Identifier for the waypoint.
+   */
   wxString m_GUID;
 
+  /**
+   * Associated tide station identifier.
+   */
   wxString m_TideStation;
-
+  /**
+   * Font used for rendering the waypoint name.
+   */
   wxFont *m_pMarkFont;
+  /**
+   * Color used for rendering the waypoint name.
+   */
   wxColour m_FontColor;
 
+  /**
+   * Size of the waypoint name text when rendered.
+   */
   wxSize m_NameExtents;
-
+  /**
+   * Flag indicating if the waypoint should blink when displayed.
+   */
   bool m_bBlink;
-  bool m_bShowName, m_bShowNameData;
+  /**
+   * Flag indicating if the waypoint name should be shown.
+   */
+  bool m_bShowName;
+  /**
+   * Flag indicating if waypoint data should be shown with the name.
+   */
+  bool m_bShowNameData;
+  /**
+   * Current rectangle occupied by the waypoint in the display.
+   */
   wxRect CurrentRect_in_DC;
+  /**
+   * Horizontal offset for waypoint name placement relative to the icon.
+   */
   int m_NameLocationOffsetX;
+  /**
+   * Vertical offset for waypoint name placement relative to the icon.
+   */
   int m_NameLocationOffsetY;
+  /**
+   * Flag indicating if the waypoint belongs to a layer.
+   */
   bool m_bIsInLayer;
+  /**
+   * Layer identifier if the waypoint belongs to a layer.
+   */
   int m_LayerID;
-
-  double m_routeprop_course;  // course from this waypoint to the next waypoint
-                              // if in a route.
-  double m_routeprop_distance;  // distance from this waypoint to the next
-                                // waypoint if in a route.
-
+  /**
+   * Course from this waypoint to the next waypoint in a route in degrees.
+   */
+  double m_routeprop_course;
+  /**
+   * Distance from this waypoint to the next waypoint in a route in nautical
+   * miles.
+   */
+  double m_routeprop_distance;
+  /**
+   * Flag indicating if this is a temporary waypoint.
+   */
   bool m_btemp;
-
+  /**
+   * Flag indicating if range rings should be shown around the waypoint.
+   */
   bool m_bShowWaypointRangeRings;
+  /**
+   * Number of range rings to display around the waypoint.
+   */
   int m_iWaypointRangeRingsNumber;
-
+  /**
+   * Distance between consecutive range rings in nautical miles.
+   */
   float m_fWaypointRangeRingsStep;
+  /**
+   * Units for the range rings step (0=nm, 1=km, 2=miles).
+   */
   int m_iWaypointRangeRingsStepUnits;
+  /**
+   * Color for the range rings display.
+   */
   wxColour m_wxcWaypointRangeRingsColour;
-
+  /**
+   * Texture identifier for rendered text.
+   */
   unsigned int m_iTextTexture;
-  int m_iTextTextureWidth, m_iTextTextureHeight;
-
+  /**
+   * Width of the text texture in pixels.
+   */
+  int m_iTextTextureWidth;
+  /**
+   * Height of the text texture in pixels.
+   */
+  int m_iTextTextureHeight;
+  /**
+   * Bounding box for the waypoint.
+   */
   LLBBox m_wpBBox;
   double m_wpBBox_view_scale_ppm, m_wpBBox_rotation;
-
+  /**
+   * Flag indicating if the waypoint is currently visible on screen.
+   */
   bool m_pos_on_screen;
-  wxPoint2DDouble m_screen_pos;  // cached for arrows and points
-
+  /**
+   * Cached screen position of the waypoint for drawing arrows and points.
+   */
+  wxPoint2DDouble m_screen_pos;
+  /**
+   * Arrival radius in nautical miles.
+   * Distance from waypoint at which it's considered reached.
+   */
   double m_WaypointArrivalRadius;
+  /**
+   * List of hyperlinks associated with this waypoint.
+   */
   HyperlinkList *m_HyperlinkList;
-
+  /**
+   * String representation of the waypoint creation time.
+   */
   wxString m_timestring;
-
+  /**
+   * Creation timestamp for the waypoint.
+   */
   wxDateTime m_CreateTimeX;
 
 private:
+  /**
+   * Name of the waypoint.
+   */
   wxString m_MarkName;
   wxBitmap *m_pbmIcon;
   wxString m_IconName;
@@ -428,8 +555,19 @@ private:
   int m_drag_line_length_man, m_drag_icon_offset;
   double m_dragHandleLat, m_dragHandleLon;
   int m_draggingOffsetx, m_draggingOffsety;
+  /**
+   * Flag indicating whether to use ScaMin visibility controls.
+   */
   bool b_UseScamin;
+  /**
+   * Minimum scale at which the waypoint is visible.
+   * Waypoint is not shown at scales larger than this value.
+   */
   long m_ScaMin;
+  /**
+   * Maximum scale at which the waypoint is visible.
+   * Waypoint is not shown at scales smaller than this value.
+   */
   long m_ScaMax;
   /**
    * The planned speed associated with this waypoint.
@@ -446,10 +584,11 @@ private:
    * The speed is stored in knots (nautical miles per hour).
    */
   double m_PlannedSpeed;
-
-  bool m_bsharedMark /*m_bKeepXRoute*/;  // This is an isolated mark which is
-                                         // also part of a route. It should not
-                                         // be deleted with route.
+  /**
+   * Flag indicating if this is a shared mark that is part of a route.
+   * When true, the waypoint should not be deleted when the route is deleted.
+   */
+  bool m_bsharedMark;
   unsigned int m_dragIconTexture;
   int m_dragIconTextureWidth, m_dragIconTextureHeight;
 };


### PR DESCRIPTION
# Overview

Plugins can create/update waypoints and set new properties like planned speed, ETD, arrival radius, range rings, scamax.

# Changes

## New `PlugIn_Waypoint_ExV2` class

This PR extends the plugin API by creating a new `PlugIn_Waypoint_ExV2` class that inherits from `PlugIn_Waypoint_Ex` to add support for additional route waypoint properties including:

1. `scamax`: Maximum display scale for waypoint visibility
2. `m_PlannedSpeed`: Planned speed for next leg (knots)
3. `m_ETD`: Estimated departure time
4. `m_WaypointArrivalRadius`: Arrival radius in nautical miles
5. `m_bShowWaypointRangeRings`: Flag for showing range rings adds several new fields:

Add proper handling of these fields in:

1. `PlugInExFromRoutePoint`: For transferring data between core RoutePoint and plugin API objects
2. `CreateNewPoint`: For creating new waypoints from plugin data
3. `UpdateSingleWaypointEx`: For updating existing waypoints

## Bug Fix

The old code had a bug. If `src->m_HyperlinkList` was `null`, it would return from the function immediately, potentially leaving the hyperlink list in dst unprocessed. This was causing an inconsistent state between source and destination objects

 This block was skipped if `src->m_HyperlinkList` was `null`:
```c++
  // Get the range ring info
  dst->nrange_rings = src->m_iWaypointRangeRingsNumber;
  dst->RangeRingSpace = src->m_fWaypointRangeRingsStep;
  dst->RangeRingColor = src->m_wxcWaypointRangeRingsColour;

  // Get other extended info
  dst->IsNameVisible = src->m_bShowName;
  dst->scamin = src->GetScaMin();
  dst->b_useScamin = src->GetUseSca();
  dst->IsActive = src->m_bIsActive;
```

## Developer manual

Added a section in the developer manual for plugin API best practices. Used the discussion from this PR to write best practices.

# Benefits

These additions allow plugins like Weather Routing to properly exchange planned speed and ETD information with the core OpenCPN routing system, enabling more sophisticated route planning and time calculations.

# Compatibility

- Backwards compatible with existing plugins using `PlugIn_Waypoint_Ex`
- Forward compatible through sub-class and dynamic casting

# Tests

This matrix shows the expected behavior when mixing different versions of the Weather Routing plugin with different versions of OpenCPN. The compatibility pattern demonstrates graceful fallbacks when new plugin versions are used with older core versions.

  | OpenCPN 5.10.x (with plugin API 18) | OpenCPN 5.12.x (with plugin API 20)
-- | -- | --
WR with plugin 1.18 (Old) | ✔️<br> - Uses base waypoint class<br>- No access to planned speed/ETD<br>- All basic routing works | ✅<br> - Uses base waypoint class<br>- No access to planned speed<br>- All basic routing works
WR with plugin 1.20 (New) | ❌<br>- Not supported<br> - Uses WaypointV2<br> | ✅<br> - Uses WaypointV2 features<br>- Full access to planned speed<br>- SOG is saved as "planned speed" in route

- [x] Install master version of WR plugin without planned speed on OpenCPN built with `planned_speed` branch. Verify plugin can save route to OpenCPN core. No planned speed is saved.
- [x] Install version of WR plugin from `planned_speed` branch on OpenCPN built from `planned_speed` branch. Verify plugin can save route to OpenCPN core. Planned speed is saved for each leg and visible in the "route" properties in the "Route & Marks" manager.

This was tested using this weather routing PR: https://github.com/rgleason/weather_routing_pi/pull/278. I manually copied the new `ocpn_plugin.h` in the weather routing git repo so I could build a new version of the WR plugin with "planned speed" enhancements.

I also tried to load a newer version of the plugin (with plugin API version 20) on a older version of OpenCPN (plugin API version 18). As expected, this does not work.

Failed to load shared library '.../OpenCPN/Contents/PlugIns/libweather_routing_pi.dylib': dlopen(.../OpenCPN/Contents/PlugIns/libweather_routing_pi.dylib, 0x0002): symbol not found in flat namespace '__ZN20PlugIn_Waypoint_ExV2C1EddRK8wxStringS2_S2_dbid8wxColour' 

