### PR TITLE
Add deprecation compile-time warnings to Plugin_Route_Ex* etc

### DIFF
--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -2357,7 +2357,7 @@ WX_DECLARE_LIST(PlugIn_Waypoint, Plugin_WaypointList);
  * This class represents a route consisting of an ordered list of waypoints.
  * Routes can be used for navigation planning and guidance.
  */
-class DECL_EXP PlugIn_Route {
+class DECL_EXP [[deprecated("Use HostApi121::Route instead.")]] PlugIn_Route {
 public:
   PlugIn_Route(void);
   ~PlugIn_Route(void);
@@ -3518,6 +3518,7 @@ extern DECL_EXP bool UpdateSingleWaypoint(PlugIn_Waypoint *pwaypoint);
  * @param b_permanent True to save persistently, false for temporary
  * @return True if successfully added
  */
+[[deprecated("Use HostApi121::AddRoute() instead.")]]
 extern DECL_EXP bool AddPlugInRoute(PlugIn_Route *proute,
                                     bool b_permanent = true);
 
@@ -3540,6 +3541,7 @@ extern DECL_EXP bool DeletePlugInRoute(wxString &GUID);
  * @param proute Route with updated properties (GUID must match existing route)
  * @return True if route was successfully updated
  */
+[[deprecated("Use HostApi121::UpdateRoute() instead.")]]
 extern DECL_EXP bool UpdatePlugInRoute(PlugIn_Route *proute);
 
 /**
@@ -5398,6 +5400,7 @@ extern DECL_EXP std::unique_ptr<PlugIn_Waypoint> GetWaypoint_Plugin(
  * @param guid GUID of route to get
  * @return Unique pointer to route data, NULL if not found
  */
+[[deprecated("Use HostApi121::GetRoute() instead.")]]
 extern DECL_EXP std::unique_ptr<PlugIn_Route> GetRoute_Plugin(const wxString &);
 
 /**
@@ -5755,7 +5758,7 @@ WX_DECLARE_LIST(PlugIn_Waypoint_ExV2, Plugin_WaypointExV2List);
  * @note Works with PlugIn_Waypoint_Ex for extended waypoint features
  * @note Used by navigation and routing plugins
  */
-class DECL_EXP PlugIn_Route_Ex {
+class DECL_EXP [[deprecated("Use HostApi121::Route instead.")]] PlugIn_Route_Ex {
 public:
   PlugIn_Route_Ex(void);
   ~PlugIn_Route_Ex(void);
@@ -5790,7 +5793,7 @@ public:
  * - Extended waypoint list management
  * - Global unique identification
  */
-class DECL_EXP PlugIn_Route_ExV2 {
+class DECL_EXP [[deprecated("Use HostApi121::Route instead.")]] PlugIn_Route_ExV2 {
 public:
   PlugIn_Route_ExV2();
   virtual ~PlugIn_Route_ExV2();
@@ -5892,6 +5895,7 @@ extern DECL_EXP bool UpdateSingleWaypointExV2(PlugIn_Waypoint_ExV2 *pwaypoint);
  * @param b_permanent True to save persistently, false for temporary
  * @return True if successfully added
  */
+[[deprecated("Use HostApi121::AddRoute() instead.")]]
 extern DECL_EXP bool AddPlugInRouteEx(PlugIn_Route_Ex *proute,
                                       bool b_permanent = true);
 
@@ -5901,6 +5905,7 @@ extern DECL_EXP bool AddPlugInRouteEx(PlugIn_Route_Ex *proute,
  * @param proute Route to add
  * @return True if route added successfully
  */
+[[deprecated("Use HostApi121::AddRoute() instead.")]]
 extern DECL_EXP bool AddPlugInRouteExV2(PlugIn_Route_ExV2 *proute,
                                         bool b_permanent = true);
 
@@ -5910,6 +5915,7 @@ extern DECL_EXP bool AddPlugInRouteExV2(PlugIn_Route_ExV2 *proute,
  * @param proute Updated route data (GUID must match existing)
  * @return True if successfully updated
  */
+[[deprecated("Use HostApi121::UpdateRoute() instead.")]]
 extern DECL_EXP bool UpdatePlugInRouteEx(PlugIn_Route_Ex *proute);
 
 /**
@@ -5920,6 +5926,7 @@ extern DECL_EXP bool UpdatePlugInRouteEx(PlugIn_Route_Ex *proute);
  * @param proute Updated route data (GUID must match existing)
  * @return True if route updated successfully
  */
+[[deprecated("Use HostApi121::UpdateRoute() instead.")]]
 extern DECL_EXP bool UpdatePlugInRouteExV2(PlugIn_Route_ExV2 *proute);
 
 /**
@@ -5952,6 +5959,7 @@ extern DECL_EXP std::unique_ptr<PlugIn_Waypoint_ExV2> GetWaypointExV2_Plugin(
  * @param guid GUID of route to get
  * @return Unique pointer to route data, NULL if not found
  */
+[[deprecated("Use HostApi121::GetRoute() instead.")]]
 extern DECL_EXP std::unique_ptr<PlugIn_Route_Ex> GetRouteEx_Plugin(
     const wxString &GUID);
 
@@ -5963,6 +5971,7 @@ extern DECL_EXP std::unique_ptr<PlugIn_Route_Ex> GetRouteEx_Plugin(
  * @param GUID Unique identifier of route to retrieve
  * @return Unique pointer to route data, NULL if not found
  */
+[[deprecated("Use HostApi121::GetRoute() instead.")]]
 extern DECL_EXP std::unique_ptr<PlugIn_Route_ExV2> GetRouteExV2_Plugin(
     const wxString &GUID);
 
@@ -7238,7 +7247,6 @@ public:
     std::string object_ident;
   };
 
-  // Extended plugin route
   class Route : public PlugIn_Route_ExV2 {
   public:
     Route();


### PR DESCRIPTION
See #4852 for prior discussion (specifically [this](https://github.com/OpenCPN/OpenCPN/pull/4867#issuecomment-3466320335)

As a brief recap:
"
I'm not proposing removing anything from the existing API at all. What I am proposing is to:

1. Provide developers of new API calls with a new, cleaner pattern by which to extend or improve the existing API.
2. Provide new plugin developers, and maintainers of actively maintained current plugins with the option to call "cleaned up" methods like Foo() rather than FooEx3(), going forward, when using newer API versions.
3. Label FooEx3() as deprecated, and thereby provide maintainers of abandoned plugins with compiler warnings giving them the option to use the "cleaned up" methods. They may well decide to ignore this option, and be no worse off.

I think that 1 and 2 alone are very powerful. 3 is not that important at all, but comes free of charge.
"

This single commit is just intended as an example of what I proposed above. 
If the general pattern/idea is acceptable to others, I can extend this to cover the entire plugin API.

cc @leamas @bdbcat 

PS: The '''deprecated''' annotation is part of C++ 14.  I'm not sure whether we accept C++ 14 features yet?  Presumably we should some time?