### PR TITLE
Build fixes: Breathe life into bookworm and Flatpak builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2747,9 +2747,6 @@ add_subdirectory(model)
 target_link_libraries(${PACKAGE_NAME} PUBLIC ocpn::model-src ocpn::model)
 
 if (OCPN_BUILD_TEST)
-  if(DEFINED ENV{CIRCLECI})
-    add_definitions(-DCCI_BUILD)
-  endif()
 
   add_subdirectory(libs/gtest)
   add_subdirectory(test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,12 +256,6 @@ option(OCPN_USE_SYSTEM_LIBARCHIVE
 
 add_definitions(-D__OCPN_USE_GLEW__)
 
-if(DEFINED ENV{CIRCLECI})
-  add_definitions(-DCCI_BUILD)
-  message(STATUS "*** Host Build Environment is CircleCI")
-endif()
-
-
 if (WIN32)
   set(cmd_snd_default OFF)
 else ()
@@ -2753,6 +2747,10 @@ add_subdirectory(model)
 target_link_libraries(${PACKAGE_NAME} PUBLIC ocpn::model-src ocpn::model)
 
 if (OCPN_BUILD_TEST)
+  if(DEFINED ENV{CIRCLECI})
+    add_definitions(-DCCI_BUILD)
+  endif()
+
   add_subdirectory(libs/gtest)
   add_subdirectory(test)
   add_custom_target(

--- a/ci/generic-build-debian.sh
+++ b/ci/generic-build-debian.sh
@@ -51,6 +51,9 @@ if [[ -n "$PACKAGE_BRANCH" && -z "$CIRCLE_PR_NUMBER" ]]; then
     (cd ..; tar xf *xz)
     cd ../opencpn-5.11.0*
 
+    # Make sure the build uses the circleci profile to disable locale tests
+    export DEB_BUILD_PROFILES=circleci
+
     # Build package and move artifacts to expected build/ dir
     debuild -us -uc -j4
     test -d ../project/build || mkdir ../project/build

--- a/ci/generic-build-debian.sh
+++ b/ci/generic-build-debian.sh
@@ -52,7 +52,7 @@ if [[ -n "$PACKAGE_BRANCH" && -z "$CIRCLE_PR_NUMBER" ]]; then
     cd ../opencpn-5.11.0*
 
     # Build package and move artifacts to expected build/ dir
-    debuild -us -uc -j4 -e CIRCLECI
+    debuild -us -uc -j4 --preserve-envvar CIRCLECI
     test -d ../project/build || mkdir ../project/build
     mv ../*deb ../project/build
 else

--- a/ci/generic-build-debian.sh
+++ b/ci/generic-build-debian.sh
@@ -52,7 +52,7 @@ if [[ -n "$PACKAGE_BRANCH" && -z "$CIRCLE_PR_NUMBER" ]]; then
     cd ../opencpn-5.11.0*
 
     # Build package and move artifacts to expected build/ dir
-    debuild -us -uc -j4 -eCIRCLECI
+    debuild -us -uc -j4 -e CIRCLECI
     test -d ../project/build || mkdir ../project/build
     mv ../*deb ../project/build
 else

--- a/ci/generic-build-debian.sh
+++ b/ci/generic-build-debian.sh
@@ -52,7 +52,7 @@ if [[ -n "$PACKAGE_BRANCH" && -z "$CIRCLE_PR_NUMBER" ]]; then
     cd ../opencpn-5.11.0*
 
     # Build package and move artifacts to expected build/ dir
-    debuild -us -uc -j4 --preserve-envvar CIRCLECI
+    debuild -us -uc -j4
     test -d ../project/build || mkdir ../project/build
     mv ../*deb ../project/build
 else

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -5,6 +5,8 @@ set(CMAKE_CXX_STANDARD 17)
 set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 message(STATUS "Building tests")
 
+option(DISABLE_LOCALE_TESTS "Disable tests requiring locale support" OFF)
+
 enable_testing ()
 
 add_library(win32_libs INTERFACE)
@@ -20,7 +22,7 @@ set(MODEL_SRC_DIR ${CMAKE_SOURCE_DIR}/model/src)
 
 set(SRC datetime_tests.cpp tests.cpp filter_tests.cpp ${CMAKE_SOURCE_DIR}/cli/api_shim.cpp)
 
-if (DEFINED ENV{CIRCLECI})
+if (DISABLE_LOCALE_TESTS OR DEFINED ENV{CIRCLECI})
   # Circle ci does not have a working local environment:
   set_source_files_properties(
     datetime_tests.cpp PROPERTIES COMPILE_FLAGS -DDISABLE_LOCALE_TESTS

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -20,6 +20,13 @@ set(MODEL_SRC_DIR ${CMAKE_SOURCE_DIR}/model/src)
 
 set(SRC datetime_tests.cpp tests.cpp filter_tests.cpp ${CMAKE_SOURCE_DIR}/cli/api_shim.cpp)
 
+if (DEFINED ENV{CIRCLECI})
+  # Circle ci does not have a working local environment:
+  set_source_files_properties(
+    datetime_tests.cpp PROPERTIES COMPILE_FLAGS -DDISABLE_LOCALE_TESTS
+  )
+endif ()
+
 if (LINUX)
   list(APPEND SRC n2k_tests.cpp)
 endif ()

--- a/test/datetime_tests.cpp
+++ b/test/datetime_tests.cpp
@@ -15,7 +15,7 @@
 #include <wx/jsonval.h>
 #include <wx/timer.h>
 
-#ifndef CCI_BUILD
+#ifndef DISABLE_LOCALE_TESTS
 #include <wx/uilocale.h>
 #endif
 
@@ -212,7 +212,7 @@ TEST_F(DateTimeFormatTest, ShowTimezoneDefault) {
   EXPECT_EQ(result, "2023-01-22 12:45:57 UTC");
 }
 
-#ifndef CCI_BUILD
+#ifndef DISABLE_LOCALE_TESTS
 // Test with Local Time in EST timezone
 TEST_F(DateTimeFormatTest, LocalTimezoneEST) {
   // Set timezone to EST for this test (UTC-5)
@@ -328,4 +328,4 @@ TEST_F(DateTimeFormatTest, LocalTimezoneCETSwedish) {
   EXPECT_FALSE(result.Contains("sommartid"))
       << "Should not contain 'sommartid' suffix: " << result;
 }
-#endif
+#endif  // DISABLE_LOCALE_TESTS


### PR DESCRIPTION
Builds, but contains unnecessary duplicates DISABLE_LOCALE_TESTS and OCPN_DISTRO_BUILD. 