### PR TITLE
comm_bridge: Log dropped signalK traffic -- #4938

### DIFF
--- a/manual/modules/ROOT/pages/messaging-debug.adoc
+++ b/manual/modules/ROOT/pages/messaging-debug.adoc
@@ -54,6 +54,9 @@ x Message contains errors and cannot be processed.
 
 | The message is blocked on input  and not processed in any way.
 
+SignalK messages with a context which does not match the own boat are handled
+as blocked on input by a user filter.
+
 === Interface - 4
 
 The interface used to receive or send message, actual formatting depends on
@@ -91,4 +94,4 @@ This format is also suitable for importing logs into spreadsheets
 like MS Excel or LibreOffice Calc.
 
 3. The CSV format is a simplified VDR format using | as field separator
-targetting traditional, command line post processing tools.
+targeting traditional, command line post processing tools.

--- a/model/src/comm_bridge.cpp
+++ b/model/src/comm_bridge.cpp
@@ -1009,8 +1009,11 @@ bool CommBridge::HandleN0183_AIVDO(const N0183MsgPtr& n0183_msg) {
 bool CommBridge::HandleSignalK(const SignalKMsgPtr& sK_msg) {
   string str = sK_msg->raw_message;
 
-  //  Here we ignore messages involving contexts other than ownship
-  if (sK_msg->context_self != sK_msg->context) return false;
+  //  Ignore messages involving contexts other than ownship, but do log them
+  if (sK_msg->context_self != sK_msg->context) {
+    g_pMUX->LogInputMessage(sK_msg, true, false);
+    return false;
+  }
 
   g_ownshipMMSI_SK = sK_msg->context_self;
 


### PR DESCRIPTION
Log incoming signalK traffic with "wrong" context as filtered input before being dropped. Update manual for those who finds it.

Closes: #4938

Result is a log like 
<img width="680" height="293" alt="image" src="https://github.com/user-attachments/assets/138956c2-2a92-4d20-b91f-b51ab38fd056" />


