### PR TITLE
Avoid potential crash when applying color schemes (Issue #4913)

### DIFF
--- a/gui/src/chartdb.cpp
+++ b/gui/src/chartdb.cpp
@@ -1467,6 +1467,10 @@ bool ChartDB::DeleteCacheChart(ChartBase *pDeleteCandidate) {
 void ChartDB::ApplyColorSchemeToCachedCharts(ColorScheme cs) {
   ChartBase *Ch;
   CacheEntry *pce;
+#ifdef ocpnUSE_GL
+  // The background texture cache threads might be running
+  if (g_glTextureManager) g_glTextureManager->PurgeJobList();
+#endif
   //    Search the cache
 
   if (wxMUTEX_NO_ERROR == m_cache_mutex.Lock()) {


### PR DESCRIPTION
Ensure pending background texture jobs are cleared in `ChartDB::ApplyColorSchemeToCachedCharts` when OpenGL support is enabled. This prevents potential conflicts by purging the background texture cache job list via `g_glTextureManager` before applying the color scheme. The change is gated by `#ifdef ocpnUSE_GL`.