### PR TITLE
Cannot create a route where a routepoint is used multiple times

### DIFF
--- a/gui/src/connections_dlg.cpp
+++ b/gui/src/connections_dlg.cpp
@@ -785,12 +785,13 @@ private:
   };
 
   /** The select Generic, Garmin or Furuno upload options choice */
-  class UploadOptionsChoice : public wxChoice, public ApplyCancel {
+  class UploadOptionsChoice : public wxRadioBox, public ApplyCancel {
   public:
-    explicit UploadOptionsChoice(wxWindow* parent) : wxChoice() {
+    explicit UploadOptionsChoice(wxWindow* parent) : wxRadioBox() {
       wxArrayString wx_choices;
       for (auto& c : choices) wx_choices.Add(c);
-      Create(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wx_choices);
+      Create(parent, wxID_ANY, _("Upload Format"), wxDefaultPosition,
+             wxDefaultSize, wx_choices, 0, wxRA_SPECIFY_ROWS);
       DimeControl(this);
       UploadOptionsChoice::Cancel();
     }
@@ -824,9 +825,7 @@ private:
     }
 
     const std::array<wxString, 3> choices = {
-        _("Use generic Nmea 0183 format for uploads"),
-        _("Use Garmin GRMN (Host) mode for uploads"),
-        _("Format uploads for Furuno GP4X")};
+        _("Generic NMEA 0183"), _("Garmin Host mode"), _("Furuno GP4X")};
   };
 
   UploadOptionsChoice* m_upload_options;

--- a/model/src/navobj_db.cpp
+++ b/model/src/navobj_db.cpp
@@ -146,7 +146,7 @@ bool CreateTables(sqlite3* db) {
             route_guid TEXT,
             point_guid TEXT,
             point_order INTEGER,
-            PRIMARY KEY (route_guid, point_guid),
+            PRIMARY KEY (route_guid, point_order),
             FOREIGN KEY (route_guid) REFERENCES routes(guid) ON DELETE CASCADE
         );
 


### PR DESCRIPTION
If a route is created where the same waypoint is used multiple times, eg. multiple legs around a regatta course, the route is incorrectly saved. This is because of the primary key constraint on routepoints_link.

Creating the route on screen:
![route-err-01](https://github.com/user-attachments/assets/51156f86-8ff2-4807-aa66-e35835affee3)

The route properties:
![route-err-02](https://github.com/user-attachments/assets/6b18a1e0-0d84-4ca1-b06c-6b596e04772a)

After restarting OpenCPN, the last legs are missing.
![route-err-03](https://github.com/user-attachments/assets/e787e39c-61a6-4771-a87d-df9329af96fd)

This PR fixes the problem for new users, but for beta testers who have upgraded, they will; find their existing routes which may have included the same waypoint multiple times in the route are now incorrect.

I fear that I may have caused this problem with the issue I raised previously  #4567

A fix could also be applied offline, but I doubt you want users to run SQLie queries, drop the route_link table and create it with the new schema definition.

Also I'm not sure when the route is initially created, when it is actually written to the database., as the initial route properties do not reflect the underlying constraints. Without deliberately crashing O, I am no longer confident that if O crashes whilst I am in the midst of creating waypoints and routes, whether they will be persisted,