### PR TITLE
WIP: Resolve multithread related crashes at startup

### DIFF
--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -1374,7 +1374,7 @@ int MyFrame::GetCanvasIndexUnderMouse() {
           return 0;
       }
       cc = ConfigMgr::Get().GetCanvasConfigArray().Item(1);
-      if (cc) {
+      if (cc && cc->canvas) {
         ChartCanvas *canvas = cc->canvas;
         if (canvas->GetScreenRect().Contains(
                 /*canvas->ScreenToClient*/ (screenPoint)))

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -1528,8 +1528,9 @@ bool options::SendIdleEvents(wxIdleEvent& event) {
 }
 
 void options::OptionsFinalizeChartDBUpdate() {
-  m_CurrentDirList =
-      *m_pWorkDirList;  // Perform a deep copy back to main database.
+  if (m_pWorkDirList)
+    m_CurrentDirList =
+        *m_pWorkDirList;  // Perform a deep copy back to main database.
   // Re-enable RNC texture caching
   g_GLOptions.m_bTextureCompressionCaching = m_bTextureCacheingSave;
 }

--- a/gui/src/s57_load.cpp
+++ b/gui/src/s57_load.cpp
@@ -17,6 +17,8 @@
 
 #include <wx/app.h>
 
+#include <mutex>
+
 #include "model/cmdline.h"
 #include "model/gui_vars.h"
 
@@ -30,6 +32,12 @@
 #include "s57registrar_mgr.h"
 
 void LoadS57() {
+  if (ps52plib)  // already loaded?
+    return;
+
+  static std::mutex loadS57Mutex;
+  std::lock_guard<std::mutex> guard(loadS57Mutex);
+
   if (ps52plib)  // already loaded?
     return;
 

--- a/libs/gdal/src/cpl_conv.cpp
+++ b/libs/gdal/src/cpl_conv.cpp
@@ -31,7 +31,7 @@
 #include "cpl_conv.h"
 #include "cpl_string.h"
 
-static char **papszConfigOptions = NULL;
+static thread_local char **papszConfigOptions = NULL;
 
 /************************************************************************/
 /*                             CPLCalloc()                              */
@@ -296,7 +296,7 @@ char *CPLFGets( char *pszBuffer, int nBufferSize, FILE * fp )
         while( (chCheck != 13 && chCheck != EOF)
                || VSIFTell(fp) < nOriginalOffset + nActuallyRead )
         {
-            static int bWarned = FALSE;
+            static thread_local int bWarned = FALSE;
 
             if( !bWarned )
             {
@@ -339,8 +339,8 @@ char *CPLFGets( char *pszBuffer, int nBufferSize, FILE * fp )
 const char *CPLReadLine( FILE * fp )
 
 {
-    static char *pszRLBuffer = NULL;
-    static int  nRLBufferSize = 0;
+    static thread_local char *pszRLBuffer = NULL;
+    static thread_local int nRLBufferSize = 0;
     int         nReadSoFar = 0;
 
 /* -------------------------------------------------------------------- */
@@ -1098,8 +1098,8 @@ const char *CPLDecToDMS( double dfAngle, const char * pszAxis,
     int         nDegrees, nMinutes;
     double      dfSeconds, dfABSAngle, dfEpsilon;
     char        szFormat[30];
-    static char szBuffer[50];
-    const char  *pszHemisphere;
+    static thread_local char szBuffer[50];
+    const thread_local char  *pszHemisphere;
 
     dfEpsilon = (0.5/3600.0) * pow(0.1,nPrecision);
 

--- a/libs/gdal/src/cpl_csv.cpp
+++ b/libs/gdal/src/cpl_csv.cpp
@@ -64,7 +64,7 @@ typedef struct ctb {
 } CSVTable;
 */
 
-static CSVTable *psCSVTableList = NULL;
+static thread_local CSVTable *psCSVTableList = NULL;
 
 /************************************************************************/
 /*                             CSVAccess()                              */
@@ -859,10 +859,10 @@ const char *CSVGetField( const char * pszFilename,
 const char * GDALDefaultCSVFilename( const char *pszBasename )
 
 {
-    static char         szPath[512];
+    static thread_local char szPath[512];
     FILE    *fp = NULL;
     const char *pszResult;
-    static int bFinderInitialized = FALSE;
+    static thread_local int bFinderInitialized = FALSE;
 
     pszResult = CPLFindFile( "epsg_csv", pszBasename );
 
@@ -909,7 +909,7 @@ const char * GDALDefaultCSVFilename( const char *pszBasename )
 /*      eventually be something the application can override.           */
 /************************************************************************/
 
-static const char *(*pfnCSVFilenameHook)(const char *) = NULL;
+static const thread_local char *(*pfnCSVFilenameHook)(const char *) = NULL;
 
 const char * CSVFilename( const char *pszBasename )
 

--- a/libs/gdal/src/cpl_error.cpp
+++ b/libs/gdal/src/cpl_error.cpp
@@ -126,11 +126,11 @@
  * messages cannot be longer than 2000 chars... which is quite reasonable
  * (that's 25 lines of 80 chars!!!)
  */
-static char gszCPLLastErrMsg[2000] = "";
-static int  gnCPLLastErrNo = 0;
-static CPLErr geCPLLastErrType = CE_None;
+static thread_local char gszCPLLastErrMsg[2000] = "";
+static thread_local int  gnCPLLastErrNo = 0;
+static thread_local CPLErr geCPLLastErrType = CE_None;
 
-static CPLErrorHandler gpfnCPLErrorHandler = CPLDefaultErrorHandler;
+static thread_local CPLErrorHandler gpfnCPLErrorHandler = CPLDefaultErrorHandler;
 
 typedef struct errHandler
 {
@@ -138,7 +138,7 @@ typedef struct errHandler
     CPLErrorHandler     pfnHandler;
 } CPLErrorHandlerNode;
 
-static CPLErrorHandlerNode * psHandlerStack = NULL;
+static thread_local CPLErrorHandlerNode * psHandlerStack = NULL;
 
 /**********************************************************************
  *                          CPLError()
@@ -412,8 +412,8 @@ void CPLDefaultErrorHandler( CPLErr eErrClass, int nError,
                              const char * pszErrorMsg )
 
 {
-    static int       bLogInit = FALSE;
-    static FILE *    fpLog = stderr;
+    static thread_local int       bLogInit = FALSE;
+    static thread_local FILE *    fpLog = stderr;
 
     if( !bLogInit )
     {
@@ -458,8 +458,8 @@ void CPLLoggingErrorHandler( CPLErr eErrClass, int nError,
                              const char * pszErrorMsg )
 
 {
-    static int       bLogInit = FALSE;
-    static FILE *    fpLog = stderr;
+    static thread_local int       bLogInit = FALSE;
+    static thread_local FILE *    fpLog = stderr;
 
     if( !bLogInit )
     {
@@ -649,4 +649,3 @@ void _CPLAssert( const char * pszExpression, const char * pszFile,
               "in file `%s', line %d\n",
               pszExpression, pszFile, iLine );
 }
-

--- a/libs/gdal/src/cpl_findfile.cpp
+++ b/libs/gdal/src/cpl_findfile.cpp
@@ -55,10 +55,10 @@
 #include "cpl_conv.h"
 #include "cpl_string.h"
 
-static int bFinderInitialized = FALSE;
-static int nFileFinders = 0;
-static CPLFileFinder *papfnFinders = NULL;
-static char **papszFinderLocations = NULL;
+static thread_local int bFinderInitialized = FALSE;
+static thread_local int nFileFinders = 0;
+static thread_local CPLFileFinder *papfnFinders = NULL;
+static thread_local char **papszFinderLocations = NULL;
 
 /************************************************************************/
 /*                           CPLFinderInit()                            */

--- a/libs/gdal/src/gdal_misc.cpp
+++ b/libs/gdal/src/gdal_misc.cpp
@@ -184,7 +184,7 @@ void __pure_virtual()
            const char *GDALVersionInfo( const char *pszRequest )
 
 {
-    static char szResult[128];
+    static thread_local char szResult[128];
 
 
     if( pszRequest == NULL || EQUAL(pszRequest,"VERSION_NUM") )
@@ -202,4 +202,3 @@ void __pure_virtual()
 
     return szResult;
 }
-

--- a/libs/gdal/src/ogrfeature.cpp
+++ b/libs/gdal/src/ogrfeature.cpp
@@ -966,8 +966,8 @@ double OGR_F_GetFieldAsDouble( OGRFeatureH hFeat, int iField )
 const char *OGRFeature::GetFieldAsString( int iField )
 
 {
-    OGRFieldDefn        *poFDefn = poDefn->GetFieldDefn( iField );
-    static char         szTempBuffer[160];
+    OGRFieldDefn              *poFDefn = poDefn->GetFieldDefn( iField );
+    static thread_local char  szTempBuffer[160];
     unsigned int max_line = 80;
 
     CPLAssert( poFDefn != NULL || iField == -1 );

--- a/libs/gdal/src/ogrgeometry.cpp
+++ b/libs/gdal/src/ogrgeometry.cpp
@@ -1096,7 +1096,7 @@ const char *OGRGeometryTypeToName( OGRwkbGeometryType eType )
 
       default:
       {
-          static char szWorkName[33];
+          static thread_local char szWorkName[33];
           sprintf( szWorkName, "Unrecognised: %d", (int) eType );
           return szWorkName;
       }


### PR DESCRIPTION
Thread safety:
Use thread_local for static buffers to ensure thread safety and prevent data races
Added mutex to s57_load.cpp for thread safe library initialization

std::sort exception:
Improved sorting logic in quilt.cpp to avoid std::sort exception

Null pointer avoidance:
Improved pointer checks in ocpn_frame.cpp and options.cpp