### PR TITLE
UI improvement for grib directory preference

### DIFF
--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -2137,7 +2137,7 @@ GribPreferencesDialogBase::GribPreferencesDialogBase(
 
   m_sdbSizer2->Realize();
 
-  itemBoxSizerMainPanel->Add(m_sdbSizer2, 0, wxEXPAND, 5);
+  itemBoxSizerMainPanel->Add(m_sdbSizer2, 0, wxEXPAND | wxALL, 5);
 
   wxStaticBoxSizer* sbSizer9;
   sbSizer9 = new wxStaticBoxSizer(
@@ -2194,6 +2194,20 @@ GribPreferencesDialogBase::GribPreferencesDialogBase(
   m_rbLoadOptions->SetSelection(0);
   bSizerPrefsMain->Add(m_rbLoadOptions, 0, wxALL | wxEXPAND, 5);
 
+  wxStaticBoxSizer* sbSizerFolder;
+  sbSizerFolder = new wxStaticBoxSizer(
+      new wxStaticBox(this, wxID_ANY, _("Grib File Directory")), wxHORIZONTAL);
+
+  m_textDirectory =
+      new wxTextCtrl(scrollWin, wxID_ANY, wxEmptyString, wxDefaultPosition,
+                     wxDefaultSize, wxTE_READONLY);
+  sbSizerFolder->Add(m_textDirectory, 1, wxALL, 5);
+
+  wxButton* dbFolderButton = new wxButton(scrollWin, wxID_ANY, _("Browse..."));
+  sbSizerFolder->Add(dbFolderButton, 0, wxALL, 5);
+
+  bSizerPrefsMain->Add(sbSizerFolder, 0, wxALL | wxEXPAND, 5);
+
   wxString m_rbStartOptionsChoices[] = {
       _("Start at the first forecast in GRIB file"),
       _("Start at the nearest forecast to current time"),
@@ -2221,15 +2235,6 @@ GribPreferencesDialogBase::GribPreferencesDialogBase(
   fgSizer47->Add(m_sIconSizeFactor, 0, wxALL | wxEXPAND, 5);
   bSizerPrefsMain->Add(fgSizer47, 0, wxALL | wxEXPAND, 5);
 #endif
-
-  wxButton* SetSaveButton =
-      new wxButton(scrollWin, wxID_ANY, _("Select GRIB download directory"));
-  bSizerPrefsMain->Add(SetSaveButton, 0, wxALL | wxEXPAND, 5);
-  SetSaveButton->Connect(
-      wxEVT_COMMAND_BUTTON_CLICKED,
-      wxCommandEventHandler(GribPreferencesDialogBase::OnDirSelClick), nullptr,
-      this);
-
   Layout();
   Fit();
 
@@ -2241,6 +2246,10 @@ GribPreferencesDialogBase::GribPreferencesDialogBase(
   m_sdbSizer2OK->Connect(
       wxEVT_COMMAND_BUTTON_CLICKED,
       wxCommandEventHandler(GribPreferencesDialogBase::OnOKClick), nullptr,
+      this);
+  dbFolderButton->Connect(
+      wxEVT_COMMAND_BUTTON_CLICKED,
+      wxCommandEventHandler(GribPreferencesDialogBase::OnDirSelClick), nullptr,
       this);
 }
 #else
@@ -2368,6 +2377,7 @@ void GribPreferencesDialogBase::OnDirSelClick(wxCommandEvent& event) {
 
   if (response == wxID_OK) {
     m_grib_dir_sel = dir_spec;
+    m_textDirectory->ChangeValue(dir_spec);
   }
 }
 

--- a/plugins/grib_pi/src/GribUIDialogBase.h
+++ b/plugins/grib_pi/src/GribUIDialogBase.h
@@ -437,6 +437,7 @@ public:
   wxRadioBox* m_rbLoadOptions;
   wxRadioBox* m_rbStartOptions;
   wxString m_grib_dir_sel;
+  wxTextCtrl* m_textDirectory;
 
 #ifdef __WXMSW__
   wxSlider* m_sIconSizeFactor;

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -248,6 +248,7 @@ void grib_pi::ShowPreferencesDialog(wxWindow *parent) {
     pConf->SetPath(_T ( "/Directories" ));
     pConf->Read(_T ( "GRIBDirectory" ), &l_grib_dir);
     Pref->m_grib_dir_sel = l_grib_dir;
+    Pref->m_textDirectory->ChangeValue(l_grib_dir);
   }
 
 #ifdef __WXMSW__


### PR DESCRIPTION
Subtle UI change,

From this (full width button, no feedback to user showing the grib file location)

![grib-old](https://github.com/user-attachments/assets/1aa278ae-c2c3-4155-8a4a-939b54b92c89)

To this:

![grib-new](https://github.com/user-attachments/assets/42ccfdb2-88b5-4e9d-8adb-0744c449273d)

text box displaying the selected file location and a browse button.

Unsure of the sizer & scrolled window though.