### PR TITLE
data monitor: Use system_clock - #4522

### DIFF
--- a/gui/src/data_monitor.cpp
+++ b/gui/src/data_monitor.cpp
@@ -122,7 +122,7 @@ static void AddVdrLogline(const Logline& ll, std::ostream& stream) {
   if (kSourceByBus.find(ll.navmsg->bus) == kSourceByBus.end()) return;
 
   using namespace std::chrono;
-  auto now = steady_clock::now();
+  auto now = system_clock::now();
   auto ms = duration_cast<milliseconds>(now.time_since_epoch()).count();
   stream << ms << ",";
 
@@ -784,7 +784,7 @@ DataLogger::DataLogger(wxWindow* parent, const fs::path& path)
       m_stream(path, std::ios_base::app),
       m_is_logging(false),
       m_format(Format::kDefault),
-      m_log_start(std::chrono::steady_clock::now()) {}
+      m_log_start(NavmsgClock::now()) {}
 
 DataLogger::DataLogger(wxWindow* parent) : DataLogger(parent, NullLogfile()) {}
 

--- a/model/include/model/comm_navmsg.h
+++ b/model/include/model/comm_navmsg.h
@@ -39,7 +39,8 @@
 
 #include "observable.h"
 
-using NavmsgTimePoint = std::chrono::time_point<std::chrono::steady_clock>;
+using NavmsgClock = std::chrono::system_clock;
+using NavmsgTimePoint = std::chrono::time_point<NavmsgClock>;
 
 struct N2kPGN {
   uint64_t pgn;
@@ -255,7 +256,7 @@ public:
 
 protected:
   NavMsg(const NavAddr::Bus& _bus, std::shared_ptr<const NavAddr> src)
-      : bus(_bus), source(src), created_at(std::chrono::steady_clock::now()) {};
+      : bus(_bus), source(src), created_at(NavmsgClock::now()) {};
 };
 
 /**


### PR DESCRIPTION
Use system_clock to resolve #4522. Marks log lines with current time which resolves the reported problem. However, the price is quite high:

  - Using system_clock means per definition that the relative time between messages is inconsistent/buggy.
  - Logs spanning over more than 24 hours are also inconsistent.

Closes: #4522