### PR TITLE
Optimize LLRegion methods

### DIFF
--- a/gui/src/chartimg.cpp
+++ b/gui/src/chartimg.cpp
@@ -1355,12 +1355,12 @@ InitReturn ChartKAP::Init(const wxString &name, ChartInitFlag init_flags) {
         m_nCOVREntries = covrRegion.contours.size();
         m_pCOVRTablePoints = (int *)malloc(m_nCOVREntries * sizeof(int));
         m_pCOVRTable = (float **)malloc(m_nCOVREntries * sizeof(float *));
-        std::list<poly_contour>::iterator it = covrRegion.contours.begin();
+        auto it = covrRegion.contours.begin();
         for (int i = 0; i < m_nCOVREntries; i++) {
           m_pCOVRTablePoints[i] = it->size();
           m_pCOVRTable[i] =
               (float *)malloc(m_pCOVRTablePoints[i] * 2 * sizeof(float));
-          std::list<contour_pt>::iterator jt = it->begin();
+          auto jt = it->begin();
           for (int j = 0; j < m_pCOVRTablePoints[i]; j++) {
             m_pCOVRTable[i][2 * j + 0] = jt->y;
             m_pCOVRTable[i][2 * j + 1] = jt->x;

--- a/gui/src/gl_chart_canvas.cpp
+++ b/gui/src/gl_chart_canvas.cpp
@@ -2856,8 +2856,7 @@ void glChartCanvas::DrawRegion(ViewPort &vp, const LLRegion &region) {
   gluTessNormal(tobj, 0, 0, 1);
 
   gluTessBeginPolygon(tobj, NULL);
-  for (std::list<poly_contour>::const_iterator i = region.contours.begin();
-       i != region.contours.end(); i++) {
+  for (auto i = region.contours.begin(); i != region.contours.end(); i++) {
     gluTessBeginContour(tobj);
     contour_pt l = *i->rbegin();
     double sml[2];

--- a/gui/src/mbtiles/mbtiles.cpp
+++ b/gui/src/mbtiles/mbtiles.cpp
@@ -510,12 +510,12 @@ InitReturn ChartMbTiles::Init(const wxString& name, ChartInitFlag init_flags) {
     m_nCOVREntries = covr_region.contours.size();
     m_pCOVRTablePoints = (int*)malloc(m_nCOVREntries * sizeof(int));
     m_pCOVRTable = (float**)malloc(m_nCOVREntries * sizeof(float*));
-    std::list<poly_contour>::iterator it = covr_region.contours.begin();
+    auto it = covr_region.contours.begin();
     for (int i = 0; i < m_nCOVREntries; i++) {
       m_pCOVRTablePoints[i] = it->size();
       m_pCOVRTable[i] =
           (float*)malloc(m_pCOVRTablePoints[i] * 2 * sizeof(float));
-      std::list<contour_pt>::iterator jt = it->begin();
+      auto jt = it->begin();
       for (int j = 0; j < m_pCOVRTablePoints[i]; j++) {
         m_pCOVRTable[i][2 * j + 0] = jt->y;
         m_pCOVRTable[i][2 * j + 1] = jt->x;

--- a/gui/src/viewport.cpp
+++ b/gui/src/viewport.cpp
@@ -413,12 +413,10 @@ OCPNRegion ViewPort::GetVPRegionIntersect(const OCPNRegion &region,
   rotation = 0;
 
   std::list<ContourRegion> cregions;
-  for (std::list<poly_contour>::const_iterator i = llregion.contours.begin();
-       i != llregion.contours.end(); i++) {
+  for (auto i = llregion.contours.begin(); i != llregion.contours.end(); i++) {
     float *contour_points = new float[2 * i->size()];
     int idx = 0;
-    std::list<contour_pt>::const_iterator j;
-    for (j = i->begin(); j != i->end(); j++) {
+    for (auto j = i->begin(); j != i->end(); j++) {
       contour_points[idx++] = j->y;
       contour_points[idx++] = j->x;
     }

--- a/libs/geoprim/src/LLRegion.h
+++ b/libs/geoprim/src/LLRegion.h
@@ -27,7 +27,7 @@
 #ifndef _LLREGION_H_
 #define _LLREGION_H_
 
-#include <list>
+#include <vector>
 
 #include "bbox.h"
 
@@ -39,7 +39,7 @@ struct contour_pt {
 // LLRegion
 // ----------------------------------------------------------------------------
 
-typedef std::list<contour_pt> poly_contour;
+typedef std::vector<contour_pt> poly_contour;
 class LLBBox;
 
 struct work;
@@ -50,7 +50,13 @@ public:
   LLRegion(const LLBBox& llbbox);
   LLRegion(size_t n, const float* points);
   LLRegion(size_t n, const double* points);
+  // Explicitly defaulted special members (optional but clear)
+  LLRegion(const LLRegion&) = default;
+  LLRegion(LLRegion&&) noexcept = default;
 
+  // Unqualified member declaration
+  LLRegion& operator=(const LLRegion& rhs);
+  LLRegion& operator=(LLRegion&&) noexcept = default;
   static bool PointsCCW(size_t n, const double* points);
 
   void Print() const;
@@ -70,7 +76,7 @@ public:
 
   void Reduce(double factor);
 
-  std::list<poly_contour> contours;
+  std::vector<poly_contour> contours;
 
 private:
   bool NoIntersection(const LLBBox& box) const;


### PR DESCRIPTION
Prefer std::vector over std::list for LLRegion internal objects

Prefer deep copy LLRegion::operator= over default operator=

Use of auto makes future maintenance easier

Use std::move to avoid needless construction of objects

Remove dead code from LLRegion