### PR TITLE
Upgrade clang-format from version 18 to 19

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -2,11 +2,18 @@
 name: test-clang-format
 on: [push, pull_request]
 jobs:
-  build:
+  # Primary check with v18 - handles developers still using older clang-format versions.
+  # Falls back to v19 if v18 fails, accommodating devs with newer clang-format installs.
+  # This dual-version approach prevents formatting conflicts during transition period.
+  format-check-v18:
     runs-on: ubuntu-latest
+    continue-on-error: true
+    outputs:
+      v18-result: ${{ steps.format-check.outcome }}
     steps:
       - uses: actions/checkout@v2
-      - uses: DoozyX/clang-format-lint-action@v0.18.2
+      - id: format-check
+        uses: DoozyX/clang-format-lint-action@v0.20
         with:
           source: >-
             ./model ./gui
@@ -20,4 +27,26 @@ jobs:
             ./plugins/grib_pi/src/bzip2
           extensions: h,cpp
           clangFormatVersion: 18
+          style: file
+
+  format-check-v19:
+    runs-on: ubuntu-latest
+    needs: format-check-v18
+    if: needs.format-check-v18.outputs.v18-result == 'failure'
+    steps:
+      - uses: actions/checkout@v2
+      - uses: DoozyX/clang-format-lint-action@v0.20
+        with:
+          source: >-
+            ./model ./gui
+            ./plugins/wmm_pi/src ./plugins/dashboard_pi/src
+            ./plugins/chartdldr_pi/src ./plugins/grib_pi/src
+            ./plugins/demo_pi_sample/src
+          exclude: >-
+            ./plugins/dashboard_pi/src/wxJSON
+            ./plugins/chartdldr_pi/src/unarr
+            ./plugins/chartdldr_pi/src/tinyxml
+            ./plugins/grib_pi/src/bzip2
+          extensions: h,cpp
+          clangFormatVersion: 19
           style: file

--- a/gui/src/OCPNPlatform.cpp
+++ b/gui/src/OCPNPlatform.cpp
@@ -514,7 +514,7 @@ void OCPNPlatform::Initialize_1(void) {
 #endif
 
 #ifdef __WXMSW__
-    //     _CrtSetBreakAlloc(25503);
+  //     _CrtSetBreakAlloc(25503);
 #endif
 
 #ifndef __WXMSW__

--- a/gui/src/Quilt.cpp
+++ b/gui/src/Quilt.cpp
@@ -1405,8 +1405,8 @@ bool Quilt::BuildExtendedChartStackAndCandidateArray(int ref_db_index,
     if (cte.GetChartType() == CHART_TYPE_CM93COMP)
       m_fullscreen_index_array.push_back(i);
 
-      //  On android, SDK > 29, we require that the directory of charts be
-      //  "writable" as determined by Android Java file system
+    //  On android, SDK > 29, we require that the directory of charts be
+    //  "writable" as determined by Android Java file system
 #ifdef __OCPN__ANDROID__
     wxFileName fn(cte.GetFullSystemPath());
     if (!androidIsDirWritable(fn.GetPath())) continue;
@@ -1430,8 +1430,8 @@ bool Quilt::BuildExtendedChartStackAndCandidateArray(int ref_db_index,
 
     if (!m_bquiltskew && fabs(skew_norm) > 1.0) continue;
 
-      //    Special case for S57 ENC
-      //    Add the chart only if the chart's fractional area exceeds n%
+    //    Special case for S57 ENC
+    //    Add the chart only if the chart's fractional area exceeds n%
 #if 0
     if( CHART_TYPE_S57 == cte.GetChartType() ) {
       //Get the fractional area of this candidate

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -7591,8 +7591,8 @@ std::shared_ptr<PI_PointContext> ChartCanvas::GetCanvasContextAtPoint(int x,
     } else if (FoundRoutePoint)
       seltype |= SELTYPE_MARKPOINT;
 
-      //      Highlite the selected point, to verify the proper right click
-      //      selection
+    //      Highlite the selected point, to verify the proper right click
+    //      selection
 #if 0
     if (m_pFoundRoutePoint) {
       m_pFoundRoutePoint->m_bPtIsSelected = true;

--- a/gui/src/cm93.cpp
+++ b/gui/src/cm93.cpp
@@ -5414,7 +5414,7 @@ bool cm93compchart::DoRenderRegionViewOnDC(wxMemoryDC &dc,
           m_pDummyBM =
               new wxBitmap(VPoint.rv_rect.width, VPoint.rv_rect.height, -1);
 
-          //    Clear the quilt
+        //    Clear the quilt
 #ifdef ocpnUSE_DIBSECTION
         ocpnMemDC dumm_dc;
 #else

--- a/gui/src/glChartCanvas.cpp
+++ b/gui/src/glChartCanvas.cpp
@@ -1199,7 +1199,7 @@ void glChartCanvas::SetupOpenGL() {
   else
     wxLogMessage(_T("OpenGL-> Vertexbuffer Objects unavailable"));
 
-    //      Can we use the stencil buffer in a FBO?
+  //      Can we use the stencil buffer in a FBO?
 #ifdef ocpnUSE_GLES
   m_b_useFBOStencil = QueryExtension("GL_OES_packed_depth_stencil");
 #else
@@ -4145,7 +4145,7 @@ void glChartCanvas::Render() {
       //  Especially seen on sparse RNC rendering
       if (fabs(VPoint.rotation) > 0) accelerated_pan = false;
 
-        // do we allow accelerated panning?  can we perform it here?
+      // do we allow accelerated panning?  can we perform it here?
 #if !defined(USE_ANDROID_GLES2) && !defined(ocpnUSE_GLSL)
 #else  // GLES2
        // enable rendering to texture in framebuffer object

--- a/include/intro-comm.h
+++ b/include/intro-comm.h
@@ -3,8 +3,8 @@
 
                   ┌─────────────────────────────────────────────────────────┐
     Plugins       │      Plugins using decoded and raw data messaging       │
-                  └─────────────────────────────────────────────────────────┘           
-                  
+                  └─────────────────────────────────────────────────────────┘
+
                   ┌─────────────────────────────────────────────────────────┐
                   │                    Plugin message API                   │
                   └───────────────────────────────────────────────┐         │
@@ -17,11 +17,11 @@
                   │                                           │   │         │
                   │  nmea0183    nmea2000    signalK   ...    │   │         │
                   └───────────────────────────────────────────┘   └─────────┘
-    
+
                   ┌─────────────────────────────────────────────────────────┐
     Transport     │             Navigation messages (raw data)              │
                   └─────────────────────────────────────────────────────────┘
-    
+
                   ┌─────────────────────────────────────────────────────────┐
                   │                   Driver registry                       │
     Drivers       ├╶╶╶╶╶╶╶-┬╶╶╶╶╶╶╶╶╶╶-┬╶╶╶╶╶╶╶┬╶╶╶╶╶╶╶╶╶╶┬╶╶╶╶╶╶╶╶╶┬╶╶╶╶╶╶╶┤
@@ -29,7 +29,7 @@
                   │        │ NGT-1     │ CAN   │          │ +ipv4   │ ...   │
                   │        │           │       │          │ TCP/IP  │       │
                   └────────┴───────────┴───────┴──────────┴─────────┴───────┘
-    
+
 
 All internal communications described here is based on the \ref observable
 library which is available in *libs*. This library implements a basic
@@ -47,9 +47,9 @@ These messages are of type NavMsg defined in *comm_navmsg.h*.
 This is a unified, common type for all sorts of messages including NMEA2000,
 NMEA0183 and SignalK.
 
-In the core, *CommDecoder* acts as a dispatcher which listens to the 
-message bus and invokes various parts when messages arrives. 
-*CommDecoder* also handles priorities when receiving the same data from 
+In the core, *CommDecoder* acts as a dispatcher which listens to the
+message bus and invokes various parts when messages arrives.
+*CommDecoder* also handles priorities when receiving the same data from
 multiple sources, selecting the data source to use.
 
 For plugins, a simplified API is available, see \ref plugincomms.

--- a/include/intro-plugin-comm.h
+++ b/include/intro-plugin-comm.h
@@ -29,13 +29,14 @@ There are other ids for NMEA2000 and SignalK messages available.
 Likewise, there are similar methods to access the payload.
 See the ocpn_plugin.h header file.
 
-To invoke this method when a GPGGA message arrives, initiate the ObsListener like:
+To invoke this method when a GPGGA message arrives, initiate the ObsListener
+like:
 
         listener.Init(NMEA0183Id("GPGGA"),
                       [&](ObservedEvt ev) { HandleGPGA(ev); });
 
-The last line is a lambda expression which could be used to much more than to just
-invoke a method, see Epilog: Using the lambda below.
+The last line is a lambda expression which could be used to much more than to
+just invoke a method, see Epilog: Using the lambda below.
 
 
 \subsection epilog Epilog: Using the lambda

--- a/include/intro.h
+++ b/include/intro.h
@@ -5,7 +5,7 @@
 
 Only very little of opencpn is documented. Bits and pieces:
 
-  - \ref comm 
+  - \ref comm
   - \ref plugincomms
   - \ref observable
 

--- a/test/cli_server.cpp
+++ b/test/cli_server.cpp
@@ -19,10 +19,9 @@ static std::string GetSocketPath() {
   return path.GetFullPath().ToStdString();
 }
 
-class CliServer: public wxConnection {
+class CliServer : public wxConnection {
 public:
-  CliServer(wxAppConsole* app)
-      : wxConnection(), wx_app(app), exit_timer(app) {}
+  CliServer(wxAppConsole* app) : wxConnection(), wx_app(app), exit_timer(app) {}
 
   class ExitTimer : public wxTimer {
   public:
@@ -30,7 +29,6 @@ public:
     ExitTimer(wxAppConsole* app) : wxTimer(), wx_app(app) {}
     void Notify() { wx_app->ExitMainLoop(); }
   };
-
 
   bool OnExec(const wxString&, const wxString& data) {
     std::cout << data << "\n" << std::flush;
@@ -66,21 +64,19 @@ private:
   ExitTimer exit_timer;
 };
 
-
 class ServerFactory : public wxServer {
 public:
-   const bool is_connected;
-   wxAppConsole* wx_app;
+  const bool is_connected;
+  wxAppConsole* wx_app;
 
-   ServerFactory() : wxServer(), is_connected(Create(GetSocketPath())) {}
+  ServerFactory() : wxServer(), is_connected(Create(GetSocketPath())) {}
 
-   wxConnectionBase* OnAcceptConnection(const wxString& topic) {
-     return new CliServer(wx_app);
-   }
+  wxConnectionBase* OnAcceptConnection(const wxString& topic) {
+    return new CliServer(wx_app);
+  }
 };
 
 class ServerApp : public wxAppConsole {
-
   ServerFactory factory;
   void OnInitCmdLine(wxCmdLineParser& parser) override {
     factory.wx_app = this;
@@ -89,11 +85,10 @@ class ServerApp : public wxAppConsole {
     wxLog::SetLogLevel(wxLOG_Warning);
   }
 
-
   bool OnCmdLineParsed(wxCmdLineParser& parser) override {
     wxInitializer initializer;
-    std::cout << "Listening on " << GetSocketPath() << ", connected: " 
-            << (factory.is_connected ? "true\n" : "false\n") << std::flush;
+    std::cout << "Listening on " << GetSocketPath() << ", connected: "
+              << (factory.is_connected ? "true\n" : "false\n") << std::flush;
     return true;
   }
 };

--- a/test/ipc_client.cpp
+++ b/test/ipc_client.cpp
@@ -20,9 +20,9 @@ static std::string SocketPath() {
 
 class _IpcClientFactory;  // forward
 
-class _IpcClient: public wxConnection {
+class _IpcClient : public wxConnection {
 public:
-  _IpcClient(wxAppConsole* app) : wxConnection(),  exit_timer(app) {}
+  _IpcClient(wxAppConsole* app) : wxConnection(), exit_timer(app) {}
 
   class ExitTimer : public wxTimer {
   public:
@@ -30,7 +30,6 @@ public:
     ExitTimer(wxAppConsole* app) : wxTimer(), console_app(app) {}
     void Notify() { console_app->ExitMainLoop(); }
   };
-
 
   bool OnExec(const wxString& tbd, const wxString& data) {
     exit_timer.Start(200, wxTIMER_ONE_SHOT);
@@ -70,23 +69,20 @@ private:
   ExitTimer exit_timer;
 };
 
-
 class _IpcClientFactory : public wxClient {
 public:
-   wxConnectionBase* connection;
-   wxAppConsole* app;
+  wxConnectionBase* connection;
+  wxAppConsole* app;
 
-   _IpcClientFactory(wxAppConsole* _app)
-       : wxClient(), connection(0), app(_app) {}
-   _IpcClientFactory(wxAppConsole* _app, const std::string& path)
-       : wxClient(), app(_app)
-   {
-      connection = MakeConnection("localhost", path, "OpenCPN");
-   }
+  _IpcClientFactory(wxAppConsole* _app)
+      : wxClient(), connection(0), app(_app) {}
+  _IpcClientFactory(wxAppConsole* _app, const std::string& path)
+      : wxClient(), app(_app) {
+    connection = MakeConnection("localhost", path, "OpenCPN");
+  }
 
-   wxConnectionBase* OnMakeConnection() { return new _IpcClient(app); }
+  wxConnectionBase* OnMakeConnection() { return new _IpcClient(app); }
 };
-
 
 class ClientApp : public wxAppConsole {
 public:
@@ -95,7 +91,8 @@ public:
   ClientApp() : wxAppConsole(), factory(this, SocketPath()) {}
 
   void OnInitCmdLine(wxCmdLineParser& parser) override {
-    parser.AddParam("command", wxCMD_LINE_VAL_STRING,  wxCMD_LINE_PARAM_MULTIPLE);
+    parser.AddParam("command", wxCMD_LINE_VAL_STRING,
+                    wxCMD_LINE_PARAM_MULTIPLE);
     wxLog::SetActiveTarget(new wxLogStderr);
     wxLog::SetTimestamp("");
     wxLog::SetLogLevel(wxLOG_Warning);
@@ -107,40 +104,36 @@ public:
     for (size_t i = 0; i < parser.GetParamCount(); i++)
       args.push_back(parser.GetParam(i).ToStdString());
     if (!factory.connection) {
-      std::cout << "Cannot connect to server at " << SocketPath() << "\n" 
-              << std::flush;
+      std::cout << "Cannot connect to server at " << SocketPath() << "\n"
+                << std::flush;
       exit(1);
     }
     if (args.size() < 1) {
       std::cerr << "que?\n";
       exit(1);
-    }
-    else if (args[0] == "raise") {
+    } else if (args[0] == "raise") {
       bool ok = factory.connection->Execute("raise");
       exit(ok ? 0 : 2);
-    }
-    else if (args[0] == "quit") {
+    } else if (args[0] == "quit") {
       bool ok = factory.connection->Execute("quit");
       exit(ok ? 0 : 2);
-    }
-    else if (args[0] == "get_rest_endpoint") {
+    } else if (args[0] == "get_rest_endpoint") {
       auto cmd = std::string(args[0]);
       const void* reply = factory.connection->Request(cmd.c_str(), 0);
       std::cout << static_cast<const char*>(reply) << "\n";
       exit(reply ? 0 : 2);
-    }
-    else if (args[0] == "open") {
+    } else if (args[0] == "open") {
       auto cmd = std::string(args[0]) + " " + args[1];
       const void* reply = factory.connection->Request(cmd.c_str(), 0);
       reply_buff = reply ? static_cast<const char*>(reply) : "";
       std::cout << reply_buff << "\n" << std::flush;
       exit(reply ? 0 : 2);
-    }
-     else {
+    } else {
       std::cerr << "que?\n";
       exit(1);
     }
   }
+
 private:
   std::string reply_buff;
 };

--- a/test/std_instance.cpp
+++ b/test/std_instance.cpp
@@ -10,7 +10,6 @@
 
 class StdInstanceApp : public wxAppConsole {
 public:
-
   StdInstanceApp() : wxAppConsole() {}
 
   bool OnInit() {

--- a/test/wx_instance.cpp
+++ b/test/wx_instance.cpp
@@ -10,7 +10,6 @@
 
 class WxInstanceApp : public wxAppConsole {
 public:
-
   WxInstanceApp() : wxAppConsole() {}
 
   void OnInitCmdLine(wxCmdLineParser& parser) override {}


### PR DESCRIPTION
## Purpose

Upgrade code formatting tool from `clang-format` version 18 to version 19 to fix incorrect comment indentation issues.

## Problem

The current `clang-format` version 18 incorrectly indents comments that follow single-statement `if` blocks (without curly braces). These comments are being indented as if they are part of the `if` statement's body, when they should maintain normal indentation at the same level as the `if` statement itself.

Additionally, developers with local clang-format versions 19 or 20 encounter formatting conflicts when they run clang-format before committing. Their newer versions produce different formatting than the project's version 18 standard, leading to unintended formatting changes in commits and pull requests.

### Example Fix

**Before (incorrect formatting with clang-format 18):**
```cpp
if (cte.GetChartType() == CHART_TYPE_CM93COMP)
  m_fullscreen_index_array.push_back(i);

  //  On android, SDK > 29, we require that the directory of charts be
  //  "writable" as determined by Android Java file system
```

I.e. the comments are indented as if they were part of the `if` block, but that's wrong. The comments are always meant to be part of the next block of code.

**After (correct formatting with clang-format 20):**
```cpp
if (cte.GetChartType() == CHART_TYPE_CM93COMP)
  m_fullscreen_index_array.push_back(i);

//  On android, SDK > 29, we require that the directory of charts be
//  "writable" as determined by Android Java file system
```


## Impact

I locally upgraded clang-format to version 20.1.8 and ran the following comand:
```bash
find . \( -name "libs" -o -name "buildandroid" -o -name "buildwin" -o -name "buildosx" \
-o -name "build" -o -name "glutil" -o -path "./plugins/chartdldr_pi/src/tinyxml" \
 -o -path "./plugins/chartdldr_pi/src/unarr" -o -path "./plugins/dashboard_pi/include/wx" \
-o -path "./plugins/dashboard_pi/src/wxJSON" \) \
-prune -o \( -name "*.h" -o -name "*.cpp" \) -print -exec clang-format -i {} \;
```

After reformatting, these files are modified:
```
	modified:   gui/include/gui/tcmgr.h
	modified:   gui/src/OCPNPlatform.cpp
	modified:   gui/src/Quilt.cpp
	modified:   gui/src/chcanv.cpp
	modified:   gui/src/cm93.cpp
	modified:   gui/src/glChartCanvas.cpp
	modified:   gui/src/ocpndc.cpp
	modified:   gui/src/s57chart.cpp
	modified:   gui/src/viewport.cpp
	modified:   include/intro-comm.h
	modified:   include/intro-plugin-comm.h
	modified:   include/intro.h
	modified:   plugins/chartdldr_pi/src/pugixml.cpp
	modified:   plugins/grib_pi/src/GribOverlayFactory.cpp
	modified:   plugins/grib_pi/src/bzip2/bzlib_private.h
	modified:   plugins/grib_pi/src/pi_shaders.cpp
	modified:   plugins/wmm_pi/src/pi_shaders.cpp
	modified:   test/cli_server.cpp
	modified:   test/ipc_client.cpp
	modified:   test/std_instance.cpp
	modified:   test/wx_instance.cpp
```

Notes:
1. Besides the comment indentation, there is a limited number of cases when the space characters have changed in expressions and macros.
2. Dev engineers who have `clang-format` version 18 locally will need to upgrade to version 20. This seems a better option versus currently forcing dev engineers to downgrade `clang-format` to version 18.