### PR TITLE
Update the CircleCI images to supported versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
 
   build-macos:
     macos:
-      xcode: "13.3.1"
+      xcode: "14.3.1"
     environment:
       - OCPN_TARGET: macos
       - pkg_mod: 11
@@ -96,7 +96,7 @@ jobs:
 
   build-macos-universal:
     macos:
-      xcode: "15.1.0"
+      xcode: "15.4.0"
     environment:
       - OCPN_TARGET: macos
       - pkg_mod: 11
@@ -119,7 +119,7 @@ jobs:
 
   build-macos-intel-legacy:
     macos:
-      xcode: "13.4.1"
+      xcode: "14.3.1"
     environment:
       - OCPN_TARGET: macos
       - pkg_mod: 11


### PR DESCRIPTION
Update the Circle CI builder images to versions supported after 2025-11-07

Addresses the deprecation of macOS builder images announced in https://circleci.com/changelog/deprecation-of-eol-xcode-versions/

macOS universal build updated to Xcode 15.4.0
macOS legacy build for Intel machines updated to Xcode 14.3.1 as even the latest Xcode 13 (13.4.1) is being removed. It is not completely clear to me if this change effectively shifts the oldest supported macOS baseline, but we have no choice anyway.