### PR TITLE
Wx 3.3  fixes: part 1

### DIFF
--- a/ci/generic-build-macos.sh
+++ b/ci/generic-build-macos.sh
@@ -28,7 +28,7 @@ brew install mpg123
 brew install xz
 brew install zstd
 brew install libarchive
-brew install wxwidgets
+brew install wxwidgets@3.2
 brew install create-dmg
 brew install gpatch
 brew install asciidoc

--- a/gui/include/gui/tcmgr.h
+++ b/gui/include/gui/tcmgr.h
@@ -106,8 +106,8 @@ public:
 
   int GetStationTimeOffset(IDX_entry *pIDX);
   int GetNextBigEvent(time_t *tm, int idx);
-  std::wstring GetTidalEventStr(int station_id, wxDateTime ref_dt, double lat,
-                                double lon, int dt_type);
+  std::string GetTidalEventStr(int station_id, wxDateTime ref_dt, double lat,
+                               double lon, int dt_type);
   double GetStationLat(IDX_entry *pIDX);
   double GetStationLon(IDX_entry *pIDX);
 

--- a/gui/src/OCPN_AUIManager.cpp
+++ b/gui/src/OCPN_AUIManager.cpp
@@ -93,6 +93,19 @@ EVT_CHILD_FOCUS(OCPN_AUIManager::OnChildFocus)
 EVT_AUI_FIND_MANAGER(OCPN_AUIManager::OnFindManager)
 END_EVENT_TABLE()
 
+static bool AuiDockUIPartsAreEqual(const wxAuiDockUIPart& lhs,
+                                   const wxAuiDockUIPart& rhs) {
+  if (lhs.type != rhs.type) return false;
+  if (lhs.orientation != rhs.orientation) return false;
+  if (lhs.dock != rhs.dock) return false;
+  if (lhs.pane != rhs.pane) return false;
+  if (lhs.button != rhs.button) return false;
+  if (lhs.cont_sizer != rhs.cont_sizer) return false;
+  if (lhs.sizer_item != rhs.sizer_item) return false;
+  if (lhs.rect != rhs.rect) return false;
+  return true;
+};
+
 OCPN_AUIManager::OCPN_AUIManager(wxWindow* managed_wnd, unsigned int flags)
     : wxAuiManager(managed_wnd, flags)
 
@@ -114,10 +127,16 @@ void OCPN_AUIManager::OnMotionx(wxMouseEvent& event) {
   if (m_action == actionResize) {
     // It's necessary to reset m_actionPart since it destroyed
     // by the Update within DoEndResizeAction.
-    if (m_currentDragItem != -1)
+    if (m_currentDragItem != -1) {
       m_actionPart = &(m_uiParts.Item(m_currentDragItem));
-    else
-      m_currentDragItem = m_uiParts.Index(*m_actionPart);
+    } else {
+      for (size_t i = 0; i < m_uiParts.GetCount(); i++) {
+        if (AuiDockUIPartsAreEqual(m_uiParts[i], *m_actionPart)) {
+          m_currentDragItem = i;
+          break;
+        }
+      }
+    }
 
     if (m_actionPart) {
       wxPoint pos = m_actionPart->rect.GetPosition();

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -10942,7 +10942,7 @@ void pupHandler_PasteRoute() {
   // don't create a new route.
   if (mergepoints && answer == wxID_YES &&
       existingWaypointCounter == pasted->GetnPoints()) {
-    wxRouteListNode *route_node = pRouteList->GetFirst();
+    RouteList::compatibility_iterator route_node = pRouteList->GetFirst();
     while (route_node) {
       Route *proute = route_node->GetData();
 
@@ -13083,7 +13083,7 @@ void ChartCanvas::DrawActiveTrackInBBox(ocpnDC &dc, LLBBox &BltBBox) {
 void ChartCanvas::DrawAllRoutesInBBox(ocpnDC &dc, LLBBox &BltBBox) {
   Route *active_route = NULL;
 
-  for (wxRouteListNode *node = pRouteList->GetFirst(); node;
+  for (RouteList::compatibility_iterator node = pRouteList->GetFirst(); node;
        node = node->GetNext()) {
     Route *pRouteDraw = node->GetData();
     if (pRouteDraw->IsActive() || pRouteDraw->IsSelected()) {
@@ -13103,7 +13103,7 @@ void ChartCanvas::DrawAllRoutesInBBox(ocpnDC &dc, LLBBox &BltBBox) {
 void ChartCanvas::DrawActiveRouteInBBox(ocpnDC &dc, LLBBox &BltBBox) {
   Route *active_route = NULL;
 
-  for (wxRouteListNode *node = pRouteList->GetFirst(); node;
+  for (RouteList::compatibility_iterator node = pRouteList->GetFirst(); node;
        node = node->GetNext()) {
     Route *pRouteDraw = node->GetData();
     if (pRouteDraw->IsActive() || pRouteDraw->IsSelected()) {

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -4008,7 +4008,7 @@ void ChartCanvas::OnRolloverPopupTimerEvent(wxTimerEvent &event) {
     SelectCtx ctx(m_bShowNavobjects, GetCanvasTrueScale(), GetScaleValue());
     SelectableItemList SelList = pSelect->FindSelectionList(
         ctx, m_cursor_lat, m_cursor_lon, SELTYPE_ROUTESEGMENT);
-    wxSelectableItemListNode *node = SelList.GetFirst();
+    SelectableItemList::compatibility_iterator node = SelList.GetFirst();
     while (node) {
       SelectItem *pFindSel = node->GetData();
 
@@ -4183,7 +4183,7 @@ void ChartCanvas::OnRolloverPopupTimerEvent(wxTimerEvent &event) {
     SelectCtx ctx(m_bShowNavobjects, GetCanvasTrueScale(), GetScaleValue());
     SelectableItemList SelList = pSelect->FindSelectionList(
         ctx, m_cursor_lat, m_cursor_lon, SELTYPE_TRACKSEGMENT);
-    wxSelectableItemListNode *node = SelList.GetFirst();
+    SelectableItemList::compatibility_iterator node = SelList.GetFirst();
     while (node) {
       SelectItem *pFindSel = node->GetData();
 
@@ -7415,7 +7415,7 @@ void ChartCanvas::FindRoutePointsAtCursor(float selectRadius,
   SelectCtx ctx(m_bShowNavobjects, GetCanvasTrueScale(), GetScaleValue());
   SelectableItemList SelList = pSelect->FindSelectionList(
       ctx, m_cursor_lat, m_cursor_lon, SELTYPE_ROUTEPOINT);
-  wxSelectableItemListNode *node = SelList.GetFirst();
+  SelectableItemList::compatibility_iterator node = SelList.GetFirst();
   while (node) {
     pFind = node->GetData();
 
@@ -7517,7 +7517,7 @@ std::shared_ptr<PI_PointContext> ChartCanvas::GetCanvasContextAtPoint(int x,
     SelectCtx ctx(m_bShowNavobjects, GetCanvasTrueScale(), GetScaleValue());
     SelectableItemList SelList =
         pSelect->FindSelectionList(ctx, slat, slon, SELTYPE_ROUTEPOINT);
-    wxSelectableItemListNode *node = SelList.GetFirst();
+    SelectableItemList::compatibility_iterator node = SelList.GetFirst();
     while (node) {
       SelectItem *pFindSel = node->GetData();
 
@@ -7615,7 +7615,7 @@ std::shared_ptr<PI_PointContext> ChartCanvas::GetCanvasContextAtPoint(int x,
     if (NULL == SelectedRoute)  // the case where a segment only is selected
     {
       //  Choose the first visible route containing segment in the list
-      wxSelectableItemListNode *node = SelList.GetFirst();
+      SelectableItemList::compatibility_iterator node = SelList.GetFirst();
       while (node) {
         SelectItem *pFindSel = node->GetData();
 
@@ -7645,7 +7645,7 @@ std::shared_ptr<PI_PointContext> ChartCanvas::GetCanvasContextAtPoint(int x,
         pSelect->FindSelectionList(ctx, slat, slon, SELTYPE_TRACKSEGMENT);
 
     //  Choose the first visible track containing segment in the list
-    wxSelectableItemListNode *node = SelList.GetFirst();
+    SelectableItemList::compatibility_iterator node = SelList.GetFirst();
     while (node) {
       SelectItem *pFindSel = node->GetData();
 
@@ -7680,7 +7680,7 @@ std::shared_ptr<PI_PointContext> ChartCanvas::GetCanvasContextAtPoint(int x,
           ctx, m_cursor_lat, m_cursor_lon, SELTYPE_CURRENTPOINT);
 
       //      Default is first entry
-      wxSelectableItemListNode *node = SelList.GetFirst();
+      SelectableItemList::compatibility_iterator node = SelList.GetFirst();
       pFind = node->GetData();
       pIDX_best_candidate = (IDX_entry *)(pFind->m_pData1);
 
@@ -7697,7 +7697,7 @@ std::shared_ptr<PI_PointContext> ChartCanvas::GetCanvasContextAtPoint(int x,
           node = node->GetNext();
         }  // while (node)
       } else {
-        wxSelectableItemListNode *node = SelList.GetFirst();
+        SelectableItemList::compatibility_iterator node = SelList.GetFirst();
         pFind = node->GetData();
         pIDX_best_candidate = (IDX_entry *)(pFind->m_pData1);
       }
@@ -8156,7 +8156,7 @@ void ChartCanvas::CallPopupMenu(int x, int y) {
     SelectCtx ctx(m_bShowNavobjects, GetCanvasTrueScale(), GetScaleValue());
     SelectableItemList SelList =
         pSelect->FindSelectionList(ctx, slat, slon, SELTYPE_ROUTEPOINT);
-    wxSelectableItemListNode *node = SelList.GetFirst();
+    SelectableItemList::compatibility_iterator node = SelList.GetFirst();
     while (node) {
       SelectItem *pFindSel = node->GetData();
 
@@ -8253,7 +8253,7 @@ void ChartCanvas::CallPopupMenu(int x, int y) {
     if (NULL == m_pSelectedRoute)  // the case where a segment only is selected
     {
       //  Choose the first visible route containing segment in the list
-      wxSelectableItemListNode *node = SelList.GetFirst();
+      SelectableItemList::compatibility_iterator node = SelList.GetFirst();
       while (node) {
         SelectItem *pFindSel = node->GetData();
 
@@ -8292,7 +8292,7 @@ void ChartCanvas::CallPopupMenu(int x, int y) {
         pSelect->FindSelectionList(ctx, slat, slon, SELTYPE_TRACKSEGMENT);
 
     //  Choose the first visible track containing segment in the list
-    wxSelectableItemListNode *node = SelList.GetFirst();
+    SelectableItemList::compatibility_iterator node = SelList.GetFirst();
     while (node) {
       SelectItem *pFindSel = node->GetData();
 
@@ -8325,7 +8325,7 @@ void ChartCanvas::CallPopupMenu(int x, int y) {
           ctx, m_cursor_lat, m_cursor_lon, SELTYPE_CURRENTPOINT);
 
       //      Default is first entry
-      wxSelectableItemListNode *node = SelList.GetFirst();
+      SelectableItemList::compatibility_iterator node = SelList.GetFirst();
       pFind = node->GetData();
       pIDX_best_candidate = (IDX_entry *)(pFind->m_pData1);
 
@@ -8342,7 +8342,7 @@ void ChartCanvas::CallPopupMenu(int x, int y) {
           node = node->GetNext();
         }  // while (node)
       } else {
-        wxSelectableItemListNode *node = SelList.GetFirst();
+        SelectableItemList::compatibility_iterator node = SelList.GetFirst();
         pFind = node->GetData();
         pIDX_best_candidate = (IDX_entry *)(pFind->m_pData1);
       }
@@ -8439,7 +8439,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
 
     SelectableItemList rpSelList =
         pSelect->FindSelectionList(ctx, zlat, zlon, SELTYPE_ROUTEPOINT);
-    wxSelectableItemListNode *node = rpSelList.GetFirst();
+    SelectableItemList::compatibility_iterator node = rpSelList.GetFirst();
     bool b_onRPtarget = false;
     while (node) {
       SelectItem *pFind = node->GetData();
@@ -8908,7 +8908,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
         SelectItem *pFind = NULL;
         SelectableItemList SelList = pSelect->FindSelectionList(
             ctx, m_cursor_lat, m_cursor_lon, SELTYPE_ROUTEPOINT);
-        wxSelectableItemListNode *node = SelList.GetFirst();
+        SelectableItemList::compatibility_iterator node = SelList.GetFirst();
         while (node) {
           pFind = node->GetData();
           RoutePoint *frp = (RoutePoint *)pFind->m_pData1;
@@ -8923,7 +8923,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
         SelectItem *pFind = NULL;
         SelectableItemList SelList = pSelect->FindSelectionList(
             ctx, m_cursor_lat, m_cursor_lon, SELTYPE_DRAGHANDLE);
-        wxSelectableItemListNode *node = SelList.GetFirst();
+        SelectableItemList::compatibility_iterator node = SelList.GetFirst();
         while (node) {
           pFind = node->GetData();
           RoutePoint *frp = (RoutePoint *)pFind->m_pData1;
@@ -9606,7 +9606,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
       if (!b_start_rollover && !b_startedit_route) {
         SelectableItemList SelList = pSelect->FindSelectionList(
             ctx, m_cursor_lat, m_cursor_lon, SELTYPE_ROUTESEGMENT);
-        wxSelectableItemListNode *node = SelList.GetFirst();
+        SelectableItemList::compatibility_iterator node = SelList.GetFirst();
         while (node) {
           SelectItem *pFindSel = node->GetData();
 
@@ -9623,7 +9623,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
       if (!b_start_rollover && !b_startedit_route) {
         SelectableItemList SelList = pSelect->FindSelectionList(
             ctx, m_cursor_lat, m_cursor_lon, SELTYPE_TRACKSEGMENT);
-        wxSelectableItemListNode *node = SelList.GetFirst();
+        SelectableItemList::compatibility_iterator node = SelList.GetFirst();
         while (node) {
           SelectItem *pFindSel = node->GetData();
 

--- a/gui/src/glChartCanvas.cpp
+++ b/gui/src/glChartCanvas.cpp
@@ -1604,7 +1604,7 @@ void glChartCanvas::DrawStaticRoutesTracksAndWaypoints(ViewPort &vp) {
     TrackGui(*pTrackDraw).Draw(m_pParentCanvas, dc, vp, vp.GetBBox());
   }
 
-  for (wxRouteListNode *node = pRouteList->GetFirst(); node;
+  for (RouteList::compatibility_iterator node = pRouteList->GetFirst(); node;
        node = node->GetNext()) {
     Route *pRouteDraw = node->GetData();
 
@@ -1644,7 +1644,7 @@ void glChartCanvas::DrawDynamicRoutesTracksAndWaypoints(ViewPort &vp) {
     // We need Track::Draw() to dynamically render last (ownship) point.
   }
 
-  for (wxRouteListNode *node = pRouteList->GetFirst(); node;
+  for (RouteList::compatibility_iterator node = pRouteList->GetFirst(); node;
        node = node->GetNext()) {
     Route *pRouteDraw = node->GetData();
 

--- a/gui/src/kml.cpp
+++ b/gui/src/kml.cpp
@@ -475,7 +475,7 @@ wxString Kml::MakeKmlFromRoute(Route* route, bool insertSeq) {
   std::stringstream lineStringCoords;
 
   RoutePointList* pointList = route->pRoutePointList;
-  wxRoutePointListNode* pointnode = pointList->GetFirst();
+  RoutePointList::compatibility_iterator pointnode = pointList->GetFirst();
   RoutePoint* routepoint;
 
   while (pointnode) {

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -2768,7 +2768,7 @@ void ExportGPX(wxWindow *parent, bool bviz_only, bool blayer) {
       node = node->GetNext();
     }
     // RTEs and TRKs
-    wxRouteListNode *node1 = pRouteList->GetFirst();
+    RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
     while (node1) {
       Route *pRoute = node1->GetData();
 

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -893,7 +893,7 @@ MyFrame::~MyFrame() {
   // delete pCurrentStack;
 
   //      Free the Route List
-  wxRouteListNode *node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node = pRouteList->GetFirst();
 
   while (node) {
     Route *pRouteDelete = node->GetData();

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -1070,7 +1070,7 @@ wxArrayString GetRouteGUIDArray(void) {
   wxArrayString result;
   RouteList* list = pRouteList;
 
-  wxRouteListNode* prpnode = list->GetFirst();
+  RouteList::compatibility_iterator prpnode = list->GetFirst();
   while (prpnode) {
     Route* proute = prpnode->GetData();
     result.Add(proute->m_GUID);
@@ -1119,7 +1119,7 @@ wxArrayString GetRouteGUIDArray(OBJECT_LAYER_REQ req) {
   wxArrayString result;
   RouteList* list = pRouteList;
 
-  wxRouteListNode* prpnode = list->GetFirst();
+  RouteList::compatibility_iterator prpnode = list->GetFirst();
   while (prpnode) {
     Route* proute = prpnode->GetData();
     switch (req) {
@@ -1883,7 +1883,7 @@ int PlugIn_Waypoint_Ex::GetRouteMembershipCount() {
   if (!pWP) return 0;
 
   int nCount = 0;
-  wxRouteListNode* node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node = pRouteList->GetFirst();
   while (node) {
     Route* proute = node->GetData();
     wxRoutePointListNode* pnode = (proute->pRoutePointList)->GetFirst();
@@ -1972,7 +1972,7 @@ int PlugIn_Waypoint_ExV2::GetRouteMembershipCount() {
   if (!pWP) return 0;
 
   int nCount = 0;
-  wxRouteListNode* node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node = pRouteList->GetFirst();
   while (node) {
     Route* proute = node->GetData();
     wxRoutePointListNode* pnode = (proute->pRoutePointList)->GetFirst();

--- a/gui/src/route_printout.cpp
+++ b/gui/src/route_printout.cpp
@@ -157,7 +157,7 @@ RoutePrintout::RoutePrintout(Route* route, const std::set<int>& options,
       m_table << point->GetName();
     }
     if (GUI::HasKey(options, RoutePrintOptions::kWaypointPosition)) {
-      std::wostringstream point_position;
+      std::ostringstream point_position;
       point_position << toSDMM(1, point->m_lat, false) << "\n"
                      << toSDMM(2, point->m_lon, false);
       m_table << point_position.str();
@@ -181,7 +181,7 @@ RoutePrintout::RoutePrintout(Route* route, const std::set<int>& options,
       }
     }
     if (GUI::HasKey(options, RoutePrintOptions::kWaypointSpeed)) {
-      std::wostringstream point_speed;
+      std::ostringstream point_speed;
       if (n > 1) {
         point_speed << std::fixed << std::setprecision(1);
         if (point->GetPlannedSpeed() < .1) {
@@ -209,7 +209,7 @@ RoutePrintout::RoutePrintout(Route* route, const std::set<int>& options,
       }
     }
     if (GUI::HasKey(options, RoutePrintOptions::kWaypointTideEvent)) {
-      std::wostringstream point_tide;
+      std::ostringstream point_tide;
       if (point->m_TideStation.Len() > 0 && point->GetETA().IsValid()) {
         int station_id = ptcmgr->GetStationIDXbyName(
             point->m_TideStation, point->m_lat, point->m_lon);
@@ -280,9 +280,9 @@ void RoutePrintout::DrawPage(wxDC* dc, int page) {
   int current_x = m_margin_x;
   int current_y = m_margin_y;
 
-  std::wostringstream title;
-  std::wostringstream subtitle;
-  std::wostringstream distance;
+  std::ostringstream title;
+  std::ostringstream subtitle;
+  std::ostringstream distance;
 
   distance << std::fixed << std::setprecision(1)
            << toUsrDistance(m_route->m_route_length)

--- a/gui/src/routemanagerdialog.cpp
+++ b/gui/src/routemanagerdialog.cpp
@@ -3047,10 +3047,10 @@ void RouteManagerDialog::OnLayDeleteClick(wxCommandEvent &event) {
   }
 
   // Process Tracks and Routes in this layer
-  wxRouteListNode *node1 = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
   while (node1) {
     Route *pRoute = node1->GetData();
-    wxRouteListNode *next_node = node1->GetNext();
+    RouteList::compatibility_iterator next_node = node1->GetNext();
     if (pRoute->m_bIsInLayer && (pRoute->m_LayerID == layer->m_LayerID)) {
       pRoute->m_bIsInLayer = false;
       pRoute->m_LayerID = 0;
@@ -3118,7 +3118,7 @@ void RouteManagerDialog::OnLayToggleChartClick(wxCommandEvent &event) {
 
 void RouteManagerDialog::ToggleLayerContentsOnChart(Layer *layer) {
   // Process Tracks and Routes in this layer
-  wxRouteListNode *node1 = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
   while (node1) {
     Route *pRoute = node1->GetData();
     if (pRoute->m_bIsInLayer && (pRoute->m_LayerID == layer->m_LayerID)) {
@@ -3170,7 +3170,7 @@ void RouteManagerDialog::OnLayToggleNamesClick(wxCommandEvent &event) {
 
 void RouteManagerDialog::ToggleLayerContentsNames(Layer *layer) {
   // Process Tracks and Routes in this layer
-  wxRouteListNode *node1 = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
   while (node1) {
     Route *pRoute = node1->GetData();
     if (pRoute->m_bIsInLayer && (pRoute->m_LayerID == layer->m_LayerID)) {
@@ -3227,7 +3227,7 @@ void RouteManagerDialog::ToggleLayerContentsOnListing(Layer *layer) {
   ::wxBeginBusyCursor();
 
   // Process Tracks and Routes in this layer
-  wxRouteListNode *node1 = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
   while (node1) {
     Route *pRoute = node1->GetData();
     if (pRoute->m_bIsInLayer && (pRoute->m_LayerID == layer->m_LayerID)) {

--- a/gui/src/tcmgr.cpp
+++ b/gui/src/tcmgr.cpp
@@ -993,24 +993,24 @@ int TCMgr::GetNextBigEvent(time_t *tm, int idx) {
   }
 }
 
-std::wstring TCMgr::GetTidalEventStr(int station_id, wxDateTime ref_dt,
-                                     double lat, double lon, int dt_type) {
+std::string TCMgr::GetTidalEventStr(int station_id, wxDateTime ref_dt,
+                                    double lat, double lon, int dt_type) {
   IDX_entry *idx = (IDX_entry *)GetIDX_entry(station_id);
   time_t dtmtt = ref_dt.FromUTC().GetTicks();
   int event = GetNextBigEvent(&dtmtt, station_id);
   wxDateTime event_dt = wxDateTime(dtmtt).MakeUTC();
 
-  std::wstring event_str;
+  std::string event_str;
   if (event == 1) {
-    event_str = _("LW").ToStdWstring();
+    event_str = _("LW").ToStdString();
   } else if (event == 2) {
-    event_str = _("HW").ToStdWstring();
+    event_str = _("HW").ToStdString();
   } else {
-    event_str = _("Unavailable").ToStdWstring();
+    event_str = _("Unavailable").ToStdString();
   }
 
   if (event > 0) {
-    event_str.append(L": ");
+    event_str.append(": ");
     event_str.append(
         toUsrDateTime(event_dt, dt_type, lon).FormatISOCombined(' '));
   }

--- a/model/include/model/route_point.h
+++ b/model/include/model/route_point.h
@@ -43,6 +43,10 @@
 #define ETA_FORMAT_STR "%x %H:%M"
 //"%d/%m/%Y %H:%M" //"%Y-%m-%d %H:%M"
 
+class RoutePoint;  // forward
+
+WX_DECLARE_LIST(RoutePoint, RoutePointList);  // establish class as list member
+
 // Default color, global state
 extern wxColour g_colourWaypointRangeRingsColour;
 
@@ -123,8 +127,16 @@ public:
   void *GetSelectNode(void) { return m_SelectNode; }
   void SetSelectNode(void *node) { m_SelectNode = node; }
 
-  void *GetManagerListNode(void) { return m_ManagerNode; }
-  void SetManagerListNode(void *node) { m_ManagerNode = node; }
+  RoutePointList::compatibility_iterator GetManagerListNode() {
+    return m_ManagerNode;
+  }
+
+  void SetManagerListNode(RoutePointList::compatibility_iterator node) {
+    m_ManagerNode = node;
+  }
+  void ClearManagerListNode() {
+    m_ManagerNode = RoutePointList::compatibility_iterator();
+  }
 
   void SetName(const wxString &name);
   void CalculateNameExtents(void);
@@ -561,7 +573,7 @@ private:
   wxString m_IconName;
 
   void *m_SelectNode;
-  void *m_ManagerNode;
+  RoutePointList::compatibility_iterator m_ManagerNode;
 
   float m_IconScaleFactor;
   wxBitmap m_ScaledBMP;
@@ -609,7 +621,5 @@ private:
   unsigned int m_dragIconTexture;
   int m_dragIconTextureWidth, m_dragIconTextureHeight;
 };
-
-WX_DECLARE_LIST(RoutePoint, RoutePointList);  // establish class as list member
 
 #endif  //  _ROUTEPOINT_H__

--- a/model/include/model/route_point.h
+++ b/model/include/model/route_point.h
@@ -32,6 +32,7 @@
 #include <wx/string.h>
 
 #include "model/hyperlink.h"
+#include "model/select_item.h"
 
 #include "bbox.h"
 
@@ -124,16 +125,26 @@ public:
   wxString GetIconName(void) { return m_IconName; }
   void SetIconName(wxString name) { m_IconName = name; }
 
-  void *GetSelectNode(void) { return m_SelectNode; }
-  void SetSelectNode(void *node) { m_SelectNode = node; }
+  SelectableItemList::compatibility_iterator GetSelectNode(void) {
+    return m_SelectNode;
+  }
 
-  RoutePointList::compatibility_iterator GetManagerListNode() {
+  void SetSelectNode(SelectableItemList::compatibility_iterator node) {
+    m_SelectNode = node;
+  }
+
+  void ClearSelectNode() {
+    m_SelectNode = SelectableItemList::compatibility_iterator();
+  }
+
+  RoutePointList::compatibility_iterator GetManagerListNode(void) {
     return m_ManagerNode;
   }
 
   void SetManagerListNode(RoutePointList::compatibility_iterator node) {
     m_ManagerNode = node;
   }
+
   void ClearManagerListNode() {
     m_ManagerNode = RoutePointList::compatibility_iterator();
   }
@@ -572,7 +583,7 @@ private:
   wxBitmap *m_pbmIcon;
   wxString m_IconName;
 
-  void *m_SelectNode;
+  SelectableItemList::compatibility_iterator m_SelectNode;
   RoutePointList::compatibility_iterator m_ManagerNode;
 
   float m_IconScaleFactor;

--- a/model/src/nav_object_database.cpp
+++ b/model/src/nav_object_database.cpp
@@ -1277,7 +1277,7 @@ static void UpdateRouteA(Route *pTentRoute, NavObjectCollection1 *navobj) {
 }
 
 Route *FindRouteContainingWaypoint(RoutePoint *pWP) {
-  wxRouteListNode *node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node = pRouteList->GetFirst();
   while (node) {
     Route *proute = node->GetData();
 
@@ -1325,7 +1325,7 @@ bool NavObjectCollection1::CreateNavObjGPXRoutes(void) {
   // Routes
   if (!pRouteList) return false;
 
-  wxRouteListNode *node1 = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
   while (node1) {
     Route *pRoute = node1->GetData();
 
@@ -1403,7 +1403,7 @@ bool NavObjectCollection1::AddGPXWaypoint(RoutePoint *pWP) {
 void NavObjectCollection1::AddGPXRoutesList(RouteList *pRoutes) {
   SetRootGPXNode();
 
-  wxRouteListNode *pRoute = pRoutes->GetFirst();
+  RouteList::compatibility_iterator pRoute = pRoutes->GetFirst();
   while (pRoute) {
     Route *pRData = pRoute->GetData();
     AddGPXRoute(pRData);
@@ -1635,7 +1635,7 @@ RoutePoint *WaypointExists(const wxString &guid) {
 bool WptIsInRouteList(RoutePoint *pr) {
   bool IsInList = false;
 
-  wxRouteListNode *node1 = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
   while (node1) {
     Route *pRoute = node1->GetData();
     RoutePointList *pRoutePointList = pRoute->pRoutePointList;
@@ -1659,7 +1659,7 @@ bool WptIsInRouteList(RoutePoint *pr) {
 }
 
 Route *RouteExists(const wxString &guid) {
-  wxRouteListNode *route_node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator route_node = pRouteList->GetFirst();
 
   while (route_node) {
     Route *proute = route_node->GetData();
@@ -1672,7 +1672,7 @@ Route *RouteExists(const wxString &guid) {
 }
 
 Route *RouteExists(Route *pTentRoute) {
-  wxRouteListNode *route_node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator route_node = pRouteList->GetFirst();
   while (route_node) {
     Route *proute = route_node->GetData();
 

--- a/model/src/navobj_db.cpp
+++ b/model/src/navobj_db.cpp
@@ -665,7 +665,7 @@ void NavObj_dB::CountImportNavObjects() {
     }
 
     input_set->LoadAllGPXRouteObjects();
-    for (wxRouteListNode* node = pRouteList->GetFirst(); node;
+    for (RouteList::compatibility_iterator node = pRouteList->GetFirst(); node;
          node = node->GetNext()) {
       Route* route_import = node->GetData();
       m_nImportObjects++;
@@ -712,7 +712,7 @@ bool NavObj_dB::ImportLegacyRoutes() {
   std::vector<Route*> routes_added;
   //  Add all routes to database
   int nroute = 0;
-  for (wxRouteListNode* node = pRouteList->GetFirst(); node;
+  for (RouteList::compatibility_iterator node = pRouteList->GetFirst(); node;
        node = node->GetNext()) {
     Route* route_import = node->GetData();
     if (InsertRoute(route_import)) {

--- a/model/src/route.cpp
+++ b/model/src/route.cpp
@@ -715,14 +715,14 @@ bool Route::IsEqualTo(Route *ptargetroute) {
   wxRoutePointListNode *pthisnode = (this->pRoutePointList)->GetFirst();
   wxRoutePointListNode *pthatnode = (ptargetroute->pRoutePointList)->GetFirst();
 
-  if (NULL == pthisnode) return false;
+  if (!pthisnode) return false;
 
   if (this->m_bIsInLayer || ptargetroute->m_bIsInLayer) return false;
 
   if (this->GetnPoints() != ptargetroute->GetnPoints()) return false;
 
   while (pthisnode) {
-    if (NULL == pthatnode) return false;
+    if (!pthatnode) return false;
 
     RoutePoint *pthisrp = pthisnode->GetData();
     RoutePoint *pthatrp = pthatnode->GetData();

--- a/model/src/route_point.cpp
+++ b/model/src/route_point.cpp
@@ -77,7 +77,6 @@ RoutePoint::RoutePoint() {
   m_NameLocationOffsetY = 8;
   m_pMarkFont = NULL;
   m_btemp = false;
-  m_SelectNode = NULL;
   m_ManagerNode = NULL;
 
   m_iTextTexture = 0;
@@ -153,7 +152,6 @@ RoutePoint::RoutePoint(RoutePoint *orig) {
   m_bIsInLayer = orig->m_bIsInLayer;
   m_GUID = pWayPointMan->CreateGUID(this);
 
-  m_SelectNode = NULL;
   m_ManagerNode = NULL;
 
   m_WaypointArrivalRadius = orig->GetWaypointArrivalRadius();
@@ -210,7 +208,6 @@ RoutePoint::RoutePoint(double lat, double lon, const wxString &icon_ident,
   m_btemp = false;
   m_bPreScaled = false;
 
-  m_SelectNode = NULL;
   m_ManagerNode = NULL;
   m_IconScaleFactor = 1.0;
   m_ScaMin = MAX_INT_VAL;

--- a/model/src/routeman.cpp
+++ b/model/src/routeman.cpp
@@ -125,7 +125,7 @@ Routeman::~Routeman() {
 }
 
 bool Routeman::IsRouteValid(Route *pRoute) {
-  wxRouteListNode *node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node = pRouteList->GetFirst();
   while (node) {
     if (pRoute == node->GetData()) return true;
     node = node->GetNext();
@@ -135,7 +135,7 @@ bool Routeman::IsRouteValid(Route *pRoute) {
 
 //    Make a 2-D search to find the route containing a given waypoint
 Route *Routeman::FindRouteContainingWaypoint(RoutePoint *pWP) {
-  wxRouteListNode *node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node = pRouteList->GetFirst();
   while (node) {
     Route *proute = node->GetData();
 
@@ -154,7 +154,7 @@ Route *Routeman::FindRouteContainingWaypoint(RoutePoint *pWP) {
 
 //    Make a 2-D search to find the route containing a given waypoint, by GUID
 Route *Routeman::FindRouteContainingWaypoint(const std::string &guid) {
-  wxRouteListNode *node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node = pRouteList->GetFirst();
   while (node) {
     Route *proute = node->GetData();
 
@@ -173,7 +173,7 @@ Route *Routeman::FindRouteContainingWaypoint(const std::string &guid) {
 
 //    Make a 2-D search to find the visual route containing a given waypoint
 Route *Routeman::FindVisibleRouteContainingWaypoint(RoutePoint *pWP) {
-  wxRouteListNode *node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node = pRouteList->GetFirst();
   while (node) {
     Route *proute = node->GetData();
     if (proute->IsVisible()) {
@@ -194,7 +194,7 @@ Route *Routeman::FindVisibleRouteContainingWaypoint(RoutePoint *pWP) {
 wxArrayPtrVoid *Routeman::GetRouteArrayContaining(RoutePoint *pWP) {
   wxArrayPtrVoid *pArray = new wxArrayPtrVoid;
 
-  wxRouteListNode *route_node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator route_node = pRouteList->GetFirst();
   while (route_node) {
     Route *proute = route_node->GetData();
 
@@ -883,7 +883,7 @@ bool Routeman::DeleteRoute(Route *pRoute) {
             pdnode = pRoute->pRoutePointList->Find(prp);
           }
 
-          pnode = NULL;
+          pnode = nullptr;
           NavObj_dB::GetInstance().DeleteRoutePoint(prp);
           delete prp;
         } else {
@@ -910,7 +910,7 @@ void Routeman::DeleteAllRoutes() {
   ::wxBeginBusyCursor();
 
   //    Iterate on the RouteList
-  wxRouteListNode *node = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node = pRouteList->GetFirst();
   while (node) {
     Route *proute = node->GetData();
     if (proute == pAISMOBRoute) {
@@ -988,7 +988,7 @@ wxString Routeman::GetRouteResequenceMessage(void) {
 }
 
 Route *Routeman::FindRouteByGUID(const wxString &guid) {
-  wxRouteListNode *node1 = pRouteList->GetFirst();
+  RouteList::compatibility_iterator node1 = pRouteList->GetFirst();
   while (node1) {
     Route *pRoute = node1->GetData();
 
@@ -1085,7 +1085,8 @@ WayPointman::~WayPointman() {
 bool WayPointman::AddRoutePoint(RoutePoint *prp) {
   if (!prp) return false;
 
-  wxRoutePointListNode *prpnode = m_pWayPointList->Append(prp);
+  auto prpnode =
+      RoutePointList::compatibility_iterator(m_pWayPointList->Append(prp));
   prp->SetManagerListNode(prpnode);
 
   return true;
@@ -1094,15 +1095,14 @@ bool WayPointman::AddRoutePoint(RoutePoint *prp) {
 bool WayPointman::RemoveRoutePoint(RoutePoint *prp) {
   if (!prp) return false;
 
-  wxRoutePointListNode *prpnode =
-      (wxRoutePointListNode *)prp->GetManagerListNode();
-
-  if (prpnode)
-    delete prpnode;
-  else
+  RoutePointList::compatibility_iterator prpnode = prp->GetManagerListNode();
+  if (prpnode) {
+    prpnode = RoutePointList::compatibility_iterator();
+  } else {
     m_pWayPointList->DeleteObject(prp);
+  }
 
-  prp->SetManagerListNode(NULL);
+  prp->ClearManagerListNode();
 
   return true;
 }
@@ -1498,7 +1498,7 @@ bool WayPointman::IsReallyVisible(RoutePoint *pWP) {
   if (pWP->m_bIsolatedMark)
     return pWP->IsVisible();  // isolated point
   else {
-    wxRouteListNode *node = pRouteList->GetFirst();
+    RouteList::compatibility_iterator node = pRouteList->GetFirst();
     while (node) {
       Route *proute = node->GetData();
       if (proute && proute->pRoutePointList) {

--- a/model/src/select.cpp
+++ b/model/src/select.cpp
@@ -51,7 +51,7 @@ bool Select::IsSelectableRoutePointValid(RoutePoint *pRoutePoint) {
   SelectItem *pFindSel;
 
   //    Iterate on the select list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
@@ -72,7 +72,7 @@ bool Select::AddSelectableRoutePoint(float slat, float slon,
   pSelItem->m_bIsSelected = false;
   pSelItem->m_pData1 = pRoutePointAdd;
 
-  wxSelectableItemListNode *node;
+  SelectableItemList::compatibility_iterator node;
 
   if (pRoutePointAdd->m_bIsInLayer)
     node = pSelectList->Append(pSelItem);
@@ -111,14 +111,14 @@ bool Select::DeleteAllSelectableRouteSegments(Route *pr) {
   SelectItem *pFindSel;
 
   //    Iterate on the select list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
     if (pFindSel->m_seltype == SELTYPE_ROUTESEGMENT &&
         (Route *)pFindSel->m_pData3 == pr) {
       delete pFindSel;
-      wxSelectableItemListNode *d = node;
+      SelectableItemList::compatibility_iterator d = node;
       node = node->GetNext();
       pSelectList->DeleteNode(d);  // delete node;
     } else
@@ -132,7 +132,7 @@ bool Select::DeleteAllSelectableRoutePoints(Route *pr) {
   SelectItem *pFindSel;
 
   //    Iterate on the select list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
@@ -147,7 +147,7 @@ bool Select::DeleteAllSelectableRoutePoints(Route *pr) {
         if (prp == ps) {
           delete pFindSel;
           pSelectList->DeleteNode(node);  // delete node;
-          prp->SetSelectNode(NULL);
+          prp->ClearSelectNode();
 
           node = pSelectList->GetFirst();
 
@@ -239,7 +239,7 @@ bool Select::UpdateSelectableRouteSegments(RoutePoint *prp) {
   bool ret = false;
 
   //    Iterate on the select list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
@@ -293,18 +293,18 @@ bool Select::DeleteSelectablePoint(void *pdata, int SeltypeToDelete) {
 
   if (NULL != pdata) {
     //    Iterate on the list
-    wxSelectableItemListNode *node = pSelectList->GetFirst();
+    SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
     while (node) {
       pFindSel = node->GetData();
       if (pFindSel->m_seltype == SeltypeToDelete) {
         if (pdata == pFindSel->m_pData1) {
           delete pFindSel;
-          delete node;
+          pSelectList->DeleteNode(node);
 
           if (SELTYPE_ROUTEPOINT == SeltypeToDelete) {
             RoutePoint *prp = (RoutePoint *)pdata;
-            prp->SetSelectNode(NULL);
+            prp->ClearSelectNode();
           }
 
           return true;
@@ -320,16 +320,16 @@ bool Select::DeleteAllSelectableTypePoints(int SeltypeToDelete) {
   SelectItem *pFindSel;
 
   //    Iterate on the list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
     if (pFindSel->m_seltype == SeltypeToDelete) {
-      delete node;
+      pSelectList->DeleteNode(node);
 
       if (SELTYPE_ROUTEPOINT == SeltypeToDelete) {
         RoutePoint *prp = (RoutePoint *)pFindSel->m_pData1;
-        prp->SetSelectNode(NULL);
+        prp->ClearSelectNode();
       }
       delete pFindSel;
 
@@ -345,15 +345,14 @@ bool Select::DeleteAllSelectableTypePoints(int SeltypeToDelete) {
 }
 
 bool Select::DeleteSelectableRoutePoint(RoutePoint *prp) {
-  if (NULL != prp) {
-    wxSelectableItemListNode *node =
-        (wxSelectableItemListNode *)prp->GetSelectNode();
+  if (prp) {
+    SelectableItemList::compatibility_iterator node = prp->GetSelectNode();
     if (node) {
       SelectItem *pFindSel = node->GetData();
       if (pFindSel) {
         delete pFindSel;
-        delete node;  // automatically removes from list
-        prp->SetSelectNode(NULL);
+        pSelectList->DeleteNode(node);  // delete node;
+        prp->ClearSelectNode();
         return true;
       }
     } else
@@ -367,7 +366,7 @@ bool Select::ModifySelectablePoint(float lat, float lon, void *data,
   SelectItem *pFindSel;
 
   //    Iterate on the list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
@@ -411,14 +410,14 @@ bool Select::DeleteAllSelectableTrackSegments(Track *pt) {
   SelectItem *pFindSel;
 
   //    Iterate on the select list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
     if (pFindSel->m_seltype == SELTYPE_TRACKSEGMENT &&
         (Track *)pFindSel->m_pData3 == pt) {
       delete pFindSel;
-      wxSelectableItemListNode *d = node;
+      SelectableItemList::compatibility_iterator d = node;
       node = node->GetNext();
       pSelectList->DeleteNode(d);  // delete node;
     } else
@@ -431,7 +430,7 @@ bool Select::DeletePointSelectableTrackSegments(TrackPoint *pt) {
   SelectItem *pFindSel;
 
   //    Iterate on the select list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
@@ -439,7 +438,7 @@ bool Select::DeletePointSelectableTrackSegments(TrackPoint *pt) {
         ((TrackPoint *)pFindSel->m_pData1 == pt ||
          (TrackPoint *)pFindSel->m_pData2 == pt)) {
       delete pFindSel;
-      wxSelectableItemListNode *d = node;
+      SelectableItemList::compatibility_iterator d = node;
       node = node->GetNext();
       pSelectList->DeleteNode(d);  // delete node;
     } else
@@ -521,7 +520,7 @@ SelectItem *Select::FindSelection(SelectCtx &ctx, float slat, float slon,
   CalcSelectRadius(ctx);
 
   //    Iterate on the list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();
@@ -568,7 +567,7 @@ find_ok:
 bool Select::IsSelectableSegmentSelected(SelectCtx &ctx, float slat, float slon,
                                          SelectItem *pFindSel) {
   bool valid = false;
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     if (pFindSel == node->GetData()) {
@@ -613,7 +612,7 @@ SelectableItemList Select::FindSelectionList(SelectCtx &ctx, float slat,
   CalcSelectRadius(ctx);
 
   //    Iterate on the list
-  wxSelectableItemListNode *node = pSelectList->GetFirst();
+  SelectableItemList::compatibility_iterator node = pSelectList->GetFirst();
 
   while (node) {
     pFindSel = node->GetData();

--- a/plugins/demo_pi_sample/src/demo_pi.cpp
+++ b/plugins/demo_pi_sample/src/demo_pi.cpp
@@ -22,6 +22,8 @@
  *   Minimal demonstration plugin.
  */
 
+#include <cstdint>
+
 #include "wx/wxprec.h"
 
 #ifndef WX_PRECOMP


### PR DESCRIPTION
Most of the 3.3 fixes are simple text substitutions. However, there are some quirks, many of which depending on that a compatibility_iterator is an object rather than a pointer.

These non-standard fixes from #4673 are here. They need separate review and testing.