### PR TITLE
Fix clang 20 build failure (-Wnontrivial-memcall)

### DIFF
--- a/gui/src/idx_entry.cpp
+++ b/gui/src/idx_entry.cpp
@@ -29,6 +29,6 @@
 
 WX_DEFINE_OBJARRAY(ArrayOfIDXEntry);
 
-IDX_entry::IDX_entry() { memset(this, 0, sizeof(IDX_entry)); }
+IDX_entry::IDX_entry() { *this = {}; }
 
 IDX_entry::~IDX_entry() { free(IDX_tzname); }


### PR DESCRIPTION
The check introduced in clang 20 breaks the build as follows:

```
first argument in call to 'memset' is a pointer to non-trivially
copyable type 'IDX_entry' [-Werror,-Wnontrivial-memcall]
```
