### PR TITLE
Make grib download progress text consistent and sane

### DIFF
--- a/plugins/grib_pi/src/GribRequestDialog.cpp
+++ b/plugins/grib_pi/src/GribRequestDialog.cpp
@@ -515,9 +515,11 @@ size_t LengthSelToHours(int sel) {
 }
 
 template <typename T>
-std::string GribRequestSetting::FormatWithCommas(T value) {
+std::string GribRequestSetting::FormatPerLocale(T value) {
   std::stringstream ss;
-  ss << std::fixed << value;
+  // use the the user-preferred locale rather than the default "C" locale
+  ss.imbue(std::locale(""));
+  ss << value;  // Output for a US locale would be: 12,345,678 for integers
   return ss.str();
 }
 
@@ -525,12 +527,12 @@ wxString GribRequestSetting::GetDownloadProgressText(long transferredBytes,
                                                      long totalBytes) {
   if (totalBytes > 0) {
     return wxString::Format(_("Downloading... %s kB / %s kB (%li%%)"),
-                            FormatWithCommas(transferredBytes / 1024).c_str(),
-                            FormatWithCommas(totalBytes / 1024).c_str(),
+                            FormatPerLocale(transferredBytes / 1024).c_str(),
+                            FormatPerLocale(totalBytes / 1024).c_str(),
                             (int)((double)transferredBytes / totalBytes * 100));
   } else {
-    return wxString::Format(_("Downloading... %s / ???"),
-                            FormatWithCommas(transferredBytes / 1024).c_str());
+    return wxString::Format(_("Downloading... %s kB / ???"),
+                            FormatPerLocale(transferredBytes / 1024).c_str());
   }
 }
 

--- a/plugins/grib_pi/src/GribRequestDialog.h
+++ b/plugins/grib_pi/src/GribRequestDialog.h
@@ -243,7 +243,7 @@ private:
   int EstimateFileSize(double *size);
 
   template <typename T>
-  static std::string FormatWithCommas(T value);
+  static std::string FormatPerLocale(T value);
 
   static wxString GetDownloadProgressText(long bytesTransferred,
                                           long bytesTotal);


### PR DESCRIPTION
Prior to this PR, downloading different grib types produced different progress indicators. In particular, the one used for many grib downloads read something like this (in bytes):

"Downloading .... 1234567689 / 2345678901"

My brain can't decode that many digits.  The new version looks like this:

"Downloading 1,234,567 kB / 2,345,678 kB (50%)"

Still need to add a progress bar to make it complete, but that can be added in a separate PR.

Also, duplicate code removed.