### PR TITLE
Cache extended AIS data & set AIS target color by Ship type

### DIFF
--- a/gui/src/ConfigMgr.cpp
+++ b/gui/src/ConfigMgr.cpp
@@ -1413,7 +1413,7 @@ bool ConfigMgr::CheckTemplate(wxString fileName) {
   CHECK_INT(_T ( "EnableRotateKeys" ), &g_benable_rotate);
   CHECK_INT(_T ( "EmailCrashReport" ), &g_bEmailCrashReport);
 
-  CHECK_INT(_T ( "EnableAISNameCache" ), &g_benableAISNameCache);
+  CHECK_INT(_T ( "EnableAISNameCache" ), &g_benableAISDataCache);
 
   CHECK_INT(_T ( "EnableUDPNullHeader" ), &g_benableUDPNullHeader);
 

--- a/gui/src/ais.cpp
+++ b/gui/src/ais.cpp
@@ -219,6 +219,8 @@ wxString ais8_001_22_notice_names[] = {
     _("Undefined (default)")  //, // 127
 };
 
+static wxColour AISGetColor(AisTargetData *td);
+
 static bool GetCanvasPointPix(ViewPort &vp, ChartCanvas *cp, double rlat,
                               double rlon, wxPoint *r) {
   if (cp != NULL) {
@@ -1027,7 +1029,7 @@ static void AISDrawTarget(AisTargetData *td, ocpnDC &dc, ViewPort &vp,
     target_brush = wxBrush(GetGlobalColor(_T ( "TEAL1" )));
 
   // Target name comes from cache
-  if (td->b_nameFromCache)
+  if (td->b_staticInfoFromCache)
     target_brush = wxBrush(GetGlobalColor(_T ( "GREEN5" )));
 
   // and....
@@ -1049,6 +1051,8 @@ static void AISDrawTarget(AisTargetData *td, ocpnDC &dc, ViewPort &vp,
 
   if (td->b_positionDoubtful)
     target_brush = wxBrush(GetGlobalColor(_T ( "UINFF" )));
+
+  target_brush = wxBrush(AISGetColor(td));
 
   wxPen target_outline_pen(UBLCK, AIS_width_target_outline);
 
@@ -1948,4 +1952,63 @@ bool AnyAISTargetsOnscreen(ChartCanvas *cc, ViewPort &vp) {
   }
 
   return false;
+}
+
+wxColour distressColor1(0xff, 0x00, 0x00);
+wxColour distressColor2(0x6f, 0x6f, 0x6f);
+wxColour aisUnspecifiedColor(0xd2, 0xd5, 0xda);
+wxColour aisUnknownColor(0x6f, 0x6f, 0x6f);
+wxColour aisFishingColor(0xf7, 0x99, 0x7c);
+wxColour aisPassengerColor(0x19, 0x7a, 0xff);
+wxColour aisDivingColor(0x26, 0xf5, 0xf5);
+wxColour aisPleasureColor(0xe3, 0x3a, 0xff);
+wxColour aisCargoColor(0x90, 0xee, 0x90);
+wxColour aisTankerColor(0xff, 0x31, 0x25);
+wxColour aisHighSpeedColor(0xff, 0xce, 0x1f);
+wxColour aisSpecialColor(0x26, 0xf5, 0xf5);
+
+static wxColour AISGetColor(AisTargetData *td) {
+  bool blink = wxGetCurrentTime() & 0x01;
+  int vesselType = td->ShipType;
+  int vesselType10 = vesselType / 10;
+
+  if ((td->n_alert_state != AIS_NO_ALERT) ||
+      ((td->Class == AIS_DSC) &&
+       ((vesselType == 12) || (vesselType == 16)))) {  // distress(relayed)
+    if (blink) {
+      return distressColor1;
+    } else {
+      return distressColor2;
+    }
+  }
+
+  if (vesselType <= 19) {
+    if (td->NavStatus == 7) {
+      return aisFishingColor;
+    } else if (td->NavStatus == 8) {
+      return aisPleasureColor;
+    } else if (td->Class == AIS_CLASS_B) {
+      return aisPleasureColor;
+    }
+    return aisUnknownColor;
+  } else if (vesselType == 30) {
+    return aisFishingColor;
+  } else if (vesselType == 34) {
+    return aisDivingColor;
+  } else if ((vesselType == 36) || (vesselType == 37)) {
+    return aisPleasureColor;
+  } else if (vesselType10 == 4) {
+    return aisHighSpeedColor;
+  } else if ((vesselType10 == 5) || (vesselType10 == 9) || (vesselType == 31) ||
+             (vesselType == 32) || (vesselType == 33)) {
+    return aisSpecialColor;
+  } else if (vesselType10 == 6) {
+    return aisPassengerColor;
+  } else if (vesselType10 == 7) {
+    return aisCargoColor;
+  } else if (vesselType10 == 8) {
+    return aisTankerColor;
+  } else {
+    return aisUnspecifiedColor;
+  }
 }

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -464,7 +464,7 @@ int MyConfig::LoadMyConfig() {
   g_bHighliteTracks = 1;
   g_bPreserveScaleOnX = 1;
   g_navobjbackups = 5;
-  g_benableAISNameCache = true;
+  g_benableAISDataCache = true;
   g_n_arrival_circle_radius = 0.05;
   g_plus_minus_zoom_factor = 2.0;
   g_mouse_zoom_sensitivity = 1.5;
@@ -934,8 +934,8 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   Read(_T ( "EnableRotateKeys" ), &g_benable_rotate);
   Read(_T ( "EmailCrashReport" ), &g_bEmailCrashReport);
 
-  g_benableAISNameCache = true;
-  Read(_T ( "EnableAISNameCache" ), &g_benableAISNameCache);
+  g_benableAISDataCache = true;
+  Read(_T ( "EnableAISNameCache" ), &g_benableAISDataCache);
 
   Read(_T ( "EnableUDPNullHeader" ), &g_benableUDPNullHeader);
 

--- a/model/include/model/ais_decoder.h
+++ b/model/include/model/ais_decoder.h
@@ -65,7 +65,7 @@ enum AISAudioSoundType {
 
 class MmsiProperties {
 public:
-  MmsiProperties() {};
+  MmsiProperties(){};
   MmsiProperties(int mmsi) {
     Init();
     MMSI = mmsi;
@@ -107,8 +107,8 @@ public:
   std::unordered_map<int, std::shared_ptr<AisTargetData>> &GetTargetList(void) {
     return AISTargetList;
   }
-  std::unordered_map<int, std::shared_ptr<AisTargetData>> &
-  GetAreaNoticeSourcesList(void) {
+  std::unordered_map<int, std::shared_ptr<AisTargetData>>
+      &GetAreaNoticeSourcesList(void) {
     return AIS_AreaNotice_Sources;
   }
   std::shared_ptr<AisTargetData> Get_Target_Data_From_MMSI(int mmsi);
@@ -189,8 +189,8 @@ private:
   std::unordered_map<int, std::shared_ptr<AisTargetData>> AISTargetList;
   std::unordered_map<int, std::shared_ptr<AisTargetData>>
       AIS_AreaNotice_Sources;
-  AIS_Target_Name_Hash *AISTargetNamesC;
-  AIS_Target_Name_Hash *AISTargetNamesNC;
+  AIS_Target_Data_Hash *AISTargetDataC;
+  AIS_Target_Data_Hash *AISTargetDataNC;
 
   ObservableListener listener_N0183_VDM;
   ObservableListener listener_N0183_FRPOS;

--- a/model/include/model/ais_defs.h
+++ b/model/include/model/ais_defs.h
@@ -27,6 +27,7 @@
 
 #include <wx/hashmap.h>
 #include <wx/string.h>
+#include "ais_target_data.h"
 
 #define TRACKTYPE_DEFAULT 0
 #define TRACKTYPE_ALWAYS 1
@@ -44,8 +45,8 @@ typedef enum AisError {
   AIS_INCOMPLETE_MULTIPART
 } _AisError;
 
-WX_DECLARE_HASH_MAP(int, wxString, wxIntegerHash, wxIntegerEqual,
-                    AIS_Target_Name_Hash);
+WX_DECLARE_HASH_MAP(int, AisTargetCacheData, wxIntegerHash, wxIntegerEqual,
+                    AIS_Target_Data_Hash);
 
 #define TIMER_AIS_MSEC 998
 #define TIMER_AIS_AUDIO_MSEC 2000

--- a/model/include/model/ais_state_vars.h
+++ b/model/include/model/ais_state_vars.h
@@ -38,7 +38,7 @@ extern bool g_bCPAMax;
 extern bool g_bCPAWarn;
 extern bool g_bDrawAISRealtime;
 extern bool g_bDrawAISSize;
-extern bool g_benableAISNameCache;
+extern bool g_benableAISDataCache;
 extern bool g_bHideMoored;
 extern bool g_bMarkLost;
 extern bool g_bRemoveLost;

--- a/model/include/model/ais_target_data.h
+++ b/model/include/model/ais_target_data.h
@@ -149,6 +149,16 @@ struct AisTargetCallbacks {
   AisTargetCallbacks() : get_mag([](double a) { return toMagnetic(a); }) {}
 };
 
+class AisTargetCacheData {
+public:
+  wxString name;
+  uint8_t type;
+  int DimA;
+  int DimB;
+  int DimC;
+  int DimD;
+};
+
 class AisTargetData {
   friend class AisTargetDataMaker;
 
@@ -224,6 +234,7 @@ public:
   bool b_positionDoubtful;
   bool b_positionOnceValid;
   bool b_nameValid;
+  bool b_staticInfoFromCache;
   bool b_isFollower;
   bool b_isDSCtarget;  // DSC flag to a possible simultaneous AIS target
   int m_dscNature;
@@ -262,7 +273,6 @@ public:
   std::unordered_map<int, Ais8_001_22> area_notices;
   bool b_SarAircraftPosnReport;
   int altitude;  // Metres, from special position report(9)
-  bool b_nameFromCache;
   float importance;
   short last_scale[AIS_TARGETDATA_MAX_CANVAS];  // where
                                                 // AIS_TARGETDATA_MAX_CANVAS is

--- a/model/src/ais_state_vars.cpp
+++ b/model/src/ais_state_vars.cpp
@@ -40,7 +40,7 @@ bool g_bCPAMax;
 bool g_bCPAWarn;
 bool g_bDrawAISRealtime;
 bool g_bDrawAISSize;
-bool g_benableAISNameCache;
+bool g_benableAISDataCache;
 bool g_bHideMoored;
 bool g_bMarkLost;
 bool g_bRemoveLost;

--- a/model/src/ais_target_data.cpp
+++ b/model/src/ais_target_data.cpp
@@ -286,7 +286,7 @@ AisTargetData::AisTargetData(AisTargetCallbacks cb) : m_callbacks(cb) {
   b_show_track = g_bAISShowTracks;
   b_SarAircraftPosnReport = false;
   altitude = 0;
-  b_nameFromCache = false;
+  b_staticInfoFromCache = false;
   importance = 0.0;
   for (unsigned int i = 0; i < AIS_TARGETDATA_MAX_CANVAS; i++)
     last_scale[i] = 50;


### PR DESCRIPTION
OpenCPN currently handles a cache of AIS names. This is useful at sea when you spot a new vessel.
This Pull Request adds Ship Type & Dimensions information to the AIS cache so that you can also have an idea of the type of vessel you are about to cross at sea.

In addition, it selects the color of the AIS target depending on its type to match Marine Traffic's colorset. Once again to help the skipper to quickly figure out what ship he is about to cross. This "color by type" feature is planned to be configurable in the option panel even if it is not yet the case today.

This is a work in progress. The pull request has been sent to OpenCPN repo as a material to help discussing the feature.

![Capture d’écran du 2025-06-23 21-29-18](https://github.com/user-attachments/assets/c8397b97-90cc-46cd-9cf8-17b080c8cb50)
