### PR TITLE
ocpn_plugin.h: api 121: Fix factory and nested Route linkage

### DIFF
--- a/cli/api_shim.cpp
+++ b/cli/api_shim.cpp
@@ -1621,9 +1621,6 @@ DECL_EXP PlugIn_Route_Ex::~PlugIn_Route_Ex(void) {}
 DECL_EXP PlugIn_Route_ExV2::PlugIn_Route_ExV2() {}
 DECL_EXP PlugIn_Route_ExV2::~PlugIn_Route_ExV2() {}
 
-HostApi121::Route::Route() {}
-HostApi121::Route::~Route() {}
-
 DECL_EXP wxArrayString GetRouteGUIDArray(void) { return dummy_array_string; }
 DECL_EXP wxArrayString GetTrackGUIDArray(void) { return dummy_array_string; }
 

--- a/gui/src/api_121.cpp
+++ b/gui/src/api_121.cpp
@@ -727,22 +727,6 @@ std::unique_ptr<HostApi> GetHostApi() {
   return std::make_unique<HostApi121>(HostApi121());
 }
 
-HostApi121::Route::Route() : PlugIn_Route_ExV2() {
-  m_PlannedSpeed = 0;
-  m_Colour = "";
-  m_style = wxPENSTYLE_SOLID;
-  m_PlannedDeparture = wxDateTime::Now();
-  m_TimeDisplayFormat = RTE_TIME_DISP_UTC;
-}
-
-HostApi121::Route::~Route() {
-  if (pWaypointList) {
-    pWaypointList->DeleteContents(true);
-    delete pWaypointList;
-    pWaypointList = NULL;
-  }
-}
-
 bool HostApi121::AddRoute(HostApi121::Route* route, bool permanent) {
   return ::AddPlugInRouteExV3(route, permanent);
 }

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -7208,7 +7208,7 @@ public:
  * HostApi factory,
  * @return Last known HostApi instance.
  */
-std::unique_ptr<HostApi> GetHostApi();
+extern DECL_EXP std::unique_ptr<HostApi> GetHostApi();
 
 class HostApi121 : public HostApi {
 public:
@@ -7241,8 +7241,14 @@ public:
   // Extended plugin route
   class Route : public PlugIn_Route_ExV2 {
   public:
-    Route();
-    virtual ~Route();
+    Route()
+        : PlugIn_Route_ExV2(),
+          m_PlannedSpeed(0),
+          m_style(wxPENSTYLE_SOLID),
+          m_PlannedDeparture(wxDateTime::Now()),
+          m_TimeDisplayFormat("UTC") {}
+
+    ~Route() override = default;
 
     double m_PlannedSpeed;
     wxString m_Colour;


### PR DESCRIPTION
The factory method GetHostApi() is the only method actually linked to the plugin. For this to work on Windows a
__declspec(dllimport/dllexport) is needed. Add this.

All other functions are virtual and part of the vtable returned by GetHostApi() and does not need any __declspec.

The nested class Route is returned as a unique_ptr<Route>. For this to work the dtor/ctor needs to known by the calling code and must thus be defined in the header. Add explicit definitions and remove in .cpp file