### PR TITLE
Install asciidoc dependency on macOS in CI scripts

### DIFF
--- a/ci/generic-build-macos.sh
+++ b/ci/generic-build-macos.sh
@@ -31,6 +31,7 @@ brew install libarchive
 brew install wxwidgets
 brew install create-dmg
 brew install gpatch
+brew install asciidoc
 
 if [ -d /usr/local/include ]; then
   ln -sf /usr/local/opt/libarchive/include/archive.h /usr/local/include/archive.h

--- a/ci/universal-build-macos.sh
+++ b/ci/universal-build-macos.sh
@@ -50,6 +50,7 @@ brew install cmake
 brew install gettext
 brew install create-dmg
 brew install gpatch
+brew install asciidoc
 
 for pkg in python3  cmake ; do
     brew list --versions $pkg || brew install $pkg || brew install $pkg || :


### PR DESCRIPTION
asciidoc is now needed to regenerate authors list, needs to be installed for CI builds to succeed