### PR TITLE
Fix unterminated string in fromDMM()

### DIFF
--- a/model/src/navutil_base.cpp
+++ b/model/src/navutil_base.cpp
@@ -778,6 +778,7 @@ double fromDMM(wxString sdms) {
       sign = -1;      /* These mean "negate" (note case insensitivity) */
     narrowbuf[i] = 0; /* Replace everything else with nuls */
   }
+  narrowbuf[len] = 0;
 
   /* Build a stack of doubles */
   stk[0] = stk[1] = stk[2] = 0;


### PR DESCRIPTION
The narrowbuf may miss correct string termination (zero byte), making atof later call return gibberish.