### PR TITLE
Console Sizing for all platforms the way it's done for Android

### DIFF
--- a/gui/src/concanv.cpp
+++ b/gui/src/concanv.cpp
@@ -964,13 +964,8 @@ void AnnunText::CalculateMinSize(void) {
   hv *= pdifactor;
 
   wxSize min;
-  min.x = wxMax(min.x, wl * 1.2);
-
-  // Space is tight on Android....
-#ifdef __ANDROID__
   min.x = wv * 1.2;
   min.x = wxMax(min.x, wl * 1.2);
-#endif
   min.y = (int)((hl + hv) * 1.2);
 
   SetMinSize(min);


### PR DESCRIPTION
Use the same Android's code for others platforms.
This is good for W11 