### PR TITLE
Bug fix: Tide dialog station text overlaps chart area when window is resized smaller

### DIFF
--- a/gui/include/gui/TCWin.h
+++ b/gui/include/gui/TCWin.h
@@ -63,12 +63,24 @@ public:
 
   void RecalculateSize();
   void SetTimeFactors();
+  void CreateLayout();
+  void InitializeStationText();
+  void PaintChart(wxDC &dc, const wxRect &chartRect);
+  void HandleChartMouseMove(int mainWindowX, int mainWindowY,
+                            const wxPoint &chartPanelPos);
 
   /** @return Pointer to the IDX_entry for the currently displayed tide/current
    * station */
   IDX_entry *GetCurrentIDX() const { return pIDX; }
 
 private:
+  // Forward declaration for custom chart panel
+  class TideChartPanel;
+
+  wxPanel *m_topPanel;           // Panel containing station info and tide list
+  TideChartPanel *m_chartPanel;  // Panel for the tide chart
+  wxPanel *m_buttonPanel;        // Panel for buttons and controls
+
   wxTextCtrl *m_ptextctrl;
   wxTimer m_TCWinPopupTimer;
   wxTimer m_TimeIndicatorTimer;


### PR DESCRIPTION

## Changes in this PR

- Fix #4666
  - Modernize TCWin layout with sizer-based layout.
  - Replace hardcoded positioning calculations with automatic layout management.
  - Eliminates text spillover and overlapping panels when resizing the window.
  - Create custom TideChartPanel class for self-contained chart rendering.
- Fix #4741

## Screenshot

When the user resizes the tide dialog, the dialog uses responsive UI to properly render and resize the sub-elements. Previously, some of the text areas were spilling into the chart.

<img width="783" height="579" alt="image" src="https://github.com/user-attachments/assets/4a5f35f8-052c-4428-b246-0ccecafe554f" />

## Tests

1. Resize tide window smaller → verify no text overlap with chart
2. Open tide window with GRIB plugin active → verify no crashes
3. Responsive Layout: Test various window sizes and aspect ratios
4. Chart Functionality: Verify all chart interactions still work (rollover, time indicators)
5. Control Panel: Test all buttons and timezone switching