### PR TITLE
Limit minimum and maximum size of comm priority dialog

### DIFF
--- a/gui/src/priority_gui.cpp
+++ b/gui/src/priority_gui.cpp
@@ -63,6 +63,9 @@ PriorityDlg::PriorityDlg(wxWindow* parent)
                wxSize(480, 420), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
   m_selIndex = 0;
   m_selmap_index = 0;
+  SetMinSize(wxSize(480, 420));
+  SetMaxSize(
+      wxSize(wxMax(gFrame->GetSize().x, 480), wxMax(gFrame->GetSize().y, 420)));
 
   wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
   SetSizer(mainSizer);


### PR DESCRIPTION
Make sure the priorities window is not larger than the main application frame and can't be made invisibly small
Closes #4974 