### PR TITLE
Document units of GRIB parameters, improve code comments of GRIB indices

### DIFF
--- a/plugins/grib_pi/src/GribRecordSet.h
+++ b/plugins/grib_pi/src/GribRecordSet.h
@@ -26,46 +26,106 @@
  */
 #include "GribRecord.h"
 
-// These are indexes into the array
+/**
+ * Indices for different meteorological parameters in GribRecordSet's record
+ * array.
+ */
 enum {
-  Idx_WIND_VX,        //!< Surface wind velocity X component
-  Idx_WIND_VX850,     //!< Wind velocity X component at 850 hPa
-  Idx_WIND_VX700,     //!< Wind velocity X component at 700 hPa
-  Idx_WIND_VX500,     //!< Wind velocity X component at 500 hPa
-  Idx_WIND_VX300,     //!< Wind velocity X component at 300 hPa
-  Idx_WIND_VY,        //!< Surface wind velocity Y component
-  Idx_WIND_VY850,     //!< Wind velocity Y component at 850 hPa
-  Idx_WIND_VY700,     //!< Wind velocity Y component at 700 hPa
-  Idx_WIND_VY500,     //!< Wind velocity Y component at 500 hPa
-  Idx_WIND_VY300,     //!< Wind velocity Y component at 300 hPa
-  Idx_WIND_GUST,      //!< Wind gust speed at surface
-  Idx_PRESSURE,       //!< Surface pressure
-  Idx_HTSIGW,         //!< Significant wave height
+  Idx_WIND_VX,     //!< Surface wind velocity X component in m/s
+  Idx_WIND_VX850,  //!< Wind velocity X component at 850 hPa in m/s
+  Idx_WIND_VX700,  //!< Wind velocity X component at 700 hPa in m/s
+  Idx_WIND_VX500,  //!< Wind velocity X component at 500 hPa in m/s
+  Idx_WIND_VX300,  //!< Wind velocity X component at 300 hPa in m/s
+  Idx_WIND_VY,     //!< Surface wind velocity Y component in m/s
+  Idx_WIND_VY850,  //!< Wind velocity Y component at 850 hPa in m/s
+  Idx_WIND_VY700,  //!< Wind velocity Y component at 700 hPa in m/s
+  Idx_WIND_VY500,  //!< Wind velocity Y component at 500 hPa in m/s
+  Idx_WIND_VY300,  //!< Wind velocity Y component at 300 hPa in m/s
+  Idx_WIND_GUST,   //!< Wind gust speed at surface in m/s
+  Idx_PRESSURE,    //!< Surface pressure in Pascal (Pa)
+  /**
+   * Significant wave height in meters
+   *
+   * Represents the average height of the highest one-third of all waves.
+   * Values typically range:
+   * 0-0.5m: Calm to smooth seas
+   * 0.5-1.25m: Slight seas
+   * 1.25-2.5m: Moderate seas
+   * 2.5-4m: Rough seas
+   * 4-6m: Very rough seas
+   * 6-9m: High seas
+   * 9-14m: Very high seas
+   * >14m: Phenomenal seas (hurricane conditions)
+   */
+  Idx_HTSIGW,
   Idx_WVDIR,          //!< Wave direction
   Idx_WVPER,          //!< Wave period
-  Idx_SEACURRENT_VX,  //!< Sea current velocity X component
-  Idx_SEACURRENT_VY,  //!< Sea current velocity Y component
-  Idx_PRECIP_TOT,     //!< Total precipitation
-  Idx_CLOUD_TOT,      //!< Total cloud cover
-  Idx_AIR_TEMP,       //!< Air temperature at 2m
-  Idx_AIR_TEMP850,    //!< Air temperature at 850 hPa
-  Idx_AIR_TEMP700,    //!< Air temperature at 700 hPa
-  Idx_AIR_TEMP500,    //!< Air temperature at 500 hPa
-  Idx_AIR_TEMP300,    //!< Air temperature at 300 hPa
-  Idx_SEA_TEMP,       //!< Sea surface temperature
-  Idx_CAPE,           //!< Convective Available Potential Energy
-  Idx_COMP_REFL,      //!< Composite radar reflectivity
-  Idx_HUMID_RE,       //!< Surface relative humidity
-  Idx_HUMID_RE850,    //!< Relative humidity at 850 hPa
-  Idx_HUMID_RE700,    //!< Relative humidity at 700 hPa
-  Idx_HUMID_RE500,    //!< Relative humidity at 500 hPa
-  Idx_HUMID_RE300,    //!< Relative humidity at 300 hPa
-  Idx_GEOP_HGT,       //!< Surface geopotential height
-  Idx_GEOP_HGT850,    //!< Geopotential height at 850 hPa
-  Idx_GEOP_HGT700,    //!< Geopotential height at 700 hPa
-  Idx_GEOP_HGT500,    //!< Geopotential height at 500 hPa
-  Idx_GEOP_HGT300,    //!< Geopotential height at 300 hPa
-  Idx_COUNT           //!< Number of supported GRIB record types
+  Idx_SEACURRENT_VX,  //!< Sea current velocity X component in m/s
+  Idx_SEACURRENT_VY,  //!< Sea current velocity Y component in m/s
+  /** Precipitation data in millimeters per hour. */
+  Idx_PRECIP_TOT,
+  Idx_CLOUD_TOT,    //!< Total cloud cover in  % (percent, range 0-100%)
+  Idx_AIR_TEMP,     //!< Air temperature at 2m in Kelvin (K)
+  Idx_AIR_TEMP850,  //!< Air temperature at 850 hPa in Kelvin (K)
+  Idx_AIR_TEMP700,  //!< Air temperature at 700 hPa in Kelvin (K)
+  Idx_AIR_TEMP500,  //!< Air temperature at 500 hPa in Kelvin (K)
+  Idx_AIR_TEMP300,  //!< Air temperature at 300 hPa in Kelvin (K)
+  /**  Sea surface temperature in Kelvin (K) */
+  Idx_SEA_TEMP,
+  /**
+   * Convective Available Potential Energy in J/kg (Joules per kilogram)
+   *
+   * CAPE measures the amount of energy available for convection in the
+   * atmosphere. Higher values (>1000 J/kg) indicate potential for severe
+   * thunderstorms. Values >2500 J/kg often associated with tornadic
+   * thunderstorms. Useful for forecasting severe weather conditions and
+   * atmospheric instability.
+   */
+  Idx_CAPE,
+  /**
+   * Composite radar reflectivity in dBZ (decibel relative to Z)
+   *
+   * Represents the maximum radar reflectivity at any altitude in the
+   * atmosphere. Values can be negative or positive: Negative values (-30 to 0
+   * dBZ): Very light precipitation, drizzle, fog, or atmospheric dust Values of
+   * 0-20 dBZ: Light precipitation or cloud droplets Values of 20-30 dBZ: Light
+   * to moderate rainfall Values of 30-40 dBZ: Moderate rainfall Values of 40-50
+   * dBZ: Heavy rainfall, possible small hail Values >50 dBZ: Intense rainfall,
+   * large hail, severe thunderstorm activity
+   */
+  Idx_COMP_REFL,
+  /** Surface relative humidity in % (percent, range 0-100%) */
+  Idx_HUMID_RE,
+  /** Relative humidity at 850 hPa in % (percent, range 0-100%) */
+  Idx_HUMID_RE850,
+  /** Relative humidity at 700 hPa in % (percent, range 0-100%) */
+  Idx_HUMID_RE700,
+  /** Relative humidity at 500 hPa in % (percent, range 0-100%) */
+  Idx_HUMID_RE500,
+  /** Relative humidity at 300 hPa in % (percent, range 0-100%) */
+  Idx_HUMID_RE300,
+  /**
+   * Surface geopotential height in gpm (geopotential meters)
+   *
+   * Geopotential height represents the height of a pressure level above mean
+   * sea level. It accounts for variations in gravity with latitude and
+   * altitude. Lower values indicate lower pressure systems (cyclonic activity,
+   * potential storms) Higher values indicate higher pressure systems
+   * (anticyclonic, typically fair weather) Typical sea level values range from
+   * 5000-5900 gpm, varying with weather systems Used to identify pressure
+   * systems, fronts, and atmospheric waves
+   */
+  Idx_GEOP_HGT,
+  /** Geopotential height at 850 hPa in gpm (geopotential meters) */
+  Idx_GEOP_HGT850,
+  /** Geopotential height at 700 hPa in gpm (geopotential meters) */
+  Idx_GEOP_HGT700,
+  /** Geopotential height at 500 hPa in gpm (geopotential meters) */
+  Idx_GEOP_HGT500,
+  /** Geopotential height at 300 hPa in gpm (geopotential meters) */
+  Idx_GEOP_HGT300,
+  /** Number of supported GRIB record types */
+  Idx_COUNT
 };
 
 /**


### PR DESCRIPTION
1. Document the units of the GRIB parameters.
2. Write better code comments.

There are no code changes.

The reason I did this is because in I am adding a weather routing table in the weather routing plugin. I found out it was unclear whether temperature was in Celsius, percentage in range 0...1 or 0...100, etc. That initially led me to display values like 284 degrees Celsius, which I'm going to fix in the WR plugin.

<img width="1721" alt="image" src="https://github.com/user-attachments/assets/0a87d9bf-fea0-4c0a-8123-87f6eb00d85e" />
