### PR TITLE
Make ocpn_plugin self contained, version 2 - #4846

### DIFF
--- a/cli/CMakeLists.txt
+++ b/cli/CMakeLists.txt
@@ -55,6 +55,7 @@ endif ()
 target_link_libraries(opencpn-cmd PRIVATE ocpn::serial)
 target_link_libraries(opencpn-cmd PRIVATE ocpn::tinyxml)
 target_link_libraries(opencpn-cmd PRIVATE ocpn::filesystem)
+target_link_libraries(opencpn-cmd PRIVATE ocpn::gl-headers)
 
 if (HAVE_LIBUDEV)
   target_link_libraries(opencpn-cmd PRIVATE ocpn::libudev)

--- a/gui/src/ais.cpp
+++ b/gui/src/ais.cpp
@@ -40,6 +40,8 @@
 #include <wx/imaglist.h>
 #include <wx/window.h>
 
+#include "gl_headers.h"  // Must come before anything including GL stuff
+
 #include "model/ais_decoder.h"
 #include "model/ais_state_vars.h"
 #include "model/ais_target_data.h"

--- a/gui/src/ais_info_gui.cpp
+++ b/gui/src/ais_info_gui.cpp
@@ -38,6 +38,7 @@
 #include <wx/string.h>
 
 #include "o_sound/o_sound.h"
+#include "gl_headers.h"  // Must be before anything including GL stuff
 
 #include "model/ais_decoder.h"
 #include "model/ais_state_vars.h"

--- a/gui/src/ais_target_list_dlg.cpp
+++ b/gui/src/ais_target_list_dlg.cpp
@@ -22,6 +22,8 @@
  ***************************************************************************
  */
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #include <wx/textctrl.h>
 #include <wx/sizer.h>
 #include <wx/tokenzr.h>

--- a/gui/src/ais_target_query_dlg.cpp
+++ b/gui/src/ais_target_query_dlg.cpp
@@ -26,6 +26,8 @@
 
 #include <wx/html/htmlwin.h>
 
+#include "gl_headers.h"  // Muyst be before anything including GL stuff
+
 #include "model/ais_decoder.h"
 #include "model/ais_state_vars.h"
 #include "model/ais_target_data.h"

--- a/gui/src/canvas_menu.cpp
+++ b/gui/src/canvas_menu.cpp
@@ -21,6 +21,8 @@
  * Implement canvas_menu.h -- Canvas context (right click) menu handler
  */
 
+#include "gl_headers.h"  // Must come before anything using GL stuff
+
 // For compilers that support precompilation, includes "wx.h".
 #include <wx/wxprec.h>
 

--- a/gui/src/catalog_mgr.cpp
+++ b/gui/src/catalog_mgr.cpp
@@ -25,6 +25,8 @@
 #include <sstream>
 #include <thread>
 
+#include "gl_headers.h"  // Must come before anything using GL stuff
+
 #include <wx/button.h>
 #include <wx/debug.h>
 #include <wx/filename.h>

--- a/gui/src/ch_info_win.cpp
+++ b/gui/src/ch_info_win.cpp
@@ -20,8 +20,11 @@
  *
  * implement ch_info_win.h -- ChInfoWin chart info panel
  */
+
 #include <wx/wxprec.h>
 #include <wx/dcclient.h>
+
+#include "gl_headers.h"  // Must come before anyting using GL stuff
 
 #include "model/config_vars.h"
 #include "ch_info_win.h"

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -23,6 +23,8 @@
 
 #include <vector>
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 // For compilers that support precompilation, includes "wx.h".
 #include <wx/wxprec.h>
 

--- a/gui/src/concanv.cpp
+++ b/gui/src/concanv.cpp
@@ -32,6 +32,8 @@
 
 #include <wx/datetime.h>
 
+#include "gl_headers.h"  // Must be before anything using GL
+
 #include "model/config_vars.h"
 #include "model/navutil_base.h"
 #include "model/own_ship.h"

--- a/gui/src/config_mgr.cpp
+++ b/gui/src/config_mgr.cpp
@@ -21,6 +21,8 @@
  * Implement config_mgr.h -- config file user configuration interface
  */
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #ifdef __MINGW32__
 #undef IPV6STRICT  // mingw FTBS fix:  missing struct ip_mreq
 #include <windows.h>

--- a/gui/src/conn_params_panel.cpp
+++ b/gui/src/conn_params_panel.cpp
@@ -21,6 +21,8 @@
  * Implement conn_params_panel.h -- panel editing a connection
  */
 
+#include "gl_headers.h"  // Must come before anything using GL stuff
+
 #ifdef __MINGW32__
 #undef IPV6STRICT  // mingw FTBS fix:  missing struct ip_mreq
 #include <windows.h>

--- a/gui/src/connection_edit.cpp
+++ b/gui/src/connection_edit.cpp
@@ -26,6 +26,8 @@
 #include <string>
 #include <vector>
 
+#include "gl_headers.h"  // Must come before anything using GL stuff
+
 #include <wx/wxprec.h>
 
 #ifndef WX_PRECOMP

--- a/gui/src/connections_dlg.cpp
+++ b/gui/src/connections_dlg.cpp
@@ -27,6 +27,8 @@
 #include <string>
 #include <vector>
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #include <wx/arrstr.h>
 #include <wx/bitmap.h>
 #include <wx/grid.h>

--- a/gui/src/download_mgr.cpp
+++ b/gui/src/download_mgr.cpp
@@ -21,6 +21,8 @@
  * Implement download_mgr.h -- generic GUI downloads tool.
  */
 
+#include "gl_headers.h"  // Must come before anything including GL stuff
+
 #include "config.h"
 #include "download_mgr.h"
 

--- a/gui/src/font_mgr.cpp
+++ b/gui/src/font_mgr.cpp
@@ -28,6 +28,8 @@
 #include <wx/gdicmn.h>
 #include <wx/tokenzr.h>
 
+#include "gl_headers.h"  // Must come before anything using GL stuff
+
 #include "model/config_vars.h"
 #include "font_mgr.h"
 #include "ocpn_platform.h"

--- a/gui/src/gui_lib.cpp
+++ b/gui/src/gui_lib.cpp
@@ -33,6 +33,8 @@
 #include <wx/textctrl.h>
 #include <wx/utils.h>
 
+#include "gl_headers.h"  // Must come before anything using GL stuff
+
 #include "model/config_vars.h"
 #include "model/gui_events.h"
 

--- a/gui/src/initwiz/wiz_ui.cpp
+++ b/gui/src/initwiz/wiz_ui.cpp
@@ -27,6 +27,8 @@
  *
  */
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #include <wx/wxprec.h>
 #ifndef WX_PRECOMP
 #include <wx/wx.h>

--- a/gui/src/kml.cpp
+++ b/gui/src/kml.cpp
@@ -25,6 +25,7 @@
  */
 
 #include "config.h"
+#include "gl_headers.h"  // Must come before anything using GL stuff
 
 #include <wx/wxprec.h>
 

--- a/gui/src/link_prop_dlg.cpp
+++ b/gui/src/link_prop_dlg.cpp
@@ -21,6 +21,8 @@
  * Implement link_prop_dlg.h -- Hyperlink properties dialog
  */
 
+#include "gl_headers.h"  // Must come before anything using GL stuff
+
 #include "link_prop_dlg.h"
 #include "navutil.h"
 #include "gui_lib.h"

--- a/gui/src/mark_info.cpp
+++ b/gui/src/mark_info.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "config.h"
+#include "gl_headers.h"  // Must be included befoore anything using GL stuff
 
 // For compilers that support precompilation, includes "wx/wx.h".
 #include <wx/wxprec.h>

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -23,6 +23,8 @@
  *  Implement nav_util.h -- Utility Functions
  */
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #include <wx/wxprec.h>
 
 #ifdef __MINGW32__

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -47,6 +47,8 @@
 #include <X11/Xlib.h>
 #endif
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #ifdef __VISUALC__
 #include <wx/msw/msvcrt.h>
 #endif

--- a/gui/src/ocpn_aui_manager.cpp
+++ b/gui/src/ocpn_aui_manager.cpp
@@ -20,12 +20,12 @@
  *
  * Implement ocpn_aui_manager.h -- OCPN_AUIManager
  */
-
+#include "gl_headers.h"  // Must come before anything using GL stuff
 #ifndef WX_PRECOMP
 #include <wx/wx.h>
 #endif
 
-#include <ocpn_aui_manager.h>
+#include "ocpn_aui_manager.h"
 #include "ocpn_plugin.h"
 #include "ocpn_frame.h"
 

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -21,6 +21,7 @@
  * OpenCPN top window
  */
 #include "config.h"
+#include "gl_headers.h"  // Must be included before anything using GL stuff
 
 #ifdef __MINGW32__
 #undef IPV6STRICT  // mingw FTBS fix:  missing struct ip_mreq

--- a/gui/src/ocpn_list_ctrl.cpp
+++ b/gui/src/ocpn_list_ctrl.cpp
@@ -21,6 +21,8 @@
  * Implement ocpn_list_ctrl.h -- AIS info display component
  */
 
+#include "gl_headers.h"  // Must come before anythng using GL stuff
+
 #include "ocpn_list_ctrl.h"
 
 #include "model/ais_state_vars.h"

--- a/gui/src/ocpn_platform.cpp
+++ b/gui/src/ocpn_platform.cpp
@@ -30,6 +30,8 @@
 #include <setjmp.h>
 #endif
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #ifdef __WXMSW__
 #undef IPV6STRICT  // mingw FTBS fix:  missing struct ip_mreq
 #include <windows.h>

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -34,6 +34,8 @@
 #include <unistd.h>
 #endif
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #ifdef __MINGW32__
 #undef IPV6STRICT  // mingw FTBS fix:  missing struct ip_mreq
 #include <windows.h>

--- a/gui/src/peer_client_dlg.cpp
+++ b/gui/src/peer_client_dlg.cpp
@@ -25,6 +25,8 @@
 #include <iostream>
 #include <sstream>
 
+#include "gl_headers.h"  // Must come before anything using GL stuff
+
 #include <wx/fileconf.h>
 #include <wx/json_defs.h>
 #include <wx/jsonreader.h>

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -34,6 +34,8 @@
 #include <typeinfo>
 #include <unordered_map>
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #ifdef _WIN32
 #include <winsock2.h>
 #include <windows.h>

--- a/gui/src/printout_base.cpp
+++ b/gui/src/printout_base.cpp
@@ -22,6 +22,8 @@
  * Implement printout_base.h -- print support abstract base class
  */
 
+#include "gl_headers.h"  // Must come before anything using GL stuff
+
 #include "ocpn_frame.h"
 #include "printout_base.h"
 

--- a/gui/src/printtable.cpp
+++ b/gui/src/printtable.cpp
@@ -39,6 +39,8 @@
 #include <setjmp.h>
 #endif
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #ifdef __WXMSW__
 // #include "c:\\Program Files\\visual leak detector\\include\\vld.h"
 #endif

--- a/gui/src/priority_gui.cpp
+++ b/gui/src/priority_gui.cpp
@@ -21,6 +21,8 @@
  * Implement priorities_gui.h -- input priorities management dialog
  */
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #ifdef __ANDROID__
 #include "qdebug.h"
 #include <QtWidgets/QScroller>

--- a/gui/src/rest_server_gui.cpp
+++ b/gui/src/rest_server_gui.cpp
@@ -15,6 +15,8 @@
  *   along with this program; if not, see <https://www.gnu.org/licenses/>. *
  ***************************************************************************/
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #include <wx/arrstr.h>
 #include <wx/button.h>
 #include <wx/combobox.h>

--- a/gui/src/route_gui.cpp
+++ b/gui/src/route_gui.cpp
@@ -25,6 +25,8 @@
 
 #include <string>
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #include <wx/colour.h>
 #include <wx/gdicmn.h>
 #include <wx/pen.h>

--- a/gui/src/route_printout.cpp
+++ b/gui/src/route_printout.cpp
@@ -34,6 +34,8 @@
 #include <setjmp.h>
 #endif
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #include <wx/wxprec.h>
 
 #ifndef WX_PRECOMP

--- a/gui/src/route_prop_dlg_impl.cpp
+++ b/gui/src/route_prop_dlg_impl.cpp
@@ -23,6 +23,8 @@
 
 #include <wx/clipbrd.h>
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #include "model/georef.h"
 #include "model/own_ship.h"
 #include "model/routeman.h"

--- a/gui/src/routeman_gui.cpp
+++ b/gui/src/routeman_gui.cpp
@@ -22,6 +22,8 @@
  * implement routeman_gui.h: Routeman drawing stuff
  */
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 // For compilers that support precompilation, includes "wx.h".
 #include <wx/wxprec.h>
 

--- a/gui/src/routemanagerdialog.cpp
+++ b/gui/src/routemanagerdialog.cpp
@@ -30,6 +30,8 @@
 #include <vector>
 #include <algorithm>
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 // For compilers that support precompilation, includes "wx/wx.h".
 #include <wx/wxprec.h>
 

--- a/gui/src/s57_query_dlg.cpp
+++ b/gui/src/s57_query_dlg.cpp
@@ -21,6 +21,8 @@
  * Implement s57_query_dlg.h -- S57 object query result window
  */
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #include <wx/wxprec.h>
 #include <wx/arrstr.h>
 #include <wx/gdicmn.h>

--- a/gui/src/send_to_gps_dlg.cpp
+++ b/gui/src/send_to_gps_dlg.cpp
@@ -21,6 +21,8 @@
  * Implement send_to_gps_dlg.h -- Send route/waypoint to GPS dialog
  */
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #include <wx/arrstr.h>
 #include <wx/button.h>
 #include <wx/combobox.h>

--- a/gui/src/send_to_peer_dlg.cpp
+++ b/gui/src/send_to_peer_dlg.cpp
@@ -27,6 +27,8 @@
 
 #include <curl/curl.h>
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #include "send_to_peer_dlg.h"
 
 #include "model/cmdline.h"

--- a/gui/src/styles.cpp
+++ b/gui/src/styles.cpp
@@ -25,6 +25,7 @@
 #include <stdlib.h>
 
 #include "config.h"
+#include "gl_headers.h"  // Must be included before anything using GL stuff
 
 #include <wx/wxprec.h>
 

--- a/gui/src/track_gui.cpp
+++ b/gui/src/track_gui.cpp
@@ -24,6 +24,8 @@
 
 #include <list>
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #include <wx/colour.h>
 #include <wx/gdicmn.h>
 #include <wx/pen.h>

--- a/gui/src/track_printout.cpp
+++ b/gui/src/track_printout.cpp
@@ -36,6 +36,8 @@
 #include <wx/wx.h>
 #endif
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #include <wx/artprov.h>
 #include <wx/aui/aui.h>
 #include <wx/brush.h>

--- a/gui/src/track_prop_dlg.cpp
+++ b/gui/src/track_prop_dlg.cpp
@@ -24,6 +24,8 @@
 
 #include "config.h"
 
+#include "gl_headers.h"  // Must be included before anything using GL stuff
+
 #include "model/georef.h"
 #include "model/gui_vars.h"
 #include "model/navobj_db.h"

--- a/gui/src/undo.cpp
+++ b/gui/src/undo.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "config.h"
+#include "gl_headers.h"  // Must be included before anything using GL stuff
 
 #include <wx/wxprec.h>
 #ifndef WX_PRECOMP

--- a/gui/src/update_mgr.cpp
+++ b/gui/src/update_mgr.cpp
@@ -22,6 +22,7 @@
  */
 
 #include "config.h"
+#include "gl_headers.h"  // Must be included before anything using GL stuff
 
 #include <set>
 #include <sstream>

--- a/gui/src/viewport.cpp
+++ b/gui/src/viewport.cpp
@@ -21,6 +21,9 @@
  * Implement viewport.h -- geographic projection and coordinate transformations
  */
 
+// Must come before any GL includes:
+#include "gl_headers.h"
+
 #include <vector>
 
 #ifndef __WXMSW__

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -43,23 +43,27 @@
 #define DECL_IMP
 #endif
 
-#include <wx/xml/xml.h>
-#include <wx/dcmemory.h>
-#include <wx/dialog.h>
-#include <wx/event.h>
-#include <wx/menuitem.h>
-#include <wx/gdicmn.h>
-
-#ifdef ocpnUSE_SVG
-#include <wx/bitmap.h>
-#endif  // ocpnUSE_SVG
-
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 #include <unordered_map>
 
-class wxGLContext;
+#include <wx/arrstr.h>
+#include <wx/aui/framemanager.h>
+#include <wx/bitmap.h>
+#include <wx/colour.h>
+#include <wx/cursor.h>
+#include <wx/dcmemory.h>
+#include <wx/dialog.h>
+#include <wx/event.h>
+#include <wx/fileconf.h>
+#include <wx/gdicmn.h>
+#include <wx/menuitem.h>
+#include <wx/notebook.h>
+#include <wx/region.h>
+#include <wx/scrolwin.h>
+#include <wx/xml/xml.h>
 
 //    This is the most modern API Version number
 //    It is expected that the API will remain downward compatible, meaning that
@@ -68,12 +72,10 @@ class wxGLContext;
 #define API_VERSION_MAJOR 1
 #define API_VERSION_MINOR 21
 
-//    Fwd Definitions
-class wxFileConfig;
-class wxNotebook;
-class wxFont;
-class wxAuiManager;
-class wxScrolledWindow;
+//  Using the correct #include <wx/glcanvas.h> causes compilation errors
+//  on windows, probably errors in bundled and partly modified GL headers.
+//  For now, use this as work around.
+class wxGLContext;
 class wxGLCanvas;
 
 //---------------------------------------------------------------------------------------------------------

--- a/plugins/grib_pi/src/CustomGrid.cpp
+++ b/plugins/grib_pi/src/CustomGrid.cpp
@@ -20,6 +20,9 @@
  * \file
  * \implements \ref CustomGrid.h
  */
+
+#include "pi_gl.h"  // Must included before anything using GL stuff
+
 #include "CustomGrid.h"
 
 #include <wx/graphics.h>

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -20,6 +20,9 @@
  * \file
  * \implements \ref GribUIDialog.h
  */
+
+#include "pi_gl.h"  // Must included before anything using GL stuff
+
 #include "wx/wx.h"
 #include "wx/tokenzr.h"
 #include "wx/datetime.h"
@@ -38,7 +41,6 @@
 #include <time.h>
 
 #include "ocpn_plugin.h"
-#include "pi_gl.h"
 #include "grib_pi.h"
 #include "GribTable.h"
 #include "email.h"

--- a/plugins/grib_pi/src/IsoLine.cpp
+++ b/plugins/grib_pi/src/IsoLine.cpp
@@ -19,6 +19,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
  * \file
  * \implements \ref IsoLine.h
  */
+
+#include "pi_gl.h"  // Must included before anything using GL stuff
+
 #include "wx/wxprec.h"
 
 #ifndef WX_PRECOMP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -74,8 +74,8 @@ endif ()
 if (UNIX AND NOT DEFINED ENV{FLATPAK_ID})
   set(_IPC_SRV_SRC ipc-srv-tests.cpp ${CMAKE_SOURCE_DIR}/cli/api_shim.cpp)
   add_executable(ipc-srv-tests ${_IPC_SRV_SRC} )
-  target_link_libraries(
-    ipc-srv-tests PRIVATE ocpn::gtest ocpn::model-src win32_libs
+  target_link_libraries(ipc-srv-tests
+    PRIVATE ocpn::gtest ocpn::model-src ocpn::gl-headers win32_libs
   )
   if (NOT "${ENABLE_SANITIZER}" STREQUAL "none")
     target_link_libraries(ipc-srv-tests PUBLIC -fsanitize=${ENABLE_SANITIZER})
@@ -88,7 +88,7 @@ endif ()
 set(_BUF_TEST_SRC buffer_tests.cpp ${CMAKE_SOURCE_DIR}/cli/api_shim.cpp)
 add_executable(buffer_tests ${_BUF_TEST_SRC})
 target_link_libraries(
-  buffer_tests PRIVATE  ocpn::model-src ocpn::gtest win32_libs
+  buffer_tests PRIVATE  ocpn::model-src ocpn::gtest ocpn::gl-headers win32_libs
 )
 target_compile_definitions(
   buffer_tests PUBLIC TESTDATA="${CMAKE_CURRENT_LIST_DIR}/testdata"


### PR DESCRIPTION
The build errors in previous attempt seems to reflect some major disorder in the bundled windows GL headers. I have not been able to sort it out so this commit contains dirty `class glSomeClass` statements  instead of the correct `#include <wx/glcanvas.h>` 

Enough for now. Intend to merge this after a night's sleep if there is no objections then from me or others

Closes: #4846