### PR TITLE
data monitor: Use relative time stamps - #4522

### DIFF
--- a/gui/src/tty_scroll.cpp
+++ b/gui/src/tty_scroll.cpp
@@ -61,11 +61,16 @@ static bool IsFilterMatch(const struct Logline& ll, const std::string& s) {
 }
 
 static std::string Timestamp(const NavmsgTimePoint& when) {
+  static const NavmsgTimePoint started_at = NavmsgClock::now();
   using namespace std;
   using namespace std::chrono;
 
-  auto now = when.time_since_epoch();
+  int days = 0;
+  auto now = when - started_at;
   auto _hours = duration_cast<hours>(now);
+  /** duration_cast<days> is C++ 20 */
+  auto _days = _hours / 24;
+  _hours = _hours % 24;
   now -= _hours;
   auto _minutes = duration_cast<minutes>(now);
   now -= _minutes;
@@ -80,9 +85,9 @@ static std::string Timestamp(const NavmsgTimePoint& when) {
   return buf;
 #else
   stringstream ss;
-  ss << setw(2) << setfill('0') << _hours.count() % 24 << ":" << setw(2)
-     << _minutes.count() << ":" << setw(2) << _seconds.count() << "." << setw(3)
-     << ms.count();
+  ss << setw(3) << _days.count() << ":" << setw(2) << setfill('0')
+     << _hours.count() % 24 << ":" << setw(2) << _minutes.count() << ":"
+     << setw(2) << _seconds.count() << "." << setw(3) << ms.count();
   return ss.str();
 #endif
 }

--- a/model/include/model/comm_navmsg.h
+++ b/model/include/model/comm_navmsg.h
@@ -39,7 +39,8 @@
 
 #include "observable.h"
 
-using NavmsgTimePoint = std::chrono::time_point<std::chrono::steady_clock>;
+using NavmsgClock = std::chrono::steady_clock;
+using NavmsgTimePoint = std::chrono::time_point<NavmsgClock>;
 
 struct N2kPGN {
   uint64_t pgn;
@@ -255,7 +256,7 @@ public:
 
 protected:
   NavMsg(const NavAddr::Bus& _bus, std::shared_ptr<const NavAddr> src)
-      : bus(_bus), source(src), created_at(std::chrono::steady_clock::now()) {};
+      : bus(_bus), source(src), created_at(NavmsgClock::now()) {};
 };
 
 /**


### PR DESCRIPTION
While on it, also make sure the the VDR format uses system_clock

Closes: #4522

New timestamps look like : 


![image](https://github.com/user-attachments/assets/3476a43c-577c-47d3-bc98-b34789995ca5)
