### PR TITLE
ocpn_app: Fix g_platform initialization order -- #4796

### DIFF
--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -1224,9 +1224,6 @@ bool MyApp::OnInit() {
                        app_style, dockart);
   wxTheApp->SetTopWindow(gFrame);
 
-  //  Do those platform specific initialization things that need gFrame
-  g_Platform->Initialize_3();
-
   //  Initialize the Plugin Manager
   g_pi_manager = new PlugInManager(gFrame);
 
@@ -1237,6 +1234,9 @@ bool MyApp::OnInit() {
 
   // tell wxAuiManager to manage the frame
   g_pauimgr->SetManagedWindow(gFrame);
+
+  //  Do those platform specific initialization things that need gFrame
+  g_Platform->Initialize_3();
 
   gFrame->CreateCanvasLayout();
 


### PR DESCRIPTION
As discussed in bug, calling g_Platform->Initialize_3() before defining g_pauimgr's managed window might lead to a crash. Thus, move the call to a point where g_pauumgr is fully initialized-

Closes: #4796