### PR TITLE
Make AIS track record/save and track visbility "logical"

### DIFF
--- a/gui/src/AISTargetListDialog.cpp
+++ b/gui/src/AISTargetListDialog.cpp
@@ -994,6 +994,13 @@ void AISTargetListDialog::OnShowAllTracks(wxCommandEvent &event) {
       auto pAISTarget = it.second;
       if (NULL != pAISTarget) {
         pAISTarget->b_show_track = true;
+
+        // Check for any persistently tracked target, force b_show_track_old ON
+        std::map<int, Track *>::iterator it;
+        it = g_pAIS->m_persistent_tracks.find(pAISTarget->MMSI);
+        if (it != g_pAIS->m_persistent_tracks.end()) {
+          pAISTarget->b_show_track_old = true;
+        }
       }
     }
     UpdateAISTargetList();
@@ -1010,8 +1017,10 @@ void AISTargetListDialog::OnHideAllTracks(wxCommandEvent &event) {
         // Check for any persistently tracked target, force b_show_track ON
         std::map<int, Track *>::iterator it;
         it = g_pAIS->m_persistent_tracks.find(pAISTarget->MMSI);
-        if (it != g_pAIS->m_persistent_tracks.end())
+        if (it != g_pAIS->m_persistent_tracks.end()) {
           pAISTarget->b_show_track = true;
+          pAISTarget->b_show_track_old = false;
+        }
       }
     }
     UpdateAISTargetList();
@@ -1030,7 +1039,9 @@ void AISTargetListDialog::OnToggleTrack(wxCommandEvent &event) {
         m_pdecoder->Get_Target_Data_From_MMSI(m_pMMSI_array->Item(selItemID));
 
   if (pAISTarget) {
-    pAISTarget->b_show_track = !pAISTarget->b_show_track;
+    pAISTarget->b_show_track_old =
+        pAISTarget->b_show_track;  // Store current state before toggling
+    pAISTarget->b_show_track = !pAISTarget->b_show_track;  // Toggle visibility
     UpdateAISTargetList();
   }
 }

--- a/gui/src/AISTargetQueryDialog.cpp
+++ b/gui/src/AISTargetQueryDialog.cpp
@@ -141,7 +141,7 @@ void AISTargetQueryDialog::OnIdTrkCreateClick(wxCommandEvent &event) {
         td->b_PersistTrack = false;
         g_pAIS->m_persistent_tracks.erase(td->MMSI);
         m_createTrkBtn->SetLabel(_("Record Track"));
-        td->b_show_track = false;
+        td->b_show_track = td->b_show_track_old;
       } else {
         TrackPoint *tp = NULL;
         TrackPoint *tp1 = NULL;
@@ -179,6 +179,7 @@ void AISTargetQueryDialog::OnIdTrkCreateClick(wxCommandEvent &event) {
                 _("OpenCPN Info"), wxYES_NO | wxCENTER, 60)) {
           td->b_PersistTrack = true;
           g_pAIS->m_persistent_tracks[td->MMSI] = t;
+          td->b_show_track_old = td->b_show_track;
           td->b_show_track = true;
         }
       }
@@ -307,7 +308,7 @@ void AISTargetQueryDialog::UpdateText() {
 
   if (td) {
     if (td->b_PersistTrack)
-      m_createTrkBtn->SetLabel(_("Stop Tracking"));
+      m_createTrkBtn->SetLabel(_("Save Track"));
     else
       m_createTrkBtn->SetLabel(_("Record Track"));
 

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -7504,6 +7504,7 @@ void options::ApplyChanges(wxCommandEvent& event) {
         it = g_pAIS->m_persistent_tracks.find(pAISTarget->MMSI);
         if (it != g_pAIS->m_persistent_tracks.end())
           pAISTarget->b_show_track = true;
+        pAISTarget->b_show_track_old = g_bAISShowTracks;
       }
     }
   }

--- a/model/include/model/ais_target_data.h
+++ b/model/include/model/ais_target_data.h
@@ -255,6 +255,7 @@ public:
   double CPA;           // Nautical Miles
   bool b_show_AIS_CPA;  // TR 2012.06.28: Show AIS-CPA
   bool b_show_track;
+  bool b_show_track_old;  // Previous state of b_show_track
 
   AisMeteoData met_data;
   std::vector<AISTargetTrackPoint> m_ptrack;


### PR DESCRIPTION
When recording AIS track keep record of AIS track visibility user requests
When recording is saved, visibility of track reverts to user requested state
Addresses: https://github.com/OpenCPN/OpenCPN/issues/4635