### PR TITLE
wxwidgets 3.3 fixes

### DIFF
--- a/android/androidUTIL.cpp
+++ b/android/androidUTIL.cpp
@@ -4447,7 +4447,8 @@ int doAndroidPersistState() {
       //    First, delete any single anchorage waypoint closer than 0.25 NM from
       //    this point This will prevent clutter and database congestion....
 
-      wxRoutePointListNode *node = pWayPointMan->GetWaypointList()->GetFirst();
+      RoutePointList::compatibility_iterator node =
+          pWayPointMan->GetWaypointList()->GetFirst();
       while (node) {
         RoutePoint *pr = node->GetData();
         if (pr->GetName().StartsWith(_T("Anchorage"))) {

--- a/gui/include/gui/Quilt.h
+++ b/gui/include/gui/Quilt.h
@@ -232,7 +232,7 @@ private:
   wxBitmap *m_pBM;
 
   bool m_bcomposed;
-  wxPatchListNode *cnode;
+  PatchList::compatibility_iterator cnode;
   bool m_bbusy;
   int m_quilt_proj;
 

--- a/gui/include/gui/tcmgr.h
+++ b/gui/include/gui/tcmgr.h
@@ -106,8 +106,8 @@ public:
 
   int GetStationTimeOffset(IDX_entry *pIDX);
   int GetNextBigEvent(time_t *tm, int idx);
-  std::wstring GetTidalEventStr(int station_id, wxDateTime ref_dt, double lat,
-                                double lon, int dt_type);
+  std::string GetTidalEventStr(int station_id, wxDateTime ref_dt, double lat,
+                               double lon, int dt_type);
   double GetStationLat(IDX_entry *pIDX);
   double GetStationLon(IDX_entry *pIDX);
 

--- a/gui/src/ConfigMgr.cpp
+++ b/gui/src/ConfigMgr.cpp
@@ -565,8 +565,9 @@ bool ConfigMgr::LoadCatalog() {
           wxString::FromUTF8(object.attribute("GUID").as_string());
 
       bool bFound = false;
-      for (ConfigObjectList::Node *node = configList->GetFirst(); node;
-           node = node->GetNext()) {
+      for (ConfigObjectList::compatibility_iterator node =
+               configList->GetFirst();
+           node; node = node->GetNext()) {
         OCPNConfigObject *look = node->GetData();
         if (look->m_GUID == testGUID) {
           bFound = true;
@@ -686,8 +687,8 @@ wxPanel *ConfigMgr::GetConfigPanel(wxWindow *parent, wxString GUID) {
 
 OCPNConfigObject *ConfigMgr::GetConfig(wxString GUID) {
   // Find the GUID-matching config in the member list
-  for (ConfigObjectList::Node *node = configList->GetFirst(); node;
-       node = node->GetNext()) {
+  for (ConfigObjectList::compatibility_iterator node = configList->GetFirst();
+       node; node = node->GetNext()) {
     OCPNConfigObject *look = node->GetData();
     if (look->m_GUID == GUID) {
       return look;
@@ -699,8 +700,8 @@ OCPNConfigObject *ConfigMgr::GetConfig(wxString GUID) {
 }
 
 wxString ConfigMgr::GetTemplateTitle(wxString GUID) {
-  for (ConfigObjectList::Node *node = configList->GetFirst(); node;
-       node = node->GetNext()) {
+  for (ConfigObjectList::compatibility_iterator node = configList->GetFirst();
+       node; node = node->GetNext()) {
     OCPNConfigObject *look = node->GetData();
     if (look->m_GUID == GUID) {
       return look->m_title;
@@ -714,8 +715,8 @@ wxString ConfigMgr::GetTemplateTitle(wxString GUID) {
 wxArrayString ConfigMgr::GetConfigGUIDArray() {
   wxArrayString ret_val;
 
-  for (ConfigObjectList::Node *node = configList->GetFirst(); node;
-       node = node->GetNext()) {
+  for (ConfigObjectList::compatibility_iterator node = configList->GetFirst();
+       node; node = node->GetNext()) {
     OCPNConfigObject *look = node->GetData();
     ret_val.Add(look->m_GUID);
   }

--- a/gui/src/MarkInfo.cpp
+++ b/gui/src/MarkInfo.cpp
@@ -1692,7 +1692,8 @@ void MarkInfoDlg::OnBitmapCombClick(wxCommandEvent& event) {
 void MarkInfoDlg::ValidateMark(void) {
   //    Look in the master list of Waypoints to see if the currently selected
   //    waypoint is still valid It may have been deleted as part of a route
-  wxRoutePointListNode* node = pWayPointMan->GetWaypointList()->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      pWayPointMan->GetWaypointList()->GetFirst();
 
   bool b_found = false;
   while (node) {

--- a/gui/src/MarkInfo.cpp
+++ b/gui/src/MarkInfo.cpp
@@ -891,7 +891,7 @@ void MarkInfoDlg::SetRoutePoint(RoutePoint* pRP) {
     m_pMyLinkList = new HyperlinkList();
     int NbrOfLinks = m_pRoutePoint->m_HyperlinkList->GetCount();
     if (NbrOfLinks > 0) {
-      wxHyperlinkListNode* linknode =
+      HyperlinkList::compatibility_iterator linknode =
           m_pRoutePoint->m_HyperlinkList->GetFirst();
       while (linknode) {
         Hyperlink* link = linknode->GetData();
@@ -915,7 +915,8 @@ void MarkInfoDlg::UpdateHtmlList() {
   int NbrOfLinks = m_pRoutePoint->m_HyperlinkList->GetCount();
 
   if (NbrOfLinks > 0) {
-    wxHyperlinkListNode* linknode = m_pRoutePoint->m_HyperlinkList->GetFirst();
+    HyperlinkList::compatibility_iterator linknode =
+        m_pRoutePoint->m_HyperlinkList->GetFirst();
     while (linknode) {
       Hyperlink* link = linknode->GetData();
       wxString s = wxString::Format(wxT("<a href='%s'>%s</a>"), link->Link,
@@ -946,7 +947,7 @@ void MarkInfoDlg::UpdateHtmlList() {
   int NbrOfLinks = m_pRoutePoint->m_HyperlinkList->GetCount();
   HyperlinkList* hyperlinklist = m_pRoutePoint->m_HyperlinkList;
   if (NbrOfLinks > 0) {
-    wxHyperlinkListNode* linknode = hyperlinklist->GetFirst();
+    HyperlinkList::compatibility_iterator linknode = hyperlinklist->GetFirst();
     while (linknode) {
       Hyperlink* link = linknode->GetData();
       wxString Link = link->Link;
@@ -1131,7 +1132,8 @@ void MarkInfoDlg::m_htmlListContextMenu(wxMouseEvent& event) {
     HyperlinkList* hyperlinklist = m_pRoutePoint->m_HyperlinkList;
     if (hyperlinklist->GetCount() > 0) {
       int i = 0;
-      wxHyperlinkListNode* linknode = hyperlinklist->GetFirst();
+      HyperlinkList::compatibility_iterator linknode =
+          hyperlinklist->GetFirst();
       while (linknode) {
         Hyperlink* link = linknode->GetData();
         if (link->DescrText == label) {
@@ -1213,7 +1215,7 @@ void MarkInfoDlg::OnAddLink(wxCommandEvent& event) {
 void MarkInfoDlg::On_html_link_popupmenu_Click(wxCommandEvent& event) {
   switch (event.GetId()) {
     case ID_RCLK_MENU_DELETE_LINK: {
-      wxHyperlinkListNode* node =
+      HyperlinkList::compatibility_iterator node =
           m_pRoutePoint->m_HyperlinkList->Item(i_htmlList_item);
       m_pRoutePoint->m_HyperlinkList->DeleteNode(node);
       UpdateHtmlList();
@@ -1384,7 +1386,8 @@ void MarkInfoDlg::OnMarkInfoCancelClick(wxCommandEvent& event) {
 
     int NbrOfLinks = m_pMyLinkList->GetCount();
     if (NbrOfLinks > 0) {
-      wxHyperlinkListNode* linknode = m_pMyLinkList->GetFirst();
+      HyperlinkList::compatibility_iterator linknode =
+          m_pMyLinkList->GetFirst();
       while (linknode) {
         Hyperlink* link = linknode->GetData();
         Hyperlink* h = new Hyperlink();

--- a/gui/src/MarkInfo.cpp
+++ b/gui/src/MarkInfo.cpp
@@ -929,7 +929,7 @@ void MarkInfoDlg::UpdateHtmlList() {
   // Clear the list
   wxWindowList kids = m_scrolledWindowLinks->GetChildren();
   for (unsigned int i = 0; i < kids.GetCount(); i++) {
-    wxWindowListNode* node = kids.Item(i);
+    wxWindowList::compatibility_iterator node = kids.Item(i);
     wxWindow* win = node->GetData();
 
     auto link_win = dynamic_cast<wxHyperlinkCtrl*>(win);

--- a/gui/src/OCPN_AUIManager.cpp
+++ b/gui/src/OCPN_AUIManager.cpp
@@ -93,6 +93,19 @@ EVT_CHILD_FOCUS(OCPN_AUIManager::OnChildFocus)
 EVT_AUI_FIND_MANAGER(OCPN_AUIManager::OnFindManager)
 END_EVENT_TABLE()
 
+static bool AuiDockUIPartsAreEqual(const wxAuiDockUIPart& lhs,
+                                   const wxAuiDockUIPart& rhs) {
+  if (lhs.type != rhs.type) return false;
+  if (lhs.orientation != rhs.orientation) return false;
+  if (lhs.dock != rhs.dock) return false;
+  if (lhs.pane != rhs.pane) return false;
+  if (lhs.button != rhs.button) return false;
+  if (lhs.cont_sizer != rhs.cont_sizer) return false;
+  if (lhs.sizer_item != rhs.sizer_item) return false;
+  if (lhs.rect != rhs.rect) return false;
+  return true;
+};
+
 OCPN_AUIManager::OCPN_AUIManager(wxWindow* managed_wnd, unsigned int flags)
     : wxAuiManager(managed_wnd, flags)
 
@@ -114,10 +127,17 @@ void OCPN_AUIManager::OnMotionx(wxMouseEvent& event) {
   if (m_action == actionResize) {
     // It's necessary to reset m_actionPart since it destroyed
     // by the Update within DoEndResizeAction.
-    if (m_currentDragItem != -1)
+    if (m_currentDragItem != -1) {
       m_actionPart = &(m_uiParts.Item(m_currentDragItem));
-    else
-      m_currentDragItem = m_uiParts.Index(*m_actionPart);
+    } else {
+      const wxAuiDockUIPart action_part = *m_actionPart;
+      for (size_t i = 0; i < m_uiParts.GetCount(); i++) {
+        if (AuiDockUIPartsAreEqual(m_uiParts[i], action_part)) {
+          m_currentDragItem = i;
+          break;
+        }
+      }
+    }
 
     if (m_actionPart) {
       wxPoint pos = m_actionPart->rect.GetPosition();

--- a/gui/src/Quilt.cpp
+++ b/gui/src/Quilt.cpp
@@ -244,8 +244,6 @@ Quilt::Quilt(ChartCanvas *parent) {
 
   m_lost_refchart_dbIndex = -1;
 
-  cnode = NULL;
-
   m_pBM = NULL;
   m_bcomposed = false;
   m_bbusy = false;
@@ -602,7 +600,7 @@ bool Quilt::IsQuiltVector(void) {
 
   bool ret = false;
 
-  wxPatchListNode *cnode = m_PatchList.GetFirst();
+  PatchList::compatibility_iterator cnode = m_PatchList.GetFirst();
   while (cnode) {
     if (cnode->GetData()) {
       QuiltPatch *pqp = cnode->GetData();
@@ -632,7 +630,7 @@ bool Quilt::DoesQuiltContainPlugins(void) {
 
   bool ret = false;
 
-  wxPatchListNode *cnode = m_PatchList.GetFirst();
+  PatchList::compatibility_iterator cnode = m_PatchList.GetFirst();
   while (cnode) {
     if (cnode->GetData()) {
       QuiltPatch *pqp = cnode->GetData();
@@ -664,7 +662,7 @@ int Quilt::GetChartdbIndexAtPix(ViewPort &VPoint, wxPoint p) {
 
   int ret = -1;
 
-  wxPatchListNode *cnode = m_PatchList.GetFirst();
+  PatchList::compatibility_iterator cnode = m_PatchList.GetFirst();
   while (cnode) {
     if (cnode->GetData()->ActiveRegion.Contains(lat, lon)) {
       ret = cnode->GetData()->dbIndex;
@@ -690,7 +688,7 @@ ChartBase *Quilt::GetChartAtPix(ViewPort &VPoint, wxPoint p) {
   //    walk the whole list.  The result will be the last one found, i.e. the
   //    largest scale chart.
   ChartBase *pret = NULL;
-  wxPatchListNode *cnode = m_PatchList.GetFirst();
+  PatchList::compatibility_iterator cnode = m_PatchList.GetFirst();
   while (cnode) {
     QuiltPatch *pqp = cnode->GetData();
     if (!pqp->b_overlay && (pqp->ActiveRegion.Contains(lat, lon)))
@@ -717,7 +715,7 @@ ChartBase *Quilt::GetOverlayChartAtPix(ViewPort &VPoint, wxPoint p) {
   //    walk the whole list.  The result will be the last one found, i.e. the
   //    largest scale chart.
   ChartBase *pret = NULL;
-  wxPatchListNode *cnode = m_PatchList.GetFirst();
+  PatchList::compatibility_iterator cnode = m_PatchList.GetFirst();
   while (cnode) {
     QuiltPatch *pqp = cnode->GetData();
     if (pqp->b_overlay && (pqp->ActiveRegion.Contains(lat, lon)))
@@ -749,7 +747,7 @@ std::vector<int> Quilt::GetQuiltIndexArray(void) {
 
   m_bbusy = true;
 
-  wxPatchListNode *cnode = m_PatchList.GetFirst();
+  PatchList::compatibility_iterator cnode = m_PatchList.GetFirst();
   while (cnode) {
     ret.push_back(cnode->GetData()->dbIndex);
     cnode = cnode->GetNext();
@@ -1126,7 +1124,7 @@ LLRegion Quilt::GetHiliteRegion() {
     xxx
     // Walk the PatchList, looking for the target hilite index
     for (unsigned int i = 0; i < m_PatchList.GetCount(); i++) {
-      wxPatchListNode *pcinode = m_PatchList.Item(i);
+      PatchList::compatibility_iterator pcinode = m_PatchList.Item(i);
       QuiltPatch *piqp = pcinode->GetData();
       if ((index == piqp->dbIndex) && (piqp->b_Valid))  // found it
       {
@@ -1144,7 +1142,7 @@ LLRegion Quilt::GetHiliteRegion() {
   if (m_nHiLiteIndex >= 0) {
     // Walk the PatchList, looking for the target hilite index
     for (unsigned int i = 0; i < m_PatchList.GetCount(); i++) {
-      wxPatchListNode *pcinode = m_PatchList.Item(i);
+      PatchList::compatibility_iterator pcinode = m_PatchList.Item(i);
       QuiltPatch *piqp = pcinode->GetData();
       if ((m_nHiLiteIndex == piqp->dbIndex) && (piqp->b_Valid))  // found it
       {
@@ -2170,7 +2168,7 @@ bool Quilt::Compose(const ViewPort &vp_in) {
     //    Walk the PatchList, marking any entries whose projection does not
     //    match the determined quilt projection
     for (unsigned int i = 0; i < m_PatchList.GetCount(); i++) {
-      wxPatchListNode *pcinode = m_PatchList.Item(i);
+      PatchList::compatibility_iterator pcinode = m_PatchList.Item(i);
       QuiltPatch *piqp = pcinode->GetData();
       if ((piqp->ProjType != m_quilt_proj) &&
           (piqp->ProjType != PROJECTION_UNKNOWN))
@@ -2180,7 +2178,7 @@ bool Quilt::Compose(const ViewPort &vp_in) {
 
   //    Walk the PatchList, marking any entries which appear in the noshow array
   for (unsigned int i = 0; i < m_PatchList.GetCount(); i++) {
-    wxPatchListNode *pcinode = m_PatchList.Item(i);
+    PatchList::compatibility_iterator pcinode = m_PatchList.Item(i);
     QuiltPatch *piqp = pcinode->GetData();
     for (unsigned int ins = 0;
          ins < m_parent->GetQuiltNoshowIindexArray().size(); ins++) {
@@ -2204,7 +2202,7 @@ bool Quilt::Compose(const ViewPort &vp_in) {
   if (m_reference_type == CHART_TYPE_CM93COMP) {
     // find cm93 in the list
     for (int i = m_PatchList.GetCount() - 1; i >= 0; i--) {
-      wxPatchListNode *pcinode = m_PatchList.Item(i);
+      PatchList::compatibility_iterator pcinode = m_PatchList.Item(i);
       QuiltPatch *piqp = pcinode->GetData();
       if (!piqp->b_Valid)  // skip invalid entries
         continue;
@@ -2229,7 +2227,7 @@ bool Quilt::Compose(const ViewPort &vp_in) {
   //  Proceeding from largest scale to smallest....
 
   for (int i = m_PatchList.GetCount() - 1; i >= 0; i--) {
-    wxPatchListNode *pcinode = m_PatchList.Item(i);
+    PatchList::compatibility_iterator pcinode = m_PatchList.Item(i);
     QuiltPatch *piqp = pcinode->GetData();
     if (!piqp->b_Valid)  // skip invalid entries
       continue;
@@ -2266,7 +2264,7 @@ bool Quilt::Compose(const ViewPort &vp_in) {
   // this is the old algorithm does the same thing in n^2/2 operations instead
   // of 2*n-1
   for (unsigned int i = 0; i < m_PatchList.GetCount(); i++) {
-    wxPatchListNode *pcinode = m_PatchList.Item(i);
+    PatchList::compatibility_iterator pcinode = m_PatchList.Item(i);
     QuiltPatch *piqp = pcinode->GetData();
 
     if (!piqp->b_Valid)  // skip invalid entries
@@ -2284,7 +2282,7 @@ bool Quilt::Compose(const ViewPort &vp_in) {
 
     // fetch and subtract regions for all larger scale charts
     for (unsigned int k = i + 1; k < m_PatchList.GetCount(); k++) {
-      wxPatchListNode *pnode = m_PatchList.Item(k);
+      PatchList::compatibility_iterator pnode = m_PatchList.Item(k);
       QuiltPatch *pqp = pnode->GetData();
 
       if (!pqp->b_Valid)  // skip invalid entries
@@ -2321,7 +2319,7 @@ bool Quilt::Compose(const ViewPort &vp_in) {
     //    Whatever is left in the vpr region and has not been yet rendered must
     //    belong to the current target chart
 
-    wxPatchListNode *pinode = m_PatchList.Item(i);
+    PatchList::compatibility_iterator pinode = m_PatchList.Item(i);
     QuiltPatch *pqpi = pinode->GetData();
     pqpi->ActiveRegion = vpr_region;
 
@@ -2349,7 +2347,7 @@ bool Quilt::Compose(const ViewPort &vp_in) {
   //    Walk the list again, removing any entries marked as eclipsed....
   unsigned int il = 0;
   while (il < m_PatchList.GetCount()) {
-    wxPatchListNode *pcinode = m_PatchList.Item(il);
+    PatchList::compatibility_iterator pcinode = m_PatchList.Item(il);
     QuiltPatch *piqp = pcinode->GetData();
     if (piqp->b_eclipsed) {
       //    Make sure that this chart appears in the eclipsed list...
@@ -2447,7 +2445,7 @@ bool Quilt::Compose(const ViewPort &vp_in) {
   //    The index array is to be built in reverse, largest scale first
   unsigned int kl = m_PatchList.GetCount();
   for (unsigned int k = 0; k < kl; k++) {
-    wxPatchListNode *cnode = m_PatchList.Item((kl - k) - 1);
+    PatchList::compatibility_iterator cnode = m_PatchList.Item((kl - k) - 1);
     m_index_array.push_back(cnode->GetData()->dbIndex);
     cnode = cnode->GetNext();
   }
@@ -2477,7 +2475,7 @@ bool Quilt::Compose(const ViewPort &vp_in) {
   }
 
   for (unsigned int k = 0; k < m_PatchList.GetCount(); k++) {
-    wxPatchListNode *pnode = m_PatchList.Item(k);
+    PatchList::compatibility_iterator pnode = m_PatchList.Item(k);
     QuiltPatch *pqp = pnode->GetData();
 
     if (!pqp->b_Valid)  // skip invalid entries
@@ -2526,7 +2524,7 @@ bool Quilt::Compose(const ViewPort &vp_in) {
   //    If still missing, remove its patch from the quilt
   //    This will probably leave a "black hole" in the quilt...
   for (unsigned int k = 0; k < m_PatchList.GetCount(); k++) {
-    wxPatchListNode *pnode = m_PatchList.Item(k);
+    PatchList::compatibility_iterator pnode = m_PatchList.Item(k);
     QuiltPatch *pqp = pnode->GetData();
 
     if (pqp->b_Valid) {
@@ -2552,7 +2550,7 @@ bool Quilt::Compose(const ViewPort &vp_in) {
   m_bquilt_has_overlays = false;
   m_max_error_factor = 0.;
   for (unsigned int k = 0; k < m_PatchList.GetCount(); k++) {
-    wxPatchListNode *pnode = m_PatchList.Item(k);
+    PatchList::compatibility_iterator pnode = m_PatchList.Item(k);
     QuiltPatch *pqp = pnode->GetData();
 
     if (!pqp->b_Valid)  // skip invalid entries

--- a/gui/src/RoutePropDlgImpl.cpp
+++ b/gui/src/RoutePropDlgImpl.cpp
@@ -527,7 +527,7 @@ void RoutePropDlgImpl::SetRouteAndUpdate(Route* pR, bool only_points) {
     if (m_scrolledWindowLinks) {
       wxWindowList kids = m_scrolledWindowLinks->GetChildren();
       for (unsigned int i = 0; i < kids.GetCount(); i++) {
-        wxWindowListNode* node = kids.Item(i);
+        wxWindowList::compatibility_iterator node = kids.Item(i);
         wxWindow* win = node->GetData();
         auto link_win = dynamic_cast<wxHyperlinkCtrl*>(win);
         if (link_win) {
@@ -1260,7 +1260,7 @@ void RoutePropDlgImpl::ItemDeleteOnMenuSelection(wxCommandEvent& event) {
 
   wxWindowList kids = m_scrolledWindowLinks->GetChildren();
   for (unsigned int i = 0; i < kids.GetCount(); i++) {
-    wxWindowListNode* node = kids.Item(i);
+    wxWindowList::compatibility_iterator node = kids.Item(i);
     wxWindow* win = node->GetData();
 
     auto link_win = dynamic_cast<wxHyperlinkCtrl*>(win);

--- a/gui/src/RoutePropDlgImpl.cpp
+++ b/gui/src/RoutePropDlgImpl.cpp
@@ -542,7 +542,8 @@ void RoutePropDlgImpl::SetRouteAndUpdate(Route* pR, bool only_points) {
       int NbrOfLinks = m_pRoute->m_HyperlinkList->GetCount();
       HyperlinkList* hyperlinklist = m_pRoute->m_HyperlinkList;
       if (NbrOfLinks > 0) {
-        wxHyperlinkListNode* linknode = hyperlinklist->GetFirst();
+        HyperlinkList::compatibility_iterator linknode =
+            hyperlinklist->GetFirst();
         while (linknode) {
           Hyperlink* link = linknode->GetData();
           wxString Link = link->Link;
@@ -1215,7 +1216,8 @@ void RoutePropDlgImpl::ItemEditOnMenuSelection(wxCommandEvent& event) {
       HyperlinkList* hyperlinklist = m_pRoute->m_HyperlinkList;
       //            int len = 0;
       if (NbrOfLinks > 0) {
-        wxHyperlinkListNode* linknode = hyperlinklist->GetFirst();
+        HyperlinkList::compatibility_iterator linknode =
+            hyperlinklist->GetFirst();
         while (linknode) {
           Hyperlink* link = linknode->GetData();
           wxString Link = link->Link;
@@ -1251,7 +1253,7 @@ void RoutePropDlgImpl::ItemAddOnMenuSelection(wxCommandEvent& event) {
 }
 
 void RoutePropDlgImpl::ItemDeleteOnMenuSelection(wxCommandEvent& event) {
-  wxHyperlinkListNode* nodeToDelete = NULL;
+  HyperlinkList::compatibility_iterator nodeToDelete;
   wxString findurl = m_pEditedLink->GetURL();
   wxString findlabel = m_pEditedLink->GetLabel();
 
@@ -1277,7 +1279,7 @@ void RoutePropDlgImpl::ItemDeleteOnMenuSelection(wxCommandEvent& event) {
   HyperlinkList* hyperlinklist = m_pRoute->m_HyperlinkList;
   //      int len = 0;
   if (NbrOfLinks > 0) {
-    wxHyperlinkListNode* linknode = hyperlinklist->GetFirst();
+    HyperlinkList::compatibility_iterator linknode = hyperlinklist->GetFirst();
     while (linknode) {
       Hyperlink* link = linknode->GetData();
       wxString Link = link->Link;

--- a/gui/src/RoutePropDlgImpl.cpp
+++ b/gui/src/RoutePropDlgImpl.cpp
@@ -348,7 +348,8 @@ void RoutePropDlgImpl::UpdatePoints() {
                        toUsrDistance(m_pRoute->m_route_length)));
   m_tcEnroute->SetValue(formatTimeDelta(wxLongLong(m_pRoute->m_route_time)));
   //  Iterate on Route Points, inserting blank fields starting with index 0
-  wxRoutePointListNode* pnode = m_pRoute->pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator pnode =
+      m_pRoute->pRoutePointList->GetFirst();
   int in = 0;
   wxString slen, eta, ete;
   double bearing, distance, speed;

--- a/gui/src/TrackPropDlg.cpp
+++ b/gui/src/TrackPropDlg.cpp
@@ -1113,7 +1113,7 @@ bool TrackPropDlg::UpdateProperties() {
   if (m_scrolledWindowLinks) {
     wxWindowList kids = m_scrolledWindowLinks->GetChildren();
     for (unsigned int i = 0; i < kids.GetCount(); i++) {
-      wxWindowListNode* node = kids.Item(i);
+      wxWindowList::compatibility_iterator node = kids.Item(i);
       wxWindow* win = node->GetData();
 
       auto link_win = dynamic_cast<wxHyperlinkCtrl*>(win);
@@ -1530,7 +1530,7 @@ void TrackPropDlg::OnDeleteLink(wxCommandEvent& event) {
 
   wxWindowList kids = m_scrolledWindowLinks->GetChildren();
   for (unsigned int i = 0; i < kids.GetCount(); i++) {
-    wxWindowListNode* node = kids.Item(i);
+    wxWindowList::compatibility_iterator node = kids.Item(i);
     wxWindow* win = node->GetData();
 
     auto link_win = dynamic_cast<wxHyperlinkCtrl*>(win);

--- a/gui/src/TrackPropDlg.cpp
+++ b/gui/src/TrackPropDlg.cpp
@@ -1052,7 +1052,8 @@ void TrackPropDlg::SetTrackAndUpdate(Track* pt) {
 
   int NbrOfLinks = m_pTrack->m_TrackHyperlinkList->GetCount();
   if (NbrOfLinks > 0) {
-    wxHyperlinkListNode* linknode = m_pTrack->m_TrackHyperlinkList->GetFirst();
+    HyperlinkList::compatibility_iterator linknode =
+        m_pTrack->m_TrackHyperlinkList->GetFirst();
     while (linknode) {
       Hyperlink* link = linknode->GetData();
 
@@ -1131,7 +1132,8 @@ bool TrackPropDlg::UpdateProperties() {
     HyperlinkList* hyperlinklist = m_pTrack->m_TrackHyperlinkList;
     //            int len = 0;
     if (NbrOfLinks > 0) {
-      wxHyperlinkListNode* linknode = hyperlinklist->GetFirst();
+      HyperlinkList::compatibility_iterator linknode =
+          hyperlinklist->GetFirst();
       while (linknode) {
         Hyperlink* link = linknode->GetData();
         wxString Link = link->Link;
@@ -1522,7 +1524,7 @@ void TrackPropDlg::PopupMenuHandler(wxCommandEvent& event) {
 }
 
 void TrackPropDlg::OnDeleteLink(wxCommandEvent& event) {
-  wxHyperlinkListNode* nodeToDelete = NULL;
+  HyperlinkList::compatibility_iterator nodeToDelete;
   wxString findurl = m_pEditedLink->GetURL();
   wxString findlabel = m_pEditedLink->GetLabel();
 
@@ -1548,7 +1550,7 @@ void TrackPropDlg::OnDeleteLink(wxCommandEvent& event) {
   HyperlinkList* hyperlinklist = m_pTrack->m_TrackHyperlinkList;
   //      int len = 0;
   if (NbrOfLinks > 0) {
-    wxHyperlinkListNode* linknode = hyperlinklist->GetFirst();
+    HyperlinkList::compatibility_iterator linknode = hyperlinklist->GetFirst();
     while (linknode) {
       Hyperlink* link = linknode->GetData();
       wxString Link = link->Link;
@@ -1594,7 +1596,8 @@ void TrackPropDlg::OnEditLink(wxCommandEvent& event) {
       HyperlinkList* hyperlinklist = m_pTrack->m_TrackHyperlinkList;
       //            int len = 0;
       if (NbrOfLinks > 0) {
-        wxHyperlinkListNode* linknode = hyperlinklist->GetFirst();
+        HyperlinkList::compatibility_iterator linknode =
+            hyperlinklist->GetFirst();
         while (linknode) {
           Hyperlink* link = linknode->GetData();
           wxString Link = link->Link;

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -10942,7 +10942,7 @@ void pupHandler_PasteRoute() {
   // don't create a new route.
   if (mergepoints && answer == wxID_YES &&
       existingWaypointCounter == pasted->GetnPoints()) {
-    wxRouteListNode *route_node = pRouteList->GetFirst();
+    RouteList::compatibility_iterator route_node = pRouteList->GetFirst();
     while (route_node) {
       Route *proute = route_node->GetData();
 
@@ -13083,7 +13083,7 @@ void ChartCanvas::DrawActiveTrackInBBox(ocpnDC &dc, LLBBox &BltBBox) {
 void ChartCanvas::DrawAllRoutesInBBox(ocpnDC &dc, LLBBox &BltBBox) {
   Route *active_route = NULL;
 
-  for (wxRouteListNode *node = pRouteList->GetFirst(); node;
+  for (RouteList::compatibility_iterator node = pRouteList->GetFirst(); node;
        node = node->GetNext()) {
     Route *pRouteDraw = node->GetData();
     if (pRouteDraw->IsActive() || pRouteDraw->IsSelected()) {
@@ -13103,7 +13103,7 @@ void ChartCanvas::DrawAllRoutesInBBox(ocpnDC &dc, LLBBox &BltBBox) {
 void ChartCanvas::DrawActiveRouteInBBox(ocpnDC &dc, LLBBox &BltBBox) {
   Route *active_route = NULL;
 
-  for (wxRouteListNode *node = pRouteList->GetFirst(); node;
+  for (RouteList::compatibility_iterator node = pRouteList->GetFirst(); node;
        node = node->GetNext()) {
     Route *pRouteDraw = node->GetData();
     if (pRouteDraw->IsActive() || pRouteDraw->IsSelected()) {

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -4008,7 +4008,7 @@ void ChartCanvas::OnRolloverPopupTimerEvent(wxTimerEvent &event) {
     SelectCtx ctx(m_bShowNavobjects, GetCanvasTrueScale(), GetScaleValue());
     SelectableItemList SelList = pSelect->FindSelectionList(
         ctx, m_cursor_lat, m_cursor_lon, SELTYPE_ROUTESEGMENT);
-    wxSelectableItemListNode *node = SelList.GetFirst();
+    SelectableItemList::compatibility_iterator node = SelList.GetFirst();
     while (node) {
       SelectItem *pFindSel = node->GetData();
 
@@ -4183,7 +4183,7 @@ void ChartCanvas::OnRolloverPopupTimerEvent(wxTimerEvent &event) {
     SelectCtx ctx(m_bShowNavobjects, GetCanvasTrueScale(), GetScaleValue());
     SelectableItemList SelList = pSelect->FindSelectionList(
         ctx, m_cursor_lat, m_cursor_lon, SELTYPE_TRACKSEGMENT);
-    wxSelectableItemListNode *node = SelList.GetFirst();
+    SelectableItemList::compatibility_iterator node = SelList.GetFirst();
     while (node) {
       SelectItem *pFindSel = node->GetData();
 
@@ -7415,7 +7415,7 @@ void ChartCanvas::FindRoutePointsAtCursor(float selectRadius,
   SelectCtx ctx(m_bShowNavobjects, GetCanvasTrueScale(), GetScaleValue());
   SelectableItemList SelList = pSelect->FindSelectionList(
       ctx, m_cursor_lat, m_cursor_lon, SELTYPE_ROUTEPOINT);
-  wxSelectableItemListNode *node = SelList.GetFirst();
+  SelectableItemList::compatibility_iterator node = SelList.GetFirst();
   while (node) {
     pFind = node->GetData();
 
@@ -7517,7 +7517,7 @@ std::shared_ptr<PI_PointContext> ChartCanvas::GetCanvasContextAtPoint(int x,
     SelectCtx ctx(m_bShowNavobjects, GetCanvasTrueScale(), GetScaleValue());
     SelectableItemList SelList =
         pSelect->FindSelectionList(ctx, slat, slon, SELTYPE_ROUTEPOINT);
-    wxSelectableItemListNode *node = SelList.GetFirst();
+    SelectableItemList::compatibility_iterator node = SelList.GetFirst();
     while (node) {
       SelectItem *pFindSel = node->GetData();
 
@@ -7615,7 +7615,7 @@ std::shared_ptr<PI_PointContext> ChartCanvas::GetCanvasContextAtPoint(int x,
     if (NULL == SelectedRoute)  // the case where a segment only is selected
     {
       //  Choose the first visible route containing segment in the list
-      wxSelectableItemListNode *node = SelList.GetFirst();
+      SelectableItemList::compatibility_iterator node = SelList.GetFirst();
       while (node) {
         SelectItem *pFindSel = node->GetData();
 
@@ -7645,7 +7645,7 @@ std::shared_ptr<PI_PointContext> ChartCanvas::GetCanvasContextAtPoint(int x,
         pSelect->FindSelectionList(ctx, slat, slon, SELTYPE_TRACKSEGMENT);
 
     //  Choose the first visible track containing segment in the list
-    wxSelectableItemListNode *node = SelList.GetFirst();
+    SelectableItemList::compatibility_iterator node = SelList.GetFirst();
     while (node) {
       SelectItem *pFindSel = node->GetData();
 
@@ -7680,7 +7680,7 @@ std::shared_ptr<PI_PointContext> ChartCanvas::GetCanvasContextAtPoint(int x,
           ctx, m_cursor_lat, m_cursor_lon, SELTYPE_CURRENTPOINT);
 
       //      Default is first entry
-      wxSelectableItemListNode *node = SelList.GetFirst();
+      SelectableItemList::compatibility_iterator node = SelList.GetFirst();
       pFind = node->GetData();
       pIDX_best_candidate = (IDX_entry *)(pFind->m_pData1);
 
@@ -7697,7 +7697,7 @@ std::shared_ptr<PI_PointContext> ChartCanvas::GetCanvasContextAtPoint(int x,
           node = node->GetNext();
         }  // while (node)
       } else {
-        wxSelectableItemListNode *node = SelList.GetFirst();
+        SelectableItemList::compatibility_iterator node = SelList.GetFirst();
         pFind = node->GetData();
         pIDX_best_candidate = (IDX_entry *)(pFind->m_pData1);
       }
@@ -8156,7 +8156,7 @@ void ChartCanvas::CallPopupMenu(int x, int y) {
     SelectCtx ctx(m_bShowNavobjects, GetCanvasTrueScale(), GetScaleValue());
     SelectableItemList SelList =
         pSelect->FindSelectionList(ctx, slat, slon, SELTYPE_ROUTEPOINT);
-    wxSelectableItemListNode *node = SelList.GetFirst();
+    SelectableItemList::compatibility_iterator node = SelList.GetFirst();
     while (node) {
       SelectItem *pFindSel = node->GetData();
 
@@ -8253,7 +8253,7 @@ void ChartCanvas::CallPopupMenu(int x, int y) {
     if (NULL == m_pSelectedRoute)  // the case where a segment only is selected
     {
       //  Choose the first visible route containing segment in the list
-      wxSelectableItemListNode *node = SelList.GetFirst();
+      SelectableItemList::compatibility_iterator node = SelList.GetFirst();
       while (node) {
         SelectItem *pFindSel = node->GetData();
 
@@ -8292,7 +8292,7 @@ void ChartCanvas::CallPopupMenu(int x, int y) {
         pSelect->FindSelectionList(ctx, slat, slon, SELTYPE_TRACKSEGMENT);
 
     //  Choose the first visible track containing segment in the list
-    wxSelectableItemListNode *node = SelList.GetFirst();
+    SelectableItemList::compatibility_iterator node = SelList.GetFirst();
     while (node) {
       SelectItem *pFindSel = node->GetData();
 
@@ -8325,7 +8325,7 @@ void ChartCanvas::CallPopupMenu(int x, int y) {
           ctx, m_cursor_lat, m_cursor_lon, SELTYPE_CURRENTPOINT);
 
       //      Default is first entry
-      wxSelectableItemListNode *node = SelList.GetFirst();
+      SelectableItemList::compatibility_iterator node = SelList.GetFirst();
       pFind = node->GetData();
       pIDX_best_candidate = (IDX_entry *)(pFind->m_pData1);
 
@@ -8342,7 +8342,7 @@ void ChartCanvas::CallPopupMenu(int x, int y) {
           node = node->GetNext();
         }  // while (node)
       } else {
-        wxSelectableItemListNode *node = SelList.GetFirst();
+        SelectableItemList::compatibility_iterator node = SelList.GetFirst();
         pFind = node->GetData();
         pIDX_best_candidate = (IDX_entry *)(pFind->m_pData1);
       }
@@ -8439,7 +8439,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
 
     SelectableItemList rpSelList =
         pSelect->FindSelectionList(ctx, zlat, zlon, SELTYPE_ROUTEPOINT);
-    wxSelectableItemListNode *node = rpSelList.GetFirst();
+    SelectableItemList::compatibility_iterator node = rpSelList.GetFirst();
     bool b_onRPtarget = false;
     while (node) {
       SelectItem *pFind = node->GetData();
@@ -8908,7 +8908,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
         SelectItem *pFind = NULL;
         SelectableItemList SelList = pSelect->FindSelectionList(
             ctx, m_cursor_lat, m_cursor_lon, SELTYPE_ROUTEPOINT);
-        wxSelectableItemListNode *node = SelList.GetFirst();
+        SelectableItemList::compatibility_iterator node = SelList.GetFirst();
         while (node) {
           pFind = node->GetData();
           RoutePoint *frp = (RoutePoint *)pFind->m_pData1;
@@ -8923,7 +8923,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
         SelectItem *pFind = NULL;
         SelectableItemList SelList = pSelect->FindSelectionList(
             ctx, m_cursor_lat, m_cursor_lon, SELTYPE_DRAGHANDLE);
-        wxSelectableItemListNode *node = SelList.GetFirst();
+        SelectableItemList::compatibility_iterator node = SelList.GetFirst();
         while (node) {
           pFind = node->GetData();
           RoutePoint *frp = (RoutePoint *)pFind->m_pData1;
@@ -9606,7 +9606,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
       if (!b_start_rollover && !b_startedit_route) {
         SelectableItemList SelList = pSelect->FindSelectionList(
             ctx, m_cursor_lat, m_cursor_lon, SELTYPE_ROUTESEGMENT);
-        wxSelectableItemListNode *node = SelList.GetFirst();
+        SelectableItemList::compatibility_iterator node = SelList.GetFirst();
         while (node) {
           SelectItem *pFindSel = node->GetData();
 
@@ -9623,7 +9623,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
       if (!b_start_rollover && !b_startedit_route) {
         SelectableItemList SelList = pSelect->FindSelectionList(
             ctx, m_cursor_lat, m_cursor_lon, SELTYPE_TRACKSEGMENT);
-        wxSelectableItemListNode *node = SelList.GetFirst();
+        SelectableItemList::compatibility_iterator node = SelList.GetFirst();
         while (node) {
           SelectItem *pFindSel = node->GetData();
 

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -4076,7 +4076,7 @@ void ChartCanvas::OnRolloverPopupTimerEvent(wxTimerEvent &event) {
             validActive = true;
 
           if (segShow_point_a != pr->pRoutePointList->GetFirst()->GetData()) {
-            wxRoutePointListNode *node =
+            RoutePointList::compatibility_iterator node =
                 (pr->pRoutePointList)->GetFirst()->GetNext();
             RoutePoint *prp;
             float dist_to_endleg = 0;
@@ -13117,7 +13117,8 @@ void ChartCanvas::DrawActiveRouteInBBox(ocpnDC &dc, LLBBox &BltBBox) {
 void ChartCanvas::DrawAllWaypointsInBBox(ocpnDC &dc, LLBBox &BltBBox) {
   if (!pWayPointMan) return;
 
-  wxRoutePointListNode *node = pWayPointMan->GetWaypointList()->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      pWayPointMan->GetWaypointList()->GetFirst();
 
   while (node) {
     RoutePoint *pWP = node->GetData();
@@ -13163,7 +13164,8 @@ void ChartCanvas::DrawBlinkObjects(void) {
 
   if (!pWayPointMan) return;
 
-  wxRoutePointListNode *node = pWayPointMan->GetWaypointList()->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      pWayPointMan->GetWaypointList()->GetFirst();
 
   while (node) {
     RoutePoint *pWP = node->GetData();

--- a/gui/src/cm93.cpp
+++ b/gui/src/cm93.cpp
@@ -3855,10 +3855,12 @@ M_COVR_Desc *cm93chart::FindM_COVR_InWorkingSet(double lat, double lon) {
   M_COVR_Desc *ret = NULL;
   //    Default is to use the first M_COVR, the usual case
   if (m_CIB.m_cell_mcovr_list.GetCount() == 1) {
-    wxList_Of_M_COVR_DescNode *node0 = m_CIB.m_cell_mcovr_list.GetFirst();
+    List_Of_M_COVR_Desc::compatibility_iterator node0 =
+        m_CIB.m_cell_mcovr_list.GetFirst();
     if (node0) ret = node0->GetData();
   } else {
-    wxList_Of_M_COVR_DescNode *node = m_CIB.m_cell_mcovr_list.GetFirst();
+    List_Of_M_COVR_Desc::compatibility_iterator node =
+        m_CIB.m_cell_mcovr_list.GetFirst();
     while (node) {
       M_COVR_Desc *pmcd = node->GetData();
 
@@ -3879,7 +3881,8 @@ wxPoint2DDouble cm93chart::FindM_COVROffset(double lat, double lon) {
   wxPoint2DDouble ret(0., 0.);
 
   //    Default is to use the first M_COVR, the usual case
-  wxList_Of_M_COVR_DescNode *node0 = m_CIB.m_cell_mcovr_list.GetFirst();
+  List_Of_M_COVR_Desc::compatibility_iterator node0 =
+      m_CIB.m_cell_mcovr_list.GetFirst();
   if (node0) {
     M_COVR_Desc *pmcd0 = node0->GetData();
     ret.m_x = pmcd0->transform_WGS84_offset_x;
@@ -3888,7 +3891,8 @@ wxPoint2DDouble cm93chart::FindM_COVROffset(double lat, double lon) {
 
   //    If there are more than one M_COVR in this cell, need to search
   if (m_CIB.m_cell_mcovr_list.GetCount() > 1) {
-    wxList_Of_M_COVR_DescNode *node = m_CIB.m_cell_mcovr_list.GetFirst();
+    List_Of_M_COVR_Desc::compatibility_iterator node =
+        m_CIB.m_cell_mcovr_list.GetFirst();
     while (node) {
       M_COVR_Desc *pmcd = node->GetData();
 

--- a/gui/src/concanv.cpp
+++ b/gui/src/concanv.cpp
@@ -366,7 +366,8 @@ void ConsoleCanvasWin::UpdateRouteData() {
         float trng = rng;
 
         Route* prt = g_pRouteMan->GetpActiveRoute();
-        wxRoutePointListNode* node = (prt->pRoutePointList)->GetFirst();
+        RoutePointList::compatibility_iterator node =
+            (prt->pRoutePointList)->GetFirst();
         RoutePoint* prp;
 
         int n_addflag = 0;
@@ -776,7 +777,8 @@ void ConsoleCanvasFrame::UpdateRouteData() {
         float trng = rng;
 
         Route* prt = g_pRouteMan->GetpActiveRoute();
-        wxRoutePointListNode* node = (prt->pRoutePointList)->GetFirst();
+        RoutePointList::compatibility_iterator node =
+            (prt->pRoutePointList)->GetFirst();
         RoutePoint* prp;
 
         int n_addflag = 0;

--- a/gui/src/conn_params_panel.cpp
+++ b/gui/src/conn_params_panel.cpp
@@ -113,7 +113,7 @@ void ConnectionParamsPanel::SetSelected(bool selected) {
 
   wxWindowList kids = GetChildren();
   for (unsigned int i = 0; i < kids.GetCount(); i++) {
-    wxWindowListNode *node = kids.Item(i);
+    wxWindowList::compatibility_iterator node = kids.Item(i);
     wxWindow *win = node->GetData();
     win->SetBackgroundColour(m_boxColour);
   }

--- a/gui/src/connections_dlg.cpp
+++ b/gui/src/connections_dlg.cpp
@@ -856,6 +856,7 @@ public:
       : wxPanel(parent, wxID_ANY) {
     auto sizer = new wxStaticBoxSizer(wxVERTICAL, this, "");
     sizer->Add(new BearingsCheckbox(this), wxSizerFlags().Expand());
+    sizer->Add(new ExtraRmbRmcCheckbox(this), wxSizerFlags().Expand());
     sizer->Add(new NmeaFilterRow(this), wxSizerFlags().Expand());
     sizer->Add(new TalkerIdRow(this), wxSizerFlags().Expand());
     sizer->Add(new NetmaskRow(this), wxSizerFlags().Expand());
@@ -875,6 +876,18 @@ private:
 
     void Apply() override { g_bMagneticAPB = GetValue(); }
     void Cancel() override { SetValue(g_bMagneticAPB); }
+  };
+
+  class ExtraRmbRmcCheckbox : public wxCheckBox, public ApplyCancel {
+  public:
+    ExtraRmbRmcCheckbox(wxWindow* parent)
+        : wxCheckBox(parent, wxID_ANY,
+                     _("Always send RMB and RMC NMEA0183 data")) {
+      wxCheckBox::SetValue(g_always_send_rmb_rmc);
+    }
+
+    void Apply() override { g_always_send_rmb_rmc = GetValue(); }
+    void Cancel() override { SetValue(g_always_send_rmb_rmc); }
   };
 
   /** NMEA filter setup bound to g_bfilter_cogsog and g_COGFilterSec. */

--- a/gui/src/glChartCanvas.cpp
+++ b/gui/src/glChartCanvas.cpp
@@ -1604,7 +1604,7 @@ void glChartCanvas::DrawStaticRoutesTracksAndWaypoints(ViewPort &vp) {
     TrackGui(*pTrackDraw).Draw(m_pParentCanvas, dc, vp, vp.GetBBox());
   }
 
-  for (wxRouteListNode *node = pRouteList->GetFirst(); node;
+  for (RouteList::compatibility_iterator node = pRouteList->GetFirst(); node;
        node = node->GetNext()) {
     Route *pRouteDraw = node->GetData();
 
@@ -1644,7 +1644,7 @@ void glChartCanvas::DrawDynamicRoutesTracksAndWaypoints(ViewPort &vp) {
     // We need Track::Draw() to dynamically render last (ownship) point.
   }
 
-  for (wxRouteListNode *node = pRouteList->GetFirst(); node;
+  for (RouteList::compatibility_iterator node = pRouteList->GetFirst(); node;
        node = node->GetNext()) {
     Route *pRouteDraw = node->GetData();
 

--- a/gui/src/glChartCanvas.cpp
+++ b/gui/src/glChartCanvas.cpp
@@ -1622,7 +1622,7 @@ void glChartCanvas::DrawStaticRoutesTracksAndWaypoints(ViewPort &vp) {
 
   /* Waypoints not drawn as part of routes, and not being edited */
   if (vp.GetBBox().GetValid() && pWayPointMan) {
-    for (wxRoutePointListNode *pnode =
+    for (RoutePointList::compatibility_iterator pnode =
              pWayPointMan->GetWaypointList()->GetFirst();
          pnode; pnode = pnode->GetNext()) {
       RoutePoint *pWP = pnode->GetData();
@@ -1670,7 +1670,7 @@ void glChartCanvas::DrawDynamicRoutesTracksAndWaypoints(ViewPort &vp) {
 
   /* Waypoints not drawn as part of routes, which are being edited right now */
   if (vp.GetBBox().GetValid() && pWayPointMan) {
-    for (wxRoutePointListNode *pnode =
+    for (RoutePointList::compatibility_iterator pnode =
              pWayPointMan->GetWaypointList()->GetFirst();
          pnode; pnode = pnode->GetNext()) {
       RoutePoint *pWP = pnode->GetData();

--- a/gui/src/glTextureManager.cpp
+++ b/gui/src/glTextureManager.cpp
@@ -769,7 +769,7 @@ void glTextureManager::OnEvtThread(OCPN_CompressionThreadEvent &event) {
     // Look for a matching entry...
     bool bfound = false;
     ProgressInfoItem *item;
-    wxProgressInfoListNode *tnode = progList.GetFirst();
+    ProgressInfoList::compatibility_iterator tnode = progList.GetFirst();
     while (tnode) {
       item = tnode->GetData();
       if (item->file_path == ticket->m_ChartPath) {
@@ -891,7 +891,7 @@ void glTextureManager::OnEvtThread(OCPN_CompressionThreadEvent &event) {
     delete ticket->pFact;
   }
 
-  wxProgressInfoListNode *tnode = progList.GetFirst();
+  ProgressInfoList::compatibility_iterator tnode = progList.GetFirst();
   while (tnode) {
     ProgressInfoItem *item = tnode->GetData();
     if (item->file_path == ticket->m_ChartPath) item->file_path = _T("");

--- a/gui/src/glTextureManager.cpp
+++ b/gui/src/glTextureManager.cpp
@@ -958,7 +958,7 @@ bool glTextureManager::ScheduleJob(glTexFactory *client, const wxRect &rect,
   if (!b_nolimit) {
     if (todo_list.GetCount() >= 50) {
       // remove last job which is least important
-      wxJobListNode *node = todo_list.GetLast();
+      JobList::compatibility_iterator node = todo_list.GetLast();
       JobTicket *ticket = node->GetData();
       todo_list.DeleteNode(node);
       delete ticket;
@@ -966,7 +966,7 @@ bool glTextureManager::ScheduleJob(glTexFactory *client, const wxRect &rect,
 
     //  Avoid adding duplicate jobs, i.e. the same chart_path, and the same
     //  rectangle
-    wxJobListNode *node = todo_list.GetFirst();
+    JobList::compatibility_iterator node = todo_list.GetFirst();
     while (node) {
       JobTicket *ticket = node->GetData();
       if ((ticket->m_ChartPath == chart_path) && (ticket->m_rect == rect)) {
@@ -981,7 +981,7 @@ bool glTextureManager::ScheduleJob(glTexFactory *client, const wxRect &rect,
     }
 
     // avoid duplicate worker jobs
-    wxJobListNode *tnode = running_list.GetFirst();
+    JobList::compatibility_iterator tnode = running_list.GetFirst();
     while (tnode) {
       JobTicket *ticket = tnode->GetData();
       if (ticket->m_rect == rect && ticket->m_ChartPath == chart_path) {
@@ -1044,7 +1044,7 @@ bool glTextureManager::ScheduleJob(glTexFactory *client, const wxRect &rect,
 }
 
 bool glTextureManager::StartTopJob() {
-  wxJobListNode *node = todo_list.GetFirst();
+  JobList::compatibility_iterator node = todo_list.GetFirst();
   if (!node) return false;
 
   JobTicket *ticket = node->GetData();
@@ -1099,7 +1099,7 @@ bool glTextureManager::DoThreadJob(JobTicket *pticket) {
 
 bool glTextureManager::AsJob(wxString const &chart_path) const {
   if (chart_path.Len()) {
-    wxJobListNode *tnode = running_list.GetFirst();
+    JobList::compatibility_iterator tnode = running_list.GetFirst();
     while (tnode) {
       JobTicket *ticket = tnode->GetData();
       if (ticket->m_ChartPath.IsSameAs(chart_path)) {
@@ -1114,7 +1114,7 @@ bool glTextureManager::AsJob(wxString const &chart_path) const {
 void glTextureManager::PurgeJobList(wxString chart_path) {
   if (chart_path.Len()) {
     //  Remove all pending jobs relating to the passed chart path
-    wxJobListNode *next, *tnode = todo_list.GetFirst();
+    JobList::compatibility_iterator next, tnode = todo_list.GetFirst();
     while (tnode) {
       JobTicket *ticket = tnode->GetData();
       next = tnode->GetNext();
@@ -1127,7 +1127,7 @@ void glTextureManager::PurgeJobList(wxString chart_path) {
       tnode = next;
     }
 
-    wxJobListNode *node = running_list.GetFirst();
+    JobList::compatibility_iterator node = running_list.GetFirst();
     while (node) {
       JobTicket *ticket = node->GetData();
       if (ticket->m_ChartPath.IsSameAs(chart_path)) {
@@ -1140,7 +1140,7 @@ void glTextureManager::PurgeJobList(wxString chart_path) {
       printf("Pool:  Purge, todo count: %lu\n",
              (long unsigned)todo_list.GetCount());
   } else {
-    wxJobListNode *node = todo_list.GetFirst();
+    JobList::compatibility_iterator node = todo_list.GetFirst();
     while (node) {
       JobTicket *ticket = node->GetData();
       delete ticket;
@@ -1158,7 +1158,7 @@ void glTextureManager::PurgeJobList(wxString chart_path) {
 }
 
 void glTextureManager::ClearJobList() {
-  wxJobListNode *node = todo_list.GetFirst();
+  JobList::compatibility_iterator node = todo_list.GetFirst();
   while (node) {
     JobTicket *ticket = node->GetData();
     delete ticket;

--- a/gui/src/kml.cpp
+++ b/gui/src/kml.cpp
@@ -475,7 +475,7 @@ wxString Kml::MakeKmlFromRoute(Route* route, bool insertSeq) {
   std::stringstream lineStringCoords;
 
   RoutePointList* pointList = route->pRoutePointList;
-  wxRoutePointListNode* pointnode = pointList->GetFirst();
+  RoutePointList::compatibility_iterator pointnode = pointList->GetFirst();
   RoutePoint* routepoint;
 
   while (pointnode) {

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -3386,7 +3386,7 @@ void DimeControl(wxWindow *ctrl, wxColour col, wxColour window_back_color,
 
   wxWindowList kids = ctrl->GetChildren();
   for (unsigned int i = 0; i < kids.GetCount(); i++) {
-    wxWindowListNode *node = kids.Item(i);
+    wxWindowList::compatibility_iterator node = kids.Item(i);
     wxWindow *win = node->GetData();
 
     if (dynamic_cast<wxListBox *>(win) || dynamic_cast<wxListCtrl *>(win) ||

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -621,6 +621,7 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   SetPath(_T ( "/Settings" ));
   Read("ActiveRoute", &g_active_route);
   Read("PersistActiveRoute", &g_persist_active_route);
+  Read("AlwaysSendRmbRmc", &g_always_send_rmb_rmc);
   Read(_T ( "LastAppliedTemplate" ), &g_lastAppliedTemplateGUID);
   Read(_T ( "CompatOS" ), &g_compatOS);
   Read(_T ( "CompatOsVersion" ), &g_compatOsVersion);
@@ -2249,6 +2250,8 @@ void MyConfig::UpdateSettings() {
   Write(_T ( "GPSIdent" ), g_GPS_Ident);
   Write("ActiveRoute", g_active_route);
   Write("PersistActiveRoute", g_persist_active_route);
+  Write("AlwaysSendRmbRmc", g_always_send_rmb_rmc);
+
   Write(_T ( "UseGarminHostUpload" ), g_bGarminHostUpload);
 
   Write(_T ( "MobileTouch" ), g_btouch);

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -2747,7 +2747,8 @@ void ExportGPX(wxWindow *parent, bool bviz_only, bool blayer) {
     // WPTs
     int ic = 1;
 
-    wxRoutePointListNode *node = pWayPointMan->GetWaypointList()->GetFirst();
+    RoutePointList::compatibility_iterator node =
+        pWayPointMan->GetWaypointList()->GetFirst();
     RoutePoint *pr;
     while (node) {
       if (pprog && !(ic % progStep)) {

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -2772,7 +2772,7 @@ void ExportGPX(wxWindow *parent, bool bviz_only, bool blayer) {
       node = node->GetNext();
     }
     // RTEs and TRKs
-    wxRouteListNode *node1 = pRouteList->GetFirst();
+    RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
     while (node1) {
       Route *pRoute = node1->GetData();
 

--- a/gui/src/notification_manager_gui.cpp
+++ b/gui/src/notification_manager_gui.cpp
@@ -210,7 +210,7 @@ NotificationListPanel::~NotificationListPanel() {}
 void NotificationListPanel::ReloadNotificationPanels() {
   wxWindowList kids = GetChildren();
   for (unsigned int i = 0; i < kids.GetCount(); i++) {
-    wxWindowListNode* node = kids.Item(i);
+    wxWindowList::compatibility_iterator node = kids.Item(i);
     wxWindow* win = node->GetData();
     NotificationPanel* pp = dynamic_cast<NotificationPanel*>(win);
     if (pp) win->Destroy();

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -1761,7 +1761,7 @@ void MyFrame::OnCloseWindow(wxCloseEvent &event) {
       //    than 0.25 NM from this point
       //    This will prevent screen clutter and database congestion.
       if (g_declutter_anchorage) {
-        wxRoutePointListNode *node =
+        RoutePointList::compatibility_iterator node =
             pWayPointMan->GetWaypointList()->GetFirst();
         while (node) {
           RoutePoint *pr = node->GetData();

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -6641,7 +6641,8 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
           w[i][_T("Description")] = (*itp)->GetDescription();
           w[i][_T("GUID")] = (*itp)->m_GUID;
           w[i][_T("ArrivalRadius")] = (*itp)->GetWaypointArrivalRadius();
-          wxHyperlinkListNode *node = (*itp)->m_HyperlinkList->GetFirst();
+          HyperlinkList::compatibility_iterator node =
+              (*itp)->m_HyperlinkList->GetFirst();
           if (node) {
             int n = 1;
             while (node) {

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -894,7 +894,7 @@ MyFrame::~MyFrame() {
   // delete pCurrentStack;
 
   //      Free the Route List
-  wxRouteListNode *node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node = pRouteList->GetFirst();
 
   while (node) {
     Route *pRouteDelete = node->GetData();

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -59,6 +59,7 @@
 #include "model/ais_decoder.h"
 #include "model/ais_state_vars.h"
 #include "model/ais_target_data.h"
+#include "model/autopilot_output.h"
 #include "model/cmdline.h"
 #include "model/comm_drv_factory.h"  //FIXME(dave) this one goes away
 #include "model/comm_drv_registry.h"
@@ -5812,6 +5813,8 @@ void MyFrame::OnFrameTimer1(wxTimerEvent &event) {
   if (!g_btenhertz) bnew_view = DoChartUpdate();
 
   nBlinkerTick++;
+
+  if (g_always_send_rmb_rmc) SendNoRouteRmbRmc(*g_pRouteMan);
 
   // This call sends autopilot output strings to output ports.
   bool bactiveRouteUpdate = RoutemanGui(*g_pRouteMan).UpdateProgress();

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -1073,7 +1073,7 @@ wxArrayString GetRouteGUIDArray(void) {
   wxArrayString result;
   RouteList* list = pRouteList;
 
-  wxRouteListNode* prpnode = list->GetFirst();
+  RouteList::compatibility_iterator prpnode = list->GetFirst();
   while (prpnode) {
     Route* proute = prpnode->GetData();
     result.Add(proute->m_GUID);
@@ -1122,7 +1122,7 @@ wxArrayString GetRouteGUIDArray(OBJECT_LAYER_REQ req) {
   wxArrayString result;
   RouteList* list = pRouteList;
 
-  wxRouteListNode* prpnode = list->GetFirst();
+  RouteList::compatibility_iterator prpnode = list->GetFirst();
   while (prpnode) {
     Route* proute = prpnode->GetData();
     switch (req) {
@@ -1887,7 +1887,7 @@ int PlugIn_Waypoint_Ex::GetRouteMembershipCount() {
   if (!pWP) return 0;
 
   int nCount = 0;
-  wxRouteListNode* node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node = pRouteList->GetFirst();
   while (node) {
     Route* proute = node->GetData();
     RoutePointList::compatibility_iterator pnode =
@@ -1977,7 +1977,7 @@ int PlugIn_Waypoint_ExV2::GetRouteMembershipCount() {
   if (!pWP) return 0;
 
   int nCount = 0;
-  wxRouteListNode* node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node = pRouteList->GetFirst();
   while (node) {
     Route* proute = node->GetData();
     RoutePointList::compatibility_iterator pnode =

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -879,7 +879,8 @@ bool AddSingleWaypoint(PlugIn_Waypoint* pwaypoint, bool b_permanent) {
   //  GUID
   //  Make sure that this GUID is indeed unique in the Routepoint list
   bool b_unique = true;
-  wxRoutePointListNode* prpnode = pWayPointMan->GetWaypointList()->GetFirst();
+  RoutePointList::compatibility_iterator prpnode =
+      pWayPointMan->GetWaypointList()->GetFirst();
   while (prpnode) {
     RoutePoint* prp = prpnode->GetData();
 
@@ -1057,7 +1058,7 @@ wxArrayString GetWaypointGUIDArray(void) {
   wxArrayString result;
   const RoutePointList* list = pWayPointMan->GetWaypointList();
 
-  wxRoutePointListNode* prpnode = list->GetFirst();
+  RoutePointList::compatibility_iterator prpnode = list->GetFirst();
   while (prpnode) {
     RoutePoint* prp = prpnode->GetData();
     result.Add(prp->m_GUID);
@@ -1096,7 +1097,7 @@ wxArrayString GetWaypointGUIDArray(OBJECT_LAYER_REQ req) {
   wxArrayString result;
   const RoutePointList* list = pWayPointMan->GetWaypointList();
 
-  wxRoutePointListNode* prpnode = list->GetFirst();
+  RoutePointList::compatibility_iterator prpnode = list->GetFirst();
   while (prpnode) {
     RoutePoint* prp = prpnode->GetData();
     switch (req) {
@@ -1627,7 +1628,8 @@ std::unique_ptr<PlugIn_Route> GetRoute_Plugin(const wxString& GUID) {
 
   // PlugIn_Waypoint *pwp;
   RoutePoint* src_wp;
-  wxRoutePointListNode* node = route->pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      route->pRoutePointList->GetFirst();
 
   while (node) {
     src_wp = node->GetData();
@@ -1888,7 +1890,8 @@ int PlugIn_Waypoint_Ex::GetRouteMembershipCount() {
   wxRouteListNode* node = pRouteList->GetFirst();
   while (node) {
     Route* proute = node->GetData();
-    wxRoutePointListNode* pnode = (proute->pRoutePointList)->GetFirst();
+    RoutePointList::compatibility_iterator pnode =
+        (proute->pRoutePointList)->GetFirst();
     while (pnode) {
       RoutePoint* prp = pnode->GetData();
       if (prp == pWP) nCount++;
@@ -1977,7 +1980,8 @@ int PlugIn_Waypoint_ExV2::GetRouteMembershipCount() {
   wxRouteListNode* node = pRouteList->GetFirst();
   while (node) {
     Route* proute = node->GetData();
-    wxRoutePointListNode* pnode = (proute->pRoutePointList)->GetFirst();
+    RoutePointList::compatibility_iterator pnode =
+        (proute->pRoutePointList)->GetFirst();
     while (pnode) {
       RoutePoint* prp = pnode->GetData();
       if (prp == pWP) nCount++;
@@ -2156,7 +2160,8 @@ bool AddSingleWaypointExV2(PlugIn_Waypoint_ExV2* pwaypointex,
   //  GUID
   //  Make sure that this GUID is indeed unique in the Routepoint list
   bool b_unique = true;
-  wxRoutePointListNode* prpnode = pWayPointMan->GetWaypointList()->GetFirst();
+  RoutePointList::compatibility_iterator prpnode =
+      pWayPointMan->GetWaypointList()->GetFirst();
   while (prpnode) {
     RoutePoint* prp = prpnode->GetData();
 
@@ -2364,7 +2369,8 @@ std::unique_ptr<PlugIn_Route_ExV2> GetRouteExV2_Plugin(const wxString& GUID) {
   PlugIn_Route_ExV2* dst_route = r.get();
 
   RoutePoint* src_wp;
-  wxRoutePointListNode* node = route->pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      route->pRoutePointList->GetFirst();
 
   while (node) {
     src_wp = node->GetData();
@@ -2521,7 +2527,8 @@ bool AddSingleWaypointEx(PlugIn_Waypoint_Ex* pwaypointex, bool b_permanent) {
   //  GUID
   //  Make sure that this GUID is indeed unique in the Routepoint list
   bool b_unique = true;
-  wxRoutePointListNode* prpnode = pWayPointMan->GetWaypointList()->GetFirst();
+  RoutePointList::compatibility_iterator prpnode =
+      pWayPointMan->GetWaypointList()->GetFirst();
   while (prpnode) {
     RoutePoint* prp = prpnode->GetData();
 
@@ -2716,7 +2723,8 @@ std::unique_ptr<PlugIn_Route_Ex> GetRouteEx_Plugin(const wxString& GUID) {
 
   // PlugIn_Waypoint *pwp;
   RoutePoint* src_wp;
-  wxRoutePointListNode* node = route->pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      route->pRoutePointList->GetFirst();
 
   while (node) {
     src_wp = node->GetData();

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -1180,7 +1180,8 @@ bool AddPlugInRoute(PlugIn_Route* proute, bool b_permanent) {
   int ip = 0;
   wxDateTime plannedDeparture;
 
-  wxPlugin_WaypointListNode* pwpnode = proute->pWaypointList->GetFirst();
+  Plugin_WaypointList::compatibility_iterator pwpnode =
+      proute->pWaypointList->GetFirst();
   while (pwpnode) {
     pwp = pwpnode->GetData();
 
@@ -1266,7 +1267,8 @@ bool AddPlugInTrack(PlugIn_Track* ptrack, bool b_permanent) {
   TrackPoint* pWP_src = 0;
   int ip = 0;
 
-  wxPlugin_WaypointListNode* pwpnode = ptrack->pWaypointList->GetFirst();
+  Plugin_WaypointList::compatibility_iterator pwpnode =
+      ptrack->pWaypointList->GetFirst();
   while (pwpnode) {
     pwp = pwpnode->GetData();
 

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -2294,7 +2294,8 @@ bool AddPlugInRouteExV2(PlugIn_Route_ExV2* proute, bool b_permanent) {
   int ip = 0;
   wxDateTime plannedDeparture;
 
-  wxPlugin_WaypointExV2ListNode* pwpnode = proute->pWaypointList->GetFirst();
+  Plugin_WaypointExV2List::compatibility_iterator pwpnode =
+      proute->pWaypointList->GetFirst();
   while (pwpnode) {
     pwaypointex = pwpnode->GetData();
 

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -2642,7 +2642,8 @@ bool AddPlugInRouteEx(PlugIn_Route_Ex* proute, bool b_permanent) {
   int ip = 0;
   wxDateTime plannedDeparture;
 
-  wxPlugin_WaypointExListNode* pwpnode = proute->pWaypointList->GetFirst();
+  Plugin_WaypointExList::compatibility_iterator pwpnode =
+      proute->pWaypointList->GetFirst();
   while (pwpnode) {
     pwaypointex = pwpnode->GetData();
 

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -856,7 +856,8 @@ static void cloneHyperlinkList(RoutePoint* dst, const PlugIn_Waypoint* src) {
   if (src->m_HyperlinkList == nullptr) return;
 
   if (src->m_HyperlinkList->GetCount() > 0) {
-    wxPlugin_HyperlinkListNode* linknode = src->m_HyperlinkList->GetFirst();
+    Plugin_HyperlinkList::compatibility_iterator linknode =
+        src->m_HyperlinkList->GetFirst();
     while (linknode) {
       Plugin_Hyperlink* link = linknode->GetData();
 
@@ -962,7 +963,7 @@ bool UpdateSingleWaypoint(PlugIn_Waypoint* pwaypoint) {
     if (pwaypoint->m_HyperlinkList) {
       prp->m_HyperlinkList->Clear();
       if (pwaypoint->m_HyperlinkList->GetCount() > 0) {
-        wxPlugin_HyperlinkListNode* linknode =
+        Plugin_HyperlinkList::compatibility_iterator linknode =
             pwaypoint->m_HyperlinkList->GetFirst();
         while (linknode) {
           Plugin_Hyperlink* link = linknode->GetData();
@@ -1024,7 +1025,8 @@ static void PlugInFromRoutePoint(PlugIn_Waypoint* dst,
   if (src->m_HyperlinkList->GetCount() > 0) {
     dst->m_HyperlinkList = new Plugin_HyperlinkList;
 
-    wxHyperlinkListNode* linknode = src->m_HyperlinkList->GetFirst();
+    HyperlinkList::compatibility_iterator linknode =
+        src->m_HyperlinkList->GetFirst();
     while (linknode) {
       Hyperlink* link = linknode->GetData();
 
@@ -2035,7 +2037,8 @@ static void PlugInExV2FromRoutePoint(PlugIn_Waypoint_ExV2* dst,
     if (src->m_HyperlinkList->GetCount() > 0) {
       dst->m_HyperlinkList = new Plugin_HyperlinkList;
 
-      wxHyperlinkListNode* linknode = src->m_HyperlinkList->GetFirst();
+      HyperlinkList::compatibility_iterator linknode =
+          src->m_HyperlinkList->GetFirst();
       while (linknode) {
         Hyperlink* link = linknode->GetData();
 
@@ -2088,7 +2091,8 @@ static void cloneHyperlinkListExV2(RoutePoint* dst,
   if (src->m_HyperlinkList == nullptr) return;
 
   if (src->m_HyperlinkList->GetCount() > 0) {
-    wxPlugin_HyperlinkListNode* linknode = src->m_HyperlinkList->GetFirst();
+    Plugin_HyperlinkList::compatibility_iterator linknode =
+        src->m_HyperlinkList->GetFirst();
     while (linknode) {
       Plugin_Hyperlink* link = linknode->GetData();
 
@@ -2206,7 +2210,7 @@ bool UpdateSingleWaypointExV2(PlugIn_Waypoint_ExV2* pwaypoint) {
     if (pwaypoint->m_HyperlinkList) {
       prp->m_HyperlinkList->Clear();
       if (pwaypoint->m_HyperlinkList->GetCount() > 0) {
-        wxPlugin_HyperlinkListNode* linknode =
+        Plugin_HyperlinkList::compatibility_iterator linknode =
             pwaypoint->m_HyperlinkList->GetFirst();
         while (linknode) {
           Plugin_Hyperlink* link = linknode->GetData();
@@ -2418,7 +2422,8 @@ static void PlugInExFromRoutePoint(PlugIn_Waypoint_Ex* dst,
     if (src->m_HyperlinkList->GetCount() > 0) {
       dst->m_HyperlinkList = new Plugin_HyperlinkList;
 
-      wxHyperlinkListNode* linknode = src->m_HyperlinkList->GetFirst();
+      HyperlinkList::compatibility_iterator linknode =
+          src->m_HyperlinkList->GetFirst();
       while (linknode) {
         Hyperlink* link = linknode->GetData();
 
@@ -2452,7 +2457,8 @@ static void cloneHyperlinkListEx(RoutePoint* dst,
   if (src->m_HyperlinkList == nullptr) return;
 
   if (src->m_HyperlinkList->GetCount() > 0) {
-    wxPlugin_HyperlinkListNode* linknode = src->m_HyperlinkList->GetFirst();
+    Plugin_HyperlinkList::compatibility_iterator linknode =
+        src->m_HyperlinkList->GetFirst();
     while (linknode) {
       Plugin_Hyperlink* link = linknode->GetData();
 
@@ -2568,7 +2574,7 @@ bool UpdateSingleWaypointEx(PlugIn_Waypoint_Ex* pwaypoint) {
     if (pwaypoint->m_HyperlinkList) {
       prp->m_HyperlinkList->Clear();
       if (pwaypoint->m_HyperlinkList->GetCount() > 0) {
-        wxPlugin_HyperlinkListNode* linknode =
+        Plugin_HyperlinkList::compatibility_iterator linknode =
             pwaypoint->m_HyperlinkList->GetFirst();
         while (linknode) {
           Plugin_Hyperlink* link = linknode->GetData();

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -769,14 +769,14 @@ unsigned int OCPNCheckedListCtrl::Append(wxString& label, bool benable,
 }
 
 void OCPNCheckedListCtrl::Check(int index, bool val) {
-  CBList::Node* node = m_list.Item(index);
+  CBList::compatibility_iterator node = m_list.Item(index);
   wxCheckBox* cb = node->GetData();
 
   if (cb) cb->SetValue(val);
 }
 
 bool OCPNCheckedListCtrl::IsChecked(int index) {
-  CBList::Node* node = m_list.Item(index);
+  CBList::compatibility_iterator node = m_list.Item(index);
   wxCheckBox* cb = node->GetData();
 
   if (cb)

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -2843,7 +2843,7 @@ void options::ClearConfigList() {
   if (m_scrollWinConfigList) {
     wxWindowList kids = m_scrollWinConfigList->GetChildren();
     for (unsigned int i = 0; i < kids.GetCount(); i++) {
-      wxWindowListNode* node = kids.Item(i);
+      wxWindowList::compatibility_iterator node = kids.Item(i);
       wxWindow* win = node->GetData();
       auto pcp = dynamic_cast<wxPanel*>(win);
       if (pcp) {
@@ -2873,7 +2873,7 @@ void options::BuildConfigList() {
       //  Set mouse handler for children of the panel, too.
       wxWindowList kids = pp->GetChildren();
       for (unsigned int i = 0; i < kids.GetCount(); i++) {
-        wxWindowListNode* node = kids.Item(i);
+        wxWindowList::compatibility_iterator node = kids.Item(i);
         wxWindow* win = node->GetData();
         win->Connect(wxEVT_LEFT_DOWN,
                      wxMouseEventHandler(options::OnConfigMouseSelected), NULL,
@@ -2959,7 +2959,7 @@ void options::OnApplyConfig(wxCommandEvent& event) {
   if (m_scrollWinConfigList) {
     wxWindowList kids = m_scrollWinConfigList->GetChildren();
     for (unsigned int i = 0; i < kids.GetCount(); i++) {
-      wxWindowListNode* node = kids.Item(i);
+      wxWindowList::compatibility_iterator node = kids.Item(i);
       wxWindow* win = node->GetData();
       auto pcp = dynamic_cast<wxPanel*>(win);
       if (pcp) {
@@ -3001,7 +3001,7 @@ void options::OnConfigMouseSelected(wxMouseEvent& event) {
     if (m_scrollWinConfigList) {
       wxWindowList kids = m_scrollWinConfigList->GetChildren();
       for (unsigned int i = 0; i < kids.GetCount(); i++) {
-        wxWindowListNode* node = kids.Item(i);
+        wxWindowList::compatibility_iterator node = kids.Item(i);
         wxWindow* win = node->GetData();
         auto panel = dynamic_cast<wxPanel*>(win);
         if (panel) {

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -2541,7 +2541,7 @@ void PluginListPanel::ReloadPluginPanels() {
 
   wxWindowList kids = GetChildren();
   for (unsigned int i = 0; i < kids.GetCount(); i++) {
-    wxWindowListNode* node = kids.Item(i);
+    wxWindowList::compatibility_iterator node = kids.Item(i);
     wxWindow* win = node->GetData();
     PluginPanel* pp = dynamic_cast<PluginPanel*>(win);
     if (pp) win->Destroy();

--- a/gui/src/route_gui.cpp
+++ b/gui/src/route_gui.cpp
@@ -126,7 +126,8 @@ void RouteGui::Draw(ocpnDC &dc, ChartCanvas *canvas, const LLBBox &box) {
   wxPoint rpt1, rpt2;
   if (m_route.m_bVisible) DrawPointWhich(dc, canvas, 1, &rpt1);
 
-  wxRoutePointListNode *node = m_route.pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      m_route.pRoutePointList->GetFirst();
   RoutePoint *prp1 = node->GetData();
   node = node->GetNext();
 
@@ -375,8 +376,9 @@ void RouteGui::DrawGL(ViewPort &vp, ChartCanvas *canvas, ocpnDC &dc) {
     DrawGLRouteLines(vp, canvas, dc);
 
   /*  Route points  */
-  for (wxRoutePointListNode *node = m_route.pRoutePointList->GetFirst(); node;
-       node = node->GetNext()) {
+  for (RoutePointList::compatibility_iterator node =
+           m_route.pRoutePointList->GetFirst();
+       node; node = node->GetNext()) {
     RoutePoint *prp = node->GetData();
     // Inflate the bounding box a bit to ensure full drawing in accelerated pan
     // mode.
@@ -450,7 +452,8 @@ void RouteGui::DrawGLRouteLines(ViewPort &vp, ChartCanvas *canvas, ocpnDC &dc) {
   /* direction arrows.. could probably be further optimized for opengl */
   dc.SetPen(*wxThePenList->FindOrCreatePen(col, 1, wxPENSTYLE_SOLID));
 
-  wxRoutePointListNode *node = m_route.pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      m_route.pRoutePointList->GetFirst();
   wxPoint rpt1, rpt2;
   while (node) {
     RoutePoint *prp = node->GetData();
@@ -474,7 +477,8 @@ void RouteGui::DrawGLLines(ViewPort &vp, ocpnDC *dc, ChartCanvas *canvas) {
   wxPoint2DDouble r1;
   wxPoint2DDouble lastpoint;
 
-  wxRoutePointListNode *node = m_route.pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      m_route.pRoutePointList->GetFirst();
   RoutePoint *prp2 = node->GetData();
   canvas->GetDoubleCanvasPointPix(prp2->m_lat, prp2->m_lon, &lastpoint);
 
@@ -594,7 +598,8 @@ void RouteGui::CalculateDCRect(wxDC &dc_route, ChartCanvas *canvas,
   // always be fully contained within the resulting rectangle.
   // Can we prove this?
   if (m_route.m_bVisible) {
-    wxRoutePointListNode *node = m_route.pRoutePointList->GetFirst();
+    RoutePointList::compatibility_iterator node =
+        m_route.pRoutePointList->GetFirst();
     while (node) {
       RoutePoint *prp2 = node->GetData();
       bool blink_save = prp2->m_bBlink;

--- a/gui/src/route_printout.cpp
+++ b/gui/src/route_printout.cpp
@@ -157,7 +157,7 @@ RoutePrintout::RoutePrintout(Route* route, const std::set<int>& options,
       m_table << point->GetName();
     }
     if (GUI::HasKey(options, RoutePrintOptions::kWaypointPosition)) {
-      std::wostringstream point_position;
+      std::ostringstream point_position;
       point_position << toSDMM(1, point->m_lat, false) << "\n"
                      << toSDMM(2, point->m_lon, false);
       m_table << point_position.str();
@@ -181,7 +181,7 @@ RoutePrintout::RoutePrintout(Route* route, const std::set<int>& options,
       }
     }
     if (GUI::HasKey(options, RoutePrintOptions::kWaypointSpeed)) {
-      std::wostringstream point_speed;
+      std::ostringstream point_speed;
       if (n > 1) {
         point_speed << std::fixed << std::setprecision(1);
         if (point->GetPlannedSpeed() < .1) {
@@ -209,7 +209,7 @@ RoutePrintout::RoutePrintout(Route* route, const std::set<int>& options,
       }
     }
     if (GUI::HasKey(options, RoutePrintOptions::kWaypointTideEvent)) {
-      std::wostringstream point_tide;
+      std::ostringstream point_tide;
       if (point->m_TideStation.Len() > 0 && point->GetETA().IsValid()) {
         int station_id = ptcmgr->GetStationIDXbyName(
             point->m_TideStation, point->m_lat, point->m_lon);
@@ -280,9 +280,9 @@ void RoutePrintout::DrawPage(wxDC* dc, int page) {
   int current_x = m_margin_x;
   int current_y = m_margin_y;
 
-  std::wostringstream title;
-  std::wostringstream subtitle;
-  std::wostringstream distance;
+  std::ostringstream title;
+  std::ostringstream subtitle;
+  std::ostringstream distance;
 
   distance << std::fixed << std::setprecision(1)
            << toUsrDistance(m_route->m_route_length)

--- a/gui/src/routemanagerdialog.cpp
+++ b/gui/src/routemanagerdialog.cpp
@@ -2390,7 +2390,8 @@ void RouteManagerDialog::UpdateWptListCtrl(RoutePoint *rp_select,
 
   m_pWptListCtrl->DeleteAllItems();
 
-  wxRoutePointListNode *node = pWayPointMan->GetWaypointList()->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      pWayPointMan->GetWaypointList()->GetFirst();
 
   int index = 0;
   bool b_anyHidden = false;
@@ -3069,8 +3070,9 @@ void RouteManagerDialog::OnLayDeleteClick(wxCommandEvent &event) {
   }
 
   // Process waypoints in this layer
-  wxRoutePointListNode *node = pWayPointMan->GetWaypointList()->GetFirst();
-  wxRoutePointListNode *node3;
+  RoutePointList::compatibility_iterator node =
+      pWayPointMan->GetWaypointList()->GetFirst();
+  RoutePointList::compatibility_iterator node3;
 
   while (node) {
     node3 = node->GetNext();
@@ -3083,7 +3085,7 @@ void RouteManagerDialog::OnLayDeleteClick(wxCommandEvent &event) {
     }
 
     node = node3;
-    node3 = NULL;
+    node3 = RoutePointList::compatibility_iterator();
   }
 
   if (g_pMarkInfoDialog) {
@@ -3135,7 +3137,8 @@ void RouteManagerDialog::ToggleLayerContentsOnChart(Layer *layer) {
   }
 
   // Process waypoints in this layer
-  wxRoutePointListNode *node = pWayPointMan->GetWaypointList()->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      pWayPointMan->GetWaypointList()->GetFirst();
 
   while (node) {
     RoutePoint *rp = node->GetData();
@@ -3174,7 +3177,8 @@ void RouteManagerDialog::ToggleLayerContentsNames(Layer *layer) {
   while (node1) {
     Route *pRoute = node1->GetData();
     if (pRoute->m_bIsInLayer && (pRoute->m_LayerID == layer->m_LayerID)) {
-      wxRoutePointListNode *node = pRoute->pRoutePointList->GetFirst();
+      RoutePointList::compatibility_iterator node =
+          pRoute->pRoutePointList->GetFirst();
       RoutePoint *prp1 = node->GetData();
       while (node) {
         if (layer->HasVisibleNames() == wxCHK_UNDETERMINED) {
@@ -3189,7 +3193,8 @@ void RouteManagerDialog::ToggleLayerContentsNames(Layer *layer) {
   }
 
   // Process waypoints in this layer
-  wxRoutePointListNode *node = pWayPointMan->GetWaypointList()->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      pWayPointMan->GetWaypointList()->GetFirst();
 
   while (node) {
     RoutePoint *rp = node->GetData();
@@ -3245,7 +3250,8 @@ void RouteManagerDialog::ToggleLayerContentsOnListing(Layer *layer) {
   //  n.b.  If the waypoint belongs to a track, and is not shared, then do not
   //  list it. This is a performance optimization, allowing large track support.
 
-  wxRoutePointListNode *node = pWayPointMan->GetWaypointList()->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      pWayPointMan->GetWaypointList()->GetFirst();
 
   while (node) {
     RoutePoint *rp = node->GetData();

--- a/gui/src/routemanagerdialog.cpp
+++ b/gui/src/routemanagerdialog.cpp
@@ -3048,10 +3048,10 @@ void RouteManagerDialog::OnLayDeleteClick(wxCommandEvent &event) {
   }
 
   // Process Tracks and Routes in this layer
-  wxRouteListNode *node1 = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
   while (node1) {
     Route *pRoute = node1->GetData();
-    wxRouteListNode *next_node = node1->GetNext();
+    RouteList::compatibility_iterator next_node = node1->GetNext();
     if (pRoute->m_bIsInLayer && (pRoute->m_LayerID == layer->m_LayerID)) {
       pRoute->m_bIsInLayer = false;
       pRoute->m_LayerID = 0;
@@ -3120,7 +3120,7 @@ void RouteManagerDialog::OnLayToggleChartClick(wxCommandEvent &event) {
 
 void RouteManagerDialog::ToggleLayerContentsOnChart(Layer *layer) {
   // Process Tracks and Routes in this layer
-  wxRouteListNode *node1 = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
   while (node1) {
     Route *pRoute = node1->GetData();
     if (pRoute->m_bIsInLayer && (pRoute->m_LayerID == layer->m_LayerID)) {
@@ -3173,7 +3173,7 @@ void RouteManagerDialog::OnLayToggleNamesClick(wxCommandEvent &event) {
 
 void RouteManagerDialog::ToggleLayerContentsNames(Layer *layer) {
   // Process Tracks and Routes in this layer
-  wxRouteListNode *node1 = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
   while (node1) {
     Route *pRoute = node1->GetData();
     if (pRoute->m_bIsInLayer && (pRoute->m_LayerID == layer->m_LayerID)) {
@@ -3232,7 +3232,7 @@ void RouteManagerDialog::ToggleLayerContentsOnListing(Layer *layer) {
   ::wxBeginBusyCursor();
 
   // Process Tracks and Routes in this layer
-  wxRouteListNode *node1 = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
   while (node1) {
     Route *pRoute = node1->GetData();
     if (pRoute->m_bIsInLayer && (pRoute->m_LayerID == layer->m_LayerID)) {

--- a/gui/src/s57_ocpn_utils.cpp
+++ b/gui/src/s57_ocpn_utils.cpp
@@ -123,8 +123,8 @@ bool s57_ProcessExtendedLightSectors(ChartCanvas *cc,
     int n_attr = 0;
     wxArrayOfS57attVal *attValArray = NULL;
 
-    ListOfObjRazRules::Node *snode = NULL;
-    ListOfPI_S57Obj::Node *pnode = NULL;
+    ListOfObjRazRules::compatibility_iterator snode;
+    ListOfPI_S57Obj::compatibility_iterator pnode;
 
     if (Chs57 && rule_list)
       snode = rule_list->GetLast();

--- a/gui/src/s57chart.cpp
+++ b/gui/src/s57chart.cpp
@@ -5600,8 +5600,8 @@ wxString s57chart::CreateObjDescriptions(ListOfObjRazRules *rule_list) {
   S57Light *curLight = nullptr;
   wxFileName file;
 
-  for (ListOfObjRazRules::Node *node = rule_list->GetLast(); node;
-       node = node->GetPrevious()) {
+  for (ListOfObjRazRules::compatibility_iterator node = rule_list->GetLast();
+       node; node = node->GetPrevious()) {
     ObjRazRules *current = node->GetData();
     positionString.Clear();
     objText.Clear();
@@ -6684,8 +6684,8 @@ bool s57_ProcessExtendedLightSectors(ChartCanvas *cc,
     int n_attr = 0;
     wxArrayOfS57attVal *attValArray = NULL;
 
-    ListOfObjRazRules::Node *snode = NULL;
-    ListOfPI_S57Obj::Node *pnode = NULL;
+    ListOfObjRazRules::compatibility_iterator snode;
+    ListOfPI_S57Obj::compatibility_iterator pnode;
 
     if (Chs57 && rule_list)
       snode = rule_list->GetLast();

--- a/gui/src/tcmgr.cpp
+++ b/gui/src/tcmgr.cpp
@@ -993,24 +993,24 @@ int TCMgr::GetNextBigEvent(time_t *tm, int idx) {
   }
 }
 
-std::wstring TCMgr::GetTidalEventStr(int station_id, wxDateTime ref_dt,
-                                     double lat, double lon, int dt_type) {
+std::string TCMgr::GetTidalEventStr(int station_id, wxDateTime ref_dt,
+                                    double lat, double lon, int dt_type) {
   IDX_entry *idx = (IDX_entry *)GetIDX_entry(station_id);
   time_t dtmtt = ref_dt.FromUTC().GetTicks();
   int event = GetNextBigEvent(&dtmtt, station_id);
   wxDateTime event_dt = wxDateTime(dtmtt).MakeUTC();
 
-  std::wstring event_str;
+  std::string event_str;
   if (event == 1) {
-    event_str = _("LW").ToStdWstring();
+    event_str = _("LW").ToStdString();
   } else if (event == 2) {
-    event_str = _("HW").ToStdWstring();
+    event_str = _("HW").ToStdString();
   } else {
-    event_str = _("Unavailable").ToStdWstring();
+    event_str = _("Unavailable").ToStdString();
   }
 
   if (event > 0) {
-    event_str.append(L": ");
+    event_str.append(": ");
     event_str.append(
         toUsrDateTime(event_dt, dt_type, lon).FormatISOCombined(' '));
   }

--- a/gui/src/waypointman_gui.cpp
+++ b/gui/src/waypointman_gui.cpp
@@ -706,7 +706,8 @@ wxRect WayPointmanGui::CropImageOnAlpha(wxImage &image) {
 void WayPointmanGui::ReloadRoutepointIcons() {
   //    Iterate on the RoutePoint list, requiring each to reload icon
 
-  wxRoutePointListNode *node = m_waypoint_man.m_pWayPointList->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      m_waypoint_man.m_pWayPointList->GetFirst();
   while (node) {
     RoutePoint *pr = node->GetData();
     pr->ReLoadIcon();

--- a/libs/nmea0183/src/nmea0183.cpp
+++ b/libs/nmea0183/src/nmea0183.cpp
@@ -351,7 +351,7 @@ wxArrayString NMEA0183::GetRecognizedArray(void)
 {
     wxArrayString ret;
 
-    wxMRLNode *node = response_table.GetFirst();
+    MRL::compatibility_iterator node = response_table.GetFirst();
 
     while(node)
     {

--- a/libs/s52plib/src/s52plib.cpp
+++ b/libs/s52plib/src/s52plib.cpp
@@ -2310,13 +2310,14 @@ bool s52plib::RenderText(wxDC *pdc, S52_TextC *ptext, int x, int y,
 bool s52plib::CheckTextRectList(const wxRect &test_rect, S52_TextC *ptext) {
   //    Iterate over the current object list, looking at rText
 
-  for (TextObjList::Node *node = m_textObjList.GetFirst(); node;
-       node = node->GetNext()) {
+  TextObjList::compatibility_iterator node = m_textObjList.GetFirst();
+  while (node)  {
     wxRect *pcurrent_rect = &(node->GetData()->rText);
 
     if (pcurrent_rect->Intersects(test_rect)) {
       if (node->GetData() != ptext) return true;
     }
+    node = node->GetNext();
   }
   return false;
 }
@@ -2525,14 +2526,15 @@ int s52plib::RenderT_All(ObjRazRules *rzRules, Rules *rules,
     if (m_bDeClutterText) {
       if (bwas_drawn) {
         bool b_found = false;
-        for (TextObjList::Node *node = m_textObjList.GetFirst(); node;
-             node = node->GetNext()) {
-          S52_TextC *oc = node->GetData();
+        TextObjList::compatibility_iterator node = m_textObjList.GetFirst();
+        while (node) {
+          auto *oc = node->GetData();
 
           if (oc == text) {
             if (!b_dupok) b_found = true;
             break;
           }
+          node = node->GetNext();
         }
         if (!b_found) m_textObjList.Append(text);
       }
@@ -10031,8 +10033,8 @@ void s52plib::AdjustTextList(int dx, int dy, int screenw, int screenh) {
   //        2.. Remove any list elements that are off screen after applied
   //        offset
 
-  TextObjList::Node *node = m_textObjList.GetFirst();
-  TextObjList::Node *next;
+  TextObjList::compatibility_iterator node = m_textObjList.GetFirst();
+  TextObjList::compatibility_iterator next;
   while (node) {
     next = node->GetNext();
     wxRect *pcurrent = &(node->GetData()->rText);

--- a/model/include/model/autopilot_output.h
+++ b/model/include/model/autopilot_output.h
@@ -31,6 +31,9 @@
 bool UpdateAutopilotN0183(Routeman &routeman);
 bool UpdateAutopilotN2K(Routeman &routeman);
 
+/** Send RMC + a faked RMB when there is no active route. */
+bool SendNoRouteRmbRmc(Routeman &routeman);
+
 bool SendPGN129283(Routeman &routeman, AbstractCommDriver *driver);
 bool SendPGN129284(Routeman &routeman, AbstractCommDriver *driver);
 bool SendPGN129285(Routeman &routeman, AbstractCommDriver *driver);

--- a/model/include/model/config_vars.h
+++ b/model/include/model/config_vars.h
@@ -49,6 +49,12 @@ extern bool g_bWplUsePosition;
 extern bool g_enable_root_menu_debug;
 extern bool g_persist_active_route;
 
+/**
+ * Always send RMB and RMC n0183 messages even if there is no active
+ * route. One use case is the Nasa Marine instruments Clipper GPS
+ */
+extern bool g_always_send_rmb_rmc;
+
 extern double g_n_arrival_circle_radius;
 extern double g_PlanSpeed;
 extern double g_TrackDeltaDistance;

--- a/model/include/model/route_point.h
+++ b/model/include/model/route_point.h
@@ -32,6 +32,7 @@
 #include <wx/string.h>
 
 #include "model/hyperlink.h"
+#include "model/select_item.h"
 
 #include "bbox.h"
 
@@ -124,9 +125,17 @@ public:
   wxString GetIconName(void) { return m_IconName; }
   void SetIconName(wxString name) { m_IconName = name; }
 
-  void *GetSelectNode(void) { return m_SelectNode; }
-  void SetSelectNode(void *node) { m_SelectNode = node; }
+  SelectableItemList::compatibility_iterator GetSelectNode(void) {
+    return m_SelectNode;
+  }
 
+  void SetSelectNode(SelectableItemList::compatibility_iterator node) {
+    m_SelectNode = node;
+  }
+
+  void SetSelectNode() {
+    m_SelectNode = SelectableItemList::compatibility_iterator();
+  }
   RoutePointList::compatibility_iterator *GetManagerListNode(void) {
     return m_ManagerNode;
   }
@@ -569,7 +578,7 @@ private:
   wxBitmap *m_pbmIcon;
   wxString m_IconName;
 
-  void *m_SelectNode;
+  SelectableItemList::compatibility_iterator m_SelectNode;
   // FIXME (leamas) use a smart pointer, ownership...
   RoutePointList::compatibility_iterator *m_ManagerNode;
 

--- a/model/include/model/route_point.h
+++ b/model/include/model/route_point.h
@@ -43,6 +43,10 @@
 #define ETA_FORMAT_STR "%x %H:%M"
 //"%d/%m/%Y %H:%M" //"%Y-%m-%d %H:%M"
 
+class RoutePoint;  // forward
+
+WX_DECLARE_LIST(RoutePoint, RoutePointList);  // establish class as list member
+
 // Default color, global state
 extern wxColour g_colourWaypointRangeRingsColour;
 
@@ -123,8 +127,13 @@ public:
   void *GetSelectNode(void) { return m_SelectNode; }
   void SetSelectNode(void *node) { m_SelectNode = node; }
 
-  void *GetManagerListNode(void) { return m_ManagerNode; }
-  void SetManagerListNode(void *node) { m_ManagerNode = node; }
+  RoutePointList::compatibility_iterator *GetManagerListNode(void) {
+    return m_ManagerNode;
+  }
+
+  void SetManagerListNode(RoutePointList::compatibility_iterator *node) {
+    m_ManagerNode = node;
+  }
 
   void SetName(const wxString &name);
   void CalculateNameExtents(void);
@@ -561,7 +570,8 @@ private:
   wxString m_IconName;
 
   void *m_SelectNode;
-  void *m_ManagerNode;
+  // FIXME (leamas) use a smart pointer, ownership...
+  RoutePointList::compatibility_iterator *m_ManagerNode;
 
   float m_IconScaleFactor;
   wxBitmap m_ScaledBMP;
@@ -609,7 +619,5 @@ private:
   unsigned int m_dragIconTexture;
   int m_dragIconTextureWidth, m_dragIconTextureHeight;
 };
-
-WX_DECLARE_LIST(RoutePoint, RoutePointList);  // establish class as list member
 
 #endif  //  _ROUTEPOINT_H__

--- a/model/src/autopilot_output.cpp
+++ b/model/src/autopilot_output.cpp
@@ -56,6 +56,114 @@ static NmeaLog *GetNmeaLog() {
   return log;
 }
 
+static void SendRmc(NMEA0183 &nmea0183, Routeman &routeman) {
+  SENTENCE snt;
+  nmea0183.Rmc.IsDataValid = bGPSValid ? NTrue : NFalse;
+
+  nmea0183.Rmc.Position.Latitude.Set(std::fabs(gLat), gLat < 0 ? "S" : "N");
+  nmea0183.Rmc.Position.Longitude.Set(std::fabs(gLon), gLon < 0 ? "W" : "E");
+
+  nmea0183.Rmc.SpeedOverGroundKnots = std::isnan(gSog) ? 0.0 : gSog;
+  nmea0183.Rmc.TrackMadeGoodDegreesTrue = std::isnan(gCog) ? 0.0 : gCog;
+
+  if (!std::isnan(gVar)) {
+    nmea0183.Rmc.MagneticVariation = std::fabs(gVar);
+    nmea0183.Rmc.MagneticVariationDirection = gVar < 0 ? West : East;
+  } else {
+    // A signal to NMEA converter, gVAR is unknown
+    nmea0183.Rmc.MagneticVariation = 361.;
+  }
+
+  // Send GPS time to autopilot if available else send local system time
+  if (!gRmcTime.IsEmpty() && !gRmcDate.IsEmpty()) {
+    nmea0183.Rmc.UTCTime = gRmcTime;
+    nmea0183.Rmc.Date = gRmcDate;
+  } else {
+    wxDateTime now = wxDateTime::Now();
+    wxDateTime utc = now.ToUTC();
+    wxString time = utc.Format(_T("%H%M%S"));
+    nmea0183.Rmc.UTCTime = time;
+    wxString date = utc.Format(_T("%d%m%y"));
+    nmea0183.Rmc.Date = date;
+  }
+
+  nmea0183.Rmc.FAAModeIndicator = "A";
+  if (!bGPSValid) nmea0183.Rmc.FAAModeIndicator = "N";
+
+  nmea0183.Rmc.Write(snt);
+
+  BroadcastNMEA0183Message(snt.Sentence, GetNmeaLog(),
+                           routeman.GetMessageSentEventVar());
+}
+
+static void SendDummyRmb(NMEA0183 &nmea0183, Routeman &routeman) {
+  nmea0183.Rmb.IsDataValid = NTrue;
+  nmea0183.Rmb.CrossTrackError = 0;
+  nmea0183.Rmb.DirectionToSteer = Left;
+  nmea0183.Rmb.RangeToDestinationNauticalMiles = 0;
+  nmea0183.Rmb.BearingToDestinationDegreesTrue = 0;
+  nmea0183.Rmb.DestinationPosition.Latitude.Set(0, "N");
+  nmea0183.Rmb.DestinationPosition.Longitude.Set(0, "E");
+  nmea0183.Rmb.DestinationClosingVelocityKnots = 0;
+  nmea0183.Rmb.IsArrivalCircleEntered = NFalse;
+  nmea0183.Rmb.FAAModeIndicator = "A";
+  nmea0183.Rmb.To = "";
+  nmea0183.Rmb.From = "";
+
+  SENTENCE snt;
+  nmea0183.Rmb.Write(snt);
+  BroadcastNMEA0183Message(snt.Sentence, GetNmeaLog(),
+                           routeman.GetMessageSentEventVar());
+}
+
+static void SendRmb(NMEA0183 &nmea0183, Routeman &routeman) {
+  SENTENCE snt;
+  RoutePoint *pActivePoint = routeman.GetpActivePoint();
+  const int maxName = 6;
+
+  nmea0183.Rmb.IsDataValid = bGPSValid ? NTrue : NFalse;
+  nmea0183.Rmb.CrossTrackError = routeman.GetCurrentXTEToActivePoint();
+  nmea0183.Rmb.DirectionToSteer = routeman.GetXTEDir() < 0 ? Left : Right;
+  nmea0183.Rmb.RangeToDestinationNauticalMiles =
+      routeman.GetCurrentRngToActivePoint();
+  nmea0183.Rmb.BearingToDestinationDegreesTrue =
+      routeman.GetCurrentBrgToActivePoint();
+
+  using std::fabs;
+  const char *ns = pActivePoint->m_lat < 0 ? "S" : "N";
+  nmea0183.Rmb.DestinationPosition.Latitude.Set(fabs(pActivePoint->m_lat), ns);
+  const char *ew = pActivePoint->m_lat < 0 ? "W" : "E";
+  nmea0183.Rmb.DestinationPosition.Longitude.Set(fabs(pActivePoint->m_lon), ew);
+
+  double sog = std::isnan(gSog) ? 0.0 : gSog;
+  double cog = std::isnan(gCog) ? 0.0 : gCog;
+  nmea0183.Rmb.DestinationClosingVelocityKnots =
+      sog * cos((cog - routeman.GetCurrentBrgToActivePoint()) * PI / 180.0);
+  nmea0183.Rmb.IsArrivalCircleEntered = routeman.GetArrival() ? NTrue : NFalse;
+  nmea0183.Rmb.FAAModeIndicator = bGPSValid ? "A" : "N";
+  // RMB is close to NMEA0183 length limit
+  // Restrict WP names further if necessary
+  int wp_len = maxName;
+  do {
+    nmea0183.Rmb.To = pActivePoint->GetName().Truncate(wp_len);
+    nmea0183.Rmb.From =
+        routeman.GetpActiveRouteSegmentBeginPoint()->GetName().Truncate(wp_len);
+    nmea0183.Rmb.Write(snt);
+    wp_len -= 1;
+  } while (snt.Sentence.size() > 82 && wp_len > 0);
+
+  BroadcastNMEA0183Message(snt.Sentence, GetNmeaLog(),
+                           routeman.GetMessageSentEventVar());
+}
+
+bool SendNoRouteRmbRmc(Routeman &routeman) {
+  if (routeman.GetpActivePoint()) return false;
+  NMEA0183 nmea0183 = routeman.GetNMEA0183();
+  SendRmc(nmea0183, routeman);
+  SendDummyRmb(nmea0183, routeman);
+  return true;
+}
+
 bool UpdateAutopilotN0183(Routeman &routeman) {
   NMEA0183 nmea0183 = routeman.GetNMEA0183();
   RoutePoint *pActivePoint = routeman.GetpActivePoint();
@@ -65,107 +173,8 @@ bool UpdateAutopilotN0183(Routeman &routeman) {
   if ((g_maxWPNameLength >= 3) && (g_maxWPNameLength <= 32))
     maxName = g_maxWPNameLength;
 
-  // Avoid a possible not initiated SOG/COG. APs can be confused if in NAV mode
-  // wo valid GPS
-  double r_Sog(0.0), r_Cog(0.0);
-  if (!std::isnan(gSog)) r_Sog = gSog;
-  if (!std::isnan(gCog)) r_Cog = gCog;
-
-  // RMB
-  {
-    SENTENCE snt;
-    nmea0183.Rmb.IsDataValid = bGPSValid ? NTrue : NFalse;
-    nmea0183.Rmb.CrossTrackError = routeman.GetCurrentXTEToActivePoint();
-    nmea0183.Rmb.DirectionToSteer = routeman.GetXTEDir() < 0 ? Left : Right;
-    nmea0183.Rmb.RangeToDestinationNauticalMiles =
-        routeman.GetCurrentRngToActivePoint();
-    nmea0183.Rmb.BearingToDestinationDegreesTrue =
-        routeman.GetCurrentBrgToActivePoint();
-
-    if (pActivePoint->m_lat < 0.)
-      nmea0183.Rmb.DestinationPosition.Latitude.Set(-pActivePoint->m_lat, "S");
-    else
-      nmea0183.Rmb.DestinationPosition.Latitude.Set(pActivePoint->m_lat, "N");
-
-    if (pActivePoint->m_lon < 0.)
-      nmea0183.Rmb.DestinationPosition.Longitude.Set(-pActivePoint->m_lon, "W");
-    else
-      nmea0183.Rmb.DestinationPosition.Longitude.Set(pActivePoint->m_lon, "E");
-
-    nmea0183.Rmb.DestinationClosingVelocityKnots =
-        r_Sog *
-        cos((r_Cog - routeman.GetCurrentBrgToActivePoint()) * PI / 180.0);
-    nmea0183.Rmb.IsArrivalCircleEntered =
-        routeman.GetArrival() ? NTrue : NFalse;
-    nmea0183.Rmb.FAAModeIndicator = bGPSValid ? "A" : "N";
-    // RMB is close to NMEA0183 length limit
-    // Restrict WP names further if necessary
-    int wp_len = maxName;
-    do {
-      nmea0183.Rmb.To = pActivePoint->GetName().Truncate(wp_len);
-      nmea0183.Rmb.From =
-          routeman.GetpActiveRouteSegmentBeginPoint()->GetName().Truncate(
-              wp_len);
-      nmea0183.Rmb.Write(snt);
-      wp_len -= 1;
-    } while (snt.Sentence.size() > 82 && wp_len > 0);
-
-    BroadcastNMEA0183Message(snt.Sentence, GetNmeaLog(),
-                             routeman.GetMessageSentEventVar());
-  }
-
-  // RMC
-  {
-    SENTENCE snt;
-    nmea0183.Rmc.IsDataValid = NTrue;
-    if (!bGPSValid) nmea0183.Rmc.IsDataValid = NFalse;
-
-    if (gLat < 0.)
-      nmea0183.Rmc.Position.Latitude.Set(-gLat, _T("S"));
-    else
-      nmea0183.Rmc.Position.Latitude.Set(gLat, _T("N"));
-
-    if (gLon < 0.)
-      nmea0183.Rmc.Position.Longitude.Set(-gLon, _T("W"));
-    else
-      nmea0183.Rmc.Position.Longitude.Set(gLon, _T("E"));
-
-    nmea0183.Rmc.SpeedOverGroundKnots = r_Sog;
-    nmea0183.Rmc.TrackMadeGoodDegreesTrue = r_Cog;
-
-    if (!std::isnan(gVar)) {
-      if (gVar < 0.) {
-        nmea0183.Rmc.MagneticVariation = -gVar;
-        nmea0183.Rmc.MagneticVariationDirection = West;
-      } else {
-        nmea0183.Rmc.MagneticVariation = gVar;
-        nmea0183.Rmc.MagneticVariationDirection = East;
-      }
-    } else
-      nmea0183.Rmc.MagneticVariation =
-          361.;  // A signal to NMEA converter, gVAR is unknown
-
-    // Send GPS time to autopilot if available else send local system time
-    if (!gRmcTime.IsEmpty() && !gRmcDate.IsEmpty()) {
-      nmea0183.Rmc.UTCTime = gRmcTime;
-      nmea0183.Rmc.Date = gRmcDate;
-    } else {
-      wxDateTime now = wxDateTime::Now();
-      wxDateTime utc = now.ToUTC();
-      wxString time = utc.Format(_T("%H%M%S"));
-      nmea0183.Rmc.UTCTime = time;
-      wxString date = utc.Format(_T("%d%m%y"));
-      nmea0183.Rmc.Date = date;
-    }
-
-    nmea0183.Rmc.FAAModeIndicator = "A";
-    if (!bGPSValid) nmea0183.Rmc.FAAModeIndicator = "N";
-
-    nmea0183.Rmc.Write(snt);
-
-    BroadcastNMEA0183Message(snt.Sentence, GetNmeaLog(),
-                             routeman.GetMessageSentEventVar());
-  }
+  SendRmb(nmea0183, routeman);
+  SendRmc(nmea0183, routeman);
 
   // APB
   {

--- a/model/src/comm_n0183_output.cpp
+++ b/model/src/comm_n0183_output.cpp
@@ -514,7 +514,8 @@ int SendRouteToGPS_N0183(Route* pr, const wxString& com_name,
 
     // Send out the waypoints, in order
     if (bsend_waypoints) {
-      wxRoutePointListNode* node = pr->pRoutePointList->GetFirst();
+      RoutePointList::compatibility_iterator node =
+          pr->pRoutePointList->GetFirst();
 
       int ip = 1;
       while (node) {

--- a/model/src/config_vars.cpp
+++ b/model/src/config_vars.cpp
@@ -44,6 +44,7 @@ bool g_bUseWptScaMin = false;
 bool g_bWplUsePosition = false;
 bool g_enable_root_menu_debug = false;
 bool g_persist_active_route = false;
+bool g_always_send_rmb_rmc = false;
 
 double g_n_arrival_circle_radius = 0.0;
 double g_PlanSpeed = 0.0;

--- a/model/src/garmin_wrapper.cpp
+++ b/model/src/garmin_wrapper.cpp
@@ -105,7 +105,7 @@ int Garmin_GPS_SendWaypoints(const wxString &port_name,
   //    Now fill in the useful elements
   for (int i = 0; i < nPoints; i++) {
     GPS_PWay pway = ppway[i];
-    wxRoutePointListNode *node = wplist->Item(i);
+    RoutePointList::compatibility_iterator node = wplist->Item(i);
     RoutePoint *prp = node->GetData();
 
     Garmin_GPS_PrepareWptData(pway, prp);
@@ -165,7 +165,7 @@ GPS_SWay **Garmin_GPS_Create_A200_Route(Route *pr, int route_number,
   //    Elements 1..n are waypoints
   for (int i = 1; i < *size; i++) {
     GPS_PWay pway = ppway[i];
-    wxRoutePointListNode *node = wplist->Item(i - 1);
+    RoutePointList::compatibility_iterator node = wplist->Item(i - 1);
     RoutePoint *prp = node->GetData();
 
     Garmin_GPS_PrepareWptData(pway, prp);
@@ -221,7 +221,7 @@ GPS_SWay **Garmin_GPS_Create_A201_Route(Route *pr, int route_number,
     if (i % 2 == 1) /* Odd */
     {
       GPS_PWay pway = ppway[i];
-      wxRoutePointListNode *node = wplist->Item((i - 1) / 2);
+      RoutePointList::compatibility_iterator node = wplist->Item((i - 1) / 2);
       RoutePoint *prp = node->GetData();
 
       Garmin_GPS_PrepareWptData(pway, prp);

--- a/model/src/nav_object_database.cpp
+++ b/model/src/nav_object_database.cpp
@@ -1074,7 +1074,7 @@ static bool GPXCreateRoute(pugi::xml_node node, Route *pRoute) {
   }
 
   RoutePointList *pRoutePointList = pRoute->pRoutePointList;
-  wxRoutePointListNode *node2 = pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node2 = pRoutePointList->GetFirst();
   RoutePoint *prp;
 
   while (node2) {
@@ -1109,7 +1109,8 @@ bool InsertRouteA(Route *pTentRoute, NavObjectCollection1 *navobj) {
     float prev_rlat = 0., prev_rlon = 0.;
     RoutePoint *prev_pConfPoint = NULL;
 
-    wxRoutePointListNode *node = pTentRoute->pRoutePointList->GetFirst();
+    RoutePointList::compatibility_iterator node =
+        pTentRoute->pRoutePointList->GetFirst();
     while (node) {
       RoutePoint *prp = node->GetData();
 
@@ -1128,7 +1129,8 @@ bool InsertRouteA(Route *pTentRoute, NavObjectCollection1 *navobj) {
     }
   } else {
     // walk the route, deleting points used only by this route
-    wxRoutePointListNode *pnode = (pTentRoute->pRoutePointList)->GetFirst();
+    RoutePointList::compatibility_iterator pnode =
+        (pTentRoute->pRoutePointList)->GetFirst();
     while (pnode) {
       RoutePoint *prp = pnode->GetData();
 
@@ -1235,7 +1237,8 @@ static void UpdateRouteA(Route *pTentRoute, NavObjectCollection1 *navobj) {
   float prev_rlat = 0., prev_rlon = 0.;
   RoutePoint *prev_pConfPoint = NULL;
 
-  wxRoutePointListNode *node = pTentRoute->pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      pTentRoute->pRoutePointList->GetFirst();
   while (node) {
     RoutePoint *prp = node->GetData();
 
@@ -1281,7 +1284,8 @@ Route *FindRouteContainingWaypoint(RoutePoint *pWP) {
   while (node) {
     Route *proute = node->GetData();
 
-    wxRoutePointListNode *pnode = (proute->pRoutePointList)->GetFirst();
+    RoutePointList::compatibility_iterator pnode =
+        (proute->pRoutePointList)->GetFirst();
     while (pnode) {
       RoutePoint *prp = pnode->GetData();
       if (prp == pWP) return proute;
@@ -1301,7 +1305,8 @@ bool NavObjectCollection1::CreateNavObjGPXPoints(void) {
 
   if (!pWayPointMan) return false;
 
-  wxRoutePointListNode *node = pWayPointMan->GetWaypointList()->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      pWayPointMan->GetWaypointList()->GetFirst();
 
   RoutePoint *pr;
 
@@ -1422,7 +1427,8 @@ void NavObjectCollection1::AddGPXTracksList(std::vector<Track *> *pTracks) {
 bool NavObjectCollection1::AddGPXPointsList(RoutePointList *pRoutePoints) {
   SetRootGPXNode();
 
-  wxRoutePointListNode *pRoutePointNode = pRoutePoints->GetFirst();
+  RoutePointList::compatibility_iterator pRoutePointNode =
+      pRoutePoints->GetFirst();
   while (pRoutePointNode) {
     RoutePoint *pRP = pRoutePointNode->GetData();
     AddGPXWaypoint(pRP);
@@ -1598,7 +1604,8 @@ bool NavObjectCollection1::LoadAllGPXPointObjects() {
 RoutePoint *WaypointExists(const wxString &name, double lat, double lon) {
   RoutePoint *pret = NULL;
   //    if( g_bIsNewLayer ) return NULL;
-  wxRoutePointListNode *node = pWayPointMan->GetWaypointList()->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      pWayPointMan->GetWaypointList()->GetFirst();
   while (node) {
     RoutePoint *pr = node->GetData();
 
@@ -1617,7 +1624,8 @@ RoutePoint *WaypointExists(const wxString &name, double lat, double lon) {
 }
 
 RoutePoint *WaypointExists(const wxString &guid) {
-  wxRoutePointListNode *node = pWayPointMan->GetWaypointList()->GetFirst();
+  RoutePointList::compatibility_iterator node =
+      pWayPointMan->GetWaypointList()->GetFirst();
   while (node) {
     RoutePoint *pr = node->GetData();
 
@@ -1640,7 +1648,7 @@ bool WptIsInRouteList(RoutePoint *pr) {
     Route *pRoute = node1->GetData();
     RoutePointList *pRoutePointList = pRoute->pRoutePointList;
 
-    wxRoutePointListNode *node2 = pRoutePointList->GetFirst();
+    RoutePointList::compatibility_iterator node2 = pRoutePointList->GetFirst();
     RoutePoint *prp;
 
     while (node2) {

--- a/model/src/nav_object_database.cpp
+++ b/model/src/nav_object_database.cpp
@@ -1280,7 +1280,7 @@ static void UpdateRouteA(Route *pTentRoute, NavObjectCollection1 *navobj) {
 }
 
 Route *FindRouteContainingWaypoint(RoutePoint *pWP) {
-  wxRouteListNode *node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node = pRouteList->GetFirst();
   while (node) {
     Route *proute = node->GetData();
 
@@ -1330,7 +1330,7 @@ bool NavObjectCollection1::CreateNavObjGPXRoutes(void) {
   // Routes
   if (!pRouteList) return false;
 
-  wxRouteListNode *node1 = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
   while (node1) {
     Route *pRoute = node1->GetData();
 
@@ -1408,7 +1408,7 @@ bool NavObjectCollection1::AddGPXWaypoint(RoutePoint *pWP) {
 void NavObjectCollection1::AddGPXRoutesList(RouteList *pRoutes) {
   SetRootGPXNode();
 
-  wxRouteListNode *pRoute = pRoutes->GetFirst();
+  RouteList::compatibility_iterator pRoute = pRoutes->GetFirst();
   while (pRoute) {
     Route *pRData = pRoute->GetData();
     AddGPXRoute(pRData);
@@ -1643,7 +1643,7 @@ RoutePoint *WaypointExists(const wxString &guid) {
 bool WptIsInRouteList(RoutePoint *pr) {
   bool IsInList = false;
 
-  wxRouteListNode *node1 = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
   while (node1) {
     Route *pRoute = node1->GetData();
     RoutePointList *pRoutePointList = pRoute->pRoutePointList;
@@ -1667,7 +1667,7 @@ bool WptIsInRouteList(RoutePoint *pr) {
 }
 
 Route *RouteExists(const wxString &guid) {
-  wxRouteListNode *route_node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator route_node = pRouteList->GetFirst();
 
   while (route_node) {
     Route *proute = route_node->GetData();
@@ -1680,7 +1680,7 @@ Route *RouteExists(const wxString &guid) {
 }
 
 Route *RouteExists(Route *pTentRoute) {
-  wxRouteListNode *route_node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator route_node = pRouteList->GetFirst();
   while (route_node) {
     Route *proute = route_node->GetData();
 

--- a/model/src/nav_object_database.cpp
+++ b/model/src/nav_object_database.cpp
@@ -692,7 +692,7 @@ static bool GPXCreateWpt(pugi::xml_node node, RoutePoint *pr,
   if (flags & OUT_HYPERLINKS) {
     HyperlinkList *linklist = pr->m_HyperlinkList;
     if (linklist && linklist->GetCount()) {
-      wxHyperlinkListNode *linknode = linklist->GetFirst();
+      HyperlinkList::compatibility_iterator linknode = linklist->GetFirst();
       while (linknode) {
         Hyperlink *link = linknode->GetData();
 
@@ -866,7 +866,7 @@ static bool GPXCreateTrk(pugi::xml_node node, Track *pTrack,
   // Hyperlinks
   HyperlinkList *linklist = pTrack->m_TrackHyperlinkList;
   if (linklist && linklist->GetCount()) {
-    wxHyperlinkListNode *linknode = linklist->GetFirst();
+    HyperlinkList::compatibility_iterator linknode = linklist->GetFirst();
     while (linknode) {
       Hyperlink *link = linknode->GetData();
 
@@ -979,7 +979,7 @@ static bool GPXCreateRoute(pugi::xml_node node, Route *pRoute) {
   // Hyperlinks
   HyperlinkList *linklist = pRoute->m_HyperlinkList;
   if (linklist && linklist->GetCount()) {
-    wxHyperlinkListNode *linknode = linklist->GetFirst();
+    HyperlinkList::compatibility_iterator linknode = linklist->GetFirst();
     while (linknode) {
       Hyperlink *link = linknode->GetData();
 

--- a/model/src/navobj_db.cpp
+++ b/model/src/navobj_db.cpp
@@ -654,7 +654,7 @@ void NavObj_dB::CountImportNavObjects() {
           pugi::xml_parse_status::status_ok) {
     input_set->LoadAllGPXPointObjects();
     auto pointlist = pWayPointMan->GetWaypointList();
-    wxRoutePointListNode* prpnode = pointlist->GetFirst();
+    RoutePointList::compatibility_iterator prpnode = pointlist->GetFirst();
     while (prpnode) {
       RoutePoint* point = prpnode->GetData();
       if (point->m_bIsolatedMark) {
@@ -746,7 +746,7 @@ bool NavObj_dB::ImportLegacyPoints() {
   if (m_nimportPoints > 10000) nmod = 100;
 
   auto pointlist = pWayPointMan->GetWaypointList();
-  wxRoutePointListNode* prpnode = pointlist->GetFirst();
+  RoutePointList::compatibility_iterator prpnode = pointlist->GetFirst();
   while (prpnode) {
     RoutePoint* point = prpnode->GetData();
     if (point->m_bIsolatedMark) {

--- a/model/src/navobj_db.cpp
+++ b/model/src/navobj_db.cpp
@@ -814,7 +814,8 @@ bool NavObj_dB::InsertTrack(Track* track) {
   //  Add HTML links to track
   int NbrOfLinks = track->m_TrackHyperlinkList->GetCount();
   if (NbrOfLinks > 0) {
-    wxHyperlinkListNode* linknode = track->m_TrackHyperlinkList->GetFirst();
+    HyperlinkList::compatibility_iterator linknode =
+        track->m_TrackHyperlinkList->GetFirst();
     while (linknode) {
       Hyperlink* link = linknode->GetData();
 
@@ -934,7 +935,8 @@ bool NavObj_dB::UpdateDBTrackAttributes(Track* track) {
   // Now add all the links to db
   int NbrOfLinks = track->m_TrackHyperlinkList->GetCount();
   if (NbrOfLinks > 0) {
-    wxHyperlinkListNode* linknode = track->m_TrackHyperlinkList->GetFirst();
+    HyperlinkList::compatibility_iterator linknode =
+        track->m_TrackHyperlinkList->GetFirst();
     while (linknode) {
       Hyperlink* link = linknode->GetData();
 
@@ -1190,7 +1192,8 @@ bool NavObj_dB::InsertRoute(Route* route) {
   //  Add HTML links to route
   int NbrOfLinks = route->m_HyperlinkList->GetCount();
   if (NbrOfLinks > 0) {
-    wxHyperlinkListNode* linknode = route->m_HyperlinkList->GetFirst();
+    HyperlinkList::compatibility_iterator linknode =
+        route->m_HyperlinkList->GetFirst();
     while (linknode) {
       Hyperlink* link = linknode->GetData();
 
@@ -1267,7 +1270,8 @@ bool NavObj_dB::UpdateRoute(Route* route) {
   //  Add HTML links to route
   int NbrOfLinks = route->m_HyperlinkList->GetCount();
   if (NbrOfLinks > 0) {
-    wxHyperlinkListNode* linknode = route->m_HyperlinkList->GetFirst();
+    HyperlinkList::compatibility_iterator linknode =
+        route->m_HyperlinkList->GetFirst();
     while (linknode) {
       Hyperlink* link = linknode->GetData();
 
@@ -1368,7 +1372,8 @@ bool NavObj_dB::UpdateDBRouteAttributes(Route* route) {
   // Now add all the links to db
   int NbrOfLinks = route->m_HyperlinkList->GetCount();
   if (NbrOfLinks > 0) {
-    wxHyperlinkListNode* linknode = route->m_HyperlinkList->GetFirst();
+    HyperlinkList::compatibility_iterator linknode =
+        route->m_HyperlinkList->GetFirst();
     while (linknode) {
       Hyperlink* link = linknode->GetData();
 
@@ -1503,7 +1508,8 @@ bool NavObj_dB::UpdateDBRoutePointAttributes(RoutePoint* point) {
   // Now add all the links to db
   int NbrOfLinks = point->m_HyperlinkList->GetCount();
   if (NbrOfLinks > 0) {
-    wxHyperlinkListNode* linknode = point->m_HyperlinkList->GetFirst();
+    HyperlinkList::compatibility_iterator linknode =
+        point->m_HyperlinkList->GetFirst();
     while (linknode) {
       Hyperlink* link = linknode->GetData();
 
@@ -2065,7 +2071,8 @@ bool NavObj_dB::InsertRoutePoint(RoutePoint* point) {
   //  Add HTML links to routepoint
   int NbrOfLinks = point->m_HyperlinkList->GetCount();
   if (NbrOfLinks > 0) {
-    wxHyperlinkListNode* linknode = point->m_HyperlinkList->GetFirst();
+    HyperlinkList::compatibility_iterator linknode =
+        point->m_HyperlinkList->GetFirst();
     while (linknode) {
       Hyperlink* link = linknode->GetData();
 

--- a/model/src/navobj_db.cpp
+++ b/model/src/navobj_db.cpp
@@ -665,7 +665,7 @@ void NavObj_dB::CountImportNavObjects() {
     }
 
     input_set->LoadAllGPXRouteObjects();
-    for (wxRouteListNode* node = pRouteList->GetFirst(); node;
+    for (RouteList::compatibility_iterator node = pRouteList->GetFirst(); node;
          node = node->GetNext()) {
       Route* route_import = node->GetData();
       m_nImportObjects++;
@@ -712,7 +712,7 @@ bool NavObj_dB::ImportLegacyRoutes() {
   std::vector<Route*> routes_added;
   //  Add all routes to database
   int nroute = 0;
-  for (wxRouteListNode* node = pRouteList->GetFirst(); node;
+  for (RouteList::compatibility_iterator node = pRouteList->GetFirst(); node;
        node = node->GetNext()) {
     Route* route_import = node->GetData();
     if (InsertRoute(route_import)) {

--- a/model/src/navobj_db.cpp
+++ b/model/src/navobj_db.cpp
@@ -1336,7 +1336,8 @@ bool NavObj_dB::UpdateDBRouteAttributes(Route* route) {
                       -1, SQLITE_TRANSIENT);
     sqlite3_bind_int(stmt, 5, route->IsVisible());
     sqlite3_bind_int(stmt, 6, route->GetSharedWPViz());
-    sqlite3_bind_int(stmt, 7, route->m_PlannedDeparture.GetTicks());
+    if (route->m_PlannedDeparture.IsValid())
+      sqlite3_bind_int(stmt, 7, route->m_PlannedDeparture.GetTicks());
     sqlite3_bind_double(stmt, 8, route->m_PlannedSpeed);
     sqlite3_bind_text(stmt, 9, route->m_TimeDisplayFormat.ToStdString().c_str(),
                       -1, SQLITE_TRANSIENT);

--- a/model/src/route.cpp
+++ b/model/src/route.cpp
@@ -136,7 +136,7 @@ void Route::CloneRoute(Route *psourceroute, int start_nPoint, int end_nPoint,
 wxString Route::IsPointNameValid(RoutePoint *pPoint,
                                  const wxString &name) const {
   RoutePoint *point;
-  wxRoutePointListNode *node = pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node = pRoutePointList->GetFirst();
   wxString substr = name.SubString(0, 6);
 
   while (node) {
@@ -232,7 +232,7 @@ void Route::InsertPointAndSegment(RoutePoint *pNewPoint, int insert_after,
 
 RoutePoint *Route::GetPoint(int nWhichPoint) {
   RoutePoint *prp;
-  wxRoutePointListNode *node = pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node = pRoutePointList->GetFirst();
 
   int i = 1;
   while (node) {
@@ -249,7 +249,7 @@ RoutePoint *Route::GetPoint(int nWhichPoint) {
 
 RoutePoint *Route::GetPoint(const wxString &guid) {
   RoutePoint *prp;
-  wxRoutePointListNode *node = pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node = pRoutePointList->GetFirst();
 
   while (node) {
     prp = node->GetData();
@@ -281,8 +281,9 @@ static void TestLongitude(double lon, double min, double max, bool &lonl,
 }
 
 bool Route::ContainsSharedWP() {
-  for (wxRoutePointListNode *node = pRoutePointList->GetFirst(); node;
-       node = node->GetNext()) {
+  for (RoutePointList::compatibility_iterator node =
+           pRoutePointList->GetFirst();
+       node; node = node->GetNext()) {
     RoutePoint *prp = node->GetData();
     if (prp->IsShared()) return true;
   }
@@ -293,7 +294,7 @@ bool Route::ContainsSharedWP() {
 int s_arrow_icon[] = {0, 0, 5, 2, 18, 6, 12, 0, 18, -6, 5, -2, 0, 0};
 void Route::ClearHighlights(void) {
   RoutePoint *prp = NULL;
-  wxRoutePointListNode *node = pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node = pRoutePointList->GetFirst();
 
   while (node) {
     prp = node->GetData();
@@ -425,7 +426,7 @@ void Route::RemovePoint(RoutePoint *rp, bool bRenamePoints) {
 }
 
 void Route::DeSelectRoute() {
-  wxRoutePointListNode *node = pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node = pRoutePointList->GetFirst();
 
   RoutePoint *rp;
   while (node) {
@@ -437,7 +438,7 @@ void Route::DeSelectRoute() {
 }
 
 void Route::ReloadRoutePointIcons() {
-  wxRoutePointListNode *node = pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node = pRoutePointList->GetFirst();
 
   RoutePoint *rp;
   while (node) {
@@ -455,7 +456,7 @@ LLBBox &Route::GetBBox(void) {
 
   double bbox_lonmin, bbox_lonmax, bbox_latmin, bbox_latmax;
 
-  wxRoutePointListNode *node = pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node = pRoutePointList->GetFirst();
   RoutePoint *data = node->GetData();
 
   if (data->m_wpBBox.GetValid()) {
@@ -571,7 +572,7 @@ void Route::UpdateSegmentDistances(double planspeed) {
   m_route_length = 0.0;
   m_route_time = 0.0;
 
-  wxRoutePointListNode *node = pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node = pRoutePointList->GetFirst();
 
   if (node) {
     //  Route start point
@@ -610,7 +611,8 @@ void Route::Reverse(bool bRenamePoints) {
     wxString GUID = RoutePointGUIDList[ip];
 
     //    And on the RoutePoints themselves
-    wxRoutePointListNode *prpnode = pWayPointMan->GetWaypointList()->GetFirst();
+    RoutePointList::compatibility_iterator prpnode =
+        pWayPointMan->GetWaypointList()->GetFirst();
     while (prpnode) {
       RoutePoint *prp = prpnode->GetData();
 
@@ -635,7 +637,7 @@ void Route::SetVisible(bool visible, bool includeWpts) {
 
   if (!includeWpts) return;
 
-  wxRoutePointListNode *node = pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node = pRoutePointList->GetFirst();
   RoutePoint *rp;
   while (node) {
     rp = node->GetData();
@@ -655,7 +657,7 @@ void Route::SetListed(bool visible) { m_bListed = visible; }
 void Route::AssembleRoute(void) {}
 
 void Route::ShowWaypointNames(bool bshow) {
-  wxRoutePointListNode *node = pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node = pRoutePointList->GetFirst();
 
   while (node) {
     RoutePoint *prp = node->GetData();
@@ -667,7 +669,7 @@ void Route::ShowWaypointNames(bool bshow) {
 
 bool Route::AreWaypointNamesVisible() {
   bool bvis = false;
-  wxRoutePointListNode *node = pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node = pRoutePointList->GetFirst();
 
   while (node) {
     RoutePoint *prp = node->GetData();
@@ -683,7 +685,7 @@ void Route::RenameRoutePoints(void) {
   //    iterate on the route points.
   //    If dynamically named, rename according to current list position
 
-  wxRoutePointListNode *node = pRoutePointList->GetFirst();
+  RoutePointList::compatibility_iterator node = pRoutePointList->GetFirst();
 
   int i = 1;
   while (node) {
@@ -712,8 +714,10 @@ void Route::RenameRoutePoints(void) {
 //    Is this route equal to another, meaning,
 //    Do all routepoint positions and names match?
 bool Route::IsEqualTo(Route *ptargetroute) {
-  wxRoutePointListNode *pthisnode = (this->pRoutePointList)->GetFirst();
-  wxRoutePointListNode *pthatnode = (ptargetroute->pRoutePointList)->GetFirst();
+  RoutePointList::compatibility_iterator pthisnode =
+      (this->pRoutePointList)->GetFirst();
+  RoutePointList::compatibility_iterator pthatnode =
+      (ptargetroute->pRoutePointList)->GetFirst();
 
   if (NULL == pthisnode) return false;
 

--- a/model/src/route.cpp
+++ b/model/src/route.cpp
@@ -719,14 +719,14 @@ bool Route::IsEqualTo(Route *ptargetroute) {
   RoutePointList::compatibility_iterator pthatnode =
       (ptargetroute->pRoutePointList)->GetFirst();
 
-  if (NULL == pthisnode) return false;
+  if (!pthisnode) return false;
 
   if (this->m_bIsInLayer || ptargetroute->m_bIsInLayer) return false;
 
   if (this->GetnPoints() != ptargetroute->GetnPoints()) return false;
 
   while (pthisnode) {
-    if (NULL == pthatnode) return false;
+    if (!pthatnode) return false;
 
     RoutePoint *pthisrp = pthisnode->GetData();
     RoutePoint *pthatrp = pthatnode->GetData();

--- a/model/src/route_point.cpp
+++ b/model/src/route_point.cpp
@@ -77,7 +77,6 @@ RoutePoint::RoutePoint() {
   m_NameLocationOffsetY = 8;
   m_pMarkFont = NULL;
   m_btemp = false;
-  m_SelectNode = NULL;
   m_ManagerNode = NULL;
 
   m_iTextTexture = 0;
@@ -153,7 +152,6 @@ RoutePoint::RoutePoint(RoutePoint *orig) {
   m_bIsInLayer = orig->m_bIsInLayer;
   m_GUID = pWayPointMan->CreateGUID(this);
 
-  m_SelectNode = NULL;
   m_ManagerNode = NULL;
 
   m_WaypointArrivalRadius = orig->GetWaypointArrivalRadius();
@@ -210,7 +208,6 @@ RoutePoint::RoutePoint(double lat, double lon, const wxString &icon_ident,
   m_btemp = false;
   m_bPreScaled = false;
 
-  m_SelectNode = NULL;
   m_ManagerNode = NULL;
   m_IconScaleFactor = 1.0;
   m_ScaMin = MAX_INT_VAL;

--- a/model/src/select.cpp
+++ b/model/src/select.cpp
@@ -51,7 +51,7 @@ bool Select::IsSelectableRoutePointValid(RoutePoint *pRoutePoint) {
   SelectItem *pFindSel;
 
   //    Iterate on the select list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
@@ -72,7 +72,7 @@ bool Select::AddSelectableRoutePoint(float slat, float slon,
   pSelItem->m_bIsSelected = false;
   pSelItem->m_pData1 = pRoutePointAdd;
 
-  wxSelectableItemListNode *node;
+  SelectableItemList::compatibility_iterator node;
 
   if (pRoutePointAdd->m_bIsInLayer)
     node = pSelectList->Append(pSelItem);
@@ -111,14 +111,14 @@ bool Select::DeleteAllSelectableRouteSegments(Route *pr) {
   SelectItem *pFindSel;
 
   //    Iterate on the select list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
     if (pFindSel->m_seltype == SELTYPE_ROUTESEGMENT &&
         (Route *)pFindSel->m_pData3 == pr) {
       delete pFindSel;
-      wxSelectableItemListNode *d = node;
+      SelectableItemList::compatibility_iterator d = node;
       node = node->GetNext();
       pSelectList->DeleteNode(d);  // delete node;
     } else
@@ -132,7 +132,7 @@ bool Select::DeleteAllSelectableRoutePoints(Route *pr) {
   SelectItem *pFindSel;
 
   //    Iterate on the select list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
@@ -148,7 +148,7 @@ bool Select::DeleteAllSelectableRoutePoints(Route *pr) {
         if (prp == ps) {
           delete pFindSel;
           pSelectList->DeleteNode(node);  // delete node;
-          prp->SetSelectNode(NULL);
+          prp->SetSelectNode();
 
           node = pSelectList->GetFirst();
 
@@ -242,7 +242,7 @@ bool Select::UpdateSelectableRouteSegments(RoutePoint *prp) {
   bool ret = false;
 
   //    Iterate on the select list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
@@ -296,18 +296,18 @@ bool Select::DeleteSelectablePoint(void *pdata, int SeltypeToDelete) {
 
   if (NULL != pdata) {
     //    Iterate on the list
-    wxSelectableItemListNode *node = pSelectList->GetFirst();
+    SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
     while (node) {
       pFindSel = node->GetData();
       if (pFindSel->m_seltype == SeltypeToDelete) {
         if (pdata == pFindSel->m_pData1) {
           delete pFindSel;
-          delete node;
+          pSelectList->DeleteNode(node);
 
           if (SELTYPE_ROUTEPOINT == SeltypeToDelete) {
             RoutePoint *prp = (RoutePoint *)pdata;
-            prp->SetSelectNode(NULL);
+            prp->SetSelectNode();
           }
 
           return true;
@@ -323,16 +323,16 @@ bool Select::DeleteAllSelectableTypePoints(int SeltypeToDelete) {
   SelectItem *pFindSel;
 
   //    Iterate on the list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
     if (pFindSel->m_seltype == SeltypeToDelete) {
-      delete node;
+      pSelectList->DeleteNode(node);
 
       if (SELTYPE_ROUTEPOINT == SeltypeToDelete) {
         RoutePoint *prp = (RoutePoint *)pFindSel->m_pData1;
-        prp->SetSelectNode(NULL);
+        prp->SetSelectNode();
       }
       delete pFindSel;
 
@@ -348,15 +348,14 @@ bool Select::DeleteAllSelectableTypePoints(int SeltypeToDelete) {
 }
 
 bool Select::DeleteSelectableRoutePoint(RoutePoint *prp) {
-  if (NULL != prp) {
-    wxSelectableItemListNode *node =
-        (wxSelectableItemListNode *)prp->GetSelectNode();
+  if (prp) {
+    SelectableItemList::compatibility_iterator node = prp->GetSelectNode();
     if (node) {
       SelectItem *pFindSel = node->GetData();
       if (pFindSel) {
         delete pFindSel;
-        delete node;  // automatically removes from list
-        prp->SetSelectNode(NULL);
+        pSelectList->DeleteNode(node);  // delete node;
+        prp->SetSelectNode();
         return true;
       }
     } else
@@ -370,7 +369,7 @@ bool Select::ModifySelectablePoint(float lat, float lon, void *data,
   SelectItem *pFindSel;
 
   //    Iterate on the list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
@@ -414,14 +413,14 @@ bool Select::DeleteAllSelectableTrackSegments(Track *pt) {
   SelectItem *pFindSel;
 
   //    Iterate on the select list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
     if (pFindSel->m_seltype == SELTYPE_TRACKSEGMENT &&
         (Track *)pFindSel->m_pData3 == pt) {
       delete pFindSel;
-      wxSelectableItemListNode *d = node;
+      SelectableItemList::compatibility_iterator d = node;
       node = node->GetNext();
       pSelectList->DeleteNode(d);  // delete node;
     } else
@@ -434,7 +433,7 @@ bool Select::DeletePointSelectableTrackSegments(TrackPoint *pt) {
   SelectItem *pFindSel;
 
   //    Iterate on the select list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
@@ -442,7 +441,7 @@ bool Select::DeletePointSelectableTrackSegments(TrackPoint *pt) {
         ((TrackPoint *)pFindSel->m_pData1 == pt ||
          (TrackPoint *)pFindSel->m_pData2 == pt)) {
       delete pFindSel;
-      wxSelectableItemListNode *d = node;
+      SelectableItemList::compatibility_iterator d = node;
       node = node->GetNext();
       pSelectList->DeleteNode(d);  // delete node;
     } else
@@ -524,7 +523,7 @@ SelectItem *Select::FindSelection(SelectCtx &ctx, float slat, float slon,
   CalcSelectRadius(ctx);
 
   //    Iterate on the list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
@@ -571,7 +570,7 @@ find_ok:
 bool Select::IsSelectableSegmentSelected(SelectCtx &ctx, float slat, float slon,
                                          SelectItem *pFindSel) {
   bool valid = false;
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     if (pFindSel == node->GetData()) {
@@ -616,7 +615,7 @@ SelectableItemList Select::FindSelectionList(SelectCtx &ctx, float slat,
   CalcSelectRadius(ctx);
 
   //    Iterate on the list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();

--- a/model/src/select.cpp
+++ b/model/src/select.cpp
@@ -140,7 +140,8 @@ bool Select::DeleteAllSelectableRoutePoints(Route *pr) {
       RoutePoint *ps = (RoutePoint *)pFindSel->m_pData1;
 
       //    inner loop iterates on the route's point list
-      wxRoutePointListNode *pnode = (pr->pRoutePointList)->GetFirst();
+      RoutePointList::compatibility_iterator pnode =
+          (pr->pRoutePointList)->GetFirst();
       while (pnode) {
         RoutePoint *prp = pnode->GetData();
 
@@ -166,7 +167,8 @@ bool Select::DeleteAllSelectableRoutePoints(Route *pr) {
 
 bool Select::AddAllSelectableRoutePoints(Route *pr) {
   if (pr->pRoutePointList->GetCount()) {
-    wxRoutePointListNode *node = (pr->pRoutePointList)->GetFirst();
+    RoutePointList::compatibility_iterator node =
+        (pr->pRoutePointList)->GetFirst();
 
     while (node) {
       RoutePoint *prp = node->GetData();
@@ -183,7 +185,8 @@ bool Select::AddAllSelectableRouteSegments(Route *pr) {
   float slat1, slon1, slat2, slon2;
 
   if (pr->pRoutePointList->GetCount()) {
-    wxRoutePointListNode *node = (pr->pRoutePointList)->GetFirst();
+    RoutePointList::compatibility_iterator node =
+        (pr->pRoutePointList)->GetFirst();
 
     RoutePoint *prp0 = node->GetData();
     slat1 = prp0->m_lat;

--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -350,7 +350,7 @@ void SetBackColor(wxWindow *ctrl, wxColour col) {
 
   wxWindowList kids = ctrl->GetChildren();
   for (unsigned int i = 0; i < kids.GetCount(); i++) {
-    wxWindowListNode *node = kids.Item(i);
+    wxWindowList::compatibility_iterator node = kids.Item(i);
     wxWindow *win = node->GetData();
 
     if (dynamic_cast<wxListBox *>(win))

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -760,7 +760,7 @@ void dashboard_pi::Notify() {
       dashboard_window->Refresh();
 #ifdef __OCPN__ANDROID__
       wxWindowList list = dashboard_window->GetChildren();
-      wxWindowListNode *node = list.GetFirst();
+      wxWindowList::compatibility_iterator node = list.GetFirst();
       for (size_t i = 0; i < list.GetCount(); i++) {
         wxWindow *win = node->GetData();
         //                qDebug() << "Refresh Dash child:" << i;
@@ -5862,7 +5862,7 @@ void DashboardWindow::ChangePaneOrientation(int orient, bool updateAUImgr,
 void DashboardWindow::SetSizerOrientation(int orient) {
   itemBoxSizer->SetOrientation(orient);
   /* We must reset all MinSize to ensure we start with new default */
-  wxWindowListNode *node = GetChildren().GetFirst();
+  wxWindowList::compatibility_iterator node = GetChildren().GetFirst();
   while (node) {
     node->GetData()->SetMinSize(wxDefaultSize);
     node = node->GetNext();

--- a/plugins/dashboard_pi/src/nmea0183/nmea0183.cpp
+++ b/plugins/dashboard_pi/src/nmea0183/nmea0183.cpp
@@ -291,7 +291,7 @@ bool NMEA0183::Parse(void) {
 
     //          Traverse the response list to find a mnemonic match
 
-    wxMRLNode *node = response_table.GetFirst();
+    MRL::compatibility_iterator node = response_table.GetFirst();
 
     int comparison = 0;
 

--- a/plugins/demo_pi_sample/src/demo_pi.cpp
+++ b/plugins/demo_pi_sample/src/demo_pi.cpp
@@ -28,6 +28,8 @@
 #include "wx/wx.h"
 #endif  // precompiled headers
 
+#include <cstdint>
+
 #include <wx/aui/aui.h>
 
 #include "demo_pi.h"

--- a/plugins/demo_pi_sample/src/nmea0183/nmea0183.cpp
+++ b/plugins/demo_pi_sample/src/nmea0183/nmea0183.cpp
@@ -278,7 +278,7 @@ bool NMEA0183::Parse(void) {
 
     //          Traverse the response list to find a mnemonic match
 
-    wxMRLNode *node = response_table.GetFirst();
+    MRL::compatibility_iterator node = response_table.GetFirst();
 
     int comparison = 0;
 
@@ -320,7 +320,7 @@ bool NMEA0183::Parse(void) {
 wxArrayString NMEA0183::GetRecognizedArray(void) {
   wxArrayString ret;
 
-  wxMRLNode *node = response_table.GetFirst();
+  MRL::compatibility_iterator node = response_table.GetFirst();
 
   while (node) {
     RESPONSE *resp = node->GetData();

--- a/plugins/grib_pi/src/CursorData.cpp
+++ b/plugins/grib_pi/src/CursorData.cpp
@@ -696,7 +696,7 @@ void CursorData::OnMenuCallBack(wxMouseEvent &event) {
   PopupMenu(menu);
 
   // apply new config
-  wxwxMenuItemListNode *node = menu->GetMenuItems().GetFirst();
+  wxMenuItemList::compatibility_iterator node = menu->GetMenuItems().GetFirst();
   while (node) {
     wxMenuItem *it = node->GetData();
     switch (it->GetId()) {

--- a/plugins/grib_pi/src/CursorData.cpp
+++ b/plugins/grib_pi/src/CursorData.cpp
@@ -36,7 +36,7 @@ CursorData::CursorData(wxWindow *window, GRIBUICtrlBar &parent)
     : CursorDataBase(window), m_gparent(parent) {
   // transform checkboxes ID to have a formal link to data type and set the
   // initial value
-  wxWindowListNode *node = this->GetChildren().GetFirst();
+  wxWindowList::compatibility_iterator node = this->GetChildren().GetFirst();
   while (node) {
     wxWindow *win = node->GetData();
     if (dynamic_cast<wxCheckBox *>(win)) {

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -1101,7 +1101,7 @@ void GRIBUICtrlBar::OnSize(wxSizeEvent &event) {
 }
 
 void GRIBUICtrlBar::OnPaint(wxPaintEvent &event) {
-  wxWindowListNode *node = this->GetChildren().GetFirst();
+  wxWindowList::compatibility_iterator node = this->GetChildren().GetFirst();
   wxPaintDC dc(this);
   while (node) {
     wxWindow *win = node->GetData();

--- a/plugins/grib_pi/src/IsoLine.cpp
+++ b/plugins/grib_pi/src/IsoLine.cpp
@@ -203,7 +203,7 @@ IsoLine::IsoLine(double val, double coeff, double offset,
 
     m_SegListList.Append(ps);
 
-    MySegList::Node *node;
+    MySegList::compatibility_iterator node;
     Segment *seg;
 
     // recreate the master list, removing used segs
@@ -241,7 +241,7 @@ IsoLine::~IsoLine() {
 }
 
 MySegList *IsoLine::BuildContinuousSegment(void) {
-  MySegList::Node *node;
+  MySegList::compatibility_iterator node;
   Segment *seg;
 
   MySegList *ret_list = new MySegList;
@@ -876,11 +876,7 @@ void GenSpline(wxList *points) {
 
   ocpn_wx_spline_add_point(x1, y1);
 
-  while ((node = node->GetNext())
-#if !wxUSE_STL
-         != nullptr
-#endif  // !wxUSE_STL
-  ) {
+  while ((node = node->GetNext())) {
     p = (wxPoint *)node->GetData();
     x1 = x2;
     y1 = y2;

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -626,7 +626,7 @@ void grib_pi::OnContextMenuItemCallback(int id) {
 void grib_pi::SetDialogFont(wxWindow *dialog, wxFont *font) {
   dialog->SetFont(*font);
   wxWindowList list = dialog->GetChildren();
-  wxWindowListNode *node = list.GetFirst();
+  wxWindowList::compatibility_iterator node = list.GetFirst();
   for (size_t i = 0; i < list.GetCount(); i++) {
     wxWindow *win = node->GetData();
     win->SetFont(*font);


### PR DESCRIPTION
wxWidgets  is dropping some old style support for wxList forcing us to use the new style. Most of it is about using `compatibility_iterator` instead of various `SomeTypeListNode` macros.

At the moment this builds, but needs polish and review. Unsure how to actually test it.