### PR TITLE
Handle non existing socketCAN interfaces - #4934

### DIFF
--- a/gui/src/connection_edit.cpp
+++ b/gui/src/connection_edit.cpp
@@ -103,6 +103,7 @@ static wxArrayString GetAvailableSocketCANInterfaces() {
 
   if ((intf = intf_open()) == NULL) {
     wxLogWarning("Error opening interface list");
+    return rv;
   }
 
   if (intf_loop(intf, print_intf, NULL) < 0) {
@@ -486,7 +487,7 @@ void ConnectionEditDialog::Init() {
       new wxChoice(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, choices);
 
   m_choiceCANSource->SetSelection(0);
-  m_choiceCANSource->Enable(TRUE);
+  m_choiceCANSource->Enable(choices.size() > 0);
   m_choiceCANSource->SetMaxSize(wxSize(column2width, -1));
   m_choiceCANSource->SetMinSize(wxSize(column2width, -1));
   fgSizer1C->Add(m_choiceCANSource, 1, wxEXPAND | wxTOP, 5);
@@ -1039,6 +1040,8 @@ void ConnectionEditDialog::ShowNMEAGPS(bool visible) {
 void ConnectionEditDialog::ShowNMEACAN(bool visible) {
   m_stCANSource->Show(visible);
   m_choiceCANSource->Show(visible);
+  if (visible && m_btnOK && m_choiceCANSource->IsEmpty())
+    m_btnOK->Enable(false);
 }
 
 void ConnectionEditDialog::ShowNMEABT(bool visible) {

--- a/model/src/conn_params.cpp
+++ b/model/src/conn_params.cpp
@@ -324,8 +324,9 @@ std::string ConnectionParams::GetStrippedDSPort() const {
     return t.ToStdString();
 
   } else if (Type == SOCKETCAN) {
-    std::string rv = "socketCAN-";
-    rv += socketCAN_port.ToStdString();
+    std::string rv;
+    if (!socketCAN_port.ToStdString().empty())
+      rv += "socketCAN-" + socketCAN_port.ToStdString();
     return rv;
   } else if (Type == INTERNAL_BT) {
     return Port.ToStdString();


### PR DESCRIPTION
Handle various cases in the create socketCAN connection dialog when there are no  socketCAN interfaces available.

Notably, disable the OK button making it impossible to create weird CAN connections in this case.

Closes: #4934