### PR TITLE
Fix typo in OpenGLFinishNeeded config key name

### DIFF
--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -554,7 +554,7 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
     Read("GPUTextureMemSize", &g_GLOptions.m_iTextureMemorySize);
     Read("DebugOpenGL", &g_bDebugOGL);
     Read("OpenGL", &g_bopengl);
-    Read("OpenGLFinsihNeeded", &g_b_needFinish);
+    Read("OpenGLFinishNeeded", &g_b_needFinish);
     Read("SoftwareGL", &g_bSoftwareGL);
   }
 #endif


### PR DESCRIPTION
Corrects the spelling of the "OpenGLFinishNeeded" key when reading from the configuration file, ensuring the value is properly loaded into g_b_needFinish.