### PR TITLE
Improve OpenGL handling in OnSize method

### DIFF
--- a/gui/src/gl_chart_canvas.cpp
+++ b/gui/src/gl_chart_canvas.cpp
@@ -530,7 +530,9 @@ void glChartCanvas::OnSize(wxSizeEvent &event) {
     wxLogMessage("BuildFBO 3");
     BuildFBO();
   }
-
+  // We need to force a complete refresh of the parent ChartCanvas
+  // First, complete any pending GL operations
+  glFinish();
   //  Set the shader viewport transform matrix
   ViewPort *vp = m_pParentCanvas->GetpVP();
   mat4x4 m;


### PR DESCRIPTION
Added `glFinish()` to finalize pending OpenGL operations before updating the viewport transformation matrix in the `OnSize` method of `glChartCanvas`. These changes improve rendering robustness and prevent potential GPU issues during resizing.

Addresses some of https://github.com/OpenCPN/OpenCPN/issues/4773 findings.
There may be other GPU intensive operations elsewhere that could benefit from `glFinish()`.