### PR TITLE
NMEA0183 driver: Updates, notably remove too long messages from input stream

### DIFF
--- a/model/include/model/comm_drv_n0183.h
+++ b/model/include/model/comm_drv_n0183.h
@@ -36,13 +36,19 @@
  * NMEA0183 basic parsing common parts:
  *
  *   - Input is processed as lines.
- *   - Lines missing an initial '$' or '!' are considered as garbage and
- *     marked as such.
+ *   - Lines missing an initial '$' or '!' are marked as garbage.
  *   - Anything preceding first '$' or '!', including v4 tags, is
  *     silently dropped.
  *   - Sentences without checksum are allowed.
+ *   - Sentences without checksum longer than 128 chars are marked as
+ *     garbage.
  *   - Sentences with an incorrect checksum are marked as such.
  *   - Sentences filtered by input filters are marked as such.
+ *
+ * For messages which are not garbage the driver guarantees that
+ *
+ * 1. First characted is '$' or '!'-
+ * 2. For messages without checksum: the length is <= 128 chars.
  *
  */
 class CommDriverN0183 : public AbstractCommDriver {

--- a/model/src/comm_drv_n0183.cpp
+++ b/model/src/comm_drv_n0183.cpp
@@ -94,10 +94,19 @@ void CommDriverN0183::SendToListener(const std::string& payload,
   else
     state = NavMsg::State::kOk;
 
-  // We notify based on full message, including the Talker ID
   std::string id =
       state == NavMsg::State::kCannotParse ? "TRASH" : sentence.substr(1, 5);
   auto msg =
       std::make_shared<const Nmea0183Msg>(id, sentence, GetAddress(), state);
-  listener.Notify(std::move(msg));
+  if (is_garbage) {
+    auto msg = std::make_shared<const Nmea0183Msg>("TRASH", payload,
+                                                   GetAddress(), state);
+    listener.Notify(std::move(msg));
+  } else {
+    // We notify based on full message, including the Talker ID
+    const std::string id = sentence.substr(1, 5);
+    auto msg =
+        std::make_shared<const Nmea0183Msg>(id, sentence, GetAddress(), state);
+    listener.Notify(std::move(msg));
+  }
 }

--- a/model/src/comm_drv_n0183.cpp
+++ b/model/src/comm_drv_n0183.cpp
@@ -78,6 +78,7 @@ void CommDriverN0183::SendToListener(const std::string& payload,
   assert(sentence.size() >= 6);
 
   const bool is_garbage =
+      sentence.size() > 128 ||
       std::any_of(sentence.begin(), sentence.end(),
                   [](char c) { return !isprint(c) && c != '\n' && c != '\r'; });
   const bool has_checksum =


### PR DESCRIPTION
Make sure that messages which are too long (> 128 chars) are not forwarded to plugins and upper layers where they can make things crash.

While on it, update docs and use the complete input when generating "garbage" messages which only are used in the Data Monitor.

Closes: #4703