### PR TITLE
Remove option to specify timezone option in GRIB preferences.

### DIFF
--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -4155,31 +4155,6 @@ void options::CreatePanel_Display(size_t parent, int border_size,
     pEnableTenHertz->SetValue(FALSE);
     boxCtrls->Add(pEnableTenHertz, verticleInputFlags);
 
-    // spacer
-    generalSizer->Add(0, border_size * 4);
-    generalSizer->Add(0, border_size * 4);
-
-    // Selection of timezone for date/time display format:
-    // UTC, local time, or specific time zone.
-    generalSizer->Add(
-        new wxStaticText(pDisplayPanel, wxID_ANY, _("Date and Time")),
-        groupLabelFlags);
-
-    wxBoxSizer* timezoneStyleBox = new wxBoxSizer(wxHORIZONTAL);
-    generalSizer->Add(timezoneStyleBox, groupInputFlags);
-    wxBoxSizer* itemTimezoneBoxSizer = new wxBoxSizer(wxHORIZONTAL);
-    timezoneStyleBox->Add(itemTimezoneBoxSizer, 1, wxEXPAND | wxALL,
-                          border_size);
-    pTimezoneLocalTime =
-        new wxRadioButton(pDisplayPanel, ID_TIMEZONE_LOCAL_TIME,
-                          _("Local Time"), wxDefaultPosition, wxDefaultSize, 0);
-    itemTimezoneBoxSizer->Add(pTimezoneLocalTime, 0,
-                              wxALIGN_CENTER_VERTICAL | wxRIGHT, border_size);
-    pTimezoneUTC = new wxRadioButton(pDisplayPanel, ID_TIMEZONE_UTC, _("UTC"),
-                                     wxDefaultPosition, wxDefaultSize, 0);
-    itemTimezoneBoxSizer->Add(pTimezoneUTC, 0,
-                              wxALIGN_CENTER_VERTICAL | wxRIGHT, border_size);
-
     if (!g_useMUI) {
       // spacer
       generalSizer->Add(0, border_size * 4);
@@ -4589,6 +4564,30 @@ void options::CreatePanel_Units(size_t parent, int border_size,
     unitsSizer->Add(0, border_size * 4);
     unitsSizer->Add(0, border_size * 4);
 
+    // Selection of timezone for date/time display format:
+    // UTC, local time, or specific time zone.
+    unitsSizer->Add(new wxStaticText(panelUnits, wxID_ANY, _("Date and Time")),
+                    groupLabelFlags);
+
+    wxBoxSizer* timezoneStyleBox = new wxBoxSizer(wxHORIZONTAL);
+    unitsSizer->Add(timezoneStyleBox, groupInputFlags);
+    wxBoxSizer* itemTimezoneBoxSizer = new wxBoxSizer(wxHORIZONTAL);
+    timezoneStyleBox->Add(itemTimezoneBoxSizer, 1, wxEXPAND | wxALL,
+                          border_size);
+    pTimezoneLocalTime =
+        new wxRadioButton(panelUnits, ID_TIMEZONE_LOCAL_TIME, _("Local Time"),
+                          wxDefaultPosition, wxDefaultSize, 0);
+    itemTimezoneBoxSizer->Add(pTimezoneLocalTime, 0,
+                              wxALIGN_CENTER_VERTICAL | wxRIGHT, border_size);
+    pTimezoneUTC = new wxRadioButton(panelUnits, ID_TIMEZONE_UTC, _("UTC"),
+                                     wxDefaultPosition, wxDefaultSize, 0);
+    itemTimezoneBoxSizer->Add(pTimezoneUTC, 0,
+                              wxALIGN_CENTER_VERTICAL | wxRIGHT, border_size);
+
+    // spacer
+    unitsSizer->Add(0, border_size * 4);
+    unitsSizer->Add(0, border_size * 4);
+
     // bearings (magnetic/true, variation)
     unitsSizer->Add(new wxStaticText(panelUnits, wxID_ANY, _("Bearings")),
                     groupLabelFlags);
@@ -4725,6 +4724,30 @@ void options::CreatePanel_Units(size_t parent, int border_size,
         new wxChoice(panelUnits, ID_SDMMFORMATCHOICE, wxDefaultPosition,
                      wxDefaultSize, m_SDMMFormatsNChoices, pSDMMFormats);
     unitsSizer->Add(pSDMMFormat, inputFlags);
+
+    // spacer
+    unitsSizer->Add(0, border_size * 4);
+    unitsSizer->Add(0, border_size * 4);
+
+    // Selection of timezone for date/time display format:
+    // UTC, local time, or specific time zone.
+    unitsSizer->Add(new wxStaticText(panelUnits, wxID_ANY, _("Date and Time")),
+                    groupLabelFlags);
+
+    wxBoxSizer* timezoneStyleBox = new wxBoxSizer(wxHORIZONTAL);
+    unitsSizer->Add(timezoneStyleBox, groupInputFlags);
+    wxBoxSizer* itemTimezoneBoxSizer = new wxBoxSizer(wxHORIZONTAL);
+    timezoneStyleBox->Add(itemTimezoneBoxSizer, 1, wxEXPAND | wxALL,
+                          border_size);
+    pTimezoneLocalTime =
+        new wxRadioButton(panelUnits, ID_TIMEZONE_LOCAL_TIME, _("Local Time"),
+                          wxDefaultPosition, wxDefaultSize, 0);
+    itemTimezoneBoxSizer->Add(pTimezoneLocalTime, 0,
+                              wxALIGN_CENTER_VERTICAL | wxRIGHT, border_size);
+    pTimezoneUTC = new wxRadioButton(panelUnits, ID_TIMEZONE_UTC, _("UTC"),
+                                     wxDefaultPosition, wxDefaultSize, 0);
+    itemTimezoneBoxSizer->Add(pTimezoneUTC, 0,
+                              wxALIGN_CENTER_VERTICAL | wxRIGHT, border_size);
 
     // spacer
     unitsSizer->Add(0, border_size * 4);

--- a/plugins/grib_pi/src/GribOverlayFactory.h
+++ b/plugins/grib_pi/src/GribOverlayFactory.h
@@ -187,7 +187,6 @@ public:
   }
   void SetMessageFont();
   void SetMessage(wxString message) { m_Message = message; }
-  void SetTimeZone(int TimeZone) { m_TimeZone = TimeZone; }
   void SetParentSize(int w, int h) {
     m_ParentSize.SetWidth(w);
     m_ParentSize.SetHeight(h);
@@ -349,7 +348,6 @@ private:
 
   wxString m_Message;
   wxString m_Message_Hiden;
-  int m_TimeZone;
 
   wxDC *m_pdc;
 #if wxUSE_GRAPHICS_CONTEXT

--- a/plugins/grib_pi/src/GribTable.cpp
+++ b/plugins/grib_pi/src/GribTable.cpp
@@ -41,8 +41,7 @@ extern double m_cursor_lat, m_cursor_lon;
 GRIBTable::GRIBTable(GRIBUICtrlBar &parent)
     : GRIBTableBase(&parent), m_pGDialog(&parent) {}
 
-void GRIBTable::InitGribTable(const wxString zone, ArrayOfGribRecordSets *rsa,
-                              int NowIndex) {
+void GRIBTable::InitGribTable(ArrayOfGribRecordSets *rsa, int NowIndex) {
   m_pGribTable->m_gParent = this;
   m_pIndex = NowIndex;
 
@@ -71,9 +70,7 @@ void GRIBTable::InitGribTable(const wxString zone, ArrayOfGribRecordSets *rsa,
     // populate time labels
     time = rsa->Item(i).m_Reference_Time;
     DateTimeFormatOptions opts =
-        DateTimeFormatOptions()
-            .SetFormatString("$short_date\n$hour_minutes")
-            .SetTimezone(zone);
+        DateTimeFormatOptions().SetFormatString("$short_date\n$hour_minutes");
     m_pGribTable->SetColLabelValue(
         i, toUsrDateTimeFormat_Plugin(wxDateTime(time), opts));
     nrows = -1;

--- a/plugins/grib_pi/src/GribTable.h
+++ b/plugins/grib_pi/src/GribTable.h
@@ -77,13 +77,11 @@ public:
   /**
    * Initialize the GRIB data table.
    *
-   * @param zone Time zone for displaying timestamps.
    * @param rsa Array of GRIB record sets containing the weather data.
    * @param NowIndex Index of the current time point to highlight.
    */
-  void InitGribTable(const wxString zone, ArrayOfGribRecordSets *rsa);
-  void InitGribTable(const wxString zone, ArrayOfGribRecordSets *rsa,
-                     int NowIndex);
+  void InitGribTable(ArrayOfGribRecordSets *rsa);
+  void InitGribTable(ArrayOfGribRecordSets *rsa, int NowIndex);
   /**
    * Set the table size and position relative to viewport.
    *

--- a/plugins/grib_pi/src/GribUIDialog.h
+++ b/plugins/grib_pi/src/GribUIDialog.h
@@ -400,6 +400,11 @@ private:
   // XyGrib panel configuration
   XyGribConfig_t xyGribConfig;
   bool m_gtk_started;
+
+  wxTimer m_tFormatRefresh;
+  wxString m_sLastTimeFormat;  // Used to detect time format changes
+
+  void OnFormatRefreshTimer(wxTimerEvent &event);
 };
 
 /**

--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -2206,15 +2206,6 @@ GribPreferencesDialogBase::GribPreferencesDialogBase(
   m_rbStartOptions->SetSelection(0);
   bSizerPrefsMain->Add(m_rbStartOptions, 0, wxALL | wxEXPAND, 5);
 
-  wxString m_rbTimeFormatChoices[] = {_("Local Time"), _("UTC"),
-                                      _("Honor Global Settings")};
-  int m_rbTimeFormatNChoices = sizeof(m_rbTimeFormatChoices) / sizeof(wxString);
-  m_rbTimeFormat = new wxRadioBox(
-      scrollWin, wxID_ANY, _("Time Options"), wxDefaultPosition, wxDefaultSize,
-      m_rbTimeFormatNChoices, m_rbTimeFormatChoices, 1, wxRA_SPECIFY_COLS);
-  m_rbTimeFormat->SetSelection(2 /*Honor Global Settings*/);
-  bSizerPrefsMain->Add(m_rbTimeFormat, 0, wxALL | wxEXPAND, 5);
-
 #ifdef __WXMSW__
   wxFlexGridSizer* fgSizer47;
   fgSizer47 = new wxFlexGridSizer(0, 2, 0, 0);
@@ -2339,16 +2330,6 @@ GribPreferencesDialogBase::GribPreferencesDialogBase(
                      m_rbStartOptionsChoices, 1, wxRA_SPECIFY_COLS);
   m_rbStartOptions->SetSelection(0);
   sbSizer9->Add(m_rbStartOptions, 0, wxALL | wxEXPAND, 5);
-
-  wxString m_rbTimeFormatChoices[] = {_("Local Time"), _("UTC"),
-                                      _("Honor Global Settings")};
-  int m_rbTimeFormatNChoices = sizeof(m_rbTimeFormatChoices) / sizeof(wxString);
-  m_rbTimeFormat =
-      new wxRadioBox(itemScrollWin, wxID_ANY, _("Time Options"),
-                     wxDefaultPosition, wxDefaultSize, m_rbTimeFormatNChoices,
-                     m_rbTimeFormatChoices, 1, wxRA_SPECIFY_COLS);
-  m_rbTimeFormat->SetSelection(2);
-  sbSizer9->Add(m_rbTimeFormat, 0, wxALL | wxEXPAND, 5);
 
   wxBoxSizer* m_sdbButtonSizer = new wxBoxSizer(wxHORIZONTAL);
   topSizer->Add(m_sdbButtonSizer, 0, wxEXPAND, 5);

--- a/plugins/grib_pi/src/GribUIDialogBase.h
+++ b/plugins/grib_pi/src/GribUIDialogBase.h
@@ -436,8 +436,8 @@ public:
   wxCheckBox* m_cZoomToCenterAtInit;
   wxRadioBox* m_rbLoadOptions;
   wxRadioBox* m_rbStartOptions;
-  wxRadioBox* m_rbTimeFormat;
   wxString m_grib_dir_sel;
+
 #ifdef __WXMSW__
   wxSlider* m_sIconSizeFactor;
 #endif

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -239,7 +239,6 @@ void grib_pi::ShowPreferencesDialog(wxWindow *parent) {
   Pref->m_cZoomToCenterAtInit->SetValue(m_bZoomToCenterAtInit);
   Pref->m_cbCopyFirstCumulativeRecord->SetValue(m_bCopyFirstCumRec);
   Pref->m_cbCopyMissingWaveRecord->SetValue(m_bCopyMissWaveRec);
-  Pref->m_rbTimeFormat->SetSelection(m_bTimeZone);
   Pref->m_rbLoadOptions->SetSelection(m_bLoadLastOpenFile);
   Pref->m_rbStartOptions->SetSelection(m_bStartOptions);
 
@@ -310,12 +309,6 @@ void grib_pi::UpdatePrefs(GribPreferencesDialog *Pref) {
     updatelevel = 1;
   }
 
-  if (m_bTimeZone != Pref->m_rbTimeFormat->GetSelection()) {
-    m_bTimeZone = Pref->m_rbTimeFormat->GetSelection();
-    if (m_pGRIBOverlayFactory) m_pGRIBOverlayFactory->SetTimeZone(m_bTimeZone);
-    updatelevel = 2;
-  }
-
   bool copyrec = Pref->m_cbCopyFirstCumulativeRecord->GetValue();
   bool copywave = Pref->m_cbCopyMissingWaveRecord->GetValue();
   if (m_bCopyFirstCumRec != copyrec || m_bCopyMissWaveRec != copywave) {
@@ -338,6 +331,8 @@ void grib_pi::UpdatePrefs(GribPreferencesDialog *Pref) {
         break;
       case 2:
         // only rebuild  data list with current index and new timezone
+        // This no longer applicable because the timezone is set in the
+        // OpenCPN core global settings (Options -> Display -> General)
         m_pGribCtrlBar->PopulateComboDataList();
         m_pGribCtrlBar->TimelineChanged();
         break;
@@ -460,7 +455,6 @@ void grib_pi::OnToolbarToolCallback(int id) {
     // Create the drawing factory
     m_pGRIBOverlayFactory = new GRIBOverlayFactory(*m_pGribCtrlBar);
     m_pGRIBOverlayFactory->SetMessageFont();
-    m_pGRIBOverlayFactory->SetTimeZone(m_bTimeZone);
     m_pGRIBOverlayFactory->SetParentSize(m_display_width, m_display_height);
     m_pGRIBOverlayFactory->SetSettings(m_bGRIBUseHiDef, m_bGRIBUseGradualColors,
                                        m_bDrawBarbedArrowHead);
@@ -779,7 +773,6 @@ bool grib_pi::LoadConfig(void) {
   pConf->Read(_T( "DrawBarbedArrowHead" ), &m_bDrawBarbedArrowHead, 1);
   pConf->Read(_T( "ZoomToCenterAtInit"), &m_bZoomToCenterAtInit, 1);
   pConf->Read(_T( "ShowGRIBIcon" ), &m_bGRIBShowIcon, 1);
-  pConf->Read(_T( "GRIBTimeZone" ), &m_bTimeZone, 2);
   pConf->Read(_T( "CopyFirstCumulativeRecord" ), &m_bCopyFirstCumRec, 1);
   pConf->Read(_T( "CopyMissingWaveRecord" ), &m_bCopyMissWaveRec, 1);
 #ifdef __WXMSW__
@@ -812,7 +805,6 @@ bool grib_pi::SaveConfig(void) {
   pConf->Write(_T ( "ShowGRIBIcon" ), m_bGRIBShowIcon);
   pConf->Write(_T ( "GRIBUseHiDef" ), m_bGRIBUseHiDef);
   pConf->Write(_T ( "GRIBUseGradualColors" ), m_bGRIBUseGradualColors);
-  pConf->Write(_T ( "GRIBTimeZone" ), m_bTimeZone);
   pConf->Write(_T ( "CopyFirstCumulativeRecord" ), m_bCopyFirstCumRec);
   pConf->Write(_T ( "CopyMissingWaveRecord" ), m_bCopyMissWaveRec);
   pConf->Write(_T ( "DrawBarbedArrowHead" ), m_bDrawBarbedArrowHead);

--- a/plugins/grib_pi/src/grib_pi.h
+++ b/plugins/grib_pi/src/grib_pi.h
@@ -141,17 +141,6 @@ public:
 
   wxPoint GetCtrlBarXY() { return m_CtrlBarxy; }
   wxPoint GetCursorDataXY() { return m_CursorDataxy; }
-  const wxString GetTimezoneSelector() {
-    switch (m_bTimeZone) {
-      case 0:
-        return "UTC";
-      case 1:
-        return "Local Time";
-      default:
-        return wxEmptyString;
-    }
-  }
-  void SetTimeZone(int tz);
   int GetStartOptions() { return m_bStartOptions; }
   /**
    * Returns true if cumulative parameters like precipitation and cloud cover
@@ -214,7 +203,6 @@ private:
   bool m_bGRIBUseHiDef;
   bool m_bGRIBUseGradualColors;
   bool m_bDrawBarbedArrowHead;
-  int m_bTimeZone;
   /** Controls whether cumulative parameters like precipitation and cloud cover
    * should initialize their start values from the first record. This avoids
    * artificial zero values at the beginning of the time series.


### PR DESCRIPTION
# Overview

This PR addresses some issues raised in #2453

# Changes

1. GRIB plugin honors global options, without having to specify "Local Time" or "UTC" in the GRIB plugin preferences. Remove option to specify timezone in GRIB preferences.
2. Move "Date and Time" options to the "Units" panel. Previously it was in the "General" tab.

<img width="912" alt="image" src="https://github.com/user-attachments/assets/f9a2259c-ef38-4717-9eb9-d8bf399e5f7d" />


When the user clicks "Options", then "Units", there is an option to specify whether date/time should be printed in local time or UTC. When the user selects a date/time format, the date/time items in the GRIB drop-down list are updated. Note it may take up to 5 seconds for the date/time items to be reformatted.

<img width="916" alt="image" src="https://github.com/user-attachments/assets/868d8ac7-5582-4230-b182-14069ae80a48" />

Removed date/time format preferences in the GRIB plugin:

<img width="748" alt="image" src="https://github.com/user-attachments/assets/25a1124a-9f78-41d7-98b2-0e7929ff6d2d" />


