### PR TITLE
Possibility to lock AIS target list #4532

### DIFF
--- a/gui/include/gui/AISTargetListDialog.h
+++ b/gui/include/gui/AISTargetListDialog.h
@@ -94,6 +94,7 @@ private:
   void OnHideAllTracks(wxCommandEvent &event);
   void OnToggleTrack(wxCommandEvent &event);
   void OnCopyMMSI(wxCommandEvent &event);
+  void OnLockAisTargetList(wxCommandEvent &event);
   void OnLimitRange(wxCommandEvent &event);
   void OnCloseButton(wxCommandEvent &event);
   void OnAutosortCB(wxCommandEvent &event);
@@ -110,6 +111,7 @@ private:
   wxButton *m_pButtonShowAllTracks;
   wxButton *m_pButtonToggleTrack;
   wxButton *m_pButtonCopyMMSI;
+  wxButton *m_pButtonLockAISTargetList;
   wxStaticText *m_pStaticTextRange;
   wxSpinCtrl *m_pSpinCtrlRange;
   wxStaticText *m_pStaticTextCount;
@@ -118,6 +120,7 @@ private:
   wxCheckBox *m_pCBAutosort;
 
   bool m_bautosort_force;
+  bool m_lockAISTargetList;
 
   DECLARE_EVENT_TABLE()
 };

--- a/gui/src/AISTargetListDialog.cpp
+++ b/gui/src/AISTargetListDialog.cpp
@@ -322,6 +322,7 @@ AISTargetListDialog::AISTargetListDialog(wxWindow *parent, wxAuiManager *auimgr,
   m_pdecoder = pdecoder;
   g_bsort_once = false;
   m_bautosort_force = false;
+  m_lockAISTargetList = false;
 
   wxFont *qFont = GetOCPNScaledFont(_("Dialog"));
   SetFont(*qFont);
@@ -754,6 +755,15 @@ void AISTargetListDialog::CreateControls() {
       wxCommandEventHandler(AISTargetListDialog::OnCopyMMSI), NULL, this);
   bsRouteButtonsInner->Add(m_pButtonCopyMMSI, 0, wxEXPAND | wxALL, 2);
 
+  m_pButtonLockAISTargetList =
+      new wxButton(winr, wxID_ANY, _("Lock list"), wxDefaultPosition,
+                   wxDefaultSize, wxBU_AUTODRAW);
+
+  m_pButtonLockAISTargetList->Connect(
+      wxEVT_COMMAND_BUTTON_CLICKED,
+      wxCommandEventHandler(AISTargetListDialog::OnLockAisTargetList), NULL, this);
+  bsRouteButtonsInner->Add(m_pButtonLockAISTargetList, 0, wxEXPAND | wxALL, 2);
+
   m_pCBAutosort =
       new wxCheckBox(winr, wxID_ANY, _("AutoSort"), wxDefaultPosition,
                      wxDefaultSize, wxBU_AUTODRAW);
@@ -1028,6 +1038,16 @@ void AISTargetListDialog::OnCopyMMSI(wxCommandEvent &event) {
   CopyMMSItoClipBoard((int)m_pMMSI_array->Item(selItemID));
 }
 
+void AISTargetListDialog::OnLockAisTargetList(wxCommandEvent &event) {
+  m_lockAISTargetList = !m_lockAISTargetList;
+
+  if (m_lockAISTargetList) {
+    m_pButtonLockAISTargetList->SetLabelText(_("Unlock list"));
+  } else {
+    m_pButtonLockAISTargetList->SetLabelText(_("Lock list"));
+  }
+}
+
 void AISTargetListDialog::CenterToTarget(bool close) {
   long selItemID = -1;
   selItemID = m_pListCtrlAISTargets->GetNextItem(selItemID, wxLIST_NEXT_ALL,
@@ -1080,6 +1100,9 @@ std::shared_ptr<AisTargetData> AISTargetListDialog::GetpTarget(
 }
 
 void AISTargetListDialog::UpdateAISTargetList(void) {
+  if (m_lockAISTargetList)
+    return;
+
   if (m_pListCtrlAISTargets && !m_pListCtrlAISTargets->IsVirtual())
     return UpdateNVAISTargetList();
 


### PR DESCRIPTION
Problem:
I have more than 3,000 AIS target on the map, and I would like to search for specific ones in the AIS target list, but it's very difficult because the list is constantly updating.

Resolution:
Add a new button call "Lock list" / "Unlock list"

#4532 