### PR TITLE
Ensure scrollbars for tall dialogs on small screen

### DIFF
--- a/libs/gui/src/dialog_base.cpp
+++ b/libs/gui/src/dialog_base.cpp
@@ -72,7 +72,7 @@ void BaseDialog::SetInitialSize() {
   rect = display.GetClientArea();
   switch (breakpoint) {
     case GUI::Breakpoint::kExtraSmall:
-      size = wxSize(rect.GetWidth() * 9 / 10, -1);
+      size = wxSize(rect.GetWidth(), -1);
       break;
     case GUI::Breakpoint::kSmall:
     case GUI::Breakpoint::kMedium:

--- a/libs/gui/src/ui_utils.cpp
+++ b/libs/gui/src/ui_utils.cpp
@@ -39,8 +39,7 @@ void GUI::LayoutResizeEvent(wxWindow* ctx) {
 }
 
 GUI::Breakpoint GUI::GetScreenSize(wxRect* rect) {
-  if (rect->GetWidth() <= static_cast<int>(Breakpoint::kSmall) ||
-      rect->GetHeight() <= static_cast<int>(Breakpoint::kSmall)) {
+  if (rect->GetWidth() < static_cast<int>(Breakpoint::kSmall)) {
     return Breakpoint::kExtraSmall;
   } else if (rect->GetWidth() < static_cast<int>(Breakpoint::kMedium)) {
     return Breakpoint::kSmall;


### PR DESCRIPTION
Make sure that the dialog mentioned in https://www.cruisersforum.com/forums/f134/opencpn-v5-11-1-beta-test-starting-now-294554-6.html#post4000344 actually displays scrollbars.

This problem actually affects all dialogs derived from `BaseDialog` in *libs/gui/src/dialog_base.cpp*, their actual size are not known in advance in the general case.

Basic testing is done, but more is needed. Test hints:

1. Clearing ConfigVersionString in the configuration file will make the welcome message run on startup.
2. The following patch makes the welcome message too big on most/all screens:
```
diff --git a/gui/src/ocpn_frame.cpp b/gui/src/ocpn_frame.cpp
index 54cd75385..b7d339abd 100644
--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -531,6 +531,7 @@ Please click \"Agree\" and proceed, or \"Cancel\" to quit.\n"));
   return true;
 #else
   msg.Replace("\n", "<br>");
+for (int i = 0; i < 50; i+= 1) msg << "new line: " << i << "<br>";
 
   std::stringstream html;
   html << "<html><body><p>";

```