### PR TITLE
Fix bug in waypoint property transfer to plugins

### DIFF
--- a/cli/api_shim.cpp
+++ b/cli/api_shim.cpp
@@ -1029,7 +1029,7 @@ DECL_EXP void SetToolbarToolBitmapsSVG(int item, wxString SVGfile,
                                        wxString SVGfileRollover,
                                        wxString SVGfileToggled) {}
 DECL_EXP void RemoveCanvasContextMenuItem(int item) {}
-DECL_EXP void JumpToPosition(double lat, double lon, double scale){};
+DECL_EXP void JumpToPosition(double lat, double lon, double scale) {};
 DECL_EXP void SetCanvasContextMenuItemViz(int item, bool viz) {}
 DECL_EXP void SetCanvasContextMenuItemGrey(int item, bool grey) {}
 DECL_EXP void RequestRefresh(wxWindow *) {}
@@ -1110,7 +1110,7 @@ DECL_EXP bool PlugIn_GSHHS_CrossesLand(double lat1, double lon1, double lat2,
   return true;
 }
 
-DECL_EXP void PlugInPlaySound(wxString &sound_file){};
+DECL_EXP void PlugInPlaySound(wxString &sound_file) {};
 
 // API 1.10 Route and Waypoint Support
 DECL_EXP wxBitmap *FindSystemWaypointIcon(wxString &icon_name) { return 0; }
@@ -1532,7 +1532,7 @@ DECL_EXP void PlugInHandleAutopilotRoute(bool enable) {}
 wxString *GetpSharedDataLocation(void) {
   return g_BasePlatform->GetSharedDataDirPtr();
 }
-DECL_EXP ArrayOfPlugIn_AIS_Targets* GetAISTargetArray() { return 0; }
+DECL_EXP ArrayOfPlugIn_AIS_Targets *GetAISTargetArray() { return 0; }
 DECL_EXP bool ShuttingDown(void) { return true; }
 
 DECL_EXP wxWindow *PluginGetFocusCanvas() { return 0; }
@@ -1579,8 +1579,8 @@ DECL_EXP int GetLatLonFormat(void) { return 0; }
 DECL_EXP void ZeroXTE() {}
 
 DECL_EXP PlugIn_Waypoint::PlugIn_Waypoint() {}
-DECL_EXP PlugIn_Waypoint::PlugIn_Waypoint(double, double, const wxString&,
-                  const wxString&, const wxString&) {}
+DECL_EXP PlugIn_Waypoint::PlugIn_Waypoint(double, double, const wxString &,
+                                          const wxString &, const wxString &) {}
 DECL_EXP PlugIn_Waypoint::~PlugIn_Waypoint() {}
 
 DECL_EXP PlugIn_Waypoint_Ex::PlugIn_Waypoint_Ex() {}

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -1907,26 +1907,26 @@ static void PlugInExFromRoutePoint(PlugIn_Waypoint_Ex* dst,
   dst->m_GUID = src->m_GUID;
 
   //  Transcribe (clone) the html HyperLink List, if present
-  if (src->m_HyperlinkList == nullptr) return;
+  if (src->m_HyperlinkList) {
+    delete dst->m_HyperlinkList;
+    dst->m_HyperlinkList = nullptr;
 
-  delete dst->m_HyperlinkList;
-  dst->m_HyperlinkList = nullptr;
+    if (src->m_HyperlinkList->GetCount() > 0) {
+      dst->m_HyperlinkList = new Plugin_HyperlinkList;
 
-  if (src->m_HyperlinkList->GetCount() > 0) {
-    dst->m_HyperlinkList = new Plugin_HyperlinkList;
+      wxHyperlinkListNode* linknode = src->m_HyperlinkList->GetFirst();
+      while (linknode) {
+        Hyperlink* link = linknode->GetData();
 
-    wxHyperlinkListNode* linknode = src->m_HyperlinkList->GetFirst();
-    while (linknode) {
-      Hyperlink* link = linknode->GetData();
+        Plugin_Hyperlink* h = new Plugin_Hyperlink();
+        h->DescrText = link->DescrText;
+        h->Link = link->Link;
+        h->Type = link->LType;
 
-      Plugin_Hyperlink* h = new Plugin_Hyperlink();
-      h->DescrText = link->DescrText;
-      h->Link = link->Link;
-      h->Type = link->LType;
+        dst->m_HyperlinkList->Append(h);
 
-      dst->m_HyperlinkList->Append(h);
-
-      linknode = linknode->GetNext();
+        linknode = linknode->GetNext();
+      }
     }
   }
 

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -5240,7 +5240,6 @@ public:
                      const int nRanges = 0, const double RangeDistance = 1.0,
                      const wxColor RangeColor = wxColor(255, 0, 0));
   ~PlugIn_Waypoint_Ex();
-
   /**
    * Initializes waypoint properties to default values.
    *

--- a/model/include/model/route_point.h
+++ b/model/include/model/route_point.h
@@ -370,7 +370,7 @@ public:
   bool m_manual_etd{false};
 
   /**
-   * Flag indicating if this waypoint is currently being edited.
+   * Flag indicating if this waypoint is currently selected.
    */
   bool m_bPtIsSelected;
   /**


### PR DESCRIPTION
# Overview

When copying a waypoint to the plugin API structure, the function was checking if the source waypoint had no hyperlinks, and if true, it would immediately return from the function. The consequence of this early return statement is that if a waypoint had no hyperlinks, none of the other properties would be copied to the plugin API structure. This means plugins would receive incomplete waypoint information for any waypoint without hyperlinks, missing data such as:

1. Range ring information
2. Waypoint visibility settings
3. Scale minimums (scamin)
4. Active status flags

# Changes

1. Removed the return statement after checking `if src->m_HyperlinkList == nullptr`
2. This ensures that even when a waypoint has no hyperlinks, other essential properties (range rings, visibility settings, etc.) are still properly copied
3. Made minor code formatting and spacing improvements (run `clang-format -i`)
