### PR TITLE
Unit categories

### DIFF
--- a/gui/include/gui/navutil.h
+++ b/gui/include/gui/navutil.h
@@ -49,7 +49,6 @@ class MyConfig;           // forward
 extern MyConfig *pConfig; /**< Global instance */
 
 extern bool LogMessageOnce(const wxString &msg);
-extern double fromUsrDistance(double usr_distance, int unit = -1);
 extern double fromUsrSpeed(double usr_speed, int unit = -1);
 extern double fromUsrWindSpeed(double usr_wspeed, int unit = -1);
 extern double fromUsrTemp(double usr_temp, int unit = -1);

--- a/gui/include/gui/options.h
+++ b/gui/include/gui/options.h
@@ -166,6 +166,7 @@ enum {
   ID_SPEEDUNITSCHOICE,
   ID_WINDSPEEDUNITCHOICE,
   ID_DEPTHUNITSCHOICE,
+  ID_HEIGHTUNITSCHOICE,
   ID_SELECTLIST,
   ID_SHOWDEPTHUNITSBOX1,
   ID_SHOWGPSWINDOW,
@@ -488,7 +489,7 @@ public:
 
   // For "Units" page
   wxChoice *pSDMMFormat, *pDistanceFormat, *pSpeedFormat, *pDepthUnitSelect,
-      *pTempFormat, *pWindSpeedFormat;
+      *pTempFormat, *pWindSpeedFormat, *pHeightUnitSelect;
   wxCheckBox *pCBTrueShow, *pCBMagShow;
   wxTextCtrl *pMagVar;
 

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -3216,31 +3216,6 @@ wxDateTime fromUsrDateTime(const wxDateTime ts, const int format,
 }
 
 /**************************************************************************/
-/*          Converts the distance from the units selected by user to NMi  */
-/**************************************************************************/
-double fromUsrDistance(double usr_distance, int unit) {
-  double ret = NAN;
-  if (unit == -1) unit = g_iDistanceFormat;
-  switch (unit) {
-    case DISTANCE_NMI:  // Nautical miles
-      ret = usr_distance;
-      break;
-    case DISTANCE_MI:  // Statute miles
-      ret = usr_distance / 1.15078;
-      break;
-    case DISTANCE_KM:
-      ret = usr_distance / 1.852;
-      break;
-    case DISTANCE_M:
-      ret = usr_distance / 1852;
-      break;
-    case DISTANCE_FT:
-      ret = usr_distance / 6076.12;
-      break;
-  }
-  return ret;
-}
-/**************************************************************************/
 /*          Converts the speed from the units selected by user to knots   */
 /**************************************************************************/
 double fromUsrSpeed(double usr_speed, int unit) {

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -856,6 +856,7 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
   Read(_T ( "WindSpeedFormat" ),
        &g_iWindSpeedFormat);  // 0 = "knots"), 1 = "m/s", 2 = "Mph", 3 = "km/h"
   Read(_T ("TemperatureFormat"), &g_iTempFormat);  // 0 = C, 1 = F, 2 = K
+  Read(_T ("HeightFormat"), &g_iHeightFormat);     // 0 = M, 1 = FT
 
   // LIVE ETA OPTION
   Read(_T ( "LiveETA" ), &g_bShowLiveETA);
@@ -2242,6 +2243,7 @@ void MyConfig::UpdateSettings() {
     Write(_T ( "WindSpeedFormat" ), g_iWindSpeedFormat);
     Write(_T ( "ShowDepthUnits" ), g_bShowDepthUnits);
     Write(_T ( "TemperatureFormat" ), g_iTempFormat);
+    Write(_T ( "HeightFormat" ), g_iHeightFormat);
   }
   Write(_T ( "GPSIdent" ), g_GPS_Ident);
   Write("ActiveRoute", g_active_route);
@@ -3086,6 +3088,7 @@ void SwitchInlandEcdisMode(bool Switch) {
       pConfig->Read(_T ( "DistanceFormat" ), &g_iDistanceFormat);
       pConfig->Read(_T ( "SpeedFormat" ), &g_iSpeedFormat);
       pConfig->Read(_T ( "ShowDepthUnits" ), &g_bShowDepthUnits, 1);
+      pConfig->Read(_T ( "HeightFormat" ), &g_iHeightFormat);
       int read_int;
       pConfig->Read(_T ( "nDisplayCategory" ), &read_int,
                     (enum _DisCat)STANDARD);

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -769,6 +769,19 @@ double fromUsrDepth_Plugin(double usr_depth, int unit) {
 
 wxString getUsrDepthUnit_Plugin(int unit) { return getUsrDepthUnit(unit); }
 
+/**
+ * Height Conversion Functions
+ */
+double toUsrHeight_Plugin(double m_height, int unit) {
+  return toUsrHeight(m_height, unit);
+}
+
+double fromUsrHeight_Plugin(double usr_height, int unit) {
+  return fromUsrHeight(usr_height, unit);
+}
+
+wxString getUsrHeightUnit_Plugin(int unit) { return getUsrHeightUnit(unit); }
+
 double fromDMM_PlugIn(wxString sdms) { return fromDMM(sdms); }
 
 bool PlugIn_GSHHS_CrossesLand(double lat1, double lon1, double lat2,

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -1583,6 +1583,7 @@ EVT_BUTTON(ID_OPENGLOPTIONS, options::OnOpenGLOptions)
 #endif
 EVT_CHOICE(ID_RADARDISTUNIT, options::OnDisplayCategoryRadioButton)
 EVT_CHOICE(ID_DEPTHUNITSCHOICE, options::OnUnitsChoice)
+EVT_CHOICE(ID_HEIGHTUNITSCHOICE, options::OnUnitsChoice)
 EVT_BUTTON(ID_CLEARLIST, options::OnButtonClearClick)
 EVT_BUTTON(ID_SELECTLIST, options::OnButtonSelectClick)
 EVT_BUTTON(ID_SETSTDLIST, options::OnButtonSetStd)
@@ -4490,12 +4491,14 @@ void options::CreatePanel_Units(size_t parent, int border_size,
     unitsSizer->Add(new wxStaticText(panelUnits, wxID_ANY, _("Distance")),
                     labelFlags);
     wxString pDistanceFormats[] = {_("Nautical miles"), _("Statute miles"),
-                                   _("Kilometers"), _("Meters")};
+                                   _("Kilometers"), _("Meters"), _("Yards")};
     int m_DistanceFormatsNChoices = sizeof(pDistanceFormats) / sizeof(wxString);
     pDistanceFormat =
         new wxChoice(panelUnits, ID_DISTANCEUNITSCHOICE, wxDefaultPosition,
                      wxSize(m_fontHeight * 4, -1), m_DistanceFormatsNChoices,
                      pDistanceFormats);
+    // Distance between geographic positions, visibility range, radar range.
+    pDistanceFormat->SetToolTip(_("Horizontal measurements and distances"));
 #ifdef __ANDROID__
     setChoiceStyleSheet(pDistanceFormat, m_fontHeight * 8 / 10);
 #endif
@@ -4509,6 +4512,7 @@ void options::CreatePanel_Units(size_t parent, int border_size,
     pSpeedFormat = new wxChoice(panelUnits, ID_SPEEDUNITSCHOICE,
                                 wxDefaultPosition, wxSize(m_fontHeight * 4, -1),
                                 m_SpeedFormatsNChoices, pSpeedFormats);
+    pSpeedFormat->SetToolTip(_("Vessel and surface speed measurements"));
 #ifdef __ANDROID__
     setChoiceStyleSheet(pSpeedFormat, m_fontHeight * 8 / 10);
 #endif
@@ -4524,6 +4528,7 @@ void options::CreatePanel_Units(size_t parent, int border_size,
         new wxChoice(panelUnits, ID_WINDSPEEDUNITCHOICE, wxDefaultPosition,
                      wxSize(m_fontHeight * 4, -1), m_WindSpeedFormatsNChoices,
                      pWindSpeedFormats);
+    pWindSpeedFormat->SetToolTip(_("Wind speed measurements and forecasts"));
 #ifdef __ANDROID__
     setChoiceStyleSheet(pWindSpeedFormat, m_fontHeight * 8 / 10);
 #endif
@@ -4540,10 +4545,31 @@ void options::CreatePanel_Units(size_t parent, int border_size,
     pDepthUnitSelect =
         new wxChoice(panelUnits, ID_DEPTHUNITSCHOICE, wxDefaultPosition,
                      wxSize(m_fontHeight * 4, -1), 3, pDepthUnitStrings);
+    // Distance below a reference surface (sea level, vessel draft)
+    pDepthUnitSelect->SetToolTip(_("Measurements below the water surface"));
 #ifdef __ANDROID__
     setChoiceStyleSheet(pDepthUnitSelect, m_fontHeight * 8 / 10);
 #endif
     unitsSizer->Add(pDepthUnitSelect, inputFlags);
+
+    // height units
+    unitsSizer->Add(new wxStaticText(panelUnits, wxID_ANY, _("Height")),
+                    labelFlags);
+    wxString pHeightUnitStrings[] = {
+        _("Meters"),
+        _("Feet"),
+    };
+    pHeightUnitSelect =
+        new wxChoice(panelUnits, ID_HEIGHTUNITSCHOICE, wxDefaultPosition,
+                     wxSize(m_fontHeight * 4, -1), 2, pHeightUnitStrings);
+    // Tide levels, wave heights, air gaps, mast clearance, elevations above
+    // reference datum
+    pHeightUnitSelect->SetToolTip(
+        _("Vertical measurements above reference datum (e.g., tide levels)"));
+#ifdef __ANDROID__
+    setChoiceStyleSheet(pHeightUnitSelect, m_fontHeight * 8 / 10);
+#endif
+    unitsSizer->Add(pHeightUnitSelect, inputFlags);
 
     // temperature units
     unitsSizer->Add(new wxStaticText(panelUnits, wxID_ANY, _("Temperature")),
@@ -4556,6 +4582,7 @@ void options::CreatePanel_Units(size_t parent, int border_size,
     pTempFormat =
         new wxChoice(panelUnits, ID_TEMPUNITSCHOICE, wxDefaultPosition,
                      wxSize(m_fontHeight * 4, -1), 3, pTempUnitStrings);
+    pTempFormat->SetToolTip(_("Temperature measurements (air, water, engine)"));
 #ifdef __ANDROID__
     setChoiceStyleSheet(pTempFormat, m_fontHeight * 8 / 10);
 #endif
@@ -4575,6 +4602,8 @@ void options::CreatePanel_Units(size_t parent, int border_size,
     pSDMMFormat = new wxChoice(panelUnits, ID_SDMMFORMATCHOICE,
                                wxDefaultPosition, wxSize(m_fontHeight * 4, -1),
                                m_SDMMFormatsNChoices, pSDMMFormats);
+    pSDMMFormat->SetToolTip(
+        _("Coordinate display format for latitude and longitude"));
 #ifdef __ANDROID__
     setChoiceStyleSheet(pSDMMFormat, m_fontHeight * 8 / 10);
 #endif
@@ -4679,11 +4708,12 @@ void options::CreatePanel_Units(size_t parent, int border_size,
     unitsSizer->Add(new wxStaticText(panelUnits, wxID_ANY, _("Distance")),
                     labelFlags);
     wxString pDistanceFormats[] = {_("Nautical miles"), _("Statute miles"),
-                                   _("Kilometers"), _("Meters")};
+                                   _("Kilometers"), _("Meters"), _("Yards")};
     int m_DistanceFormatsNChoices = sizeof(pDistanceFormats) / sizeof(wxString);
     pDistanceFormat = new wxChoice(panelUnits, ID_DISTANCEUNITSCHOICE,
                                    wxDefaultPosition, wxSize(item_h_size, -1),
                                    m_DistanceFormatsNChoices, pDistanceFormats);
+    pDistanceFormat->SetToolTip(_("Horizontal measurements and distances"));
 #ifdef __ANDROID__
     setChoiceStyleSheet(pDistanceFormat, m_fontHeight * 8 / 10);
 #endif
@@ -4697,6 +4727,7 @@ void options::CreatePanel_Units(size_t parent, int border_size,
     pSpeedFormat = new wxChoice(panelUnits, ID_SPEEDUNITSCHOICE,
                                 wxDefaultPosition, wxSize(item_h_size, -1),
                                 m_SpeedFormatsNChoices, pSpeedFormats);
+    pSpeedFormat->SetToolTip(_("Vessel and surface speed measurements"));
 #ifdef __ANDROID__
     setChoiceStyleSheet(pSpeedFormat, m_fontHeight * 8 / 10);
 #endif
@@ -4711,6 +4742,7 @@ void options::CreatePanel_Units(size_t parent, int border_size,
     pWindSpeedFormat = new wxChoice(
         panelUnits, ID_WINDSPEEDUNITCHOICE, wxDefaultPosition,
         wxSize(item_h_size, -1), m_WindSpeedFormatsNChoices, pWindSpeedFormats);
+    pWindSpeedFormat->SetToolTip(_("Wind speed measurements and forecasts"));
 #ifdef __ANDROID__
     setChoiceStyleSheet(pWindSpeedFormat, m_fontHeight * 8 / 10);
 #endif
@@ -4727,10 +4759,28 @@ void options::CreatePanel_Units(size_t parent, int border_size,
     pDepthUnitSelect =
         new wxChoice(panelUnits, ID_DEPTHUNITSCHOICE, wxDefaultPosition,
                      wxSize(item_h_size, -1), 3, pDepthUnitStrings);
+    pDepthUnitSelect->SetToolTip(_("Measurements below the water surface"));
 #ifdef __ANDROID__
     setChoiceStyleSheet(pDepthUnitSelect, m_fontHeight * 8 / 10);
 #endif
     unitsSizer->Add(pDepthUnitSelect, inputFlags);
+
+    // height units
+    unitsSizer->Add(new wxStaticText(panelUnits, wxID_ANY, _("Height")),
+                    labelFlags);
+    wxString pHeightUnitStrings[] = {
+        _("Meters"),
+        _("Feet"),
+    };
+    pHeightUnitSelect =
+        new wxChoice(panelUnits, ID_HEIGHTUNITSCHOICE, wxDefaultPosition,
+                     wxSize(item_h_size, -1), 2, pHeightUnitStrings);
+    pHeightUnitSelect->SetToolTip(
+        _("Vertical measurements above reference datum (e.g., tide levels)"));
+#ifdef __ANDROID__
+    setChoiceStyleSheet(pHeightUnitSelect, m_fontHeight * 8 / 10);
+#endif
+    unitsSizer->Add(pHeightUnitSelect, inputFlags);
 
     // temperature units
     unitsSizer->Add(new wxStaticText(panelUnits, wxID_ANY, _("Temperature")),
@@ -4743,6 +4793,7 @@ void options::CreatePanel_Units(size_t parent, int border_size,
     pTempFormat =
         new wxChoice(panelUnits, ID_TEMPUNITSCHOICE, wxDefaultPosition,
                      wxSize(item_h_size, -1), 3, pTempUnitStrings);
+    pTempFormat->SetToolTip(_("Temperature measurements (air, water, engine)"));
 #ifdef __ANDROID__
     setChoiceStyleSheet(pTempFormat, m_fontHeight * 8 / 10);
 #endif
@@ -4762,6 +4813,8 @@ void options::CreatePanel_Units(size_t parent, int border_size,
     pSDMMFormat = new wxChoice(panelUnits, ID_SDMMFORMATCHOICE,
                                wxDefaultPosition, wxSize(item_h_size, -1),
                                m_SDMMFormatsNChoices, pSDMMFormats);
+    pSDMMFormat->SetToolTip(
+        _("Coordinate display format for latitude and longitude"));
 #ifdef __ANDROID__
     setChoiceStyleSheet(pSDMMFormat, m_fontHeight * 8 / 10);
 #endif
@@ -6482,6 +6535,7 @@ void options::SetInitialSettings() {
   pSpeedFormat->Select(g_iSpeedFormat);
   pWindSpeedFormat->Select(g_iWindSpeedFormat);
   pTempFormat->Select(g_iTempFormat);
+  if (pHeightUnitSelect) pHeightUnitSelect->SetSelection(g_iHeightFormat);
 
   pAdvanceRouteWaypointOnArrivalOnly->SetValue(
       g_bAdvanceRouteWaypointOnArrivalOnly);
@@ -7419,6 +7473,7 @@ void options::ApplyChanges(wxCommandEvent& event) {
   g_iSpeedFormat = pSpeedFormat->GetSelection();
   g_iWindSpeedFormat = pWindSpeedFormat->GetSelection();
   g_iTempFormat = pTempFormat->GetSelection();
+  if (pHeightUnitSelect) g_iHeightFormat = pHeightUnitSelect->GetSelection();
 
   // LIVE ETA OPTION
   if (pSLiveETA) g_bShowLiveETA = pSLiveETA->GetValue();

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -3181,6 +3181,35 @@ extern DECL_EXP double toUsrDepth_Plugin(double m_depth, int unit = -1);
 extern DECL_EXP double fromUsrDepth_Plugin(double usr_depth, int unit = -1);
 
 /**
+ * Gets display string for user's preferred height unit.
+ *
+ * @param unit Override unit choice (-1 for user preference):
+ *             0=meters, 1=feet
+ * @return Localized unit string (e.g. "m", "ft")
+ */
+extern DECL_EXP wxString getUsrHeightUnit_Plugin(int unit = -1);
+
+/**
+ * Converts meters to user's preferred height unit.
+ *
+ * @param m_height Height in meters
+ * @param unit Override unit choice (-1 for user preference):
+ *             0=meters, 1=feet
+ * @return Height in user's preferred unit
+ */
+extern DECL_EXP double toUsrHeight_Plugin(double m_height, int unit = -1);
+
+/**
+ * Converts from user's preferred height unit to meters.
+ *
+ * @param usr_height Height in user's unit
+ * @param unit Override unit choice (-1 for user preference):
+ *             0=meters, 1=feet
+ * @return Height in meters
+ */
+extern DECL_EXP double fromUsrHeight_Plugin(double usr_height, int unit = -1);
+
+/**
  * Parse a formatted coordinate string to get decimal degrees.
  *
  * Attempt to parse a wide variety of formatted coordinate

--- a/model/include/model/config_vars.h
+++ b/model/include/model/config_vars.h
@@ -157,6 +157,7 @@ extern int g_GUIScaleFactor;
 extern int g_iDistanceFormat;
 extern int g_iENCToolbarPosX;
 extern int g_iENCToolbarPosY;
+extern int g_iHeightFormat;
 extern int g_iNavAidRadarRingsNumberVisible;
 extern int g_iSDMMFormat;
 extern int g_iSoundDeviceIndex;

--- a/model/include/model/navutil_base.h
+++ b/model/include/model/navutil_base.h
@@ -64,7 +64,13 @@ extern double toUsrTemp(double cel_temp, int unit = -1);
 
 extern double toUsrDistance(double nm_distance, int unit = -1);
 extern wxString getUsrDistanceUnit(int unit = -1);
-extern double fromUsrDistance(double usr_distance, int unit, int default_val);
+/** Convert distance from user units to nautical miles.
+ * @param usr_distance Distance in user units
+ * @param unit Unit to convert from, or -1 to use default_val
+ * @param default_val Default unit when unit=-1, or -1 to use g_iDistanceFormat
+ */
+extern double fromUsrDistance(double usr_distance, int unit,
+                              int default_val = -1);
 extern double fromUsrSpeed(double usr_speed, int unit, int default_val);
 
 extern double toUsrDepth(double cel_depth, int unit = -1);

--- a/model/include/model/navutil_base.h
+++ b/model/include/model/navutil_base.h
@@ -36,6 +36,9 @@
 enum { SPEED_KTS = 0, SPEED_MPH, SPEED_KMH, SPEED_MS };
 enum { WSPEED_KTS = 0, WSPEED_MS, WSPEED_MPH, WSPEED_KMH };
 enum { DEPTH_FT = 0, DEPTH_M, DEPTH_FA };
+/** Height unit format constants for vertical measurements above reference datum
+ */
+enum { HEIGHT_M = 0, HEIGHT_FT };
 enum { TEMPERATURE_C = 0, TEMPERATURE_F = 1, TEMPERATURE_K = 2 };
 
 enum {
@@ -44,6 +47,7 @@ enum {
   DISTANCE_KM,
   DISTANCE_M,
   DISTANCE_FT,
+  DISTANCE_YD,
   DISTANCE_FA,
   DISTANCE_IN,
   DISTANCE_CM
@@ -66,6 +70,13 @@ extern double fromUsrSpeed(double usr_speed, int unit, int default_val);
 extern double toUsrDepth(double cel_depth, int unit = -1);
 extern double fromUsrDepth(double usr_depth, int unit = -1);
 extern wxString getUsrDepthUnit(int unit = -1);
+
+/** Convert height from meters to user-selected height units */
+extern double toUsrHeight(double m_height, int unit = -1);
+/** Convert height from user-selected height units to meters */
+extern double fromUsrHeight(double usr_height, int unit = -1);
+/** Get the abbreviation for the user-selected height unit */
+extern wxString getUsrHeightUnit(int unit = -1);
 
 /**
  * This function parses a string containing a GPX time representation

--- a/model/src/config_vars.cpp
+++ b/model/src/config_vars.cpp
@@ -150,6 +150,7 @@ int g_GUIScaleFactor = 0;
 int g_iDistanceFormat = 0;
 int g_iENCToolbarPosX = 0;
 int g_iENCToolbarPosY = 0;
+int g_iHeightFormat = 0;
 int g_iNavAidRadarRingsNumberVisible = 0;
 int g_iSDMMFormat = 0;
 int g_iSoundDeviceIndex = 0;

--- a/model/src/navutil_base.cpp
+++ b/model/src/navutil_base.cpp
@@ -220,6 +220,9 @@ double toUsrDistance(double nm_distance, int unit) {
     case DISTANCE_FT:
       ret = nm_distance * 6076.12;
       break;
+    case DISTANCE_YD:
+      ret = nm_distance * 2025.37;
+      break;
     case DISTANCE_FA:
       ret = nm_distance * 1012.68591;
       break;
@@ -294,6 +297,9 @@ wxString getUsrDistanceUnit(int unit) {
       break;
     case DISTANCE_FT:
       ret = _("ft");
+      break;
+    case DISTANCE_YD:
+      ret = _("yd");
       break;
     case DISTANCE_FA:
       ret = _("fa");
@@ -423,6 +429,18 @@ double fromUsrDistance(double usr_distance, int unit, int default_val) {
     case DISTANCE_FT:
       ret = usr_distance / 6076.12;
       break;
+    case DISTANCE_YD:
+      ret = usr_distance / 2025.37;
+      break;
+    case DISTANCE_FA:
+      ret = usr_distance / 1012.68591;
+      break;
+    case DISTANCE_IN:
+      ret = usr_distance / 72913.4;
+      break;
+    case DISTANCE_CM:
+      ret = usr_distance / 185200;
+      break;
   }
   return ret;
 }
@@ -482,6 +500,48 @@ wxString getUsrDepthUnit(int unit) {
       break;
     case DEPTH_FA:  // Fathoms
       ret = _("fa");
+      break;
+  }
+  return ret;
+}
+
+double toUsrHeight(double m_height, int unit) {
+  double ret = NAN;
+  if (unit == -1) unit = g_iHeightFormat;
+  switch (unit) {
+    case HEIGHT_M:  // Meters
+      ret = m_height;
+      break;
+    case HEIGHT_FT:  // Feet
+      ret = m_height / 0.3048;
+      break;
+  }
+  return ret;
+}
+
+double fromUsrHeight(double usr_height, int unit) {
+  double ret = NAN;
+  if (unit == -1) unit = g_iHeightFormat;
+  switch (unit) {
+    case HEIGHT_M:  // Meters
+      ret = usr_height;
+      break;
+    case HEIGHT_FT:  // Feet
+      ret = usr_height * 0.3048;
+      break;
+  }
+  return ret;
+}
+
+wxString getUsrHeightUnit(int unit) {
+  wxString ret;
+  if (unit == -1) unit = g_iHeightFormat;
+  switch (unit) {
+    case HEIGHT_M:  // Meters
+      ret = _("m");
+      break;
+    case HEIGHT_FT:  // Feet
+      ret = _("ft");
       break;
   }
   return ret;

--- a/model/src/navutil_base.cpp
+++ b/model/src/navutil_base.cpp
@@ -412,7 +412,10 @@ double fromUsrSpeed(double usr_speed, int unit, int default_val) {
 /**************************************************************************/
 double fromUsrDistance(double usr_distance, int unit, int default_val) {
   double ret = NAN;
-  if (unit == -1) unit = default_val;
+  if (unit == -1) {
+    // Use g_iDistanceFormat as default when default_val is -1
+    unit = (default_val == -1) ? g_iDistanceFormat : default_val;
+  }
   switch (unit) {
     case DISTANCE_NMI:  // Nautical miles
       ret = usr_distance;


### PR DESCRIPTION
WIP - will expose in upstream when it's ready.

# Overview

Implement #4772 (unit categorization) and #4735 (tide display units), plus fixes several related bugs discovered during implementation.

# Changes

1. Unit Categorization: Restructured Options > Settings > Display units into logical categories:
   - Distance (horizontal): NMi, mi, km, m, ft, yards (new)
   - Depth (below surface): m, ft, fa
   - Height (above reference datum): m, ft (new category)
2. Added Yards Support (@rgleason request) for horizontal distance
3. Add Tooltips for unit customization: tooltips for all unit categories in options dialog
4. Tide Display Fix: Tide curves now properly use height units instead of depth units