### PR TITLE
Data Monitor: bugfixes - #5061

### DIFF
--- a/model/include/model/comm_navmsg_bus.h
+++ b/model/include/model/comm_navmsg_bus.h
@@ -32,11 +32,13 @@
 #include <set>
 #include <string>
 
+#include <wx/event.h>
+
 #include "model/comm_driver.h"
 #include "observable_evtvar.h"
 
 /** The raw message layer, a singleton. */
-class NavMsgBus : public DriverListener {
+class NavMsgBus : public wxEvtHandler, public DriverListener {
 public:
   /* Singleton implementation. */
   static NavMsgBus& GetInstance();
@@ -48,8 +50,11 @@ public:
   void SendMessage(std::shared_ptr<const NavMsg> message,
                    std::shared_ptr<const NavAddr> address);
 
-  /** Register a message type in list the GetActiveMessages() list. */
-  void RegisterKey(const std::string& key);
+  /**
+   * Register a message type in list the GetActiveMessages() list
+   * @return true if key is inserted, false if already registered.
+   */
+  bool RegisterKey(const std::string& key);
 
   /** Accept message received by driver, make it available for upper layers. */
   void Notify(std::shared_ptr<const NavMsg> message);

--- a/model/include/model/data_monitor_src.h
+++ b/model/include/model/data_monitor_src.h
@@ -62,7 +62,6 @@ private:
   std::unordered_map<std::string, ObsListener> m_listeners;
   ObsListener new_msg_lstnr;
   ObsListener undelivered_msg_lstnr;
-  std::string m_last_payload;  // Horrible hack (tm)
 
   /** Handle new message type detected. */
   void OnNewMessage();

--- a/model/src/data_monitor_src.cpp
+++ b/model/src/data_monitor_src.cpp
@@ -101,8 +101,5 @@ void DataMonitorSrc::OnNewMessage() {
 
 void DataMonitorSrc::OnMessage(ObservedEvt& ev) {
   auto ptr = UnpackEvtPointer<NavMsg>(ev);
-  if (ptr && ptr->to_string() != m_last_payload) {
-    m_last_payload = ptr->to_string();
-    m_sink_func(ptr);
-  }
+  m_sink_func(ptr);
 }

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -844,8 +844,8 @@ public:
     auto driver = make_unique<FileCommDriver>(inputfile + ".log", path, msgbus);
     CommDriverRegistry::GetInstance().Activate(std::move(driver));
     ProcessPendingEvents();
-    EXPECT_NEAR(gLat, 57.6460, 0.001);
-    EXPECT_NEAR(gLon, 11.7130, 0.001);
+    EXPECT_NEAR(gLat, 57.6460, 0.004);
+    EXPECT_NEAR(gLon, 11.7130, 0.004);
   }
 };
 


### PR DESCRIPTION
#5061 reveals two bugs.

1. A horrible hack related to the previous msg-ALL data paths has been left in place. This hack dropped the second  of two consecutive messages with the  same payload.  This hack has been removed.
2. When registering a new message the very message which caused the registration is lost. This is because the listeners have not been able to Init() before the message arrives. Handled by a slight delay when forwarding a message  which is not yet registered.

