### PR TITLE
Add an option to color AIS targets by ship type

### DIFF
--- a/gui/include/gui/options.h
+++ b/gui/include/gui/options.h
@@ -526,7 +526,9 @@ public:
   wxCheckBox *m_pCheck_Draw_Target_Size, *m_pCheck_Draw_Realtime_Prediction;
   wxCheckBox *m_pCheck_Show_Target_Name;
   wxChoice *m_pWplAction;
+  wxChoice *m_p_ais_color_action;
   wxCheckBox *m_pCheck_use_Wpl, *m_pCheck_ShowAllCPA;
+  wxStaticText *m_p_check_ais_color;
   wxTextCtrl *m_pText_CPA_Max, *m_pText_CPA_Warn, *m_pText_CPA_WarnT;
   wxTextCtrl *m_pText_Mark_Lost, *m_pText_Remove_Lost, *m_pText_COG_Predictor;
   wxTextCtrl *m_pText_Track_Length, *m_pText_Moored_Speed,

--- a/gui/src/ConfigMgr.cpp
+++ b/gui/src/ConfigMgr.cpp
@@ -1005,6 +1005,7 @@ bool ConfigMgr::SaveTemplate(wxString fileName) {
   conf->Write(_T ( "ShowAISTargetNameScale" ), g_Show_Target_Name_Scale);
   conf->Write(_T ( "bWplIsAprsPositionReport" ), g_bWplUsePosition);
   conf->Write(_T ( "WplSelAction" ), g_WplAction);
+  conf->Write(_T ( "AisColorSet" ), g_ais_color_set);
   conf->Write(_T ( "AISCOGPredictorWidth" ), g_ais_cog_predictor_width);
   conf->Write(_T ( "bShowScaledTargets" ), g_bAllowShowScaled);
   conf->Write(_T ( "AISScaledNumber" ), g_ShowScaled_Num);
@@ -1477,6 +1478,7 @@ bool ConfigMgr::CheckTemplate(wxString fileName) {
   CHECK_INT(_T ( "ShowAISTargetNameScale" ), &g_Show_Target_Name_Scale);
   CHECK_INT(_T ( "bWplIsAprsPositionReport" ), &g_bWplUsePosition);
   CHECK_INT(_T ( "WplSelAction" ), &g_WplAction);
+  CHECK_INT(_T ( "AisColorSet" ), &g_ais_color_set);
   CHECK_INT(_T ( "AISCOGPredictorWidth" ), &g_ais_cog_predictor_width);
   CHECK_INT(_T ( "bAISAlertAudio" ), &g_bAIS_CPA_Alert_Audio);
   CHECK_STR(_T ( "AISAlertAudioFile" ), g_sAIS_Alert_Sound_File);

--- a/gui/src/ais.cpp
+++ b/gui/src/ais.cpp
@@ -62,6 +62,7 @@
 
 extern MyFrame *gFrame;
 extern OCPNPlatform *g_Platform;
+extern ColorScheme global_color_scheme;
 
 int g_ais_cog_predictor_width;
 extern AISTargetQueryDialog *g_pais_query_dialog_active;
@@ -218,6 +219,47 @@ wxString ais8_001_22_notice_names[] = {
       "ID"),                  // 126
     _("Undefined (default)")  //, // 127
 };
+
+/**
+ * Colors used to render a blinking AIS target under alert
+ */
+wxColour g_ais_alert_color[2] = {wxColor(0xff, 0x00, 0x00),
+                                 wxColor(0xff, 0xff, 0x00)};
+
+/**
+ * Marine Traffic AIS colorset
+ */
+wxColour g_ais_marine_traffic_colorset[10] = {
+    wxColour(0xd2, 0xd5, 0xda),  // Unspecified / military
+    wxColour(0x6f, 0x6f, 0x6f),  // Unknown
+    wxColour(0xf7, 0x99, 0x7c),  // Fishing
+    wxColour(0x19, 0x7a, 0xff),  // Passenger
+    wxColour(0x26, 0xf5, 0xf5),  // Diving
+    wxColour(0xe3, 0x3a, 0xff),  // Pleasure / Sailing
+    wxColour(0x90, 0xee, 0x90),  // Cargo
+    wxColour(0xff, 0x31, 0x25),  // Tanker
+    wxColour(0xff, 0xce, 0x1f),  // High Speed
+    wxColour(0x26, 0xf5, 0xf5)   // Special
+};
+
+/**
+ * Vessel Finder AIS colorset
+ */
+wxColour g_ais_vessel_finder_colorset[10] = {
+    wxColour(0xff, 0x2e, 0x2e),  // Unspecified / military
+    wxColour(0x6f, 0x6f, 0x6f),  // Unknown
+    wxColour(0x7d, 0xcc, 0xff),  // Fishing
+    wxColour(0x2b, 0xff, 0x0e),  // Passenger
+    wxColour(0x66, 0x98, 0xdc),  // Diving
+    wxColour(0xfa, 0x40, 0xf6),  // Pleasure / Sailing
+    wxColour(0xff, 0xff, 0x0f),  // Cargo
+    wxColour(0xff, 0xa9, 0x2f),  // Tanker
+    wxColour(0x66, 0x98, 0xdc),  // High Speed
+    wxColour(0x66, 0x98, 0xdc)   // Special
+};
+
+static wxColour AisGetOpenCpnColor(AisTargetData *td);
+static wxColour AisGetColorByType(AisTargetData *td, wxColour colorset[]);
 
 static bool GetCanvasPointPix(ViewPort &vp, ChartCanvas *cp, double rlat,
                               double rlon, wxPoint *r) {
@@ -1019,38 +1061,24 @@ static void AISDrawTarget(AisTargetData *td, ocpnDC &dc, ViewPort &vp,
   dc.SetPen(wxPen(UBLCK));
 
   // Default color is green
-  wxColour UINFG = GetGlobalColor(_T ( "UINFG" ));
-  wxBrush target_brush = wxBrush(UINFG);
+  wxBrush target_brush;
 
-  // Euro Inland targets render slightly differently, unless in InlandENC mode
-  if (td->b_isEuroInland && !g_bInlandEcdis)
-    target_brush = wxBrush(GetGlobalColor(_T ( "TEAL1" )));
-
-  // Target name comes from cache
-  if (td->b_nameFromCache)
-    target_brush = wxBrush(GetGlobalColor(_T ( "GREEN5" )));
-
-  // and....
-  wxColour URED = GetGlobalColor(_T ( "URED" ));
-  if (!td->b_nameValid) target_brush = wxBrush(GetGlobalColor(_T ( "CHYLW" )));
-
-  if ((td->Class == AIS_DSC) &&
-      ((td->ShipType == 12) || (td->ShipType == 16)))  // distress(relayed)
-    target_brush = wxBrush(URED);
-
-  if (td->b_SarAircraftPosnReport) target_brush = wxBrush(UINFG);
-
-  if ((td->n_alert_state == AIS_ALERT_SET) && (td->bCPA_Valid))
-    target_brush = wxBrush(URED);
-
-  if ((td->n_alert_state == AIS_ALERT_NO_DIALOG_SET) && (td->bCPA_Valid) &&
-      (!td->b_isFollower))
-    target_brush = wxBrush(URED);
-
-  if (td->b_positionDoubtful)
-    target_brush = wxBrush(GetGlobalColor(_T ( "UINFF" )));
+  switch (g_ais_color_set) {
+    case 1:  // Marine Traffic colorset
+      target_brush =
+          wxBrush(AisGetColorByType(td, g_ais_marine_traffic_colorset));
+      break;
+    case 2:  // Vessel finder colorset
+      target_brush =
+          wxBrush(AisGetColorByType(td, g_ais_vessel_finder_colorset));
+      break;
+    default:  // OpenCPN S52
+      target_brush = wxBrush(AisGetOpenCpnColor(td));
+      break;
+  }
 
   wxPen target_outline_pen(UBLCK, AIS_width_target_outline);
+  wxColour URED = GetGlobalColor(_T ( "URED" ));
 
   //    Check for alarms here, maintained by AIS class timer tick
   if (((td->n_alert_state == AIS_ALERT_SET) && (td->bCPA_Valid)) ||
@@ -1955,4 +1983,133 @@ bool AnyAISTargetsOnscreen(ChartCanvas *cc, ViewPort &vp) {
   }
 
   return false;
+}
+
+static wxColour AisGetOpenCpnColor(AisTargetData *td) {
+  wxColour target_color = GetGlobalColor(_T ( "UINFG" ));
+
+  // Euro Inland targets render slightly differently, unless in InlandENC mode
+  if (td->b_isEuroInland && !g_bInlandEcdis)
+    target_color = GetGlobalColor(_T ( "TEAL1" ));
+
+  // Target name comes from cache
+  if (td->b_nameFromCache) target_color = GetGlobalColor(_T ( "GREEN5" ));
+
+  // and....
+  wxColour URED = GetGlobalColor(_T ( "URED" ));
+  wxColour UINFG = GetGlobalColor(_T ( "UINFG" ));
+  if (!td->b_nameValid) target_color = GetGlobalColor(_T ( "CHYLW" ));
+
+  if ((td->Class == AIS_DSC) &&
+      ((td->ShipType == 12) || (td->ShipType == 16)))  // distress(relayed)
+    target_color = URED;
+
+  if (td->b_SarAircraftPosnReport) target_color = UINFG;
+
+  if ((td->n_alert_state == AIS_ALERT_SET) && (td->bCPA_Valid))
+    target_color = URED;
+
+  if ((td->n_alert_state == AIS_ALERT_NO_DIALOG_SET) && (td->bCPA_Valid) &&
+      (!td->b_isFollower))
+    target_color = URED;
+
+  if (td->b_positionDoubtful) target_color = GetGlobalColor(_T ( "UINFF" ));
+
+  return target_color;
+}
+
+/**
+ * Get rendering color of the AIS target matching its type and the privded
+ * colorset. Color is adapted to match chart's rendering scheme
+ * (day/dusk/night).
+ * @param td Pointer to the AIS target definition
+ * @param colorset Array of colors for each vessel type
+ * @return Color to use for rendering
+ */
+static wxColour AisGetColorByType(AisTargetData *td, wxColour colorset[]) {
+  wxColor target_color;
+  // Compute blink boolean for alert rendering
+  bool blink = wxGetCurrentTime() & 0x01;
+  // Get vessel type digits
+  int vessel_type = td->ShipType;
+  int vessel_type10 = vessel_type / 10;
+
+  // Compute integer dim factor for day/dusk/night rendering
+  int dim_factor = 256;
+  switch (global_color_scheme) {
+    case GLOBAL_COLOR_SCHEME_DUSK:
+      dim_factor = (int)(0.8 * 256);
+      break;
+    case GLOBAL_COLOR_SCHEME_NIGHT:
+      dim_factor = (int)(0.3 * 256);
+      break;
+    default:
+      break;
+  }
+
+  // Select color by ship type & status
+  if (vessel_type <= 19) {
+    // Unknown vessel type
+    if (td->NavStatus == 7) {
+      // Fishing vessel
+      target_color = colorset[2];
+    } else if (td->NavStatus == 8) {
+      // High speed vessel
+      target_color = colorset[5];
+    } else if (td->Class == AIS_CLASS_B) {
+      // By default, we consider B-CLASS vessel as pleasure craft if navigation
+      // status is not giving us more clue on their nature
+      target_color = colorset[5];
+    } else {
+      // Unknown type
+      target_color = colorset[1];
+    }
+  } else if (vessel_type == 30) {
+    // Fishing vessel
+    target_color = colorset[2];
+  } else if (vessel_type == 34) {
+    // Vessel with divers
+    target_color = colorset[4];
+  } else if ((vessel_type == 36) || (vessel_type == 37)) {
+    // Pleasure craft or sailing vessel
+    target_color = colorset[5];
+  } else if (vessel_type10 == 4) {
+    // High speed vessel
+    target_color = colorset[8];
+  } else if ((vessel_type10 == 5) || (vessel_type10 == 9) ||
+             (vessel_type == 31) || (vessel_type == 32) ||
+             (vessel_type == 33)) {
+    // Special vessel
+    target_color = colorset[9];
+  } else if (vessel_type10 == 6) {
+    // Passenger vessel
+    target_color = colorset[3];
+  } else if (vessel_type10 == 7) {
+    // Cargo ship
+    target_color = colorset[6];
+  } else if (vessel_type10 == 8) {
+    // Tanker ship
+    target_color = colorset[7];
+  } else {
+    // Unspecified or military target
+    target_color = colorset[0];
+  }
+
+  // Check if the target is under alert or distress status
+  if ((td->n_alert_state != AIS_NO_ALERT) ||
+      ((td->Class == AIS_DSC) &&
+       ((vessel_type == 12) || (vessel_type == 16)))) {  // distress(relayed)
+    if (blink) {
+      target_color = g_ais_alert_color[0];
+    } else {
+      target_color = g_ais_alert_color[1];
+    }
+  }
+
+  // Apply dim factor on color
+  target_color.Set((target_color.Red() * dim_factor) >> 8,
+                   (target_color.Green() * dim_factor) >> 8,
+                   (target_color.Blue() * dim_factor) >> 8);
+
+  return target_color;
 }

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -482,6 +482,7 @@ int MyConfig::LoadMyConfig() {
   g_Show_Target_Name_Scale = 250000;
   g_bWplUsePosition = 0;
   g_WplAction = 0;
+  g_ais_color_set = 0;
   g_ais_cog_predictor_width = 3;
   g_ais_alert_dialog_sx = 200;
   g_ais_alert_dialog_sy = 200;
@@ -1065,6 +1066,7 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   Read(_T ( "ShowAISTargetNameScale" ), &g_Show_Target_Name_Scale);
   Read(_T ( "bWplIsAprsPositionReport" ), &g_bWplUsePosition);
   Read(_T ( "WplSelAction"), &g_WplAction);
+  Read(_T ( "AisColorSet"), &g_ais_color_set);
   Read(_T ( "AISCOGPredictorWidth" ), &g_ais_cog_predictor_width);
 
   Read(_T ( "bAISAlertAudio" ), &g_bAIS_CPA_Alert_Audio);
@@ -2418,6 +2420,7 @@ void MyConfig::UpdateSettings() {
   Write(_T ( "ShowAISTargetNameScale" ), g_Show_Target_Name_Scale);
   Write(_T ( "bWplIsAprsPositionReport" ), g_bWplUsePosition);
   Write(_T ( "WplSelAction" ), g_WplAction);
+  Write(_T ( "AisColorSet" ), g_ais_color_set);
   Write(_T ( "AISCOGPredictorWidth" ), g_ais_cog_predictor_width);
   Write(_T ( "bShowScaledTargets" ), g_bAllowShowScaled);
   Write(_T ( "AISScaledNumber" ), g_ShowScaled_Num);

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -5407,6 +5407,23 @@ void options::CreatePanel_AIS(size_t parent, int border_size,
         "chart."));
   pDisplayGrid->Add(m_pWplAction, 1, wxALIGN_RIGHT | wxALL, group_item_spacing);
 
+  // AIS target coloring
+  m_p_check_ais_color =
+      new wxStaticText(panelAIS, -1, _("AIS target color scheme"));
+  m_p_check_ais_color->SetToolTip(
+      _("Choose the colorset used to fill AIS targets on the map."));
+  pDisplayGrid->Add(m_p_check_ais_color, 1, wxALL, group_item_spacing);
+
+  wxString ais_color_action[] = {_("OpenCPN S52"), _("Marine Traffic"),
+                                 "Vessel Finder"};
+  m_p_ais_color_action = new wxChoice(panelAIS, wxID_ANY, wxDefaultPosition,
+                                      wxDefaultSize, 3, ais_color_action);
+  m_p_ais_color_action->SetToolTip(
+      _("Select the colorset to use to render AIS targets : OpenCPN S52, Marine "
+        "Traffic, or Vessel Finder"));
+  pDisplayGrid->Add(m_p_ais_color_action, 1, wxALIGN_RIGHT | wxALL,
+                    group_item_spacing);
+
   // Rollover
   wxStaticBox* rolloverBox = new wxStaticBox(panelAIS, wxID_ANY, _("Rollover"));
   wxStaticBoxSizer* rolloverSizer =
@@ -6550,6 +6567,7 @@ void options::SetInitialSettings(void) {
 
   m_pCheck_use_Wpl->SetValue(g_bWplUsePosition);
   m_pWplAction->SetSelection(g_WplAction);
+  m_p_ais_color_action->SetSelection(g_ais_color_set);
 
   // Alerts
   m_pCheck_AlertDialog->SetValue(g_bAIS_CPA_Alert);
@@ -7527,6 +7545,7 @@ void options::ApplyChanges(wxCommandEvent& event) {
   g_Show_Target_Name_Scale = (int)wxMax(5000, ais_name_scale);
   g_bWplUsePosition = m_pCheck_use_Wpl->GetValue();
   g_WplAction = m_pWplAction->GetSelection();
+  g_ais_color_set = m_p_ais_color_action->GetSelection();
 
   //   Alert
   g_bAIS_CPA_Alert = m_pCheck_AlertDialog->GetValue();

--- a/model/include/model/config_vars.h
+++ b/model/include/model/config_vars.h
@@ -63,6 +63,7 @@ extern int g_COGFilterSec;
 extern int g_NMEAAPBPrecision;
 extern int g_SOGFilterSec;
 extern int g_WplAction;
+extern int g_ais_color_set;
 extern int g_iDistanceFormat;
 extern int g_iSDMMFormat;
 extern int g_iSpeedFormat;

--- a/model/src/config_vars.cpp
+++ b/model/src/config_vars.cpp
@@ -78,6 +78,7 @@ int g_SOGFilterSec = 0;
 int g_trackFilterMax = 0;
 int g_track_line_width = 0;
 int g_WplAction = 0;
+int g_ais_color_set = 0;
 int sat_watchdog_timeout_ticks = 12;
 
 wxString g_active_route;


### PR DESCRIPTION
This is a proposal associated to discussion #4224 .
It keeps the current S52 compliant coloring of AIS targets by default but offers a new option in "AIS Targets" panel to change the coloring scheme to "Marine Traffic" or "Vessel Finder". If chosen, AIS targets are colored the same way than on the corresponding sites by using both ship type and ship status.
Note that the colors are properly dimmed in case of dusk or night display.