### PR TITLE
libs observable: fix ObsListener std::move bug,  general update

### DIFF
--- a/libs/observable/include/observable.h
+++ b/libs/observable/include/observable.h
@@ -1,9 +1,7 @@
 /*************************************************************************
  *
- * Project:  OpenCPN
- * Purpose: General observable implementation with several specializations.
  *
- * Copyright (C) 2022 Alec Leamas
+ * Copyright (C) 2022 - 2025 Alec Leamas
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +18,13 @@
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.
  **************************************************************************/
+
+ /**
+  * \file
+  * General observable implementation with several specializations.
+  *
+  * A Notify() / Listen() library built on top of wxWidget's event handling.
+  */
 
 #ifndef OBSERVABLE_H
 #define OBSERVABLE_H

--- a/libs/observable/include/observable_confvar.h
+++ b/libs/observable/include/observable_confvar.h
@@ -26,7 +26,6 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 
 #include <wx/config.h>
 
@@ -68,13 +67,13 @@ class ConfigVar : public Observable {
 public:
   ConfigVar(const std::string& section_, const std::string& key_,
             wxConfigBase* cb);
+  ConfigVar() = delete;
 
   void Set(const T& arg);
 
   const T Get(const T& default_val);
 
 private:
-  ConfigVar();  // not implemented
 
   const std::string section;
   const std::string key;

--- a/libs/observable/include/observable_confvar.h
+++ b/libs/observable/include/observable_confvar.h
@@ -1,9 +1,6 @@
 /*************************************************************************
  *
- * Project:  OpenCPN
- * Purpose: Notify/listen config var wrapper
- *
- * Copyright (C) 2022 Alec Leamas
+ * Copyright (C) 2022 - 2025 Alec Leamas
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +17,12 @@
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.
  **************************************************************************/
+
+/**
+ * \file
+ *
+ * Notify()/Listen() configuration variable wrapper
+ */
 
 #ifndef OBSERVABLE_CONFVAR_H
 #define OBSERVABLE_CONFVAR_H

--- a/libs/observable/include/observable_evt.h
+++ b/libs/observable/include/observable_evt.h
@@ -1,9 +1,6 @@
 /*************************************************************************
  *
- * Project:  OpenCPN
- * Purpose: wxCommandEvt subclass which can carry also a shared_ptr<void>
- *
- * Copyright (C) 2022 Alec Leamas
+ * Copyright (C) 2022 - 2025 Alec Leamas
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +17,14 @@
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.
  **************************************************************************/
+
+/**
+ *\file
+ *
+ * wxCommandEvt subclass which can carry also a shared_ptr<void>
+ *
+ * This definition is duplicated and used also in the plugin interface
+ */
 
 #ifndef OBSERVABLE_EVT_H  // Guard also used in ocpn_plugin.h
 #define OBSERVABLE_EVT_H
@@ -47,7 +52,7 @@ public:
 
   [[nodiscard]] std::shared_ptr<const void> GetSharedPtr() const { return m_shared_ptr; }
 
-  void SetSharedPtr(const std::shared_ptr<const void>& p) { m_shared_ptr = p; }
+  void SetSharedPtr(const std::shared_ptr<const void> p) { m_shared_ptr = p; }
 
 private:
   std::shared_ptr<const void> m_shared_ptr;

--- a/libs/observable/include/observable_evt.h
+++ b/libs/observable/include/observable_evt.h
@@ -36,18 +36,18 @@ wxDECLARE_EVENT(obsNOTIFY, ObservedEvt);
 /** Adds a std::shared<void> element to wxCommandEvent. */
 class ObservedEvt : public wxCommandEvent {
 public:
-  ObservedEvt(wxEventType commandType = obsNOTIFY, int id = 0)
+  explicit ObservedEvt(wxEventType commandType = obsNOTIFY, int id = 0)
       : wxCommandEvent(commandType, id) {}
 
   ObservedEvt(const ObservedEvt& event) : wxCommandEvent(event) {
     this->m_shared_ptr = event.m_shared_ptr;
   }
 
-  wxEvent* Clone() const { return new ObservedEvt(*this); }
+  [[nodiscard]] wxEvent* Clone() const override{ return new ObservedEvt(*this); }
 
-  std::shared_ptr<const void> GetSharedPtr() const { return m_shared_ptr; }
+  [[nodiscard]] std::shared_ptr<const void> GetSharedPtr() const { return m_shared_ptr; }
 
-  void SetSharedPtr(std::shared_ptr<const void> p) { m_shared_ptr = p; }
+  void SetSharedPtr(const std::shared_ptr<const void>& p) { m_shared_ptr = p; }
 
 private:
   std::shared_ptr<const void> m_shared_ptr;

--- a/libs/observable/include/observable_evtvar.h
+++ b/libs/observable/include/observable_evtvar.h
@@ -21,15 +21,12 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.
  **************************************************************************/
 
-#ifndef _OBSERVABLE_EVTVAR_H
-#define _OBSERVABLE_EVTVAR_H
+#ifndef OBSERVABLE___EVTVAR__H
+#define OBSERVABLE___EVTVAR__H
 
 #include <atomic>
 #include <memory>
 #include <string>
-#include <vector>
-
-#include <wx/event.h>
 
 #include "observable.h"
 
@@ -73,26 +70,27 @@ public:
   EventVar() : Observable(Autokey()) {}
 
   /** Notify all listeners, no data supplied. */
-  const void Notify() { Observable::Notify("", 0); }
+  void Notify() override { Observable::Notify("", nullptr)
+    ; }
 
   /** Notify all listeners about variable change with ClientData. */
-  const void Notify(void* data) { Observable::Notify("", data); }
+  void Notify(void* data) { Observable::Notify("", data); }
 
   /** Notify all listeners about variable change with a string. */
-  const void Notify(const std::string& s) { Observable::Notify(s, 0); }
+  void Notify(const std::string& s) { Observable::Notify(s, nullptr); }
 
   /** Notify all listeners about variable change with a string and an int */
-  const void Notify(int n, const std::string& s) { Observable::Notify(0, s, n, 0); }
+  void Notify(int n, const std::string& s) { Observable::Notify(nullptr, s, n, nullptr); }
 
   /** Notify all listeners about variable change with an int and ClientData */
-  const void Notify(int n, void* p) { Observable::Notify(0, "", n, p); }
+  void Notify(int n, void* p) { Observable::Notify(nullptr, "", n, p); }
 
   /**
    * Notify all listeners about variable change with shared_ptr,
    * a string and an optional number.
    */
-  const void Notify(std::shared_ptr<void> p, const std::string& s, int n = 0) {
-    Observable::Notify(p, s, n, 0);
+  void Notify(const std::shared_ptr<void>& p, const std::string& s, int n = 0) {
+    Observable::Notify(p, s, n, nullptr);
   }
 
 private:
@@ -102,4 +100,4 @@ private:
   }
 };
 
-#endif  // _OBSERVABLE_EVTVAR_H
+#endif  // OBSERVABLE___EVTVAR__H

--- a/libs/observable/include/observable_evtvar.h
+++ b/libs/observable/include/observable_evtvar.h
@@ -1,9 +1,6 @@
 /*************************************************************************
  *
- * Project:  OpenCPN
- * Purpose: General observable implementation with several specializations.
- *
- * Copyright (C) 2022 Alec Leamas
+ * Copyright (C) 2022 - 2025 Alec Leamas
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +17,14 @@
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.
  **************************************************************************/
+
+/**
+ *\file
+ *
+ * A common variable shared between producer and consumer which supports
+ * Listen() and Notify().
+ */
+
 
 #ifndef OBSERVABLE___EVTVAR__H
 #define OBSERVABLE___EVTVAR__H

--- a/libs/observable/include/observable_globvar.h
+++ b/libs/observable/include/observable_globvar.h
@@ -1,9 +1,6 @@
 /*************************************************************************
  *
- * Project:  OpenCPN
- * Purpose:  global variables listen/notify wrapper.
- *
- * Copyright (C) 2022 Alec Leamas
+ * Copyright (C) 2022 - 2025 Alec Leamas
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -21,6 +18,11 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.
  **************************************************************************/
 
+/**
+ * \file
+ *
+ * Global variables Listen()/Notify() wrapper.
+ */
 #ifndef OBSERVABLE_GLOBVAR_H
 #define OBSERVABLE_GLOBVAR_H
 

--- a/libs/observable/include/observable_globvar.h
+++ b/libs/observable/include/observable_globvar.h
@@ -21,14 +21,8 @@
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.
  **************************************************************************/
 
-#ifndef _OBSERVABLE_GLOBVAR_H
-#define _OBSERVABLE_GLOBVAR_H
-
-#include <memory>
-#include <string>
-#include <vector>
-
-#include <wx/event.h>
+#ifndef OBSERVABLE_GLOBVAR_H
+#define OBSERVABLE_GLOBVAR_H
 
 #include "observable.h"
 
@@ -70,19 +64,20 @@
 template <typename T>
 class GlobalVar : public Observable {
 public:
-  GlobalVar(T* ptr) : Observable(ptr_key(ptr)), variable(ptr) {}
+  explicit GlobalVar(T* ptr) : Observable(ptr_key(ptr)), variable(ptr) {}
+
+  GlobalVar() = delete;
 
   void Set(const T& arg) {
     *variable = arg;
     Observable::Notify();
   }
 
-  const T Get() { return *variable; }
+  T Get() { return *variable; }
 
 private:
-  GlobalVar();  // not implemented
 
   T* const variable;
 };
 
-#endif  // _OBSERVABLE_GLOBVAR_H
+#endif  // OBSERVABLE_GLOBVAR_H

--- a/libs/observable/src/observable.cpp
+++ b/libs/observable/src/observable.cpp
@@ -1,9 +1,7 @@
 /*************************************************************************
  *
- * Project: OpenCPN
- * Purpose: Implement observable.h
  *
- * Copyright (C) 2022 Alec Leamas
+ * Copyright (C) 2022 - 2025 Alec Leamas
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +18,13 @@
  * Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.
  **************************************************************************/
+
+/**
+ *\file
+ *
+ * Implement observable.h
+ */
+
 
 #include <algorithm>
 #include <mutex>


### PR DESCRIPTION
Fix  bugs in  `ObsListener(ObsListener&& other)` and  `ObsListener& operator=(ObsListener&& other)` which basically made std::move to crash.

While on it, update file level comments and fix clang-tidy diagnostics.