### PR TITLE
Add scrolling to overall  connections dialog - CF beta feedback

### DIFF
--- a/gui/include/gui/connections_dlg.h
+++ b/gui/include/gui/connections_dlg.h
@@ -34,7 +34,6 @@ private:
   const std::vector<ConnectionParams*>& m_connections;
   std::function<void()> m_on_exit;
   EventVar m_evt_add_connection;
-  ObsListener m_add_connection_lstnr;
 };
 
 #endif  //  CONNECT_NEW_DLG__

--- a/gui/include/gui/connections_dlg.h
+++ b/gui/include/gui/connections_dlg.h
@@ -25,7 +25,7 @@ public:
    */
   void CancelSettings();
 
-  void OnResize();
+  void OnResize(const wxSize& size);
 
 private:
   void DoApply(wxWindow* root);

--- a/gui/src/connections_dlg.cpp
+++ b/gui/src/connections_dlg.cpp
@@ -881,12 +881,8 @@ ConnectionsDlg::ConnectionsDlg(
               wxTAB_TRAVERSAL, "ConnectionsDlg"),
       m_connections(connections) {
   auto vbox = new wxBoxSizer(wxVERTICAL);
-  auto scrolled_window = new ScrolledWindow(this);
-  auto conn_grid =
-      new Connections(scrolled_window, m_connections, m_evt_add_connection);
-  scrolled_window->AddClient(conn_grid, conn_grid->GetGridMaxSize(),
-                             conn_grid->GetGridMinSize());
-  vbox->Add(scrolled_window, wxSizerFlags(5).Expand().Border());
+  auto conn_grid = new Connections(this, m_connections, m_evt_add_connection);
+  vbox->Add(conn_grid, wxSizerFlags(5).Expand().Border());
   vbox->Add(new AddConnectionButton(this, m_evt_add_connection),
             wxSizerFlags().Border());
   vbox->Add(0, wxWindow::GetCharHeight());  // Expanding spacer
@@ -906,12 +902,9 @@ ConnectionsDlg::ConnectionsDlg(
   SetAutoLayout(true);
   wxWindow::Fit();
 
-  auto on_evt_update_connections = [&, conn_grid,
-                                    scrolled_window](ObservedEvt&) {
+  auto on_evt_update_connections = [&, conn_grid](ObservedEvt&) {
     conn_grid->ReloadGrid(TheConnectionParams());
     conn_grid->Show(conn_grid->GetNumberRows() > 0);
-    scrolled_window->SetMinClientSize(conn_grid->GetGridMinSize());
-    scrolled_window->SetMaxSize(conn_grid->GetGridMaxSize());
     Layout();
   };
   m_add_connection_lstnr.Init(m_evt_add_connection, on_evt_update_connections);

--- a/gui/src/connections_dlg.cpp
+++ b/gui/src/connections_dlg.cpp
@@ -263,7 +263,8 @@ public:
       OnMouseMove(ev);
       ev.Skip();
     });
-
+    GetGridWindow()->Bind(wxEVT_MOUSEWHEEL,
+                          [&](wxMouseEvent& ev) { OnWheel(ev); });
     Bind(wxEVT_GRID_LABEL_LEFT_CLICK,
          [&](wxGridEvent& ev) { HandleSort(ev.GetCol()); });
     Bind(wxEVT_GRID_CELL_LEFT_CLICK,
@@ -275,6 +276,22 @@ public:
     conn_change_lstnr.Init(
         m_conn_states.evt_conn_status_change,
         [&](ObservedEvt&) { OnConnectionChange(m_connections); });
+  }
+
+  /** Mouse wheel: scroll the TopScroll window */
+  void OnWheel(wxMouseEvent& ev) {
+    auto w = static_cast<wxScrolledWindow*>(
+        wxWindow::FindWindowByName(TopScrollWindowName));
+    assert(w && "No TopScroll window found");
+    int xpos;
+    int ypos;
+    w->GetViewStart(&xpos, &ypos);
+    int x;
+    int y;
+    w->GetScrollPixelsPerUnit(&x, &y);
+    // Not sure where the factor "4" comes from...
+    int dir = ev.GetWheelRotation();
+    w->Scroll(-1, ypos - dir / y / 4);
   }
 
   /** Reload grid using data from given list of connections. */

--- a/gui/src/connections_dlg.cpp
+++ b/gui/src/connections_dlg.cpp
@@ -254,9 +254,6 @@ public:
     ReloadGrid(connections);
     DisableDragColSize();
     DisableDragRowSize();
-    wxWindow* options = wxWindow::FindWindowByName("Options");
-    assert(options && "Null Options window!");
-    SetSize(wxSize(options->GetSize().x, options->GetSize().y * 8 / 10));
     wxWindow::Show(GetNumberRows() > 0);
 
     GetGridWindow()->Bind(wxEVT_MOTION, [&](wxMouseEvent& ev) {
@@ -633,12 +630,14 @@ private:
 /** Indeed: the General  panel. */
 class GeneralPanel : public wxPanel {
 public:
-  explicit GeneralPanel(wxWindow* parent) : wxPanel(parent, wxID_ANY) {
+  explicit GeneralPanel(wxWindow* parent, wxSize max_size)
+      : wxPanel(parent, wxID_ANY) {
     auto sizer = new wxStaticBoxSizer(wxVERTICAL, this, _("General"));
     SetSizer(sizer);
     auto flags = wxSizerFlags().Border();
     sizer->Add(new UploadOptionsChoice(this), flags);
     sizer->Add(new PrioritiesBtn(this), flags);
+    SetMaxSize(max_size);
   }
 
 private:
@@ -725,13 +724,15 @@ private:
 /** Indeed: The "Advanced" panel. */
 class AdvancedPanel : public wxPanel {
 public:
-  explicit AdvancedPanel(wxWindow* parent) : wxPanel(parent, wxID_ANY) {
+  explicit AdvancedPanel(wxWindow* parent, wxSize max_size)
+      : wxPanel(parent, wxID_ANY) {
     auto sizer = new wxStaticBoxSizer(wxVERTICAL, this, "");
     sizer->Add(new BearingsCheckbox(this), wxSizerFlags().Expand());
     sizer->Add(new NmeaFilterRow(this), wxSizerFlags().Expand());
     sizer->Add(new TalkerIdRow(this), wxSizerFlags().Expand());
     sizer->Add(new NetmaskRow(this), wxSizerFlags().Expand());
     SetSizer(sizer);
+    SetMaxSize(max_size);
   }
 
 private:
@@ -869,15 +870,16 @@ public:
         m_evt_add_connection(evt_add_connection) {
     auto vbox = new wxBoxSizer(wxVERTICAL);
     auto conn_grid = new Connections(this, m_connections, m_evt_add_connection);
-    vbox->Add(conn_grid, wxSizerFlags(5).Expand().Border());
+    wxSize panel_max_size(conn_grid->GetSize().x, -1);
+    vbox->Add(conn_grid, wxSizerFlags(5).Border());
     vbox->Add(new AddConnectionButton(this, m_evt_add_connection),
               wxSizerFlags().Border());
     vbox->Add(0, wxWindow::GetCharHeight());  // Expanding spacer
     auto panel_flags =
         wxSizerFlags().Border(wxLEFT | wxDOWN | wxRIGHT).Expand();
-    vbox->Add(new GeneralPanel(this), panel_flags);
+    vbox->Add(new GeneralPanel(this, panel_max_size), panel_flags);
 
-    auto advanced_panel = new AdvancedPanel(this);
+    auto advanced_panel = new AdvancedPanel(this, panel_max_size);
     auto on_toggle = [&, advanced_panel, vbox](bool show) {
       advanced_panel->Show(show);
       vbox->SetSizeHints(this);

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -1964,10 +1964,11 @@ void options::CreatePanel_NMEA(size_t parent, int border_size,
 
   comm_dialog =
       std::make_shared<ConnectionsDlg>(m_pNMEAForm, TheConnectionParams());
-  // Hijacks the options | Resize event for use by comm_dialog only.
+  // Hijack the options | Resize event for use by comm_dialog only.
   // Needs new solution if other pages also have a need to act on it.
   Bind(wxEVT_SIZE, [&](wxSizeEvent& ev) {
-    comm_dialog->OnResize();
+    auto w = m_pListbook->GetCurrentPage();
+    comm_dialog->OnResize(w ? w->GetClientSize() : wxSize());
     ev.Skip();
   });
 }

--- a/model/include/model/filters_on_disk.h
+++ b/model/include/model/filters_on_disk.h
@@ -32,7 +32,4 @@ bool Write(const NavmsgFilter& filter, const std::string& name);
 /** Read filter with given name from disk. */
 NavmsgFilter Read(const std::string& name);
 
-/** Return true iff name refers to a read-only system filter. */
-bool IsSystemFilter(std::string& name);
-
 }  // namespace filters_on_disk

--- a/model/src/filters_on_disk.cpp
+++ b/model/src/filters_on_disk.cpp
@@ -93,6 +93,4 @@ NavmsgFilter Read(const std::string& name) {
   return NavmsgFilter::Parse(ss.str());
 }
 
-bool IsSystemFilter(std::string& name) { return true; }
-
 }  // namespace filters_on_disk


### PR DESCRIPTION
Remove current scrollbars attached to the connection grid in the connections page, add scrollbars to overall page instead.
Fixes problems described in   https://www.cruisersforum.com/forums/f134/opencpn-v5-11-1-beta-test-starting-now-294554.html#post3998040