### PR TITLE
Avoid showing the GRIB on screen when answering plugin messages

### DIFF
--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -467,10 +467,10 @@ void grib_pi::OnToolbarToolCallback(int id) {
   }
 
   // Toggle GRIB overlay display
-  m_bShowGrib = !m_bShowGrib;
+  if (id >= 0) m_bShowGrib = !m_bShowGrib;
 
   //    Toggle dialog?
-  if (m_bShowGrib) {
+  if (m_bShowGrib || id < 0) {
     // A new file could have been added since grib plugin opened
     if (!starting && m_bLoadLastOpenFile == 0) {
       m_pGribCtrlBar->OpenFile(true);
@@ -496,7 +496,7 @@ void grib_pi::OnToolbarToolCallback(int id) {
       m_pGribCtrlBar->Refresh();
 #endif
     }
-    m_pGribCtrlBar->Show();
+    if (id >= 0) m_pGribCtrlBar->Show();
     if (m_pGribCtrlBar->m_bGRIBActiveFile) {
       if (m_pGribCtrlBar->m_bGRIBActiveFile->IsOK()) {
         ArrayOfGribRecordSets *rsa =
@@ -639,7 +639,7 @@ void grib_pi::SetDialogFont(wxWindow *dialog, wxFont *font) {
 
 void grib_pi::SetPluginMessage(wxString &message_id, wxString &message_body) {
   if (message_id == _T("GRIB_VALUES_REQUEST")) {
-    if (!m_pGribCtrlBar) OnToolbarToolCallback(0);
+    if (!m_pGribCtrlBar) OnToolbarToolCallback(-1);
 
     // lat, lon, time, what
     wxJSONReader r;
@@ -731,7 +731,7 @@ void grib_pi::SetPluginMessage(wxString &message_id, wxString &message_body) {
                     v[_T("Year")].AsInt(), v[_T("Hour")].AsInt(),
                     v[_T("Minute")].AsInt(), v[_T("Second")].AsInt());
 
-    if (!m_pGribCtrlBar) OnToolbarToolCallback(0);
+    if (!m_pGribCtrlBar) OnToolbarToolCallback(-1);
 
     GribTimelineRecordSet *set =
         m_pGribCtrlBar ? m_pGribCtrlBar->GetTimeLineRecordSet(time) : nullptr;


### PR DESCRIPTION
SetPluginMessage() requires an initialized m_pGribCtrlBar. To this purpose it calls OnToolbarToolCallback(). This results in the grib control bar and the grib overlay being shown on screen. That is not necessary for SetPluginMessage() and has the following disadvantages:
- The user might not want to see the grib at all (e.g. when Weather Routing sends a GRIB_TIMELINE_RECORD_REQUEST)
- Showing the grib overlay consumes unnecessary CPU cycles and makes the UI less responsive

The patch recognizes OnToolbarToolCallback() coming from SetPluginMessage() and suppresses showing the UI in this case.

IMHO a better solution would be to separate UI and data into two objects. Then SetPluginMessage() could initialize the data object without touching the UI object. At least the methods OpenFile(), getTimeInterpolatedValue() and getTimeInterpolatedValues() should be moved from the UI to the data object.