### PR TITLE
serial driver: Don't add extra crlf -- #4918

### DIFF
--- a/model/src/std_serial_io.cpp
+++ b/model/src/std_serial_io.cpp
@@ -133,7 +133,9 @@ void* StdSerialIo::Entry() {
     //  Handle pending output messages
     std::string qmsg;
     while (KeepGoing() && m_out_que.Get(qmsg)) {
-      qmsg += "\r\n";
+      if (qmsg.size() < 3) continue;
+      if (qmsg.find("\r\n", qmsg.size() - 2) == std::string::npos)
+        qmsg += "\r\n";
       bool failed_write = WriteComPortPhysical(qmsg.c_str()) == -1;
       if (!failed_write) {
         std::lock_guard lock(m_stats_mutex);


### PR DESCRIPTION
Arguably, upper layers should not add any crlf, it is  the driver's task. But they do, so just make sure is is there in the driver.

Closes: #4918