### PR TITLE
MMSI property dialog: Add tooltips and "Name" field

### DIFF
--- a/gui/include/gui/options.h
+++ b/gui/include/gui/options.h
@@ -871,9 +871,10 @@ public:
   void OnMMSIEditCancelClick(wxCommandEvent &event);
   void OnMMSIEditOKClick(wxCommandEvent &event);
   void OnCtlUpdated(wxCommandEvent &event);
+  void OnMMSIChanged(wxCommandEvent &event);
 
   MmsiProperties *m_props;
-  wxTextCtrl *m_MMSICtl, m_ShipNameCtl;  // Has ToDo take away?
+  wxTextCtrl *m_MMSICtl, *m_ShipNameCtl;  // Has ToDo take away?
   wxRadioButton *m_rbTypeTrackDefault, *m_rbTypeTrackAlways;
   wxRadioButton *m_rbTypeTrackNever;
   wxCheckBox *m_cbTrackPersist, *m_IgnoreButton, *m_MOBButton, *m_VDMButton,

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -910,50 +910,102 @@ void MMSIEditDialog::CreateControls(void) {
   wxStaticBoxSizer* mmsiSizer = new wxStaticBoxSizer(mmsiBox, wxVERTICAL);
   mainSizer->Add(mmsiSizer, 0, wxEXPAND | wxALL, 5);
 
-  mmsiSizer->Add(new wxStaticText(this, wxID_STATIC, _("MMSI")), 0,
-                 wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5);
+  wxStaticText* mmsiLabel = new wxStaticText(this, wxID_STATIC, _("MMSI"));
+  mmsiLabel->SetToolTip(
+      _("Maritime Mobile Service Identity - A unique 9-digit number assigned "
+        "to a vessel or navigation aid. Used to identify vessels and devices "
+        "in AIS transmissions and DSC calls."));
+  mmsiSizer->Add(mmsiLabel, 0, wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5);
 
   m_MMSICtl = new wxTextCtrl(this, ID_MMSI_CTL, wxEmptyString,
                              wxDefaultPosition, wxSize(180, -1), 0);
+  m_MMSICtl->SetToolTip(
+      _("Enter the 9-digit MMSI number for this vessel or station"));
   mmsiSizer->Add(m_MMSICtl, 0,
                  wxALIGN_LEFT | wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 5);
+  m_MMSICtl->Bind(wxEVT_TEXT, &MMSIEditDialog::OnMMSIChanged, this);
 
-  wxStaticBoxSizer* trackSizer = new wxStaticBoxSizer(
-      new wxStaticBox(this, wxID_ANY, _("Tracking")), wxVERTICAL);
+  wxStaticText* userLabelText = new wxStaticText(this, wxID_STATIC, _("Name"));
+  userLabelText->SetToolTip(
+      _("Display name for this vessel or device - can override names received "
+        "in AIS messages"));
+  mmsiSizer->Add(userLabelText, 0, wxALIGN_LEFT | wxLEFT | wxRIGHT | wxTOP, 5);
+
+  m_ShipNameCtl = new wxTextCtrl(this, wxID_ANY, wxEmptyString,
+                                 wxDefaultPosition, wxSize(180, -1), 0);
+  m_ShipNameCtl->SetToolTip(_(
+      "Set the name for this vessel or device. If specified, this name takes "
+      "precedence over names received via AIS messages. Note that standard AIS "
+      "only supports uppercase letters (A-Z), numbers, and limited "
+      "punctuation. Your manual entries are stored in the mmsitoname.csv file "
+      "and preserved across sessions."));
+  mmsiSizer->Add(m_ShipNameCtl, 0,
+                 wxALIGN_LEFT | wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 5);
+
+  wxStaticBox* trackBox = new wxStaticBox(this, wxID_ANY, _("Tracking"));
+  trackBox->SetToolTip(_("Control how tracks are created for this MMSI"));
+  wxStaticBoxSizer* trackSizer = new wxStaticBoxSizer(trackBox, wxVERTICAL);
 
   wxGridSizer* gridSizer = new wxGridSizer(0, 3, 0, 0);
 
   m_rbTypeTrackDefault =
       new wxRadioButton(this, wxID_ANY, _("Default tracking"),
                         wxDefaultPosition, wxDefaultSize, wxRB_GROUP);
+  m_rbTypeTrackDefault->SetToolTip(
+      _("Use the global tracking settings for this vessel"));
   m_rbTypeTrackDefault->SetValue(TRUE);
   gridSizer->Add(m_rbTypeTrackDefault, 0, wxALL, 5);
 
   m_rbTypeTrackAlways = new wxRadioButton(this, wxID_ANY, _("Always track"));
+  m_rbTypeTrackAlways->SetToolTip(_(
+      "Always create a track for this vessel, regardless of global settings"));
   gridSizer->Add(m_rbTypeTrackAlways, 0, wxALL, 5);
 
   m_rbTypeTrackNever = new wxRadioButton(this, wxID_ANY, _(" Never track"));
+  m_rbTypeTrackNever->SetToolTip(
+      _("Never create a track for this vessel, regardless of global settings"));
   gridSizer->Add(m_rbTypeTrackNever, 0, wxALL, 5);
 
   m_cbTrackPersist = new wxCheckBox(this, wxID_ANY, _("Persistent"));
+  m_cbTrackPersist->SetToolTip(
+      _("Save this vessel's track between OpenCPN sessions. Useful for vessels "
+        "you want to monitor continuously over time."));
   gridSizer->Add(m_cbTrackPersist, 0, wxALL, 5);
 
   trackSizer->Add(gridSizer, 0, wxEXPAND, 0);
   mmsiSizer->Add(trackSizer, 0, wxEXPAND, 0);
 
   m_IgnoreButton = new wxCheckBox(this, wxID_ANY, _("Ignore this MMSI"));
+  m_IgnoreButton->SetToolTip(
+      _("When checked, AIS data for this MMSI will be ignored and the vessel "
+        "will not appear on the chart. Useful for suppressing shore stations, "
+        "permanently moored vessels, or duplicate AIS signals that you don't "
+        "need to monitor."));
   mmsiSizer->Add(m_IgnoreButton, 0, wxEXPAND, 5);
 
   m_MOBButton = new wxCheckBox(this, wxID_ANY,
                                _("Handle this MMSI as SART/PLB(AIS) MOB."));
+  m_MOBButton->SetToolTip(
+      _("When checked, OpenCPN will display a special icon for this device, "
+        "sound a distinctive alarm, and automatically create a temporary MOB "
+        "route from your vessel to this device in emergency. For crew safety "
+        "devices, you can assign the crew member's name using the Name "
+        "field above for quick identification."));
   mmsiSizer->Add(m_MOBButton, 0, wxEXPAND, 5);
 
   m_VDMButton =
       new wxCheckBox(this, wxID_ANY, _("Convert AIVDM to AIVDO for this MMSI"));
+  m_VDMButton->SetToolTip(
+      _("When checked, converts AIS messages for this vessel from AIVDM (other "
+        "vessel) to AIVDO (own vessel) format."));
   mmsiSizer->Add(m_VDMButton, 0, wxEXPAND, 5);
 
   m_FollowerButton = new wxCheckBox(
       this, wxID_ANY, _("This MMSI is my Follower - No CPA Alert"));
+  m_FollowerButton->SetToolTip(
+      _("When checked, disables CPA (Closest Point of Approach) alerts for "
+        "this vessel as it's considered intentionally following your vessel. "
+        "Follower vessels are displayed with a special own-ship style icon."));
   mmsiSizer->Add(m_FollowerButton, 0, wxEXPAND, 5);
 
   wxBoxSizer* btnSizer = new wxBoxSizer(wxHORIZONTAL);
@@ -973,6 +1025,11 @@ void MMSIEditDialog::CreateControls(void) {
   else
     sMMSI = _T("");
   m_MMSICtl->AppendText(sMMSI);
+
+  // Initialize user label with existing ship name if available
+  if (!m_props->m_ShipName.IsEmpty()) {
+    m_ShipNameCtl->SetValue(m_props->m_ShipName);
+  }
 
   switch (m_props->TrackType) {
     case TRACKTYPE_ALWAYS:
@@ -1014,7 +1071,21 @@ void MMSIEditDialog::Persist() {
     m_props->m_bVDM = m_VDMButton->GetValue();
     m_props->m_bFollower = m_FollowerButton->GetValue();
     m_props->m_bPersistentTrack = m_cbTrackPersist->GetValue();
-    if (m_props->m_ShipName == wxEmptyString) {
+
+    // Get user-defined ship name if provided.
+    wxString shipName = m_ShipNameCtl->GetValue().Upper();
+    if (!shipName.IsEmpty()) {
+      m_props->m_ShipName = shipName;
+
+      // Save the custom name to mmsitoname.csv file
+      wxString mmsi = m_MMSICtl->GetValue();
+      if (!mmsi.IsEmpty() && mmsi.Length() == 9 && mmsi.IsNumber()) {
+        g_pAIS->UpdateMMSItoNameFile(mmsi, shipName);
+      }
+    }
+    // If no user label provided and no existing name, try to get from AIS data
+    // or file
+    else if (m_props->m_ShipName == wxEmptyString) {
       auto proptarget = g_pAIS->Get_Target_Data_From_MMSI(m_props->MMSI);
       if (proptarget) {
         wxString s = proptarget->GetFullName();
@@ -1055,6 +1126,31 @@ void MMSIEditDialog::OnMMSIEditOKClick(wxCommandEvent& event) {
 }
 
 void MMSIEditDialog::OnCtlUpdated(wxCommandEvent& event) {}
+
+void MMSIEditDialog::OnMMSIChanged(wxCommandEvent& event) {
+  wxString mmsi = m_MMSICtl->GetValue();
+
+  // Only proceed if we have a valid MMSI (9 digits)
+  if (!mmsi.IsEmpty() && mmsi.Length() == 9 && mmsi.IsNumber()) {
+    // First check for a stored name in mmsitoname.csv
+    wxString shipName = g_pAIS->GetMMSItoNameEntry(mmsi);
+
+    // If no stored name found, try to get from AIS data
+    if (shipName.IsEmpty()) {
+      auto target = g_pAIS->Get_Target_Data_From_MMSI(wxAtoi(mmsi));
+      if (target) {
+        shipName = target->GetFullName();
+      }
+    }
+
+    // Update the ship name field if we found a name
+    if (!shipName.IsEmpty()) {
+      m_ShipNameCtl->SetValue(shipName);
+    }
+  }
+
+  event.Skip();
+}
 
 BEGIN_EVENT_TABLE(MMSIListCtrl, wxListCtrl)
 EVT_LIST_ITEM_SELECTED(ID_MMSI_PROPS_LIST, MMSIListCtrl::OnListItemClick)

--- a/model/include/model/ais_decoder.h
+++ b/model/include/model/ais_decoder.h
@@ -115,6 +115,8 @@ public:
   int GetNumTargets(void) { return m_n_targets; }
   bool IsAISSuppressed(void) { return m_bSuppressed; }
   bool IsAISAlertGeneral(void) { return m_bGeneralAlert; }
+  void UpdateMMSItoNameFile(const wxString &mmsi, const wxString &name);
+  wxString GetMMSItoNameEntry(const wxString &mmsi);
   AisError DecodeSingleVDO(const wxString &str, GenericPosDatEx *pos,
                            wxString *acc);
   void DeletePersistentTrack(Track *track);

--- a/model/src/ais_decoder.cpp
+++ b/model/src/ais_decoder.cpp
@@ -4630,6 +4630,45 @@ wxString GetShipNameFromFile(int nmmsi) {
   return name;
 }
 
+void AisDecoder::UpdateMMSItoNameFile(const wxString &mmsi,
+                                      const wxString &name) {
+  // Path to the mmsitoname.csv file is already in AISTargetNameFileName
+
+  // Create a map to hold the current contents of the file
+  std::map<wxString, wxString> mmsi_name_map;
+
+  // Read the existing file
+  std::ifstream infile(AISTargetNameFileName.mb_str());
+  if (infile) {
+    std::string line;
+    while (getline(infile, line)) {
+      wxStringTokenizer tokenizer(wxString::FromUTF8(line.c_str()), _T(","));
+      wxString file_mmsi = tokenizer.GetNextToken();
+      wxString file_name = tokenizer.GetNextToken().Trim();
+      mmsi_name_map[file_mmsi] = file_name;
+    }
+    infile.close();
+  }
+
+  // Update or add the new entry.
+  mmsi_name_map[mmsi] = name.Upper();
+
+  // Write the updated map back to the file
+  std::ofstream outfile(AISTargetNameFileName.mb_str());
+  if (outfile) {
+    for (const auto &pair : mmsi_name_map) {
+      std::string line = std::string(pair.first.mb_str()) + "," +
+                         std::string(pair.second.mb_str()) + "\n";
+      outfile << line;
+    }
+    outfile.close();
+  }
+}
+
+wxString AisDecoder::GetMMSItoNameEntry(const wxString &mmsi) {
+  return GetShipNameFromFile(wxAtoi(mmsi));
+}
+
 // Assign a unique meteo mmsi related to position
 int AisMeteoNewMmsi(int orig_mmsi, int m_lat, int m_lon, int lon_bits = 0,
                     int siteID = 0) {


### PR DESCRIPTION
# Changes

1. When a user enters a valid MMSI number (9 digits), the dialog automatically looks up the vessel name from:
   1. First, the `mmsitoname.csv` file (persistent custom names)
   2. If not found, from active AIS target data if available
2. When a user manually sets a vessel name, the name is automatically saved to the `mmsitoname.csv` file, making it persistent across sessions.
3. Add tooltips in the "Edit MMSI Properties" dialog.
4. Added two new methods to the AIS decoder class:
   - `UpdateMMSItoNameFile()`: Writes MMSI-to-name mappings to the CSV file
   - `GetMMSItoNameEntry()`: Retrieves a name from the CSV file for a given MMSI


<img width="476" alt="image" src="https://github.com/user-attachments/assets/b0f058c3-e402-424f-9271-793ae75eb72e" />

# Benefits

This enhancement is particularly useful for MOB (Man Overboard) devices, such as personal MOB beacons worn inside PFDs (Personal Flotation Devices). These safety devices:

1. Often don't transmit a "ship name" in their AIS data
2. Need to be configured with crew member names before an emergency occurs
3. May not have been tested at the time the MMSI number is entered in OpenCPN, and therefore wouldn't appear in AIS history at configuration time.

This feature allows users to pre-configure their MOB devices with crew member names by MMSI, ensuring that in an emergency situation, the MOB alarm will clearly identify which crew member is in distress.

# Tests

- [x] Test "Name" text field is displayed.
- [x] Test by entering a valid MMSI for a vessel previously seen. Validate the "Name" field is automatically populated.
- [x] Test by manually setting a vessel name and confirming it persists when reopening OpenCPN.
- [x] Test that renaming a vessel properly updates the stored name.
- [x] Test tooltips are displayed for each of the labels and controls.