### PR TITLE
drivers: n2k: Don't update obsoleted all channel - #4990

### DIFF
--- a/model/src/comm_drv_n2k_net.cpp
+++ b/model/src/comm_drv_n2k_net.cpp
@@ -1919,15 +1919,11 @@ bool CommDriverN2KNet::SendN2KNetwork(std::shared_ptr<const Nmea2000Msg>& msg,
   SendSentenceNetwork(out_data);
   m_driver_stats.tx_count += msg->payload.size();
 
-  // Create the internal message for all N2K listeners
+  // Create the internal message  and notify listener
   std::vector<unsigned char> msg_payload = PrepareLogPayload(msg, addr);
   auto msg_one =
       std::make_shared<const Nmea2000Msg>(msg->PGN.pgn, msg_payload, addr);
-  auto msg_all = std::make_shared<const Nmea2000Msg>(1, msg_payload, addr);
-
-  // Notify listeners
   m_listener.Notify(std::move(msg_one));
-  m_listener.Notify(std::move(msg_all));
 
   return true;
 };

--- a/model/src/comm_drv_n2k_serial.cpp
+++ b/model/src/comm_drv_n2k_serial.cpp
@@ -342,19 +342,13 @@ bool CommDriverN2KSerial::SendMessage(std::shared_ptr<const NavMsg> msg,
 
   const std::vector<uint8_t> acti_pkg = BufferToActisenseFormat(N2kMsg);
 
-  // Create the internal message for all N2K listeners
+  // Create the internal message  and notify upper layers
   std::vector<unsigned char> msg_payload;
   for (size_t i = 2; i < acti_pkg.size() - 2; i++)
     msg_payload.push_back(acti_pkg[i]);
   auto name = PayloadToName(load);
-  auto msg_all =
-      std::make_shared<const Nmea2000Msg>(1, msg_payload, GetAddress(name));
-  auto msg_internal =
-      std::make_shared<const Nmea2000Msg>(_pgn, msg_payload, GetAddress(name));
-
-  // Notify listeners
-  m_listener.Notify(std::move(msg_internal));
-  m_listener.Notify(std::move(msg_all));
+  m_listener.Notify(
+      std::make_shared<const Nmea2000Msg>(_pgn, msg_payload, GetAddress(name)));
 
   if (GetSecondaryThread()) {
     if (IsSecThreadActive()) {


### PR DESCRIPTION
Don't notify the obsoleted "all" channel previously  used to list to all n2k messages. Avoids useless cycles and duplicated entries in the Data Monitor 