### PR TITLE
User colors: Make night text font lighter - #5058

### DIFF
--- a/gui/src/connections_dlg.cpp
+++ b/gui/src/connections_dlg.cpp
@@ -228,7 +228,7 @@ public:
 
   void Draw(wxGrid& grid, wxGridCellAttr& attr, wxDC& dc, const wxRect& rect,
             int row, int col, bool isSelected) override {
-    dc.SetBrush(wxBrush(GetGlobalColor("DILG2")));
+    dc.SetBrush(wxBrush(GetGlobalColor("DILG1")));
     if ((m_cs != GLOBAL_COLOR_SCHEME_DAY) && m_cs != GLOBAL_COLOR_SCHEME_RGB)
       dc.SetBrush(wxBrush(GetDialogColor(DLG_BACKGROUND)));
     if (IsWindows()) dc.SetBrush(wxBrush(GetGlobalColor("DILG1")));

--- a/gui/src/user_colors.cpp
+++ b/gui/src/user_colors.cpp
@@ -166,10 +166,10 @@ static const char *const usercolors[] = {
     "UBLCK;   0;  0;  0;", "URED;   60; 27;  5;", "UGREN;  17; 55; 10;",
     "YELO1;  60; 65; 12;", "YELO2;  32; 20;  0;", "TEAL1;   0; 32; 32;",
     "GREEN5; 44; 64; 0;", "COMPT;  48; 49; 51",
-    "DILG0;  80; 80; 80;",  // Dialog Background
-    "DILG1;  80; 80; 80;",  // Dialog Background
-    "DILG2;   0;  0;  0;",  // Control Background
-    "DILG3;  65; 65; 65;",  // Text
+    "DILG0;  80; 80; 80;",     // Dialog Background
+    "DILG1;  80; 80; 80;",     // Dialog Background
+    "DILG2;   0;  0;  0;",     // Control Background
+    "DILG3;  180; 180; 180;",  // Text
     "DILG4; 220;220;220;",
     "UITX1;  31; 34; 35;",  // Menu text color
     "UDKRD;  50;  0;  0;",  // Dark red variant - reduced visibility alternative


### PR DESCRIPTION
Black text on dark grey background is in general not that readable. Use  a light colour instead, avoiding full white.

Resultiing AIS taget query:

<img width="423" height="719" alt="Image" src="https://github.com/user-attachments/assets/0f1e71b6-1cc3-48f9-b371-00113f38b125" />

This affects all widgets using DimeControl() so should not be taken lightly.

Closes: #5058