### PR TITLE
Fix GL grid label DPI scaling

### DIFF
--- a/gui/src/gl_chart_canvas.cpp
+++ b/gui/src/gl_chart_canvas.cpp
@@ -1859,8 +1859,9 @@ void glChartCanvas::GridDraw() {
     double dpi_factor = g_BasePlatform->GetDisplayDIPMult(this);
     wxFont *dFont = FontMgr::Get().GetFont(_("GridText"), 0);
     wxFont font = *dFont;
-    double dpi_scale = 1. / dpi_factor;
-    int font_size = wxMax(10, dFont->GetPointSize() * dpi_scale);
+    // Keep point size unscaled here; TexFont::Build handles DPI and display
+    // scale.
+    int font_size = wxMax(10, dFont->GetPointSize());
     font.SetPointSize(font_size);
     font.SetWeight(wxFONTWEIGHT_NORMAL);
 


### PR DESCRIPTION
## Summary
- normalize GL grid label font size using DIP scaling (matching non-GL)
- pass display scale to texture font build instead of point-size scaling

## Testing
- Not run (local manual verification: GL grid label size now correct on macOS)

Closes #5035.