### PR TITLE
Allow using nearby layer waypoints in routes

### DIFF
--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -8621,7 +8621,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
         RoutePoint *pNearbyPoint =
             pWayPointMan->GetNearbyWaypoint(rlat, rlon, nearby_radius_meters);
         if (pNearbyPoint && (pNearbyPoint != m_prev_pMousePoint) &&
-            !pNearbyPoint->m_bIsInLayer && pNearbyPoint->IsVisible()) {
+            pNearbyPoint->IsVisible()) {
           wxArrayPtrVoid *proute_array =
               g_pRouteMan->GetRouteArrayContaining(pNearbyPoint);
 
@@ -9245,7 +9245,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
         RoutePoint *pNearbyPoint =
             pWayPointMan->GetNearbyWaypoint(rlat, rlon, nearby_radius_meters);
         if (pNearbyPoint && (pNearbyPoint != m_prev_pMousePoint) &&
-            !pNearbyPoint->m_bIsInLayer && pNearbyPoint->IsVisible()) {
+            pNearbyPoint->IsVisible()) {
           int dlg_return;
 #ifndef __WXOSX__
           m_FinishRouteOnKillFocus =
@@ -9715,8 +9715,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
             RoutePoint *pNearbyPoint = pWayPointMan->GetOtherNearbyWaypoint(
                 m_pRoutePointEditTarget->m_lat, m_pRoutePointEditTarget->m_lon,
                 nearby_radius_meters, m_pRoutePointEditTarget->m_GUID);
-            if (pNearbyPoint && !pNearbyPoint->m_bIsInLayer &&
-                pWayPointMan->IsReallyVisible(pNearbyPoint)) {
+            if (pNearbyPoint && pWayPointMan->IsReallyVisible(pNearbyPoint)) {
               bool duplicate =
                   false;  // ensure we won't create duplicate point in routes
               if (m_pEditRouteArray && !pNearbyPoint->m_bIsolatedMark) {
@@ -9988,8 +9987,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
             RoutePoint *pNearbyPoint = pWayPointMan->GetOtherNearbyWaypoint(
                 m_pRoutePointEditTarget->m_lat, m_pRoutePointEditTarget->m_lon,
                 nearby_radius_meters, m_pRoutePointEditTarget->m_GUID);
-            if (pNearbyPoint && !pNearbyPoint->m_bIsInLayer &&
-                pWayPointMan->IsReallyVisible(pNearbyPoint)) {
+            if (pNearbyPoint && pWayPointMan->IsReallyVisible(pNearbyPoint)) {
               bool duplicate = false;  // don't create duplicate point in routes
               if (m_pEditRouteArray && !pNearbyPoint->m_bIsolatedMark) {
                 for (unsigned int ir = 0; ir < m_pEditRouteArray->GetCount();


### PR DESCRIPTION
Reverts the regression discussed in #5004, allows reusing nearby waypoint from layer by duplicating it as already implemented. 