### PR TITLE
Feature/improve virtual destructors to avoid leaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ cscope.out
 data/doc/local/*
 index.sh
 tags
+
+# Ignore Build Dependency files
+*build-deps*

--- a/gui/include/gui/WindowDestroyListener.h
+++ b/gui/include/gui/WindowDestroyListener.h
@@ -25,8 +25,22 @@
 #ifndef __WINDOWDESTROYLISTENER_H__
 #define __WINDOWDESTROYLISTENER_H__
 
+/**
+ * Interface for a listener object that listens for windows to be destroyed.
+ *
+ * @interface WindowDestroyListener
+ * @headerfile WindowDestroyListener.h "gui/WindowDestroyListener/h"
+ */
 class WindowDestroyListener {
 public:
+  /**
+   * Destroy the Window Destroy Listener object.
+   */
+  virtual ~WindowDestroyListener() = default;
+
+  /**
+   * Destroy the window.
+   */
   virtual void DestroyWindow() = 0;
 };
 

--- a/gui/src/connections_dlg.cpp
+++ b/gui/src/connections_dlg.cpp
@@ -262,6 +262,9 @@ private:
  */
 class ApplyCancel {
 public:
+  /**
+   * Destroy the Apply Cancel object.
+   */
   virtual ~ApplyCancel() = default;
 
   /** Make values set by user actually being used. */

--- a/libs/gui/include/dialog_alert.h
+++ b/libs/gui/include/dialog_alert.h
@@ -28,9 +28,16 @@
 
 /**
  * Alert confirmation listener interface.
+ *
+ * @interface IAlertConfirmation dialog_alert.h "dialog_alert.h"
  */
 class IAlertConfirmation {
 public:
+  /**
+   * Destroy the IAlertConfirmation object.
+   */
+  virtual ~IAlertConfirmation() = default;
+
   /**
    * Handle confirmation response.
    * @param result User response.

--- a/libs/observable/include/observable.h
+++ b/libs/observable/include/observable.h
@@ -51,9 +51,23 @@ std::string ptr_key(const void* ptr);
 class Observable;
 class ObservableListener;
 
-/** Interface implemented by classes which listens. */
+/**
+ * Interface implemented by classes which listens.
+ *
+ * @interface KeyProvider observable.h "observable.h"
+ */
 class KeyProvider {
 public:
+  /**
+   * Destroy the Key Provider object.
+   */
+  virtual ~KeyProvider() = default;
+
+  /**
+   * Get the Key object from the Key Provider.
+   *
+   * @return std::string Key Object.
+   */
   virtual std::string GetKey() const = 0;
 };
 
@@ -86,6 +100,11 @@ public:
       : key(_key), m_list(ListenersByKey::GetInstance(_key)) {}
 
   Observable(const KeyProvider& kp) : Observable(kp.GetKey()) {}
+
+  /**
+   * Destroy the Observable object.
+   */
+  virtual ~Observable() = default;
 
   /** Notify all listeners about variable change. */
   virtual const void Notify();

--- a/model/include/model/comm_driver.h
+++ b/model/include/model/comm_driver.h
@@ -42,11 +42,20 @@ enum class CommStatus { Ok, NotImplemented, NotSupported, NameInUse };
 class AbstractCommDriver;  // forward
 
 /**
- * Interface implemented by transport layer and possible other parties
+ * Interface for handling incoming messages.
+ *
+ * Implemented by transport layer and possible other parties
  * like test code which should handle incoming messages
+ *
+ * @interface DriverListener comm_driver.h "model/comm_driver.h"
  */
 class DriverListener {
 public:
+  /**
+   * Destroy the Driver Listener object.
+   */
+  virtual ~DriverListener() = default;
+
   /** Handle a received message. */
   virtual void Notify(std::shared_ptr<const NavMsg> message) = 0;
 

--- a/model/include/model/comm_drv_stats.h
+++ b/model/include/model/comm_drv_stats.h
@@ -50,9 +50,23 @@ struct DriverStats {
         available(false) {}
 };
 
-/** Driver interface providing driver statistics */
+/**
+ * Driver interface providing driver statistics
+ *
+ * @interface DriverStatsProvider comm_drv_stats.h "model/comm_drv_stats.h"
+ */
 class DriverStatsProvider {
 public:
+  /**
+   * Destroy the Driver Stats Provider object.
+   */
+  virtual ~DriverStatsProvider() = default;
+
+  /**
+   * Get the Driver Statistics.
+   *
+   * @return DriverStats Object containing the driver statistics.
+   */
   virtual DriverStats GetDriverStats() const = 0;
 };
 

--- a/model/include/model/downloader.h
+++ b/model/include/model/downloader.h
@@ -30,10 +30,19 @@
 #include <string>
 #include <ostream>
 
-/** Default downloader, usable in a CLI context.*/
+/**
+ * Default downloader, usable in a CLI context.
+ *
+ * @class Downloader downloader.h "model/downloader.h"
+ */
 class Downloader {
 public:
-  Downloader(std::string url);
+  explicit Downloader(std::string url);
+
+  /**
+   * Destroy the Downloader object.
+   */
+  virtual ~Downloader() = default;
 
   /** Download url into stream, return false on errors. */
   bool download(std::ostream* stream);

--- a/model/include/model/ipc_api.h
+++ b/model/include/model/ipc_api.h
@@ -134,6 +134,12 @@ public:
   }
 
   void Serve() {}
+
+protected:
+  /**
+   * Destroy the Dummy Ipc Server object.
+   */
+  ~DummyIpcServer() = default;
 };
 
 class DummyIpcClient : public LocalClientApi {

--- a/model/include/model/local_api.h
+++ b/model/include/model/local_api.h
@@ -57,7 +57,11 @@ private:
   std::string reason;
 };
 
-/** Base interface for local server command handling. */
+/**
+ * Base interface for local server command handling.
+ *
+ * @class LocalServerApi local_api.h "model/local_api.h"
+ */
 class LocalServerApi {
 public:
   /** @return Reference to a LocalServerApi implementation. */
@@ -85,6 +89,11 @@ public:
 protected:
   LocalServerApi()
       : get_rest_api_endpoint_cb([]() { return "0.0.0.0/1024"; }) {}
+
+  /**
+   * Destroy the Local Server Api object.
+   */
+  ~LocalServerApi() = default;
 };
 
 /** Base interface for local clients. */

--- a/model/include/model/nmea_log.h
+++ b/model/include/model/nmea_log.h
@@ -24,8 +24,21 @@ struct Logline {
       : Logline(navmsg, NavmsgStatus()) {}
 };
 
+/**
+ * NMEA Log Interface
+ *
+ * Provides interface for interacting with NMEA log.
+ *
+ * @interface NmeaLog nmea_log.h "model/nmea_log.h"
+ *
+ */
 class NmeaLog {
 public:
+  /**
+   * Destroy the NMEA Log object.
+   */
+  virtual ~NmeaLog() = default;
+
   /** Add an formatted string to log output. */
   virtual void Add(const Logline& l) = 0;
 

--- a/model/include/model/thread_ctrl.h
+++ b/model/include/model/thread_ctrl.h
@@ -33,6 +33,11 @@ class ThreadCtrl {
 public:
   ThreadCtrl() : m_keep_going(1) {}
 
+  /**
+   * Destroy the Thread Ctrl object.
+   */
+  virtual ~ThreadCtrl() = default;
+
   /** Return true if thread is running. */
   bool IsRunning() const { return KeepGoing(); }
 


### PR DESCRIPTION
# Overview
I noticed that there were a lot of instances of interfaces/base classes containing no or incorrectly implemented destructors. This can possibly lead to memory leaks and undefined behavior as destructors might not be called, leading to not all objects being destroyed.

This is outlined in the C++ Core Guidelines in C.35. Read more [here](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c35-a-base-class-destructor-should-be-either-public-and-virtual-or-protected-and-non-virtual)

Note: Inside the _libs_ directory, it was hard to distinguish what was 3rd-party code and what was OpenCPN internal code, so I tried my best in there.

# Documentation
I made some small updates to the Doxygen for the classes I had to update. I didn't see anyone else using the _@interface_ or _@class_ keywords, but I added those in, as they are very helpful inside of documentation to know in what file a class is defined in. Read more [here](https://www.doxygen.nl/manual/commands.html#cmdclass).