### PR TITLE
Add global g_b_needFinish for conditional glFinish() in OpenGL

### DIFF
--- a/gui/src/gl_chart_canvas.cpp
+++ b/gui/src/gl_chart_canvas.cpp
@@ -178,9 +178,6 @@ private:
 
 extern bool g_running;  ///< Android only
 
-//    For VBO(s)
-static bool g_b_needFinish;  // Need glFinish() call on each frame?
-
 static wxColor s_regionColor;
 static float g_GLMinCartographicLineWidth;
 // MacOS has some missing parts:
@@ -932,6 +929,8 @@ bool glChartCanvas::buildFBOSize(int fboSize) {
 #endif
 
 void glChartCanvas::BuildFBO() {
+  if (g_b_needFinish) glFinish();
+
   if (m_b_BuiltFBO) {
     // return;
     glDeleteTextures(2, m_cache_tex);
@@ -4559,8 +4558,6 @@ void glChartCanvas::Render() {
 
   //  Some older MSW OpenGL drivers are generally very unstable.
   //  This helps...
-
-  if (g_b_needFinish) glFinish();
 
   SwapBuffers();
 

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -554,6 +554,7 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
     Read("GPUTextureMemSize", &g_GLOptions.m_iTextureMemorySize);
     Read("DebugOpenGL", &g_bDebugOGL);
     Read("OpenGL", &g_bopengl);
+    Read("OpenGLFinsihNeeded", &g_b_needFinish);
     Read("SoftwareGL", &g_bSoftwareGL);
   }
 #endif

--- a/model/include/model/gui_vars.h
+++ b/model/include/model/gui_vars.h
@@ -50,6 +50,7 @@ extern bool g_bhide_route_console;
 extern bool g_b_legacy_input_filter_behaviour;
 extern bool g_bmasterToolbarFull;
 extern bool g_bopengl;
+extern bool g_b_needFinish;
 extern bool g_b_overzoom_x;  ///< Allow high overzoom
 extern bool g_bPauseTest;
 extern bool g_bquiting;

--- a/model/src/config_vars.cpp
+++ b/model/src/config_vars.cpp
@@ -41,6 +41,8 @@ bool g_bCourseUp = false;
 bool g_bDebugCM93 = false;
 bool g_bDebugGPSD = false;
 bool g_bDebugOGL = false;
+//    For VBO(s)
+bool g_b_needFinish = false;  // Need glFinish() call on each frame?
 bool g_bDebugS57 = false;
 bool g_bDisplayGrid = false;
 bool g_bEmailCrashReport = false;


### PR DESCRIPTION
Introduced a global config variable g_b_needFinish to control whether glFinish() is called during OpenGL rendering. The call was added to BuildFBO() which is where it is really needed for some Intel GPU's with limited command buffer depth.

Global variable is initialized false but can be overridden through OpenCPN config file value "OpenGLFinsihNeeded=1".

TODO: Possible improvement would be to check if running on Windows with Intel graphics chip and turn the g_b_needFinish on automatically if variable not found in opencpn.conf.