### PR TITLE
Set system time from gps

### DIFF
--- a/gui/include/gui/navutil.h
+++ b/gui/include/gui/navutil.h
@@ -196,5 +196,5 @@ private:
 };
 
 void SwitchInlandEcdisMode(bool Switch);
-
+void SetSystemtime();
 #endif

--- a/gui/src/config_mgr.cpp
+++ b/gui/src/config_mgr.cpp
@@ -591,7 +591,6 @@ bool ConfigMgr::SaveTemplate(wxString fileName) {
 
   conf->Write("Fullscreen", g_bFullscreen);
   conf->Write("ShowCompassWindow", g_bShowCompassWin);
-  conf->Write("SetSystemTime", s_bSetSystemTime);
   conf->Write("ShowGrid", g_bDisplayGrid);
   conf->Write("PlayShipsBells", g_bPlayShipsBells);
   conf->Write("SoundDeviceIndex", g_iSoundDeviceIndex);

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -607,7 +607,6 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
 
   Read("SkewCompUpdatePeriod", &g_SkewCompUpdatePeriod);
 
-  Read("SetSystemTime", &s_bSetSystemTime);
   Read("EnableKioskStartup", &g_kiosk_startup);
   Read("ShowStatusBar", &g_bShowStatusBar);
 #ifndef __WXOSX__
@@ -1886,7 +1885,6 @@ void MyConfig::UpdateSettings() {
 
   Write("Fullscreen", g_bFullscreen);
   Write("ShowCompassWindow", g_bShowCompassWin);
-  Write("SetSystemTime", s_bSetSystemTime);
   Write("ShowGrid", g_bDisplayGrid);
   Write("PlayShipsBells", g_bPlayShipsBells);
   Write("SoundDeviceIndex", g_iSoundDeviceIndex);

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -39,6 +39,8 @@
 #include <list>
 #include <limits>
 #include <string>
+#include <thread>
+#include <chrono>
 
 #ifndef WX_PRECOMP
 #include <wx/wx.h>
@@ -109,6 +111,7 @@
 
 #ifdef ocpnUSE_GL
 #include "gl_chart_canvas.h"
+#include <model/comm_vars.h>
 #endif
 
 #ifdef __ANDROID__
@@ -2884,6 +2887,69 @@ void SwitchInlandEcdisMode(bool Switch) {
       pConfig->Read("bDrawAISRealtime", &g_bDrawAISRealtime);
     }
     if (top_frame::Get()) top_frame::Get()->RequestNewToolbars(true);
+  }
+}
+
+//------------------------------------------------------------------------
+// Set system time from GPS time (nmea0183 RMC)
+//------------------------------------------------------------------------
+// This functon is started in it's own thread at startup
+// It does check for a valid fixtime every 10 seconds.
+// If found and updated once thread will be closed.
+void SetSystemtime() {
+  bool TimeSet = false;
+  while (!TimeSet) {
+    std::this_thread::sleep_for(std::chrono::seconds(10));
+    if ((gRmcTime != wxEmptyString) && (gRmcDate != wxEmptyString)) {
+      wxDateTime GPS_DT, SYS_DT;
+      wxDateSpan TimeDelta;
+      wxString::const_iterator end;
+      GPS_DT.ParseFormat(gRmcDate, "%d%m%y", &end);
+      GPS_DT.ParseFormat(gRmcTime, "%H%M%S", &end);
+      SYS_DT = wxDateTime::Now().ToGMT();
+      if (GPS_DT < SYS_DT) {
+        wxLogMessage("Sorry, we will NOT set systemtime backwards");
+        break;
+      }
+
+#ifdef __WXMSW__
+      //    Code snippet following borrowed from wxDateCtrl, MSW
+
+      const wxDateTime::Tm tm(GPS_DT.GetTm());
+
+      SYSTEMTIME stm;
+      stm.wYear = (WXWORD)tm.year;
+      stm.wMonth = (WXWORD)(tm.mon - wxDateTime::Jan + 1);
+      stm.wDay = tm.mday;
+
+      stm.wDayOfWeek = 0;
+      stm.wHour = GPS_DT.GetHour();
+      stm.wMinute = tm.min;
+      stm.wSecond = tm.sec;
+      stm.wMilliseconds = 0;
+
+      ::SetSystemTime(&stm);  // in GMT
+
+#else
+
+      //      This contortion sets the system date/time on POSIX host
+      //      Requires the following line in /etc/sudoers
+      //          user ALL=NOPASSWD:/bin/date -s *
+
+      wxString msg, sdate;
+      sdate = GPS_DT.Format(_T("sudo /bin/date -s \"%D %T\""));
+      msg.Printf(_T("Linux command is: "));
+      msg += sdate;
+      wxLogMessage(msg);
+      if (wxExecute(sdate, wxEXEC_ASYNC)) {
+        wxLogMessage(
+            "Could not set systemtime. Try to add\n user "
+            "ALL=NOPASSWD:/bin/date -s *\n to /etc/sudoers.");
+      }
+#endif  //__WXMSW__
+
+      TimeSet = true;  // to end while loop
+    }
   }
 }
 

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -96,6 +96,7 @@
 #include <wx/settings.h>
 #include <wx/stdpaths.h>
 #include <wx/tokenzr.h>
+#include <thread>
 
 #include "o_sound/o_sound.h"
 
@@ -271,8 +272,6 @@ static unsigned int malloc_max;
 
 static int osMajor, osMinor;
 
-static bool g_bHasHwClock;
-
 #if wxUSE_XLOCALE || !wxCHECK_VERSION(3, 0, 0)
 // FIXME (leamas) find a new home
 wxLocale *plocale_def_lang = 0;
@@ -317,6 +316,7 @@ static bool LoadAllPlugIns(bool load_enabled) {
 
 #if defined(__WXGTK__) || defined(__WXQT__)
 #include "bitmaps/opencpn.xpm"
+#include <navutil.h>
 #endif
 
 wxString newPrivateFileName(wxString, const char *name,
@@ -1274,15 +1274,16 @@ bool MyApp::OnInit() {
     }
   }
 
-  // As an a.e. Raspberry does not have a hardwareclock we will have some
-  // problems with date/time setting
-  g_bHasHwClock = true;  // by default most computers do have a hwClock
-#if defined(__UNIX__) && !defined(__ANDROID__)
-  struct stat buffer;
-  g_bHasHwClock =
-      ((stat("/dev/rtc", &buffer) == 0) || (stat("/dev/rtc0", &buffer) == 0) ||
-       (stat("/dev/misc/rtc", &buffer) == 0));
-#endif
+  // Changing systemtime by users does have some security issues.
+  // Therefore we only allow it as the environment variable
+  // ocpnUPDATE_SYSTEM_TIME is set!
+  if (getenv("ocpnUPDATE_SYSTEM_TIME") != NULL) {
+    wxLogMessage("Change systemtime from GPS is permitted");
+    // Start a new thread, to pol if a gps fix time is available
+    std::thread systimeset(SetSystemtime);
+    systimeset.detach();
+  } else
+    wxLogMessage("Change systemtime from GPS is prohibited");
 
   g_config_version_string = vs;
 
@@ -1492,9 +1493,9 @@ void MyApp::BuildMainFrame() {
     gFrame->Maximize(true);
 #endif
 
-    //      All set to go.....
+  //      All set to go.....
 
-    // Process command line option to rebuild cache
+  // Process command line option to rebuild cache
 #ifdef ocpnUSE_GL
   extern ocpnGLOptions g_GLOptions;
 
@@ -1601,8 +1602,8 @@ void MyApp::BuildMainFrame() {
 
   if (!bno_load) g_pauimgr->LoadPerspective(perspective, false);
 
-    // Touch up the AUI manager
-    //  Make sure that any pane width is reasonable default value
+  // Touch up the AUI manager
+  //  Make sure that any pane width is reasonable default value
 #if 0  // TODO nees this?
   for (unsigned int i = 0; i < g_canvasArray.GetCount(); i++) {
     ChartCanvas *cc = g_canvasArray.Item(i);

--- a/model/include/model/config_vars.h
+++ b/model/include/model/config_vars.h
@@ -131,7 +131,6 @@ extern bool g_fog_overzoom;
 extern bool g_oz_vector_scale;
 extern bool g_persist_active_route;
 extern bool g_useMUI;
-extern bool s_bSetSystemTime;
 extern bool g_kiosk_startup;
 
 extern double g_COGAvg;  ///< Debug only usage

--- a/model/src/config_vars.cpp
+++ b/model/src/config_vars.cpp
@@ -114,7 +114,6 @@ bool g_fog_overzoom = false;
 bool g_oz_vector_scale = false;
 bool g_persist_active_route = false;
 bool g_useMUI = false;
-bool s_bSetSystemTime = false;
 bool g_kiosk_startup = false;
 
 double g_COGAvg = 0.0;


### PR DESCRIPTION
Some versions ago the option to update the systemtime from gps fixime was removed. I think with the rewrite of the comm system. I made a rewrite for this option.
I'm aware that there are some 'disadvantages' of changing system time, special by an ordinary user. Therefore I removed the option from the config file and instead make a check on an environment variable. As asking the system permission before trying to set time. To prevent strange logfiles it is not allowed to set time 'backwards'.

This comes in convenient especial for raspberry users without internet(npt) connection.