### PR TITLE
Add N0183 sentence $xxTHS for true heading to OCPN core. ref: #4714

### DIFF
--- a/libs/nmea0183/CMakeLists.txt
+++ b/libs/nmea0183/CMakeLists.txt
@@ -26,6 +26,8 @@ SET(SRC
     src/wpl.cpp
     src/rte.hpp
     src/rte.cpp
+    src/ths.hpp
+    src/ths.cpp
     src/hdt.hpp
     src/hdt.cpp
     src/hdg.hpp

--- a/libs/nmea0183/src/nmea0183.cpp
+++ b/libs/nmea0183/src/nmea0183.cpp
@@ -78,6 +78,7 @@ NMEA0183::NMEA0183(const NmeaContext& ctx) : caller_ctx(ctx)
    response_table.Append( (RESPONSE *) &Hdm );
    response_table.Append( (RESPONSE *) &Hdg );
    response_table.Append( (RESPONSE *) &Hdt );
+   response_table.Append( (RESPONSE *) &Ths );
    response_table.Append( (RESPONSE *) &Rmb );
    response_table.Append( (RESPONSE *) &Rmc );
    response_table.Append( (RESPONSE *) &Wpl );

--- a/libs/nmea0183/src/nmea0183.hpp
+++ b/libs/nmea0183/src/nmea0183.hpp
@@ -91,6 +91,7 @@
 #include "hdm.hpp"
 #include "hdg.hpp"
 #include "hdt.hpp"
+#include "ths.hpp"
 #include "RMB.hpp"
 #include "RMC.HPP"
 #include "wpl.hpp"
@@ -194,6 +195,7 @@ class NMEA0183
        HDM Hdm;
        HDG Hdg;
        HDT Hdt;
+       THS Ths;
        RMB Rmb;
        RMC Rmc;
        WPL Wpl;

--- a/libs/nmea0183/src/ths.cpp
+++ b/libs/nmea0183/src/ths.cpp
@@ -1,0 +1,117 @@
+/***************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  NMEA0183 Support Classes
+ * Author:   Samuel R. Blackburn, David S. Register, Hakan Svensson
+ *
+ ***************************************************************************
+ *   Copyright (C) 2010 by Samuel R. Blackburn.                            *
+ *   2025 by David S Register, Hakan Svensson                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ *
+ *   S Blackburn's original source license:                                *
+ *         "You can use it any way you like."                              *
+ *   More recent (2010) license statement:                                 *
+ *         "It is BSD license, do with it what you will"                   *
+ */
+
+
+#include "nmea0183.h"
+
+/*
+** Author: Samuel R. Blackburn
+** CI$: 76300,326
+** Internet: sammy@sed.csc.com
+**
+** You can use it any way you like.
+*/
+
+
+THS::THS()
+{
+   Mnemonic = _T("THS");
+   Empty();
+}
+
+THS::~THS()
+{
+   Mnemonic.Empty();
+   Empty();
+}
+
+void THS::Empty( void )
+{
+  TrueHeading = 0.0;
+  ModeInd.Empty();
+}
+
+bool THS::Parse( const SENTENCE& sentence )
+{
+
+   /*
+   ** THS - True heading and status
+   **
+   **        1   2 3
+   **        |   | |
+   ** $--THS,x.x,A*hh<CR><LF>
+   **
+   ** Field Number:
+   **  1) Heading Degrees, TRUE
+   **  2) Mode indicator A = Autonomous. Mode: E/M/S/V, are not valid for navigation
+   **  3) Checksum
+   */
+
+   /*
+   ** First we check the checksum...
+   */
+
+   if ( sentence.IsChecksumBad( 3 ) == TRUE )
+   {
+      SetErrorMessage( _T("Invalid Checksum") );
+      return( FALSE );
+   }
+
+   TrueHeading = sentence.Double(1);
+   ModeInd = sentence.Field( 2 );
+
+   return( TRUE );
+}
+
+bool THS::Write( SENTENCE& sentence )
+{
+   /*
+   ** Let the parent do its thing
+   */
+
+   RESPONSE::Write( sentence );
+
+   sentence += TrueHeading;
+   sentence += ModeInd;
+
+   sentence.Finish();
+
+   return( TRUE );
+}
+
+const THS& THS::operator = ( const THS& source )
+{
+  TrueHeading = source.TrueHeading;
+  ModeInd = source.ModeInd;
+
+   return( *this );
+}

--- a/libs/nmea0183/src/ths.hpp
+++ b/libs/nmea0183/src/ths.hpp
@@ -1,0 +1,65 @@
+/***************************************************************************
+ *
+ * Project:  OpenCPN
+ * Purpose:  NMEA0183 Support Classes
+ * Author:   Samuel R. Blackburn, David S. Register, Hakan Svensson
+ *
+ ***************************************************************************
+ *   Copyright (C) 2010 by Samuel R. Blackburn.                            *
+ *   2025 by David S Register, Hakan Svensson                              *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ ***************************************************************************
+ *
+ *   S Blackburn's original source license:                                *
+ *         "You can use it any way you like."                              *
+ *   More recent (2010) license statement:                                 *
+ *         "It is BSD license, do with it what you will"                   *
+ */
+#if ! defined( THS_CLASS_HEADER )
+#define THS_CLASS_HEADER
+
+class THS : public RESPONSE
+{
+
+   public:
+
+      THS();
+     ~THS();
+
+      /*
+      ** Data
+      */
+
+      double TrueHeading;
+	    wxString ModeInd;
+
+      /*
+      ** Methods
+      */
+
+      virtual void Empty( void );
+      virtual bool Parse( const SENTENCE& sentence );
+      virtual bool Write( SENTENCE& sentence );
+
+      /*
+      ** Operators
+      */
+
+      virtual const THS& operator = ( const THS& source );
+};
+
+#endif // THS_CLASS_HEADER

--- a/model/include/model/comm_bridge.h
+++ b/model/include/model/comm_bridge.h
@@ -151,6 +151,7 @@ private:
   ObsListener m_n2k_129540_lstnr;
 
   ObsListener m_n0183_rmc_lstnr;
+  ObsListener m_n0183_ths_lstnr;
   ObsListener m_n0183_hdt_lstnr;
   ObsListener m_n0183_hdg_lstnr;
   ObsListener m_n0183_hdm_lstnr;
@@ -197,6 +198,7 @@ private:
   bool HandleN2K_129540(const N2000MsgPtr& n2k_msg);
 
   bool HandleN0183_RMC(const N0183MsgPtr& n0183_msg);
+  bool HandleN0183_THS(const N0183MsgPtr& n0183_msg);
   bool HandleN0183_HDT(const N0183MsgPtr& n0183_msg);
   bool HandleN0183_HDG(const N0183MsgPtr& n0183_msg);
   bool HandleN0183_HDM(const N0183MsgPtr& n0183_msg);

--- a/model/include/model/comm_decoder.h
+++ b/model/include/model/comm_decoder.h
@@ -60,6 +60,7 @@ public:
   // NMEA0183 decoding, by sentence.
   bool DecodeRMC(std::string s, NavData& temp_data);
   bool DecodeHDM(std::string s, NavData& temp_data);
+  bool DecodeTHS(std::string s, NavData& temp_data);
   bool DecodeHDT(std::string s, NavData& temp_data);
   bool DecodeHDG(std::string s, NavData& temp_data);
   bool DecodeVTG(std::string s, NavData& temp_data);

--- a/model/src/comm_decoder.cpp
+++ b/model/src/comm_decoder.cpp
@@ -131,6 +131,21 @@ bool CommDecoder::DecodeHDM(std::string s, NavData& temp_data) {
   return true;
 }
 
+bool CommDecoder::DecodeTHS(std::string s, NavData& temp_data) {
+  wxString sentence(s.c_str());
+  wxString sentence3 = ProcessNMEA4Tags(sentence);
+  m_NMEA0183 << sentence3;
+
+  if (!m_NMEA0183.PreParse()) return false;
+  if (!m_NMEA0183.Parse()) return false;
+
+  // Handle only valid data A = Autonomous
+  if (!(m_NMEA0183.Ths.ModeInd == "A")) return false;
+  temp_data.gHdt = m_NMEA0183.Ths.TrueHeading;
+
+  return true;
+}
+
 bool CommDecoder::DecodeHDT(std::string s, NavData& temp_data) {
   wxString sentence(s.c_str());
   wxString sentence3 = ProcessNMEA4Tags(sentence);

--- a/model/src/navobj_db.cpp
+++ b/model/src/navobj_db.cpp
@@ -1997,7 +1997,7 @@ bool NavObj_dB::LoadAllPoints() {
       point->m_fWaypointRangeRingsStep = range_ring_step;
       point->m_iWaypointRangeRingsStepUnits = range_ring_units;
       point->SetShowWaypointRangeRings(range_ring_visible == 1);
-      
+
       point->m_wxcWaypointRangeRingsColour.Set(range_ring_color);
 
       point->SetScaMin(scamin);


### PR DESCRIPTION
Note: Only O core. I assume the following:
Dashboard gets heading, pfix.Hdt by SetPositionFixEx(), so there is no need to parse N0183 THS also there.