### PR TITLE
Change Menu Bar-Tool-Data Monitor key shortcut tips > E

### DIFF
--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -3666,7 +3666,7 @@ void MyFrame::RegisterGlobalMenuItems() {
 
   wxMenu *tools_menu = new wxMenu();
   tools_menu->Append(ID_MENU_TOOL_NMEA_DBG_LOG,
-                     _menuText(_("Data Monitor"), "Alt-C"));
+                     _menuText(_("Data Monitor"), "E"));
 #ifndef __WXOSX__
   tools_menu->Append(ID_MENU_TOOL_MEASURE,
                      _menuText(_("Measure Distance"), "M"));


### PR DESCRIPTION
As discussed in various places, including [here ](https://github.com/OpenCPN/OpenCPN/issues/5022#issuecomment-3798079707)
The "E" key also tested by the help of a MacOS user:
_"It is the same on macOS (using a 5.13 OCPN). Including the Alt-C in the menu bar. Which does not make sense as you pointed out: If you see it, the menu bar is already open."_