### PR TITLE
Make GDAL library thread-safe when used by OpenCPN

### DIFF
--- a/libs/gdal/include/gdal/ogrsf_frmts.h
+++ b/libs/gdal/include/gdal/ogrsf_frmts.h
@@ -32,6 +32,8 @@
 #ifndef _OGRSF_FRMTS_H_INCLUDED
 #define _OGRSF_FRMTS_H_INCLUDED
 
+#include <atomic>
+
 #include "ogr_feature.h"
 
 /**
@@ -105,7 +107,7 @@ class CPL_DLL OGRLayer
 //    OGRFeatureQuery     *m_poAttrQuery;
     OGRLayerAttrIndex   *m_poAttrIndex;
 
-    int                  m_nRefCount;
+    std::atomic<int>     m_nRefCount;
 };
 
 
@@ -166,7 +168,7 @@ class CPL_DLL OGRDataSource
     OGRErr              ProcessSQLDropIndex( const char * );
 
     OGRStyleTable      *m_poStyleTable;
-    int                 m_nRefCount;
+    std::atomic<int>   m_nRefCount;
 };
 
 /************************************************************************/

--- a/libs/gdal/src/cpl_conv.cpp
+++ b/libs/gdal/src/cpl_conv.cpp
@@ -31,7 +31,7 @@
 #include "cpl_conv.h"
 #include "cpl_string.h"
 
-static char **papszConfigOptions = NULL;
+static thread_local char **papszConfigOptions = NULL;
 
 /************************************************************************/
 /*                             CPLCalloc()                              */
@@ -296,7 +296,7 @@ char *CPLFGets( char *pszBuffer, int nBufferSize, FILE * fp )
         while( (chCheck != 13 && chCheck != EOF)
                || VSIFTell(fp) < nOriginalOffset + nActuallyRead )
         {
-            static int bWarned = FALSE;
+            static thread_local int bWarned = FALSE;
 
             if( !bWarned )
             {
@@ -339,8 +339,8 @@ char *CPLFGets( char *pszBuffer, int nBufferSize, FILE * fp )
 const char *CPLReadLine( FILE * fp )
 
 {
-    static char *pszRLBuffer = NULL;
-    static int  nRLBufferSize = 0;
+    static thread_local char *pszRLBuffer = NULL;
+    static thread_local int nRLBufferSize = 0;
     int         nReadSoFar = 0;
 
 /* -------------------------------------------------------------------- */
@@ -1098,7 +1098,7 @@ const char *CPLDecToDMS( double dfAngle, const char * pszAxis,
     int         nDegrees, nMinutes;
     double      dfSeconds, dfABSAngle, dfEpsilon;
     char        szFormat[30];
-    static char szBuffer[50];
+    static thread_local char szBuffer[50];
     const char  *pszHemisphere;
 
     dfEpsilon = (0.5/3600.0) * pow(0.1,nPrecision);

--- a/libs/gdal/src/cpl_csv.cpp
+++ b/libs/gdal/src/cpl_csv.cpp
@@ -64,7 +64,7 @@ typedef struct ctb {
 } CSVTable;
 */
 
-static CSVTable *psCSVTableList = NULL;
+static thread_local CSVTable *psCSVTableList = NULL;
 
 /************************************************************************/
 /*                             CSVAccess()                              */
@@ -859,10 +859,10 @@ const char *CSVGetField( const char * pszFilename,
 const char * GDALDefaultCSVFilename( const char *pszBasename )
 
 {
-    static char         szPath[512];
+    static thread_local char szPath[512];
     FILE    *fp = NULL;
     const char *pszResult;
-    static int bFinderInitialized = FALSE;
+    static thread_local int bFinderInitialized = FALSE;
 
     pszResult = CPLFindFile( "epsg_csv", pszBasename );
 

--- a/libs/gdal/src/cpl_error.cpp
+++ b/libs/gdal/src/cpl_error.cpp
@@ -126,11 +126,11 @@
  * messages cannot be longer than 2000 chars... which is quite reasonable
  * (that's 25 lines of 80 chars!!!)
  */
-static char gszCPLLastErrMsg[2000] = "";
-static int  gnCPLLastErrNo = 0;
-static CPLErr geCPLLastErrType = CE_None;
+static thread_local char gszCPLLastErrMsg[2000] = "";
+static thread_local int  gnCPLLastErrNo = 0;
+static thread_local CPLErr geCPLLastErrType = CE_None;
 
-static CPLErrorHandler gpfnCPLErrorHandler = CPLDefaultErrorHandler;
+static thread_local CPLErrorHandler gpfnCPLErrorHandler = CPLDefaultErrorHandler;
 
 typedef struct errHandler
 {
@@ -138,7 +138,7 @@ typedef struct errHandler
     CPLErrorHandler     pfnHandler;
 } CPLErrorHandlerNode;
 
-static CPLErrorHandlerNode * psHandlerStack = NULL;
+static thread_local CPLErrorHandlerNode * psHandlerStack = NULL;
 
 /**********************************************************************
  *                          CPLError()
@@ -412,8 +412,8 @@ void CPLDefaultErrorHandler( CPLErr eErrClass, int nError,
                              const char * pszErrorMsg )
 
 {
-    static int       bLogInit = FALSE;
-    static FILE *    fpLog = stderr;
+    static thread_local int       bLogInit = FALSE;
+    static thread_local FILE *    fpLog = stderr;
 
     if( !bLogInit )
     {
@@ -458,8 +458,8 @@ void CPLLoggingErrorHandler( CPLErr eErrClass, int nError,
                              const char * pszErrorMsg )
 
 {
-    static int       bLogInit = FALSE;
-    static FILE *    fpLog = stderr;
+    static thread_local int       bLogInit = FALSE;
+    static thread_local FILE *    fpLog = stderr;
 
     if( !bLogInit )
     {
@@ -649,4 +649,3 @@ void _CPLAssert( const char * pszExpression, const char * pszFile,
               "in file `%s', line %d\n",
               pszExpression, pszFile, iLine );
 }
-

--- a/libs/gdal/src/cpl_findfile.cpp
+++ b/libs/gdal/src/cpl_findfile.cpp
@@ -55,10 +55,10 @@
 #include "cpl_conv.h"
 #include "cpl_string.h"
 
-static int bFinderInitialized = FALSE;
-static int nFileFinders = 0;
-static CPLFileFinder *papfnFinders = NULL;
-static char **papszFinderLocations = NULL;
+static thread_local int bFinderInitialized = FALSE;
+static thread_local int nFileFinders = 0;
+static thread_local CPLFileFinder *papfnFinders = NULL;
+static thread_local char **papszFinderLocations = NULL;
 
 /************************************************************************/
 /*                           CPLFinderInit()                            */

--- a/libs/gdal/src/cpl_string.cpp
+++ b/libs/gdal/src/cpl_string.cpp
@@ -799,8 +799,8 @@ char ** CSLTokenizeString2( const char * pszString,
  */
 #define CPLSPrintf_BUF_SIZE 8000
 #define CPLSPrintf_BUF_Count 10
-static char gszCPLSPrintfBuffer[CPLSPrintf_BUF_Count][CPLSPrintf_BUF_SIZE];
-static int gnCPLSPrintfBuffer = 0;
+static thread_local char gszCPLSPrintfBuffer[CPLSPrintf_BUF_Count][CPLSPrintf_BUF_SIZE];
+static thread_local int gnCPLSPrintfBuffer = 0;
 
 const char *CPLSPrintf(char *fmt, ...)
 {

--- a/libs/gdal/src/gdal_misc.cpp
+++ b/libs/gdal/src/gdal_misc.cpp
@@ -184,7 +184,7 @@ void __pure_virtual()
            const char *GDALVersionInfo( const char *pszRequest )
 
 {
-    static char szResult[128];
+    static thread_local char szResult[128];
 
 
     if( pszRequest == NULL || EQUAL(pszRequest,"VERSION_NUM") )
@@ -202,4 +202,3 @@ void __pure_virtual()
 
     return szResult;
 }
-

--- a/libs/gdal/src/ogrfeature.cpp
+++ b/libs/gdal/src/ogrfeature.cpp
@@ -967,7 +967,7 @@ const char *OGRFeature::GetFieldAsString( int iField )
 
 {
     OGRFieldDefn        *poFDefn = poDefn->GetFieldDefn( iField );
-    static char         szTempBuffer[160];
+    static thread_local char         szTempBuffer[160];
     unsigned int max_line = 80;
 
     CPLAssert( poFDefn != NULL || iField == -1 );

--- a/libs/gdal/src/ogrgeometry.cpp
+++ b/libs/gdal/src/ogrgeometry.cpp
@@ -1096,7 +1096,7 @@ const char *OGRGeometryTypeToName( OGRwkbGeometryType eType )
 
       default:
       {
-          static char szWorkName[33];
+          static thread_local char szWorkName[33];
           sprintf( szWorkName, "Unrecognised: %d", (int) eType );
           return szWorkName;
       }


### PR DESCRIPTION
Refactored static variables across GDAL/OGR source files to use thread_local storage, preventing data races. Applied minor code cleanups and type casts for correctness. Removed varous GCC pragmas that are out-dated and caused needless compiler warnings on some platforms.