### PR TITLE
Export available  message types in plugin API - #5008

### DIFF
--- a/gui/include/gui/ocpn_app.h
+++ b/gui/include/gui/ocpn_app.h
@@ -69,9 +69,9 @@ public:
   bool OpenFile(const std::string& path);
   void OnUnhandledException() override;
 
-  CallbacksByPlugin& GetApiEventsCallbacks() override {
-    return m_api_events_callbacks;
-  }
+  void RegisterApiEventCallback(
+      const std::string& plugin_name,
+      std::function<void(HostApi122::EventType what)> callback) override;
 
 #ifdef LINUX_CRASHRPT
   //! fatal exeption handling

--- a/gui/include/gui/ocpn_app.h
+++ b/gui/include/gui/ocpn_app.h
@@ -42,8 +42,12 @@
 #include "model/usb_watch_daemon.h"
 
 #include "data_monitor.h"
+#include "ocpn_plugin.h"
 
-class MyApp : public wxApp {
+using CallbacksByPlugin =
+    std::unordered_map<std::string, std::function<void(HostApi122::EventType)>>;
+
+class MyApp : public wxApp, public Api122Impl {
 public:
   MyApp();
   ~MyApp() {};
@@ -64,6 +68,10 @@ public:
   void OnActivateApp(wxActivateEvent& event);
   bool OpenFile(const std::string& path);
   void OnUnhandledException() override;
+
+  CallbacksByPlugin& GetApiEventsCallbacks() override {
+    return m_api_events_callbacks;
+  }
 
 #ifdef LINUX_CRASHRPT
   //! fatal exeption handling
@@ -96,8 +104,14 @@ private:
   int m_exitcode;  ///< by default -2. Otherwise, forces exit(exit_code)
 
   void InitRestListeners();
+
+  void OnNewMsgTypes();
+
   ObsListener rest_activate_listener;
   ObsListener rest_reverse_listener;
+  ObsListener new_msg_type_listener;
+
+  CallbacksByPlugin m_api_events_callbacks;
 };
 
 wxDECLARE_APP(MyApp);

--- a/gui/src/api_122.cpp
+++ b/gui/src/api_122.cpp
@@ -26,22 +26,16 @@
 
 #include "ocpn_plugin.h"
 
-static Api122Impl* GetApiSupport() {
-  auto* support = dynamic_cast<Api122Impl*>(wxTheApp);
-  assert(support && "wxTheApp does not implement Api122Support");
-  return support;
-}
-
 // FIXME (leamas) find new home.
 std::unique_ptr<HostApi> GetHostApi() {
-  return std::make_unique<HostApi122>(HostApi122(GetApiSupport()));
+  auto impl = dynamic_cast<Api122Impl*>(wxTheApp);
+  assert(impl && "wxTheApp does not implement Api122Impl");
+  return std::make_unique<HostApi122>(HostApi122(impl));
 }
 
 void HostApi122::RegisterApiEventCallback(
     const std::string& plugin_name, std::function<void(EventType)> callback) {
-  auto& msg_types_callbacks = m_api_impl->GetApiEventsCallbacks();
-  if (callback)
-    msg_types_callbacks[plugin_name] = std::move(callback);
-  else
-    msg_types_callbacks.erase(plugin_name);
+  auto impl = dynamic_cast<Api122Impl*>(wxTheApp);
+  assert(impl && "wxTheApp does not implement Api122Impl");
+  impl->RegisterApiEventCallback(plugin_name, callback);
 }

--- a/gui/src/api_122.cpp
+++ b/gui/src/api_122.cpp
@@ -21,9 +21,27 @@
  *
  * ocpn_plugin.h HostApi122 implementation
  */
+
+#include <wx/app.h>
+
 #include "ocpn_plugin.h"
+
+static Api122Impl* GetApiSupport() {
+  auto* support = dynamic_cast<Api122Impl*>(wxTheApp);
+  assert(support && "wxTheApp does not implement Api122Support");
+  return support;
+}
 
 // FIXME (leamas) find new home.
 std::unique_ptr<HostApi> GetHostApi() {
-  return std::make_unique<HostApi122>(HostApi122());
+  return std::make_unique<HostApi122>(HostApi122(GetApiSupport()));
+}
+
+void HostApi122::RegisterApiEventCallback(
+    const std::string& plugin_name, std::function<void(EventType)> callback) {
+  auto& msg_types_callbacks = m_api_impl->GetApiEventsCallbacks();
+  if (callback)
+    msg_types_callbacks[plugin_name] = std::move(callback);
+  else
+    msg_types_callbacks.erase(plugin_name);
 }

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -12,9 +12,7 @@
  *   GNU General Public License for more details.                          *
  *                                                                         *
  *   You should have received a copy of the GNU General Public License     *
- *   along with this program; if not, write to the                         *
- *   Free Software Foundation, Inc.,                                       *
- *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,  USA.         *
+ *   along with this program; if not, see <https://www.gnu.org/licenses/>. *
  **************************************************************************/
 
 /**
@@ -319,8 +317,8 @@ static bool LoadAllPlugIns(bool load_enabled) {
 #include "bitmaps/opencpn.xpm"
 #endif
 
-wxString newPrivateFileName(wxString, const char *name,
-                            [[maybe_unused]] const char *windowsName) {
+static wxString newPrivateFileName(wxString, const char *name,
+                                   [[maybe_unused]] const char *windowsName) {
   wxString fname = wxString::FromUTF8(name);
   wxString filePathAndName;
 
@@ -336,6 +334,11 @@ wxString newPrivateFileName(wxString, const char *name,
 #endif
 
   return filePathAndName;
+}
+
+void MyApp::OnNewMsgTypes() {
+  for (auto it : m_api_events_callbacks)
+    it.second(HostApi122::EventType::kNewMessageType);
 }
 
 class WallpaperFrame : public wxFrame {
@@ -1204,6 +1207,8 @@ bool MyApp::OnInit() {
   }
 
   InitRestListeners();
+  new_msg_type_listener.Init(NavMsgBus::GetInstance().new_msg_event,
+                             [&](ObservedEvt &) { OnNewMsgTypes(); });
 
   //      Establish the GSHHS Dataset location
   gDefaultWorldMapLocation = "gshhs";

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -341,6 +341,15 @@ void MyApp::OnNewMsgTypes() {
     it.second(HostApi122::EventType::kNewMessageType);
 }
 
+void MyApp::RegisterApiEventCallback(
+    const std::string &plugin_name,
+    std::function<void(HostApi122::EventType what)> callback) {
+  if (callback)
+    m_api_events_callbacks[plugin_name] = std::move(callback);
+  else
+    m_api_events_callbacks.erase(plugin_name);
+}
+
 class WallpaperFrame : public wxFrame {
 public:
   WallpaperFrame()
@@ -1210,7 +1219,7 @@ bool MyApp::OnInit() {
   new_msg_type_listener.Init(NavMsgBus::GetInstance().new_msg_event,
                              [&](ObservedEvt &) { OnNewMsgTypes(); });
 
-  //      Establish the GSHHS Dataset location
+  //  Establish the GSHHS Dataset location
   gDefaultWorldMapLocation = "gshhs";
   gDefaultWorldMapLocation.Prepend(g_Platform->GetSharedDataDir());
   gDefaultWorldMapLocation.Append(wxFileName::GetPathSeparator());

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -1152,6 +1152,11 @@ void PlugInManager::OnPluginActivate(const PlugInContainer* pic) {
 }
 
 void PlugInManager::OnPluginDeactivate(const PlugInContainer* pic) {
+  // Remove possible event callbacks
+  auto name = pic->m_pplugin->GetCommonName().ToStdString();
+  auto api_impl = dynamic_cast<Api122Impl*>(wxTheApp);
+  assert(api_impl && "wxTheApp does not implement Api122Impl");
+  api_impl->RegisterApiEventCallback(name, nullptr);
   // Unload chart cache if this plugin is responsible for any charts
   if ((pic->m_cap_flag & INSTALLS_PLUGIN_CHART) ||
       (pic->m_cap_flag & INSTALLS_PLUGIN_CHART_GL)) {

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -46,6 +46,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 #include <unordered_map>
@@ -7258,6 +7259,7 @@ public:
         kContextMenuDisableRoute(2),
         kContextMenuDisableTrack(4),
         kContextMenuDisableAistarget(8) {}
+
   ~HostApi121() override = default;
 
   const int kContextMenuDisableWaypoint;
@@ -7387,7 +7389,48 @@ public:
   virtual bool GetTideHeight(int stationIndex, time_t time, float *height);
 };
 
+class Api122Impl;  // forward
+
 /** Unstable development API */
-class HostApi122 : public HostApi121 {};
+class HostApi122 : public HostApi121 {
+public:
+  HostApi122(Api122Impl *support) : m_api_impl(support) {}
+
+  /** Reported events bitmask. */
+  enum class EventType {
+    kNewMessageType = 1  // A new message type is detected
+  };
+
+  /**
+   * Register a new callback invoked when an EventType event occurs.
+   *
+   * @param plugin_name Invoking plugin name as of GetCommonName().
+   * @param callback Invoked with an EventType argument defining the
+   *     actual event which occurred. Use nullptr to deregister
+   *     possibly existing callback
+   */
+  void RegisterApiEventCallback(const std::string &plugin_name,
+                                std::function<void(EventType what)> callback);
+
+  /**
+   * Return currently known messages types flowing through system.
+   *
+   * General item format: <bus>::<key>
+   * bus  ::= "nmea0183" | "nmea2000" | "SignalK" | "Plugin"
+   * <key> depends on bus -- TBD
+   */
+  const std::set<std::string> &GetActiveMessages();
+
+private:
+  Api122Impl *m_api_impl;
+};
+
+/** @interface providing backend api support.  */
+class Api122Impl {
+public:
+  virtual std::unordered_map<std::string,
+                             std::function<void(HostApi122::EventType)>> &
+  GetApiEventsCallbacks() = 0;
+};
 
 #endif  //_PLUGIN_H_

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -2304,6 +2304,11 @@ public:
   virtual void OnTideCurrentClick(TCClickInfo info);
 };
 
+class DECL_EXP opencpn_plugin_122 : public opencpn_plugin_121 {
+public:
+  opencpn_plugin_122(void *pmgr) : opencpn_plugin_121(pmgr) {}
+};
+
 //------------------------------------------------------------------
 //      Route and Waypoint PlugIn support
 //

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -7422,15 +7422,14 @@ public:
   const std::set<std::string> &GetActiveMessages();
 
 private:
-  Api122Impl *m_api_impl;
+  Api122Impl *m_api_impl;  // Raw ptr to app object managed by wxWidgets
 };
 
 /** @interface providing backend api support.  */
 class Api122Impl {
 public:
-  virtual std::unordered_map<std::string,
-                             std::function<void(HostApi122::EventType)>> &
-  GetApiEventsCallbacks() = 0;
+  virtual void RegisterApiEventCallback(
+      const std::string &, std::function<void(HostApi122::EventType what)>) = 0;
 };
 
 #endif  //_PLUGIN_H_

--- a/model/include/model/plugin_loader.h
+++ b/model/include/model/plugin_loader.h
@@ -186,8 +186,7 @@ public:
   EventVar evt_pluglist_change;
 
   /**
-   * Carries a malloc'ed read-only copy of a PlugInContainer owned: by
-   * listener.
+   * Notified with plugin name when it's deactivated.
    */
   EventVar evt_deactivate_plugin;
 

--- a/model/src/plugin_handler.cpp
+++ b/model/src/plugin_handler.cpp
@@ -366,7 +366,7 @@ PluginHandler::PluginHandler() {}
 bool PluginHandler::IsCompatible(const PluginMetadata& metadata, const char* os,
                                  const char* os_version) {
   static const SemanticVersion kMinApi = SemanticVersion(1, 16);
-  static const SemanticVersion kMaxApi = SemanticVersion(1, 21);
+  static const SemanticVersion kMaxApi = SemanticVersion(1, 22);
   auto plugin_api = SemanticVersion::parse(metadata.api_version);
   if (plugin_api.major == -1) {
     DEBUG_LOG << "Cannot parse API version \"" << metadata.api_version << "\"";

--- a/model/src/plugin_loader.cpp
+++ b/model/src/plugin_loader.cpp
@@ -878,6 +878,8 @@ bool PluginLoader::DeactivatePlugIn(PlugInContainer* pic) {
     m_on_deactivate_cb(pic);
     pic->m_init_state = false;
     pic->m_pplugin->DeInit();
+    auto name = pic->m_pplugin->GetCommonName().ToStdString();
+    evt_deactivate_plugin.Notify(name);
   }
   return true;
 }

--- a/model/src/plugin_loader.cpp
+++ b/model/src/plugin_loader.cpp
@@ -1692,6 +1692,10 @@ PlugInContainer* PluginLoader::LoadPlugIn(const wxString& plugin_file,
       pic->m_pplugin = dynamic_cast<opencpn_plugin_121*>(plug_in);
       break;
 
+    case 122:
+      pic->m_pplugin = dynamic_cast<opencpn_plugin_122*>(plug_in);
+      break;
+
     default:
       break;
   }


### PR DESCRIPTION
Make the currently available message types visible in the plugin API. Useful for plugins which wants to for example listen to all NMEA0183 messages.

The `GetActiveMessages()`  function just returns currently known messages. The  ` RegisterApiEventCallback()` function registers a callback invoked  when a system event occurs.

The only implemented system event is when  `GetActiveMessages()`  is updated i. e., when a new message type is detected by the core which will trigger the callback.

Typical usage in  Init() assuming that the `m_api_122` pointer is set up and a `OnNewMessageType()`  function is defined:
```
m_api_122->RegisterApiEventCallback(GetCommonName(),
                                      [&] { OnNewMessageType(); });
```
~It's important to deregister  in DeInit(), failure to do so might lead to a crash:~
Callbacks are automagically removed when a plugin is deactivatd.


Closes: #5008