### PR TITLE
Link layer waypoints

### DIFF
--- a/gui/include/gui/mark_info.h
+++ b/gui/include/gui/mark_info.h
@@ -308,6 +308,7 @@ protected:
   wxStaticText* m_staticTextEditEnabled;
   wxStaticText* m_staticTextGpx;
   wxStaticText* m_staticTextGuid;
+  wxStaticText* m_staticTextLinkedGuid;
   wxStaticText* m_staticTextTideStation;
   wxStaticText* m_staticTextIcon;
   wxStaticText* m_staticTextLatitude;
@@ -331,6 +332,7 @@ protected:
   wxTextCtrl* m_textCtrlExtDescription;
   wxTextCtrl* m_textCtrlGpx;
   wxTextCtrl* m_textCtrlGuid;
+  wxTextCtrl* m_textCtrlLinkedGuid;
   wxScrolledWindow* m_scrolledWindowLinks;
   wxHyperlinkCtrl* m_hyperlink17;
   wxMenu* m_menuLink;

--- a/gui/include/gui/mark_info.h
+++ b/gui/include/gui/mark_info.h
@@ -430,6 +430,7 @@ public:
   void InitialFocus();
   void RecalculateSize();
   RoutePoint* GetRoutePoint() { return m_pRoutePoint; }
+  bool PromptUnlinkLinkedLayer();
   void SetColorScheme(ColorScheme cs);
   void SetRoutePoint(RoutePoint* pRP);
   void ClearData();

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -8622,20 +8622,10 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
 
         RoutePoint *pNearbyPoint =
             pWayPointMan->GetNearbyWaypoint(rlat, rlon, nearby_radius_meters);
+        bool link_layer_point = false;
         if (pNearbyPoint && (pNearbyPoint != m_prev_pMousePoint) &&
             pNearbyPoint->IsVisible()) {
           bool use_nearby = true;
-          bool allow_layer_reuse = false;
-          if (pNearbyPoint->m_bIsInLayer) {
-            int layer_answer = OCPNMessageBox(
-                this, _("Duplicate layer waypoint?"),
-                _("OpenCPN Route Create"),
-                (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
-            if (layer_answer == wxID_NO)
-              allow_layer_reuse = true;
-            else if (layer_answer != wxID_YES)
-              use_nearby = false;
-          }
           wxArrayPtrVoid *proute_array =
               g_pRouteMan->GetRouteArrayContaining(pNearbyPoint);
 
@@ -8675,41 +8665,72 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                                (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
             m_FinishRouteOnKillFocus = true;
             if (dlg_return == wxID_YES) {
-              if (noname) {
-                if (m_pMouseRoute) {
-                  int last_wp_num = m_pMouseRoute->GetnPoints();
-                  // AP-ECRMB will truncate to 6 characters
-                  wxString guid_short = m_pMouseRoute->GetGUID().Left(2);
-                  wxString wp_name = wxString::Format(
-                      "M%002i-%s", last_wp_num + 1, guid_short);
-                  pNearbyPoint->SetName(wp_name);
-                } else
-                  pNearbyPoint->SetName("WPXX");
+              if (pNearbyPoint->m_bIsInLayer &&
+                  pNearbyPoint->m_bLayerGuidIsPersistent) {
+                m_FinishRouteOnKillFocus = false;
+                int layer_answer = OCPNMessageBox(
+                    this,
+                    _("Link layer waypoint?\n\n"
+                      "Yes: link to the layer waypoint (route point updates when the layer updates).\n"
+                      "No: keep a copy in the route (won't follow layer changes)."),
+                    _("OpenCPN Route Create"),
+                    (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+                m_FinishRouteOnKillFocus = true;
+                if (layer_answer == wxID_CANCEL)
+                  use_nearby = false;
+                else if (layer_answer == wxID_YES)
+                  link_layer_point = true;
               }
-              pMousePoint = pNearbyPoint;
-              if (allow_layer_reuse) pMousePoint->m_bAllowLayerReuse = true;
+              if (!use_nearby) {
+                // fall through to create a new point
+              } else {
+                if (noname) {
+                  if (m_pMouseRoute) {
+                    int last_wp_num = m_pMouseRoute->GetnPoints();
+                    // AP-ECRMB will truncate to 6 characters
+                    wxString guid_short = m_pMouseRoute->GetGUID().Left(2);
+                    wxString wp_name = wxString::Format(
+                        "M%002i-%s", last_wp_num + 1, guid_short);
+                    pNearbyPoint->SetName(wp_name);
+                  } else
+                    pNearbyPoint->SetName("WPXX");
+                }
+                if (pNearbyPoint->m_bIsInLayer) {
+                  RoutePoint *clone = new RoutePoint(pNearbyPoint);
+                  clone->m_bIsInLayer = false;
+                  clone->m_LayerID = 0;
+                  clone->m_bAllowLayerReuse = false;
+                  clone->m_bLayerGuidIsPersistent = false;
+                  clone->m_LinkedLayerGUID =
+                      link_layer_point ? pNearbyPoint->m_GUID : wxString();
+                  if (pWayPointMan) pWayPointMan->AddRoutePoint(clone);
+                  pMousePoint = clone;
+                  pSelect->AddSelectableRoutePoint(
+                      pMousePoint->m_lat, pMousePoint->m_lon, pMousePoint);
+                } else {
+                  pMousePoint = pNearbyPoint;
+                }
 
-              // Using existing waypoint, so nothing to delete for undo.
-              if (m_routeState > 1)
-                undo->BeforeUndoableAction(Undo_AppendWaypoint, pMousePoint,
-                                           Undo_HasParent, NULL);
+                // Using existing waypoint, so nothing to delete for undo.
+                if (m_routeState > 1)
+                  undo->BeforeUndoableAction(Undo_AppendWaypoint, pMousePoint,
+                                             Undo_HasParent, NULL);
 
-              tail =
-                  g_pRouteMan->FindVisibleRouteContainingWaypoint(pMousePoint);
-              bool procede = false;
-              if (tail) {
-                procede = true;
-                // if (pMousePoint == tail->GetLastPoint()) procede = false;
-                if (m_routeState > 1 && m_pMouseRoute && tail == m_pMouseRoute)
-                  procede = false;
-              }
+                tail =
+                    g_pRouteMan->FindVisibleRouteContainingWaypoint(pMousePoint);
+                bool procede = false;
+                if (tail) {
+                  procede = true;
+                  // if (pMousePoint == tail->GetLastPoint()) procede = false;
+                  if (m_routeState > 1 && m_pMouseRoute && tail == m_pMouseRoute)
+                    procede = false;
+                }
 
-              if (procede) {
+                if (procede) {
                 int dlg_return;
                 m_FinishRouteOnKillFocus = false;
-                if (m_routeState ==
-                    1) {  // first point in new route, preceeding route to be
-                          // added?  Not touch case
+                if (m_routeState == 1) {  // first point in new route, preceeding
+                                          // route to be added?  touch case
 
                   wxString dmsg =
                       _("Insert first part of this route in the new route?");
@@ -8718,10 +8739,10 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                                            // route?
                     dmsg = _("Insert this route in the new route?");
 
-                  if (tail->GetIndexOf(pMousePoint) > 0) {  // Anything to do?
-                    dlg_return = OCPNMessageBox(
-                        this, dmsg, _("OpenCPN Route Create"),
-                        (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+                  if (tail->GetIndexOf(pMousePoint) != 1) {  // Anything to do?
+                    dlg_return =
+                        OCPNMessageBox(this, dmsg, _("OpenCPN Route Create"),
+                                       (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
                     m_FinishRouteOnKillFocus = true;
 
                     if (dlg_return == wxID_YES) {
@@ -8735,14 +8756,13 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                   if (tail->GetIndexOf(pMousePoint) == 1)
                     dmsg = _(
                         "Append this route to the new route?");  // Picking the
-                                                                 // first point
-                                                                 // of another
-                                                                 // route?
+                                                                 // first point of
+                                                                 // another route?
 
                   if (tail->GetLastPoint() != pMousePoint) {  // Anything to do?
-                    dlg_return = OCPNMessageBox(
-                        this, dmsg, _("OpenCPN Route Create"),
-                        (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+                    dlg_return =
+                        OCPNMessageBox(this, dmsg, _("OpenCPN Route Create"),
+                                       (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
                     m_FinishRouteOnKillFocus = true;
 
                     if (dlg_return == wxID_YES) {
@@ -8753,11 +8773,12 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                 }
               }
 
-              // check all other routes to see if this point appears in any
-              // other route If it appears in NO other route, then it should e
-              // considered an isolated mark
-              if (!FindRouteContainingWaypoint(pMousePoint))
-                pMousePoint->SetShared(true);
+                // check all other routes to see if this point appears in any
+                // other route If it appears in NO other route, then it should e
+                // considered an isolated mark
+                if (!FindRouteContainingWaypoint(pMousePoint))
+                  pMousePoint->SetShared(true);
+              }
             }
           }
         }
@@ -8866,8 +8887,6 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
         if (m_pMouseRoute)
           m_pMouseRoute->m_lastMousePointIndex = m_pMouseRoute->GetnPoints();
 
-        if (allow_layer_reuse && pMousePoint)
-          pMousePoint->m_bAllowLayerReuse = false;
         m_routeState++;
 
         if (appending ||
@@ -9261,20 +9280,10 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
 
         RoutePoint *pNearbyPoint =
             pWayPointMan->GetNearbyWaypoint(rlat, rlon, nearby_radius_meters);
+        bool link_layer_point = false;
         if (pNearbyPoint && (pNearbyPoint != m_prev_pMousePoint) &&
             pNearbyPoint->IsVisible()) {
           bool use_nearby = true;
-          bool allow_layer_reuse = false;
-          if (pNearbyPoint->m_bIsInLayer) {
-            int layer_answer = OCPNMessageBox(
-                this, _("Duplicate layer waypoint?"),
-                _("OpenCPN Route Create"),
-                (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
-            if (layer_answer == wxID_NO)
-              allow_layer_reuse = true;
-            else if (layer_answer != wxID_YES)
-              use_nearby = false;
-          }
           int dlg_return;
 #ifndef __WXOSX__
           m_FinishRouteOnKillFocus =
@@ -9287,75 +9296,108 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
           dlg_return = wxID_YES;
 #endif
           if (dlg_return == wxID_YES && use_nearby) {
-            pMousePoint = pNearbyPoint;
-            if (allow_layer_reuse) pMousePoint->m_bAllowLayerReuse = true;
-
-            // Using existing waypoint, so nothing to delete for undo.
-            if (m_routeState > 1)
-              undo->BeforeUndoableAction(Undo_AppendWaypoint, pMousePoint,
-                                         Undo_HasParent, NULL);
-            tail = g_pRouteMan->FindVisibleRouteContainingWaypoint(pMousePoint);
-
-            bool procede = false;
-            if (tail) {
-              procede = true;
-              // if (pMousePoint == tail->GetLastPoint()) procede = false;
-              if (m_routeState > 1 && m_pMouseRoute && tail == m_pMouseRoute)
-                procede = false;
-            }
-
-            if (procede) {
-              int dlg_return;
+            if (pNearbyPoint->m_bIsInLayer &&
+                pNearbyPoint->m_bLayerGuidIsPersistent) {
               m_FinishRouteOnKillFocus = false;
-              if (m_routeState == 1) {  // first point in new route, preceeding
-                                        // route to be added?  touch case
-
-                wxString dmsg =
-                    _("Insert first part of this route in the new route?");
-                if (tail->GetIndexOf(pMousePoint) ==
-                    tail->GetnPoints())  // Starting on last point of another
-                                         // route?
-                  dmsg = _("Insert this route in the new route?");
-
-                if (tail->GetIndexOf(pMousePoint) != 1) {  // Anything to do?
-                  dlg_return =
-                      OCPNMessageBox(this, dmsg, _("OpenCPN Route Create"),
-                                     (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
-                  m_FinishRouteOnKillFocus = true;
-
-                  if (dlg_return == wxID_YES) {
-                    inserting = true;  // part of the other route will be
-                                       // preceeding the new route
-                  }
+                int layer_answer = OCPNMessageBox(
+                    this,
+                    _("Link layer waypoint?\n\n"
+                      "Yes: link to the layer waypoint (route point updates when the layer updates).\n"
+                      "No: keep a copy in the route (won't follow layer changes)."),
+                    _("OpenCPN Route Create"),
+                    (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+              m_FinishRouteOnKillFocus = true;
+              if (layer_answer == wxID_CANCEL)
+                use_nearby = false;
+              else if (layer_answer == wxID_YES)
+                link_layer_point = true;
+            }
+            if (!use_nearby) {
+              // fall through to create a new point
+            } else {
+                if (pNearbyPoint->m_bIsInLayer) {
+                  RoutePoint *clone = new RoutePoint(pNearbyPoint);
+                  clone->m_bIsInLayer = false;
+                  clone->m_LayerID = 0;
+                  clone->m_bAllowLayerReuse = false;
+                  clone->m_bLayerGuidIsPersistent = false;
+                  clone->m_LinkedLayerGUID =
+                      link_layer_point ? pNearbyPoint->m_GUID : wxString();
+                  if (pWayPointMan) pWayPointMan->AddRoutePoint(clone);
+                  pMousePoint = clone;
+                  pSelect->AddSelectableRoutePoint(
+                      pMousePoint->m_lat, pMousePoint->m_lon, pMousePoint);
+                } else {
+                  pMousePoint = pNearbyPoint;
                 }
-              } else {
-                wxString dmsg =
-                    _("Append last part of this route to the new route?");
-                if (tail->GetIndexOf(pMousePoint) == 1)
-                  dmsg = _(
-                      "Append this route to the new route?");  // Picking the
-                                                               // first point of
-                                                               // another route?
 
-                if (tail->GetLastPoint() != pMousePoint) {  // Anything to do?
-                  dlg_return =
-                      OCPNMessageBox(this, dmsg, _("OpenCPN Route Create"),
-                                     (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
-                  m_FinishRouteOnKillFocus = true;
+              // Using existing waypoint, so nothing to delete for undo.
+              if (m_routeState > 1)
+                undo->BeforeUndoableAction(Undo_AppendWaypoint, pMousePoint,
+                                           Undo_HasParent, NULL);
+              tail = g_pRouteMan->FindVisibleRouteContainingWaypoint(pMousePoint);
 
-                  if (dlg_return == wxID_YES) {
-                    appending = true;  // part of the other route will be
-                                       // appended to the new route
+              bool procede = false;
+              if (tail) {
+                procede = true;
+                // if (pMousePoint == tail->GetLastPoint()) procede = false;
+                if (m_routeState > 1 && m_pMouseRoute && tail == m_pMouseRoute)
+                  procede = false;
+              }
+
+              if (procede) {
+                int dlg_return;
+                m_FinishRouteOnKillFocus = false;
+                if (m_routeState == 1) {  // first point in new route, preceeding
+                                          // route to be added?  touch case
+
+                  wxString dmsg =
+                      _("Insert first part of this route in the new route?");
+                  if (tail->GetIndexOf(pMousePoint) ==
+                      tail->GetnPoints())  // Starting on last point of another
+                                           // route?
+                    dmsg = _("Insert this route in the new route?");
+
+                  if (tail->GetIndexOf(pMousePoint) != 1) {  // Anything to do?
+                    dlg_return =
+                        OCPNMessageBox(this, dmsg, _("OpenCPN Route Create"),
+                                       (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+                    m_FinishRouteOnKillFocus = true;
+
+                    if (dlg_return == wxID_YES) {
+                      inserting = true;  // part of the other route will be
+                                         // preceeding the new route
+                    }
+                  }
+                } else {
+                  wxString dmsg =
+                      _("Append last part of this route to the new route?");
+                  if (tail->GetIndexOf(pMousePoint) == 1)
+                    dmsg = _(
+                        "Append this route to the new route?");  // Picking the
+                                                                   // first point of
+                                                                   // another route?
+
+                  if (tail->GetLastPoint() != pMousePoint) {  // Anything to do?
+                    dlg_return =
+                        OCPNMessageBox(this, dmsg, _("OpenCPN Route Create"),
+                                       (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+                    m_FinishRouteOnKillFocus = true;
+
+                    if (dlg_return == wxID_YES) {
+                      appending = true;  // part of the other route will be
+                                         // appended to the new route
+                    }
                   }
                 }
               }
-            }
 
-            // check all other routes to see if this point appears in any other
-            // route If it appears in NO other route, then it should e
-            // considered an isolated mark
-            if (!FindRouteContainingWaypoint(pMousePoint))
-              pMousePoint->SetShared(true);
+              // check all other routes to see if this point appears in any other
+              // route If it appears in NO other route, then it should e
+              // considered an isolated mark
+              if (!FindRouteContainingWaypoint(pMousePoint))
+                pMousePoint->SetShared(true);
+            }
           }
         }
 
@@ -9457,8 +9499,6 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
           }
         }
 
-        if (allow_layer_reuse && pMousePoint)
-          pMousePoint->m_bAllowLayerReuse = false;
         m_prev_rlat = rlat;
         m_prev_rlon = rlon;
         m_prev_pMousePoint = pMousePoint;
@@ -9739,6 +9779,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
           // Check to see if there is a nearby point which may replace the
           // dragged one
           RoutePoint *pMousePoint = NULL;
+          bool link_layer_point = false;
 
           int index_last;
           if (m_bRoutePoinDragging && !m_pRoutePointEditTarget->m_bIsActive) {
@@ -9749,17 +9790,6 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                 nearby_radius_meters, m_pRoutePointEditTarget->m_GUID);
             if (pNearbyPoint && pWayPointMan->IsReallyVisible(pNearbyPoint)) {
               bool use_nearby = true;
-              bool allow_layer_reuse = false;
-              if (pNearbyPoint->m_bIsInLayer) {
-                int layer_answer = OCPNMessageBox(
-                    this, _("Duplicate layer waypoint?"),
-                    _("OpenCPN RoutePoint change"),
-                    (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
-                if (layer_answer == wxID_NO)
-                  allow_layer_reuse = true;
-                else if (layer_answer != wxID_YES)
-                  use_nearby = false;
-              }
               bool duplicate =
                   false;  // ensure we won't create duplicate point in routes
               if (m_pEditRouteArray && !pNearbyPoint->m_bIsolatedMark) {
@@ -9861,8 +9891,50 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                   }
                 }
                 if (dlg_return == wxID_YES) {
-                  pMousePoint = pNearbyPoint;
-                  if (allow_layer_reuse) pMousePoint->m_bAllowLayerReuse = true;
+                  if (pNearbyPoint->m_bIsInLayer) {
+                    RoutePoint *clone = new RoutePoint(pNearbyPoint);
+                    clone->m_bIsInLayer = false;
+                    clone->m_LayerID = 0;
+                    clone->m_bAllowLayerReuse = false;
+                    clone->m_bLayerGuidIsPersistent = false;
+                    pMousePoint = clone;
+                    bool already_linked =
+                        !m_pRoutePointEditTarget->m_LinkedLayerGUID.IsEmpty() &&
+                        m_pRoutePointEditTarget->m_LinkedLayerGUID ==
+                            pNearbyPoint->m_GUID;
+                    if (pNearbyPoint->m_bLayerGuidIsPersistent) {
+                      if (already_linked) {
+                        link_layer_point = true;
+                      } else {
+                        int layer_answer = OCPNMessageBox(
+                            this,
+                            _("Link layer waypoint?\n\n"
+                              "Yes: link to the layer waypoint (route point updates when the layer updates).\n"
+                              "No: keep a copy in the route (won't follow layer changes)."),
+                            _("OpenCPN RoutePoint change"),
+                            (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+                        if (layer_answer == wxID_CANCEL) {
+                          use_nearby = false;
+                        } else if (layer_answer == wxID_YES) {
+                          link_layer_point = true;
+                        }
+                      }
+                    }
+                    if (!use_nearby) {
+                      if (pWayPointMan) pWayPointMan->RemoveRoutePoint(clone);
+                      delete clone;
+                      pMousePoint = NULL;
+                    } else {
+                      pMousePoint->m_LinkedLayerGUID =
+                          link_layer_point ? pNearbyPoint->m_GUID
+                                           : wxString();
+                      if (pWayPointMan) pWayPointMan->AddRoutePoint(pMousePoint);
+                      pSelect->AddSelectableRoutePoint(
+                          pMousePoint->m_lat, pMousePoint->m_lon, pMousePoint);
+                    }
+                  } else {
+                    pMousePoint = pNearbyPoint;
+                  }
                   if (pMousePoint->m_bIsolatedMark) {
                     pMousePoint->SetShared(true);
                   }
@@ -9873,8 +9945,6 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
               }
             }
           }
-          if (allow_layer_reuse && pMousePoint)
-            pMousePoint->m_bAllowLayerReuse = false;
           if (!pMousePoint)
             pSelect->UpdateSelectableRouteSegments(m_pRoutePointEditTarget);
 
@@ -10028,6 +10098,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
           // Check to see if there is a nearby point which may replace the
           // dragged one
           RoutePoint *pMousePoint = NULL;
+          bool link_layer_point = false;
           if (m_bRoutePoinDragging && !m_pRoutePointEditTarget->m_bIsActive) {
             double nearby_radius_meters =
                 g_Platform->GetSelectRadiusPix() / m_true_scale_ppm;
@@ -10036,17 +10107,6 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                 nearby_radius_meters, m_pRoutePointEditTarget->m_GUID);
             if (pNearbyPoint && pWayPointMan->IsReallyVisible(pNearbyPoint)) {
               bool use_nearby = true;
-              bool allow_layer_reuse = false;
-              if (pNearbyPoint->m_bIsInLayer) {
-                int layer_answer = OCPNMessageBox(
-                    this, _("Duplicate layer waypoint?"),
-                    _("OpenCPN RoutePoint change"),
-                    (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
-                if (layer_answer == wxID_NO)
-                  allow_layer_reuse = true;
-                else if (layer_answer != wxID_YES)
-                  use_nearby = false;
-              }
               bool duplicate = false;  // don't create duplicate point in routes
               if (m_pEditRouteArray && !pNearbyPoint->m_bIsolatedMark) {
                 for (unsigned int ir = 0; ir < m_pEditRouteArray->GetCount();
@@ -10146,8 +10206,50 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                   }
                 }
                 if (dlg_return == wxID_YES) {
-                  pMousePoint = pNearbyPoint;
-                  if (allow_layer_reuse) pMousePoint->m_bAllowLayerReuse = true;
+                  if (pNearbyPoint->m_bIsInLayer) {
+                    RoutePoint *clone = new RoutePoint(pNearbyPoint);
+                    clone->m_bIsInLayer = false;
+                    clone->m_LayerID = 0;
+                    clone->m_bAllowLayerReuse = false;
+                    clone->m_bLayerGuidIsPersistent = false;
+                    pMousePoint = clone;
+                    bool already_linked =
+                        !m_pRoutePointEditTarget->m_LinkedLayerGUID.IsEmpty() &&
+                        m_pRoutePointEditTarget->m_LinkedLayerGUID ==
+                            pNearbyPoint->m_GUID;
+                    if (pNearbyPoint->m_bLayerGuidIsPersistent) {
+                      if (already_linked) {
+                        link_layer_point = true;
+                      } else {
+                        int layer_answer = OCPNMessageBox(
+                            this,
+                            _("Link layer waypoint?\n\n"
+                              "Yes: link to the layer waypoint (route point updates when the layer updates).\n"
+                              "No: keep a copy in the route (won't follow layer changes)."),
+                            _("OpenCPN RoutePoint change"),
+                            (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+                        if (layer_answer == wxID_CANCEL) {
+                          use_nearby = false;
+                        } else if (layer_answer == wxID_YES) {
+                          link_layer_point = true;
+                        }
+                      }
+                    }
+                    if (!use_nearby) {
+                      if (pWayPointMan) pWayPointMan->RemoveRoutePoint(clone);
+                      delete clone;
+                      pMousePoint = NULL;
+                    } else {
+                      pMousePoint->m_LinkedLayerGUID =
+                          link_layer_point ? pNearbyPoint->m_GUID
+                                           : wxString();
+                      if (pWayPointMan) pWayPointMan->AddRoutePoint(pMousePoint);
+                      pSelect->AddSelectableRoutePoint(
+                          pMousePoint->m_lat, pMousePoint->m_lon, pMousePoint);
+                    }
+                  } else {
+                    pMousePoint = pNearbyPoint;
+                  }
                   if (pMousePoint->m_bIsolatedMark) {
                     pMousePoint->SetShared(true);
                   }
@@ -10158,8 +10260,6 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
               }
             }
           }
-          if (allow_layer_reuse && pMousePoint)
-            pMousePoint->m_bAllowLayerReuse = false;
           if (!pMousePoint)
             pSelect->UpdateSelectableRouteSegments(m_pRoutePointEditTarget);
 

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -8623,7 +8623,19 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
         RoutePoint *pNearbyPoint =
             pWayPointMan->GetNearbyWaypoint(rlat, rlon, nearby_radius_meters);
         if (pNearbyPoint && (pNearbyPoint != m_prev_pMousePoint) &&
-            !pNearbyPoint->m_bIsInLayer && pNearbyPoint->IsVisible()) {
+            pNearbyPoint->IsVisible()) {
+          bool use_nearby = true;
+          bool allow_layer_reuse = false;
+          if (pNearbyPoint->m_bIsInLayer) {
+            int layer_answer = OCPNMessageBox(
+                this, _("Duplicate layer waypoint?"),
+                _("OpenCPN Route Create"),
+                (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+            if (layer_answer == wxID_NO)
+              allow_layer_reuse = true;
+            else if (layer_answer != wxID_YES)
+              use_nearby = false;
+          }
           wxArrayPtrVoid *proute_array =
               g_pRouteMan->GetRouteArrayContaining(pNearbyPoint);
 
@@ -8647,7 +8659,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
           } else
             brp_viz = pNearbyPoint->IsVisible();  // isolated point
 
-          if (brp_viz) {
+          if (brp_viz && use_nearby) {
             wxString msg = _("Use nearby waypoint?");
             // Don't add a mark without name to the route. Name it if needed
             const bool noname(pNearbyPoint->GetName() == "");
@@ -8675,6 +8687,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                   pNearbyPoint->SetName("WPXX");
               }
               pMousePoint = pNearbyPoint;
+              if (allow_layer_reuse) pMousePoint->m_bAllowLayerReuse = true;
 
               // Using existing waypoint, so nothing to delete for undo.
               if (m_routeState > 1)
@@ -8853,6 +8866,8 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
         if (m_pMouseRoute)
           m_pMouseRoute->m_lastMousePointIndex = m_pMouseRoute->GetnPoints();
 
+        if (allow_layer_reuse && pMousePoint)
+          pMousePoint->m_bAllowLayerReuse = false;
         m_routeState++;
 
         if (appending ||
@@ -9247,7 +9262,19 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
         RoutePoint *pNearbyPoint =
             pWayPointMan->GetNearbyWaypoint(rlat, rlon, nearby_radius_meters);
         if (pNearbyPoint && (pNearbyPoint != m_prev_pMousePoint) &&
-            !pNearbyPoint->m_bIsInLayer && pNearbyPoint->IsVisible()) {
+            pNearbyPoint->IsVisible()) {
+          bool use_nearby = true;
+          bool allow_layer_reuse = false;
+          if (pNearbyPoint->m_bIsInLayer) {
+            int layer_answer = OCPNMessageBox(
+                this, _("Duplicate layer waypoint?"),
+                _("OpenCPN Route Create"),
+                (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+            if (layer_answer == wxID_NO)
+              allow_layer_reuse = true;
+            else if (layer_answer != wxID_YES)
+              use_nearby = false;
+          }
           int dlg_return;
 #ifndef __WXOSX__
           m_FinishRouteOnKillFocus =
@@ -9259,8 +9286,9 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
 #else
           dlg_return = wxID_YES;
 #endif
-          if (dlg_return == wxID_YES) {
+          if (dlg_return == wxID_YES && use_nearby) {
             pMousePoint = pNearbyPoint;
+            if (allow_layer_reuse) pMousePoint->m_bAllowLayerReuse = true;
 
             // Using existing waypoint, so nothing to delete for undo.
             if (m_routeState > 1)
@@ -9429,6 +9457,8 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
           }
         }
 
+        if (allow_layer_reuse && pMousePoint)
+          pMousePoint->m_bAllowLayerReuse = false;
         m_prev_rlat = rlat;
         m_prev_rlon = rlon;
         m_prev_pMousePoint = pMousePoint;
@@ -9717,8 +9747,19 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
             RoutePoint *pNearbyPoint = pWayPointMan->GetOtherNearbyWaypoint(
                 m_pRoutePointEditTarget->m_lat, m_pRoutePointEditTarget->m_lon,
                 nearby_radius_meters, m_pRoutePointEditTarget->m_GUID);
-            if (pNearbyPoint && !pNearbyPoint->m_bIsInLayer &&
-                pWayPointMan->IsReallyVisible(pNearbyPoint)) {
+            if (pNearbyPoint && pWayPointMan->IsReallyVisible(pNearbyPoint)) {
+              bool use_nearby = true;
+              bool allow_layer_reuse = false;
+              if (pNearbyPoint->m_bIsInLayer) {
+                int layer_answer = OCPNMessageBox(
+                    this, _("Duplicate layer waypoint?"),
+                    _("OpenCPN RoutePoint change"),
+                    (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+                if (layer_answer == wxID_NO)
+                  allow_layer_reuse = true;
+                else if (layer_answer != wxID_YES)
+                  use_nearby = false;
+              }
               bool duplicate =
                   false;  // ensure we won't create duplicate point in routes
               if (m_pEditRouteArray && !pNearbyPoint->m_bIsolatedMark) {
@@ -9743,7 +9784,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
               // polygon route
               if (m_pEditRouteArray->GetCount() == 1) duplicate = false;
 
-              if (!duplicate) {
+              if (!duplicate && use_nearby) {
                 int dlg_return;
                 dlg_return =
                     OCPNMessageBox(this,
@@ -9821,6 +9862,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                 }
                 if (dlg_return == wxID_YES) {
                   pMousePoint = pNearbyPoint;
+                  if (allow_layer_reuse) pMousePoint->m_bAllowLayerReuse = true;
                   if (pMousePoint->m_bIsolatedMark) {
                     pMousePoint->SetShared(true);
                   }
@@ -9831,6 +9873,8 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
               }
             }
           }
+          if (allow_layer_reuse && pMousePoint)
+            pMousePoint->m_bAllowLayerReuse = false;
           if (!pMousePoint)
             pSelect->UpdateSelectableRouteSegments(m_pRoutePointEditTarget);
 
@@ -9990,8 +10034,19 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
             RoutePoint *pNearbyPoint = pWayPointMan->GetOtherNearbyWaypoint(
                 m_pRoutePointEditTarget->m_lat, m_pRoutePointEditTarget->m_lon,
                 nearby_radius_meters, m_pRoutePointEditTarget->m_GUID);
-            if (pNearbyPoint && !pNearbyPoint->m_bIsInLayer &&
-                pWayPointMan->IsReallyVisible(pNearbyPoint)) {
+            if (pNearbyPoint && pWayPointMan->IsReallyVisible(pNearbyPoint)) {
+              bool use_nearby = true;
+              bool allow_layer_reuse = false;
+              if (pNearbyPoint->m_bIsInLayer) {
+                int layer_answer = OCPNMessageBox(
+                    this, _("Duplicate layer waypoint?"),
+                    _("OpenCPN RoutePoint change"),
+                    (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+                if (layer_answer == wxID_NO)
+                  allow_layer_reuse = true;
+                else if (layer_answer != wxID_YES)
+                  use_nearby = false;
+              }
               bool duplicate = false;  // don't create duplicate point in routes
               if (m_pEditRouteArray && !pNearbyPoint->m_bIsolatedMark) {
                 for (unsigned int ir = 0; ir < m_pEditRouteArray->GetCount();
@@ -10015,7 +10070,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
               // polygon route
               if (m_pEditRouteArray->GetCount() == 1) duplicate = false;
 
-              if (!duplicate) {
+              if (!duplicate && use_nearby) {
                 int dlg_return;
                 dlg_return =
                     OCPNMessageBox(this,
@@ -10092,6 +10147,7 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                 }
                 if (dlg_return == wxID_YES) {
                   pMousePoint = pNearbyPoint;
+                  if (allow_layer_reuse) pMousePoint->m_bAllowLayerReuse = true;
                   if (pMousePoint->m_bIsolatedMark) {
                     pMousePoint->SetShared(true);
                   }
@@ -10102,6 +10158,8 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
               }
             }
           }
+          if (allow_layer_reuse && pMousePoint)
+            pMousePoint->m_bAllowLayerReuse = false;
           if (!pMousePoint)
             pSelect->UpdateSelectableRouteSegments(m_pRoutePointEditTarget);
 

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -8668,13 +8668,15 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
               if (pNearbyPoint->m_bIsInLayer &&
                   pNearbyPoint->m_bLayerGuidIsPersistent) {
                 m_FinishRouteOnKillFocus = false;
-                int layer_answer = OCPNMessageBox(
-                    this,
-                    _("Link layer waypoint?\n\n"
-                      "Yes: link to the layer waypoint (route point updates when the layer updates).\n"
-                      "No: keep a copy in the route (won't follow layer changes)."),
-                    _("OpenCPN Route Create"),
-                    (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+                int layer_answer =
+                    OCPNMessageBox(this,
+                                   _("Link layer waypoint?\n\n"
+                                     "Yes: link to the layer waypoint (route "
+                                     "point updates when the layer updates).\n"
+                                     "No: keep a copy in the route (won't "
+                                     "follow layer changes)."),
+                                   _("OpenCPN Route Create"),
+                                   (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
                 m_FinishRouteOnKillFocus = true;
                 if (layer_answer == wxID_CANCEL)
                   use_nearby = false;
@@ -8716,62 +8718,68 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                   undo->BeforeUndoableAction(Undo_AppendWaypoint, pMousePoint,
                                              Undo_HasParent, NULL);
 
-                tail =
-                    g_pRouteMan->FindVisibleRouteContainingWaypoint(pMousePoint);
+                tail = g_pRouteMan->FindVisibleRouteContainingWaypoint(
+                    pMousePoint);
                 bool procede = false;
                 if (tail) {
                   procede = true;
                   // if (pMousePoint == tail->GetLastPoint()) procede = false;
-                  if (m_routeState > 1 && m_pMouseRoute && tail == m_pMouseRoute)
+                  if (m_routeState > 1 && m_pMouseRoute &&
+                      tail == m_pMouseRoute)
                     procede = false;
                 }
 
                 if (procede) {
-                int dlg_return;
-                m_FinishRouteOnKillFocus = false;
-                if (m_routeState == 1) {  // first point in new route, preceeding
-                                          // route to be added?  touch case
+                  int dlg_return;
+                  m_FinishRouteOnKillFocus = false;
+                  if (m_routeState ==
+                      1) {  // first point in new route, preceeding
+                            // route to be added?  touch case
 
-                  wxString dmsg =
-                      _("Insert first part of this route in the new route?");
-                  if (tail->GetIndexOf(pMousePoint) ==
-                      tail->GetnPoints())  // Starting on last point of another
-                                           // route?
-                    dmsg = _("Insert this route in the new route?");
+                    wxString dmsg =
+                        _("Insert first part of this route in the new route?");
+                    if (tail->GetIndexOf(pMousePoint) ==
+                        tail->GetnPoints())  // Starting on last point of
+                                             // another route?
+                      dmsg = _("Insert this route in the new route?");
 
-                  if (tail->GetIndexOf(pMousePoint) != 1) {  // Anything to do?
-                    dlg_return =
-                        OCPNMessageBox(this, dmsg, _("OpenCPN Route Create"),
-                                       (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
-                    m_FinishRouteOnKillFocus = true;
+                    if (tail->GetIndexOf(pMousePoint) !=
+                        1) {  // Anything to do?
+                      dlg_return = OCPNMessageBox(
+                          this, dmsg, _("OpenCPN Route Create"),
+                          (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+                      m_FinishRouteOnKillFocus = true;
 
-                    if (dlg_return == wxID_YES) {
-                      inserting = true;  // part of the other route will be
-                                         // preceeding the new route
+                      if (dlg_return == wxID_YES) {
+                        inserting = true;  // part of the other route will be
+                                           // preceeding the new route
+                      }
                     }
-                  }
-                } else {
-                  wxString dmsg =
-                      _("Append last part of this route to the new route?");
-                  if (tail->GetIndexOf(pMousePoint) == 1)
-                    dmsg = _(
-                        "Append this route to the new route?");  // Picking the
-                                                                 // first point of
-                                                                 // another route?
+                  } else {
+                    wxString dmsg =
+                        _("Append last part of this route to the new route?");
+                    if (tail->GetIndexOf(pMousePoint) == 1)
+                      dmsg = _(
+                          "Append this route to the new route?");  // Picking
+                                                                   // the first
+                                                                   // point of
+                                                                   // another
+                                                                   // route?
 
-                  if (tail->GetLastPoint() != pMousePoint) {  // Anything to do?
-                    dlg_return =
-                        OCPNMessageBox(this, dmsg, _("OpenCPN Route Create"),
-                                       (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
-                    m_FinishRouteOnKillFocus = true;
+                    if (tail->GetLastPoint() !=
+                        pMousePoint) {  // Anything to do?
+                      dlg_return = OCPNMessageBox(
+                          this, dmsg, _("OpenCPN Route Create"),
+                          (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+                      m_FinishRouteOnKillFocus = true;
 
-                    if (dlg_return == wxID_YES) {
-                      appending = true;  // part of the other route will be
-                                         // appended to the new route
+                      if (dlg_return == wxID_YES) {
+                        appending = true;  // part of the other route will be
+                                           // appended to the new route
+                      }
                     }
                   }
                 }
-              }
 
                 // check all other routes to see if this point appears in any
                 // other route If it appears in NO other route, then it should e
@@ -9299,13 +9307,15 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
             if (pNearbyPoint->m_bIsInLayer &&
                 pNearbyPoint->m_bLayerGuidIsPersistent) {
               m_FinishRouteOnKillFocus = false;
-                int layer_answer = OCPNMessageBox(
-                    this,
-                    _("Link layer waypoint?\n\n"
-                      "Yes: link to the layer waypoint (route point updates when the layer updates).\n"
-                      "No: keep a copy in the route (won't follow layer changes)."),
-                    _("OpenCPN Route Create"),
-                    (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+              int layer_answer =
+                  OCPNMessageBox(this,
+                                 _("Link layer waypoint?\n\n"
+                                   "Yes: link to the layer waypoint (route "
+                                   "point updates when the layer updates).\n"
+                                   "No: keep a copy in the route (won't follow "
+                                   "layer changes)."),
+                                 _("OpenCPN Route Create"),
+                                 (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
               m_FinishRouteOnKillFocus = true;
               if (layer_answer == wxID_CANCEL)
                 use_nearby = false;
@@ -9315,27 +9325,28 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
             if (!use_nearby) {
               // fall through to create a new point
             } else {
-                if (pNearbyPoint->m_bIsInLayer) {
-                  RoutePoint *clone = new RoutePoint(pNearbyPoint);
-                  clone->m_bIsInLayer = false;
-                  clone->m_LayerID = 0;
-                  clone->m_bAllowLayerReuse = false;
-                  clone->m_bLayerGuidIsPersistent = false;
-                  clone->m_LinkedLayerGUID =
-                      link_layer_point ? pNearbyPoint->m_GUID : wxString();
-                  if (pWayPointMan) pWayPointMan->AddRoutePoint(clone);
-                  pMousePoint = clone;
-                  pSelect->AddSelectableRoutePoint(
-                      pMousePoint->m_lat, pMousePoint->m_lon, pMousePoint);
-                } else {
-                  pMousePoint = pNearbyPoint;
-                }
+              if (pNearbyPoint->m_bIsInLayer) {
+                RoutePoint *clone = new RoutePoint(pNearbyPoint);
+                clone->m_bIsInLayer = false;
+                clone->m_LayerID = 0;
+                clone->m_bAllowLayerReuse = false;
+                clone->m_bLayerGuidIsPersistent = false;
+                clone->m_LinkedLayerGUID =
+                    link_layer_point ? pNearbyPoint->m_GUID : wxString();
+                if (pWayPointMan) pWayPointMan->AddRoutePoint(clone);
+                pMousePoint = clone;
+                pSelect->AddSelectableRoutePoint(
+                    pMousePoint->m_lat, pMousePoint->m_lon, pMousePoint);
+              } else {
+                pMousePoint = pNearbyPoint;
+              }
 
               // Using existing waypoint, so nothing to delete for undo.
               if (m_routeState > 1)
                 undo->BeforeUndoableAction(Undo_AppendWaypoint, pMousePoint,
                                            Undo_HasParent, NULL);
-              tail = g_pRouteMan->FindVisibleRouteContainingWaypoint(pMousePoint);
+              tail =
+                  g_pRouteMan->FindVisibleRouteContainingWaypoint(pMousePoint);
 
               bool procede = false;
               if (tail) {
@@ -9348,8 +9359,9 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
               if (procede) {
                 int dlg_return;
                 m_FinishRouteOnKillFocus = false;
-                if (m_routeState == 1) {  // first point in new route, preceeding
-                                          // route to be added?  touch case
+                if (m_routeState ==
+                    1) {  // first point in new route, preceeding
+                          // route to be added?  touch case
 
                   wxString dmsg =
                       _("Insert first part of this route in the new route?");
@@ -9359,9 +9371,9 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                     dmsg = _("Insert this route in the new route?");
 
                   if (tail->GetIndexOf(pMousePoint) != 1) {  // Anything to do?
-                    dlg_return =
-                        OCPNMessageBox(this, dmsg, _("OpenCPN Route Create"),
-                                       (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+                    dlg_return = OCPNMessageBox(
+                        this, dmsg, _("OpenCPN Route Create"),
+                        (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
                     m_FinishRouteOnKillFocus = true;
 
                     if (dlg_return == wxID_YES) {
@@ -9375,13 +9387,14 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                   if (tail->GetIndexOf(pMousePoint) == 1)
                     dmsg = _(
                         "Append this route to the new route?");  // Picking the
-                                                                   // first point of
-                                                                   // another route?
+                                                                 // first point
+                                                                 // of another
+                                                                 // route?
 
                   if (tail->GetLastPoint() != pMousePoint) {  // Anything to do?
-                    dlg_return =
-                        OCPNMessageBox(this, dmsg, _("OpenCPN Route Create"),
-                                       (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
+                    dlg_return = OCPNMessageBox(
+                        this, dmsg, _("OpenCPN Route Create"),
+                        (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
                     m_FinishRouteOnKillFocus = true;
 
                     if (dlg_return == wxID_YES) {
@@ -9392,8 +9405,8 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                 }
               }
 
-              // check all other routes to see if this point appears in any other
-              // route If it appears in NO other route, then it should e
+              // check all other routes to see if this point appears in any
+              // other route If it appears in NO other route, then it should e
               // considered an isolated mark
               if (!FindRouteContainingWaypoint(pMousePoint))
                 pMousePoint->SetShared(true);
@@ -9909,8 +9922,10 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                         int layer_answer = OCPNMessageBox(
                             this,
                             _("Link layer waypoint?\n\n"
-                              "Yes: link to the layer waypoint (route point updates when the layer updates).\n"
-                              "No: keep a copy in the route (won't follow layer changes)."),
+                              "Yes: link to the layer waypoint (route point "
+                              "updates when the layer updates).\n"
+                              "No: keep a copy in the route (won't follow "
+                              "layer changes)."),
                             _("OpenCPN RoutePoint change"),
                             (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
                         if (layer_answer == wxID_CANCEL) {
@@ -9926,9 +9941,9 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                       pMousePoint = NULL;
                     } else {
                       pMousePoint->m_LinkedLayerGUID =
-                          link_layer_point ? pNearbyPoint->m_GUID
-                                           : wxString();
-                      if (pWayPointMan) pWayPointMan->AddRoutePoint(pMousePoint);
+                          link_layer_point ? pNearbyPoint->m_GUID : wxString();
+                      if (pWayPointMan)
+                        pWayPointMan->AddRoutePoint(pMousePoint);
                       pSelect->AddSelectableRoutePoint(
                           pMousePoint->m_lat, pMousePoint->m_lon, pMousePoint);
                     }
@@ -10224,8 +10239,10 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                         int layer_answer = OCPNMessageBox(
                             this,
                             _("Link layer waypoint?\n\n"
-                              "Yes: link to the layer waypoint (route point updates when the layer updates).\n"
-                              "No: keep a copy in the route (won't follow layer changes)."),
+                              "Yes: link to the layer waypoint (route point "
+                              "updates when the layer updates).\n"
+                              "No: keep a copy in the route (won't follow "
+                              "layer changes)."),
                             _("OpenCPN RoutePoint change"),
                             (long)wxYES_NO | wxCANCEL | wxYES_DEFAULT);
                         if (layer_answer == wxID_CANCEL) {
@@ -10241,9 +10258,9 @@ bool ChartCanvas::MouseEventProcessObjects(wxMouseEvent &event) {
                       pMousePoint = NULL;
                     } else {
                       pMousePoint->m_LinkedLayerGUID =
-                          link_layer_point ? pNearbyPoint->m_GUID
-                                           : wxString();
-                      if (pWayPointMan) pWayPointMan->AddRoutePoint(pMousePoint);
+                          link_layer_point ? pNearbyPoint->m_GUID : wxString();
+                      if (pWayPointMan)
+                        pWayPointMan->AddRoutePoint(pMousePoint);
                       pSelect->AddSelectableRoutePoint(
                           pMousePoint->m_lat, pMousePoint->m_lon, pMousePoint);
                     }

--- a/gui/src/mark_info.cpp
+++ b/gui/src/mark_info.cpp
@@ -556,6 +556,17 @@ void MarkInfoDlg::Create() {
   m_textCtrlGuid->SetEditable(false);
   gbSizerInnerExtProperties2->Add(m_textCtrlGuid, 0, wxALL | wxEXPAND, 5);
 
+  m_staticTextLinkedGuid = new wxStaticText(
+      sbSizerExtProperties->GetStaticBox(), wxID_ANY, _("Linked Layer GUID"),
+      wxDefaultPosition, wxDefaultSize, 0);
+  gbSizerInnerExtProperties2->Add(m_staticTextLinkedGuid, 0,
+                                  wxALIGN_CENTRE_VERTICAL, 0);
+  m_textCtrlLinkedGuid =
+      new wxTextCtrl(sbSizerExtProperties->GetStaticBox(), wxID_ANY, "",
+                     wxDefaultPosition, wxDefaultSize, wxTE_READONLY);
+  m_textCtrlLinkedGuid->SetEditable(false);
+  gbSizerInnerExtProperties2->Add(m_textCtrlLinkedGuid, 0, wxALL | wxEXPAND, 5);
+
   wxFlexGridSizer* gbSizerInnerExtProperties1 = new wxFlexGridSizer(3, 0, 0);
   gbSizerInnerExtProperties1->AddGrowableCol(1);
 
@@ -1423,23 +1434,22 @@ bool MarkInfoDlg::PromptUnlinkLinkedLayer() {
   if (m_pRoutePoint->m_bIsInLayer) return false;
   if (m_pRoutePoint->m_LinkedLayerGUID.IsEmpty()) return true;
 
-  int answer = OCPNMessageBox(
-      this,
-      _("This waypoint is linked to a layer.\n\n"
-        "Do you want to unlink it to allow editing?\n\n"
-        "Yes: unlink and allow edits.\n"
-        "No: keep linked and discard edits."),
-      _("Linked layer waypoint"),
-      (long)wxYES_NO | wxNO_DEFAULT);
+  int answer =
+      OCPNMessageBox(this,
+                     _("This waypoint is linked to a layer.\n\n"
+                       "Do you want to unlink it to allow editing?\n\n"
+                       "Yes: unlink and allow edits.\n"
+                       "No: keep linked and discard edits."),
+                     _("Linked layer waypoint"), (long)wxYES_NO | wxNO_DEFAULT);
   if (answer != wxID_YES) return false;
 
   m_pRoutePoint->m_LinkedLayerGUID = wxEmptyString;
   if (m_pRoutePoint->m_bIsInRoute) {
-    wxArrayPtrVoid *routes =
+    wxArrayPtrVoid* routes =
         g_pRouteMan->GetRouteArrayContaining(m_pRoutePoint);
     if (routes) {
       for (unsigned int ir = 0; ir < routes->GetCount(); ir++) {
-        Route *pr = (Route *)routes->Item(ir);
+        Route* pr = (Route*)routes->Item(ir);
         NavObj_dB::GetInstance().UpdateRoute(pr);
       }
       delete routes;
@@ -1468,6 +1478,7 @@ bool MarkInfoDlg::UpdateProperties(bool positionOnly) {
     m_textScaMax->SetValue(
         wxString::Format("%i", (int)m_pRoutePoint->GetScaMax()));
     m_textCtrlGuid->SetValue(m_pRoutePoint->m_GUID);
+    m_textCtrlLinkedGuid->SetValue(m_pRoutePoint->m_LinkedLayerGUID);
     m_ChoiceWaypointRangeRingsNumber->SetSelection(
         m_pRoutePoint->GetWaypointRangeRingsNumber());
     wxString buf;

--- a/model/include/model/navobj_db_util.h
+++ b/model/include/model/navobj_db_util.h
@@ -31,3 +31,5 @@ void setUserVersion(sqlite3* db, int v);
 
 bool needsMigration_0_1(sqlite3* db);
 std::string SchemaUpdate_0_1(sqlite3* db, wxFrame* frame);
+bool needsMigration_1_2(sqlite3* db);
+std::string SchemaUpdate_1_2(sqlite3* db, wxFrame* frame);

--- a/model/include/model/route_point.h
+++ b/model/include/model/route_point.h
@@ -215,6 +215,7 @@ public:
    *         wxInvalidDateTime if no manual ETD has been set.
    */
   wxDateTime GetManualETD();
+  bool UpdateFromLinkedLayer();
   /**
    * Sets the Estimated Time of Departure for this waypoint, in UTC.
    *
@@ -473,9 +474,17 @@ public:
    */
   bool m_bAllowLayerReuse;
   /**
+   * True if layer waypoint GUID came from the GPX file (stable across reloads).
+   */
+  bool m_bLayerGuidIsPersistent;
+  /**
    * Layer identifier if the waypoint belongs to a layer.
    */
   int m_LayerID;
+  /**
+   * GUID of a layer waypoint this point is linked to (empty if none).
+   */
+  wxString m_LinkedLayerGUID;
   /**
    * Course from this waypoint to the next waypoint, in degrees.
    * @note Calculated field - Calculated from bearing between points.

--- a/model/include/model/route_point.h
+++ b/model/include/model/route_point.h
@@ -469,6 +469,10 @@ public:
    */
   bool m_bIsInLayer;
   /**
+   * Allow using a layer waypoint directly in a route (no cloning).
+   */
+  bool m_bAllowLayerReuse;
+  /**
    * Layer identifier if the waypoint belongs to a layer.
    */
   int m_LayerID;

--- a/model/src/nav_object_database.cpp
+++ b/model/src/nav_object_database.cpp
@@ -137,7 +137,8 @@ RoutePoint *GPXLoadWaypoint1(pugi::xml_node &wpt_node, wxString def_symbol_name,
           } else if (ext_name == "opencpn:link_layer_guid") {
             // Optional link to a layer waypoint GUID.
             // Stored on cloned routepoints to allow syncing with layer changes.
-            link_layer_guid = wxString::FromUTF8(ext_child.first_child().value());
+            link_layer_guid =
+                wxString::FromUTF8(ext_child.first_child().value());
           } else if (ext_name == "opencpn:viz") {
             b_propviz = true;
             wxString s = wxString::FromUTF8(ext_child.first_child().value());
@@ -238,9 +239,9 @@ RoutePoint *GPXLoadWaypoint1(pugi::xml_node &wpt_node, wxString def_symbol_name,
   if (!link_layer_guid.IsEmpty()) pWP->m_LinkedLayerGUID = link_layer_guid;
   pWP->m_bLayerGuidIsPersistent = layer_guid_is_persistent;
 
-    if (!b_layer && !pWP->m_LinkedLayerGUID.IsEmpty()) {
-      RoutePoint *linked_layer =
-          pWayPointMan->FindRoutePointByGUID(pWP->m_LinkedLayerGUID);
+  if (!b_layer && !pWP->m_LinkedLayerGUID.IsEmpty()) {
+    RoutePoint *linked_layer =
+        pWayPointMan->FindRoutePointByGUID(pWP->m_LinkedLayerGUID);
     if (linked_layer && linked_layer->m_bIsInLayer &&
         linked_layer->m_bLayerGuidIsPersistent) {
       pSelect->DeleteSelectableRoutePoint(pWP);
@@ -258,8 +259,7 @@ RoutePoint *GPXLoadWaypoint1(pugi::xml_node &wpt_node, wxString def_symbol_name,
       pWP->m_fWaypointRangeRingsStep = linked_layer->m_fWaypointRangeRingsStep;
       pWP->m_iWaypointRangeRingsStepUnits =
           linked_layer->m_iWaypointRangeRingsStepUnits;
-      pWP->SetShowWaypointRangeRings(
-          linked_layer->m_bShowWaypointRangeRings);
+      pWP->SetShowWaypointRangeRings(linked_layer->m_bShowWaypointRangeRings);
       pWP->m_wxcWaypointRangeRingsColour =
           linked_layer->m_wxcWaypointRangeRingsColour;
       pWP->SetScaMin(linked_layer->GetScaMin());
@@ -789,15 +789,15 @@ static bool GPXCreateWpt(pugi::xml_node node, RoutePoint *pr,
       child.append_child(pugi::node_pcdata).set_value("1");
     }
 
-  if ((flags & OUT_SHARED) && pr->IsShared()) {
-    child = child_ext.append_child("opencpn:shared");
-    child.append_child(pugi::node_pcdata).set_value("1");
-  }
-  if ((flags & OUT_GUID) && !pr->m_LinkedLayerGUID.IsEmpty()) {
-    child = child_ext.append_child("opencpn:link_layer_guid");
-    child.append_child(pugi::node_pcdata)
-        .set_value(pr->m_LinkedLayerGUID.mb_str());
-  }
+    if ((flags & OUT_SHARED) && pr->IsShared()) {
+      child = child_ext.append_child("opencpn:shared");
+      child.append_child(pugi::node_pcdata).set_value("1");
+    }
+    if ((flags & OUT_GUID) && !pr->m_LinkedLayerGUID.IsEmpty()) {
+      child = child_ext.append_child("opencpn:link_layer_guid");
+      child.append_child(pugi::node_pcdata)
+          .set_value(pr->m_LinkedLayerGUID.mb_str());
+    }
     if (flags & OUT_ARRIVAL_RADIUS) {
       child = child_ext.append_child("opencpn:arrival_radius");
       s.Printf("%.3f", pr->GetWaypointArrivalRadius());

--- a/model/src/navobj_db.cpp
+++ b/model/src/navobj_db.cpp
@@ -1497,9 +1497,8 @@ bool NavObj_dB::UpdateDBRoutePointAttributes(RoutePoint* point) {
     int iso = point->m_bIsolatedMark;
     sqlite3_bind_int(stmt, 23, iso);  // point->m_bIsolatedMark);
 
-    sqlite3_bind_text(stmt, 24,
-                      point->m_LinkedLayerGUID.ToStdString().c_str(), -1,
-                      SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 24, point->m_LinkedLayerGUID.ToStdString().c_str(),
+                      -1, SQLITE_TRANSIENT);
     sqlite3_bind_text(stmt, 25, point->m_GUID.ToStdString().c_str(), -1,
                       SQLITE_TRANSIENT);
 
@@ -1781,8 +1780,7 @@ bool NavObj_dB::LoadAllRoutes() {
           sqlite3_column_text(stmt_rp, col++);
       std::string linked_layer_guid;
       if (linked_guid_text)
-        linked_layer_guid =
-            reinterpret_cast<const char*>(linked_guid_text);
+        linked_layer_guid = reinterpret_cast<const char*>(linked_guid_text);
       std::string point_created_at =
           reinterpret_cast<const char*>(sqlite3_column_text(stmt_rp, col++));
 
@@ -1813,11 +1811,9 @@ bool NavObj_dB::LoadAllRoutes() {
         existing_point = resolve_linked_clone(linked_layer_guid);
       }
       if (!existing_point && !linked_layer_guid.empty()) {
-        existing_point =
-            pWayPointMan->FindRoutePointByGUID(linked_layer_guid);
-        if (existing_point &&
-            (!existing_point->m_bIsInLayer ||
-             !existing_point->m_bLayerGuidIsPersistent)) {
+        existing_point = pWayPointMan->FindRoutePointByGUID(linked_layer_guid);
+        if (existing_point && (!existing_point->m_bIsInLayer ||
+                               !existing_point->m_bLayerGuidIsPersistent)) {
           existing_point = NULL;
         }
       }
@@ -2094,8 +2090,7 @@ bool NavObj_dB::LoadAllPoints() {
         sqlite3_column_text(stmt_point, col++);
     std::string linked_layer_guid;
     if (linked_guid_text)
-      linked_layer_guid =
-          reinterpret_cast<const char*>(linked_guid_text);
+      linked_layer_guid = reinterpret_cast<const char*>(linked_guid_text);
     std::string point_created_at =
         reinterpret_cast<const char*>(sqlite3_column_text(stmt_point, col++));
 

--- a/model/src/navobj_db.cpp
+++ b/model/src/navobj_db.cpp
@@ -23,6 +23,7 @@
 
 #include <cmath>
 #include <iomanip>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -138,6 +139,7 @@ bool CreateTables(sqlite3* db) {
             viz_name INTEGER,
             shared INTEGER,
             isolated INTEGER,
+            linked_layer_guid TEXT,
             created_at DATETIME DEFAULT CURRENT_TIMESTAMP
         );
 
@@ -629,12 +631,22 @@ bool NavObj_dB::FullSchemaMigrate(wxFrame* frame) {
       wxLogMessage("Schema update and migration 0->1 successful");
   }
 
+  if (needsMigration_1_2(m_db)) {
+    std::string rs = SchemaUpdate_1_2(m_db, frame);
+    if (rs.size()) {
+      wxLogMessage("Error on: Schema update and migration 1->2");
+      wxLogMessage(wxString(rs.c_str()));
+      return false;
+    } else
+      wxLogMessage("Schema update and migration 1->2 successful");
+  }
+
   try {
     setUserVersion(m_db,
-                   1);  // Be sure all users get updated to version 1 at least
+                   2);  // Be sure all users get updated to version 2 at least
   } catch (const std::runtime_error& e) {
     // Known errors (e.g., SQLite issues)
-    wxLogMessage("Error on: Schema update and migration 0->1, setUserVersion");
+    wxLogMessage("Error on: Schema update and migration, setUserVersion");
     wxLogMessage(wxString(std::string(e.what())).c_str());
   }
 
@@ -1439,7 +1451,8 @@ bool NavObj_dB::UpdateDBRoutePointAttributes(RoutePoint* point) {
       "visibility = ?, "
       "viz_name = ?, "
       "shared = ?, "
-      "isolated = ? "
+      "isolated = ?, "
+      "linked_layer_guid = ? "
       "WHERE guid = ?";
 
   sqlite3_stmt* stmt;
@@ -1459,7 +1472,6 @@ bool NavObj_dB::UpdateDBRoutePointAttributes(RoutePoint* point) {
     if (point->GetManualETD().IsValid()) etd = point->GetManualETD().GetTicks();
     sqlite3_bind_int(stmt, 8, etd);
     sqlite3_bind_text(stmt, 9, "type", -1, SQLITE_TRANSIENT);
-    std::string timit = point->m_timestring.ToStdString().c_str();
     sqlite3_bind_text(stmt, 10, point->m_timestring.ToStdString().c_str(), -1,
                       SQLITE_TRANSIENT);
     sqlite3_bind_double(stmt, 11, point->m_WaypointArrivalRadius);
@@ -1485,7 +1497,10 @@ bool NavObj_dB::UpdateDBRoutePointAttributes(RoutePoint* point) {
     int iso = point->m_bIsolatedMark;
     sqlite3_bind_int(stmt, 23, iso);  // point->m_bIsolatedMark);
 
-    sqlite3_bind_text(stmt, 24, point->m_GUID.ToStdString().c_str(), -1,
+    sqlite3_bind_text(stmt, 24,
+                      point->m_LinkedLayerGUID.ToStdString().c_str(), -1,
+                      SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 25, point->m_GUID.ToStdString().c_str(), -1,
                       SQLITE_TRANSIENT);
 
   } else {
@@ -1645,6 +1660,13 @@ bool NavObj_dB::LoadAllRoutes() {
         reinterpret_cast<const char*>(sqlite3_column_text(stmt_routes, 12));
 
     Route* route = NULL;
+    std::map<std::string, RoutePoint*> linked_clones;
+    const auto resolve_linked_clone =
+        [&linked_clones](const std::string& guid) -> RoutePoint* {
+      auto it = linked_clones.find(guid);
+      if (it != linked_clones.end()) return it->second;
+      return NULL;
+    };
 
     //  Add the route_points
     const char* sql = R"(
@@ -1679,6 +1701,7 @@ bool NavObj_dB::LoadAllRoutes() {
         "p.viz_name, "
         "p.shared, "
         "p.isolated, "
+        "p.linked_layer_guid, "
         "p.created_at "
         "FROM routepoints_link tp "
         "JOIN routepoints p ON p.guid = tp.point_guid "
@@ -1754,6 +1777,12 @@ bool NavObj_dB::LoadAllRoutes() {
       int viz_name = sqlite3_column_int(stmt_rp, col++);
       int shared = sqlite3_column_int(stmt_rp, col++);
       int isolated = sqlite3_column_int(stmt_rp, col++);
+      const unsigned char* linked_guid_text =
+          sqlite3_column_text(stmt_rp, col++);
+      std::string linked_layer_guid;
+      if (linked_guid_text)
+        linked_layer_guid =
+            reinterpret_cast<const char*>(linked_guid_text);
       std::string point_created_at =
           reinterpret_cast<const char*>(sqlite3_column_text(stmt_rp, col++));
 
@@ -1779,6 +1808,18 @@ bool NavObj_dB::LoadAllRoutes() {
       // Or isolated?
       if (!existing_point) {
         existing_point = pWayPointMan->FindRoutePointByGUID(point_guid.c_str());
+      }
+      if (!existing_point && !linked_layer_guid.empty()) {
+        existing_point = resolve_linked_clone(linked_layer_guid);
+      }
+      if (!existing_point && !linked_layer_guid.empty()) {
+        existing_point =
+            pWayPointMan->FindRoutePointByGUID(linked_layer_guid);
+        if (existing_point &&
+            (!existing_point->m_bIsInLayer ||
+             !existing_point->m_bLayerGuidIsPersistent)) {
+          existing_point = NULL;
+        }
       }
 
       if (existing_point) {
@@ -1816,6 +1857,8 @@ bool NavObj_dB::LoadAllRoutes() {
         point->SetNameShown(viz_name == 1);
         point->SetShared(shared == 1);
         point->m_bIsolatedMark = (isolated == 1);
+        if (!linked_layer_guid.empty())
+          point->m_LinkedLayerGUID = linked_layer_guid;
 
         if (point_created_at.size()) {
           // Convert from sqLite default date/time format to wxDateTime
@@ -1863,6 +1906,42 @@ bool NavObj_dB::LoadAllRoutes() {
           sqlite3_finalize(stmt_point_link);
         }
       }  // new point
+
+      if (point->m_bIsInLayer) {
+        RoutePoint* cloned =
+            new RoutePoint(point->m_lat, point->m_lon, point->GetIconName(),
+                           point->GetName(), point_guid, true);
+        cloned->m_MarkDescription = point->m_MarkDescription;
+        cloned->m_TideStation = point->m_TideStation;
+        cloned->SetPlannedSpeed(point->GetPlannedSpeed());
+        cloned->SetETD(point->GetETD());
+
+        cloned->m_WaypointArrivalRadius = point->m_WaypointArrivalRadius;
+        cloned->m_iWaypointRangeRingsNumber =
+            point->m_iWaypointRangeRingsNumber;
+        cloned->m_fWaypointRangeRingsStep = point->m_fWaypointRangeRingsStep;
+        cloned->m_iWaypointRangeRingsStepUnits =
+            point->m_iWaypointRangeRingsStepUnits;
+        cloned->SetShowWaypointRangeRings(point->m_bShowWaypointRangeRings);
+        cloned->m_wxcWaypointRangeRingsColour =
+            point->m_wxcWaypointRangeRingsColour;
+        cloned->SetScaMin(point->GetScaMin());
+        cloned->SetScaMax(point->GetScaMax());
+        cloned->SetUseSca(point->GetUseSca());
+        cloned->SetVisible(point->IsVisible());
+        cloned->SetNameShown(point->IsNameShown());
+        cloned->SetShared(shared == 1);
+        cloned->m_bIsolatedMark = (isolated == 1);
+        if (!linked_layer_guid.empty()) {
+          cloned->m_LinkedLayerGUID = linked_layer_guid;
+        } else if (point->m_bLayerGuidIsPersistent) {
+          cloned->m_LinkedLayerGUID = point->m_GUID;
+        }
+        point = cloned;
+        if (!cloned->m_LinkedLayerGUID.IsEmpty()) {
+          linked_clones[cloned->m_LinkedLayerGUID.ToStdString()] = cloned;
+        }
+      }
 
       route->AddPoint(point);
     }  // route points
@@ -1962,6 +2041,7 @@ bool NavObj_dB::LoadAllPoints() {
       "p.viz_name, "
       "p.shared, "
       "p.isolated, "
+      "p.linked_layer_guid, "
       "p.created_at "
       "FROM routepoints p ";
 
@@ -2010,6 +2090,12 @@ bool NavObj_dB::LoadAllPoints() {
     int viz_name = sqlite3_column_int(stmt_point, col++);
     int shared = sqlite3_column_int(stmt_point, col++);
     int isolated = sqlite3_column_int(stmt_point, col++);
+    const unsigned char* linked_guid_text =
+        sqlite3_column_text(stmt_point, col++);
+    std::string linked_layer_guid;
+    if (linked_guid_text)
+      linked_layer_guid =
+          reinterpret_cast<const char*>(linked_guid_text);
     std::string point_created_at =
         reinterpret_cast<const char*>(sqlite3_column_text(stmt_point, col++));
 
@@ -2037,6 +2123,8 @@ bool NavObj_dB::LoadAllPoints() {
       point->SetNameShown(viz_name == 1);
       point->SetShared(shared == 1);
       point->m_bIsolatedMark = (isolated == 1);
+      if (!linked_layer_guid.empty())
+        point->m_LinkedLayerGUID = linked_layer_guid;
 
       if (point_created_at.size()) {
         // Convert from sqLite default date/time format to wxDateTime

--- a/model/src/navobj_db_util.cpp
+++ b/model/src/navobj_db_util.cpp
@@ -84,6 +84,29 @@ inline bool columnInPrimaryKey(sqlite3* db, const std::string& table,
   return found;
 }
 
+inline bool columnExists(sqlite3* db, const std::string& table,
+                         const std::string& column) {
+  std::string sql = "PRAGMA table_info(" + table + ");";
+  sqlite3_stmt* stmt;
+
+  if (sqlite3_prepare_v2(db, sql.c_str(), -1, &stmt, nullptr) != SQLITE_OK)
+    return false;
+
+  bool found = false;
+
+  while (sqlite3_step(stmt) == SQLITE_ROW) {
+    std::string name =
+        reinterpret_cast<const char*>(sqlite3_column_text(stmt, 1));
+    if (name == column) {
+      found = true;
+      break;
+    }
+  }
+
+  sqlite3_finalize(stmt);
+  return found;
+}
+
 bool needsMigration_0_1(sqlite3* db) {
   int version = getUserVersion(db);
   if (version < 1) {
@@ -152,6 +175,43 @@ std::string SchemaUpdate_0_1(sqlite3* db, wxFrame* frame) {
       return (std::string("Unexpected error on migration 0->1: ") + e.what());
     } catch (...) {
       // Truly unknown (rare, but good safety net)
+      return ("Unknown non-standard exception during migration");
+    }
+  }
+
+  return "";
+}
+
+bool needsMigration_1_2(sqlite3* db) {
+  int version = getUserVersion(db);
+  if (version < 2) {
+    return !columnExists(db, "routepoints", "linked_layer_guid");
+  }
+  return false;
+}
+
+std::string SchemaUpdate_1_2(sqlite3* db, wxFrame* frame) {
+  if (needsMigration_1_2(db)) {
+    DbMigrator migrator(db);
+    migrator.addMigration(2, [](sqlite3* db) {
+      char* errMsg = nullptr;
+      const char* sql =
+          "ALTER TABLE routepoints ADD COLUMN linked_layer_guid TEXT;";
+
+      if (sqlite3_exec(db, sql, nullptr, nullptr, &errMsg) != SQLITE_OK) {
+        std::string err = errMsg ? errMsg : "";
+        sqlite3_free(errMsg);
+        throw std::runtime_error(err);
+      }
+    });
+
+    try {
+      migrator.migrate();
+    } catch (const std::runtime_error& e) {
+      return (std::string("Migration 1->2 failed: ") + e.what());
+    } catch (const std::exception& e) {
+      return (std::string("Unexpected error on migration 1->2: ") + e.what());
+    } catch (...) {
       return ("Unknown non-standard exception during migration");
     }
   }

--- a/model/src/route.cpp
+++ b/model/src/route.cpp
@@ -170,7 +170,7 @@ void Route::AddPointAndSegment(RoutePoint *pNewPoint, bool b_rename_in_sequence,
                                bool b_deferBoxCalc) {
   int npoints = GetnPoints();
   RoutePoint *newpoint = pNewPoint;
-  if (newpoint->m_bIsInLayer) {
+  if (newpoint->m_bIsInLayer && !newpoint->m_bAllowLayerReuse) {
     newpoint = new RoutePoint(pNewPoint->m_lat, pNewPoint->m_lon,
                               pNewPoint->GetIconName(), pNewPoint->GetName(),
                               "", false);

--- a/model/src/route.cpp
+++ b/model/src/route.cpp
@@ -176,6 +176,8 @@ void Route::AddPointAndSegment(RoutePoint *pNewPoint, bool b_rename_in_sequence,
                               "", false);
     newpoint->m_bShowName =
         pNewPoint->m_bShowName;  // do not change new wpt's name visibility
+    if (pNewPoint->m_bLayerGuidIsPersistent)
+      newpoint->m_LinkedLayerGUID = pNewPoint->m_GUID;
   }
   AddPoint(newpoint, false);
   if (npoints != 0) {

--- a/model/src/route_point.cpp
+++ b/model/src/route_point.cpp
@@ -601,8 +601,7 @@ bool RoutePoint::UpdateFromLinkedLayer() {
   SetWaypointArrivalRadius(linked_layer->GetWaypointArrivalRadius());
   m_iWaypointRangeRingsNumber = linked_layer->m_iWaypointRangeRingsNumber;
   m_fWaypointRangeRingsStep = linked_layer->m_fWaypointRangeRingsStep;
-  m_iWaypointRangeRingsStepUnits =
-      linked_layer->m_iWaypointRangeRingsStepUnits;
+  m_iWaypointRangeRingsStepUnits = linked_layer->m_iWaypointRangeRingsStepUnits;
   SetShowWaypointRangeRings(linked_layer->m_bShowWaypointRangeRings);
   m_wxcWaypointRangeRingsColour = linked_layer->m_wxcWaypointRangeRingsColour;
   SetScaMin(linked_layer->GetScaMin());

--- a/model/src/route_point.cpp
+++ b/model/src/route_point.cpp
@@ -88,6 +88,7 @@ RoutePoint::RoutePoint() {
   m_MarkName = "";
 
   m_bIsInLayer = false;
+  m_bAllowLayerReuse = false;
   m_LayerID = 0;
 
   m_WaypointArrivalRadius = g_n_arrival_circle_radius;
@@ -148,6 +149,7 @@ RoutePoint::RoutePoint(RoutePoint *orig) {
   SetPlannedSpeed(orig->GetPlannedSpeed());
 
   m_bIsInLayer = orig->m_bIsInLayer;
+  m_bAllowLayerReuse = orig->m_bAllowLayerReuse;
   m_GUID = pWayPointMan->CreateGUID(this);
 
   m_SelectNode = NULL;
@@ -233,6 +235,7 @@ RoutePoint::RoutePoint(double lat, double lon, const wxString &icon_ident,
   if (bAddToList && NULL != pWayPointMan) pWayPointMan->AddRoutePoint(this);
 
   m_bIsInLayer = false;
+  m_bAllowLayerReuse = false;
   m_LayerID = 0;
 
   SetWaypointArrivalRadius(g_n_arrival_circle_radius);


### PR DESCRIPTION
## Summary
- Add optional linking between route point copies and layer waypoints using persistent layer GUIDs.
- Store linked layer GUIDs in GPX and navobj.db; sync linked copies when layers reload.
- Update route creation/drag to link or copy layer waypoints.
- Defer unlink prompt to save action.
## Testing
- Created a route using a GUID-backed layer waypoint and verified link persistence.
- Edited layer GPX and reloaded to confirm linked routepoints update.

Closes #5015
