### PR TITLE
ci: Flatpak: Build wxWidgets using cmake

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
   build-flatpak:
     working_directory: ~/OpenCPN
     machine:
-      image: ubuntu-2204:current
+      image: ubuntu-2404:current
     environment:
       - OCPN_TARGET: flatpak
     steps:

--- a/ci/circleci-build-flatpak.sh
+++ b/ci/circleci-build-flatpak.sh
@@ -27,7 +27,7 @@ wget -q -O - https://dl.google.com/linux/linux_signing_key.pub \
 sudo apt-key adv \
     --keyserver keyserver.ubuntu.com --recv-keys 78BD65473CB3BD13
 # Needed on 20.04: sudo add-apt-repository -y ppa:alexlarsson/flatpak
-# sudo apt update -q -y
+sudo apt update -q -y
 
 # Avoid using outdated TLS certificates, see #2419.
 sudo apt install --reinstall  ca-certificates

--- a/flatpak/Makefile
+++ b/flatpak/Makefile
@@ -33,6 +33,7 @@ manifest: submodules
 	        -e '/name: opencpn/,$$s/commit:.*/branch: master/' \
 	             org.opencpn.OpenCPN.yaml
 ci-build: manifest
+	cd ../flatpak; patch  -p0 < ./manifest.patch
 	flatpak-builder --repo=$(CURDIR)/repo --force-clean \
 	    --default-branch=devel \
 	    app ../flatpak/org.opencpn.OpenCPN.yaml

--- a/flatpak/manifest.patch
+++ b/flatpak/manifest.patch
@@ -1,0 +1,29 @@
+--- org.opencpn.OpenCPN.yaml.BAK	2025-04-09 15:22:08.455442710 +0200
++++ org.opencpn.OpenCPN.yaml	2025-04-09 15:23:09.985703030 +0200
+@@ -103,4 +103,5 @@
+ 
+     - name: wxGTK3
++      buildsystem: cmake
+       sources:
+           - type: archive
+@@ -110,12 +111,12 @@
+             paths:
+               - org.opencpn.OpenCPN/patches/0101-Support-EGL-1.4-on-wxGTK.patch
+-      config-opts:
+-          - --with-gtk=3
+-          - --with-opengl
+-          - --with-sdl
+-          - --with-libmspack
+-          - --enable-intl
+-          - --disable-rpath
+-          - --enable-ipv6
++      # config-opts:
++      #     - --with-gtk=3
++      #     - --with-opengl
++      #     - --with-sdl
++      #     - --with-libmspack
++      #     - --enable-intl
++      #     - --disable-rpath
++      #     - --enable-ipv6
+       cleanup:
+           - /include/


### PR DESCRIPTION
Handles FTBFS on the circleci build host. 