### PR TITLE
Ensure single instance of tide dialog

### DIFF
--- a/gui/include/gui/TCWin.h
+++ b/gui/include/gui/TCWin.h
@@ -64,6 +64,10 @@ public:
   void RecalculateSize();
   void SetTimeFactors();
 
+  /** @return Pointer to the IDX_entry for the currently displayed tide/current
+   * station */
+  IDX_entry *GetCurrentIDX() const { return pIDX; }
+
 private:
   wxTextCtrl *m_ptextctrl;
   wxTimer m_TCWinPopupTimer;

--- a/gui/include/gui/chcanv.h
+++ b/gui/include/gui/chcanv.h
@@ -659,7 +659,29 @@ public:
   void ShowMarkPropertiesDialog(RoutePoint *markPoint);
   void ShowRoutePropertiesDialog(wxString title, Route *selected);
   void ShowTrackPropertiesDialog(Track *selected);
+  /** Legacy tide dialog creation method. Redirects to ShowSingleTideDialog for
+   * single-instance behavior. */
   void DrawTCWindow(int x, int y, void *pIDX);
+
+  /**
+   * Display tide/current dialog with single-instance management.
+   *
+   * Handles the following scenarios:
+   * - If no dialog exists: Creates new dialog
+   * - If same station clicked: Brings existing dialog to front with visual
+   * feedback
+   * - If different station clicked: Closes current dialog and opens new one
+   * @param x Mouse click x-coordinate in canvas pixels
+   * @param y Mouse click y-coordinate in canvas pixels
+   * @param pvIDX Pointer to IDX_entry for the tide/current station
+   */
+  void ShowSingleTideDialog(int x, int y, void *pvIDX);
+
+  /** @return true if a tide dialog is currently open and visible */
+  bool IsTideDialogOpen() const;
+
+  /** Close any open tide dialog */
+  void CloseTideDialog();
 
   void UpdateGPSCompassStatusBox(bool b_force_new);
   ocpnCompass *GetCompass() { return m_Compass; }

--- a/gui/src/TCWin.cpp
+++ b/gui/src/TCWin.cpp
@@ -413,11 +413,22 @@ void TCWin::RecalculateSize() {
 
 void TCWin::OKEvent(wxCommandEvent &event) {
   Hide();
-  pParent->pCwin = NULL;
+
+  // Ensure parent pointer is cleared before any potential deletion
+  if (pParent && pParent->pCwin == this) {
+    pParent->pCwin = NULL;
+  }
+
+  // Clean up global tide window counter and associated resources
   --gpIDXn;
   delete m_pTCRolloverWin;
+  m_pTCRolloverWin = NULL;
   delete m_tList;
-  pParent->Refresh(false);
+  m_tList = NULL;
+
+  if (pParent) {
+    pParent->Refresh(false);
+  }
 
   // Update the config file to set the user specified time zone.
   if (pConfig) {
@@ -430,10 +441,18 @@ void TCWin::OKEvent(wxCommandEvent &event) {
 
 void TCWin::OnCloseWindow(wxCloseEvent &event) {
   Hide();
-  pParent->pCwin = NULL;
+
+  // Ensure parent pointer is cleared before any potential deletion
+  if (pParent && pParent->pCwin == this) {
+    pParent->pCwin = NULL;
+  }
+
+  // Clean up global tide window counter and associated resources
   --gpIDXn;
   delete m_pTCRolloverWin;
+  m_pTCRolloverWin = NULL;
   delete m_tList;
+  m_tList = NULL;
 
   // Update the config file to set the user specified time zone.
   if (pConfig) {


### PR DESCRIPTION
This is a follow up to #4664 , specifically to address https://github.com/OpenCPN/OpenCPN/issues/4663#issuecomment-3118000622

**Problem**

The current `pCwin` field design in `ChartCanvas` allows multiple tide dialogs to be opened simultaneously, causing memory leaks and inconsistent state.

**Solution**

Implement single-instance management that ensures only one tide dialog can be open at a time while providing enhanced user experience:

1. Same-station detection: Clicking the same tide station brings existing dialog to front instead of recreating it.
2. Station switching: Clicking different stations cleanly transitions between dialogs
3. Context preservation: User's scroll position and view state maintained

**Tests**

✅ Single station click (creates dialog)
✅ Same station re-click (brings to front, no flicker)
✅ Different station clicks (clean transitions)
✅ Dialog close and reopen (proper cleanup)
