### PR TITLE
tooltip: Fix destroy() race condition - #4821

### DIFF
--- a/gui/include/gui/tooltip.h
+++ b/gui/include/gui/tooltip.h
@@ -20,12 +20,15 @@
 #ifndef _TOOLTIP_H__
 #define _TOOLTIP_H__
 
+#include <functional>
+
 #include <wx/frame.h>
 #include <wx/timer.h>
 #include <wx/bitmap.h>
 #include "color_types.h"
 
-class ChartCanvas;
+class Tooltip;  // forward
+using TooltipCallback = std::function<void(const Tooltip *)>;
 
 /**
  * Tooltip with color scheme support and high-visibility mode.
@@ -35,7 +38,7 @@ class ChartCanvas;
  */
 class Tooltip : public wxFrame {
 public:
-  Tooltip(wxWindow *parent);
+  Tooltip(wxWindow *parent, TooltipCallback on_destroy);
   ~Tooltip();
 
   /** Set the tooltip text to display */
@@ -85,6 +88,8 @@ public:
   /** Hide the tooltip immediately */
   void HideTooltip();
 
+  bool Destroy() override;
+
   // Event handlers
   void OnPaint(wxPaintEvent &event);
   void OnTimer(wxTimerEvent &event);
@@ -109,6 +114,7 @@ private:
 
   wxTimer m_showTimer;
   bool m_showPending;
+  TooltipCallback m_on_destroy;
 
   DECLARE_EVENT_TABLE()
 };


### PR DESCRIPTION
The tooltips managed by TooltipManager are owned by a unknown parent from the perspective of the manager. This carries a risk: if the tooltip is destroyed as part of the parent destruction the manager is unaware of that the tooltip is unavailable.

Fix by adding a callback to tooltip so that the manager is aware of destroyed tooltips.