### PR TITLE
Add ChartTextFont to the s52plib statehash

### DIFF
--- a/libs/s52plib/src/s52plib.cpp
+++ b/libs/s52plib/src/s52plib.cpp
@@ -742,6 +742,12 @@ void s52plib::GenerateStateHash() {
     offset += sizeof(int);
   }
 
+  wxFont *templateFont = GetOCPNScaledFont_PlugIn(_("ChartTexts"));
+  if (offset + sizeof(templateFont) < sizeof(state_buffer)) {
+    memcpy(&state_buffer[offset], &templateFont, sizeof(templateFont));
+    offset += sizeof(templateFont);
+  }
+
   m_state_hash = crc32buf(state_buffer, offset);
 }
 


### PR DESCRIPTION
Changing the charttextfont currently needs a restart of O. 
This is because the s52lib has no way to find out the font was changed. Adding the (pointer) of the font to the statehash does fix this. 
Tested for ENC and CM93 (On my machine Debian 13) 