### PR TITLE
Fix clang 20 build failure (-Wnontrivial-memcall), attempt 2

### DIFF
--- a/gui/src/idx_entry.cpp
+++ b/gui/src/idx_entry.cpp
@@ -29,6 +29,56 @@
 
 WX_DEFINE_OBJARRAY(ArrayOfIDXEntry);
 
-IDX_entry::IDX_entry() { memset(this, 0, sizeof(IDX_entry)); }
+IDX_entry::IDX_entry()
+    : source_data_type(SOURCE_TYPE_UNKNOWN),
+      pDataSource(nullptr),
+      IDX_rec_num(0),
+      IDX_type(0),
+      IDX_lon(0.0),
+      IDX_lat(0.0),
+      IDX_ht_time_off(0),
+      IDX_ht_mpy(0.0f),
+      IDX_ht_off(0.0f),
+      IDX_lt_time_off(0),
+      IDX_lt_mpy(0.0f),
+      IDX_lt_off(0.0f),
+      IDX_sta_num(0),
+      IDX_flood_dir(0),
+      IDX_ebb_dir(0),
+      IDX_Useable(0),
+      Valid15(0),
+      Value15(0.0f),
+      Dir15(0.0f),
+      Ret15(false),
+      IDX_tzname(nullptr),
+      IDX_ref_file_num(0),
+      IDX_ref_dbIndex(0),
+      max_amplitude(0.0),
+      have_offsets(0),
+      station_tz_offset(0),
+      IDX_time_zone(0),
+      pref_sta_data(nullptr),
+      num_nodes(0),
+      num_csts(0),
+      num_epochs(0),
+      m_cst_speeds(nullptr),
+      m_cst_nodes(nullptr),
+      m_cst_epochs(nullptr),
+      m_work_buffer(nullptr),
+      first_year(0),
+      epoch(0),
+      epoch_year(0),
+      current_depth(0),
+      b_skipTooDeep(false),
+      recent_highlow_calc_time(0),
+      recent_high_level(0.0f),
+      recent_high_time(0),
+      recent_low_level(0.0f),
+      recent_low_time(0) {
+  memset(source_ident, 0, sizeof(source_ident));
+  memset(IDX_zone, 0, sizeof(IDX_zone));
+  memset(IDX_station_name, 0, sizeof(IDX_station_name));
+  memset(IDX_reference_name, 0, sizeof(IDX_reference_name));
+}
 
 IDX_entry::~IDX_entry() { free(IDX_tzname); }


### PR DESCRIPTION
The previous attempt [1] resulted in -Werror=use-after-free violation
when built with gcc on bookworm because `*this` triggered the class
destructor, calling `free` on an uninitialized pointer.

In this new patch, we are going to use an explicit initializer list to
initialize all class members with zero values.

[1] d3eb15de1e5aa8f85890d5c83cbc025ac7a467be
