### PR TITLE
Grib request e-mail address validation

### DIFF
--- a/plugins/grib_pi/src/GribRequestDialog.cpp
+++ b/plugins/grib_pi/src/GribRequestDialog.cpp
@@ -20,6 +20,10 @@
  * \file
  * \implements \ref GribRequestDialog.h
  */
+// Disable the maybe-uninitialized warning as it triggers in std::regex and
+// makes the build with sanitizers impossible
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
 #include "wx/wx.h"
 #include <wx/utils.h>
 #include <sstream>


### PR DESCRIPTION
Before trying to send the e-mail request for grib data, check if the addresses that user can set in the config file make sense and actually look like e-mail addresses.