### PR TITLE
concanv: Don't toggle ETA visibility - #4439

### DIFF
--- a/gui/src/concanv.cpp
+++ b/gui/src/concanv.cpp
@@ -249,12 +249,7 @@ void ConsoleCanvas::OnContextMenuSelection(wxCommandEvent& event) {
 }
 
 void ConsoleCanvas::ToggleRouteTotalDisplay() {
-  if (m_speedUsed == SPEED_VMG) {
-    m_speedUsed = SPEED_SOG;
-  } else {
-    m_speedUsed = SPEED_VMG;
-    g_bShowRouteTotal = !g_bShowRouteTotal;
-  }
+  m_speedUsed = m_speedUsed == SPEED_VMG ? SPEED_SOG : SPEED_VMG;
   LegRoute();
 }
 


### PR DESCRIPTION
I can't see that the visibility of ETA should be affected by the change from using SOG to VMG or the other way around. The bug is caused by this, triggered by a @VMG -> @SOG change every second time.

Closes: #4439