### PR TITLE
Improve DC checks and chart sorting stability - #5114

### DIFF
--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -6881,7 +6881,9 @@ void ChartCanvas::UpdateShips() {
   //  Get the rectangle in the current dc which bounds the "ownship" symbol
 
   wxClientDC dc(this);
-  if (!dc.IsOk()) return;
+  // Sometimes during startup the dc x or y size is zero, which causes the
+  // bitmap creation to fail. Just skip the update in this case.
+  if (!dc.IsOk() || dc.GetSize().x < 1 || dc.GetSize().y < 1) return;
 
   wxBitmap test_bitmap(dc.GetSize().x, dc.GetSize().y);
   if (!test_bitmap.IsOk()) return;

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -1367,7 +1367,7 @@ int MyFrame::GetCanvasIndexUnderMouse() {
           return 0;
       }
       cc = ConfigMgr::Get().GetCanvasConfigArray().Item(1);
-      if (cc) {
+      if (cc && cc->canvas) {
         ChartCanvas *canvas = cc->canvas;
         if (canvas->GetScreenRect().Contains(
                 /*canvas->ScreenToClient*/ (screenPoint)))

--- a/gui/src/quilt.cpp
+++ b/gui/src/quilt.cpp
@@ -66,28 +66,16 @@
 
 WX_DEFINE_LIST(PatchList);
 
-static int CompareScales(int i1, int i2) {
+// Compare chart Z stack based on scale
+// Equal scale charts will be stacked indiscriminately
+static int CompareScales(const int i1, const int i2) {
   if (!ChartData) return 0;
 
   const ChartTableEntry &cte1 = ChartData->GetChartTableEntry(i1);
   const ChartTableEntry &cte2 = ChartData->GetChartTableEntry(i2);
 
-  if (cte1.Scale_eq(cte2.GetScale())) {  // same scales, so sort on dbIndex
-    float lat1, lat2;
-    lat1 = cte1.GetLatMax();
-    lat2 = cte2.GetLatMax();
-    if (roundf(lat1 * 100.) == roundf(lat2 * 100.)) {
-      float lon1, lon2;
-      lon1 = cte1.GetLonMin();
-      lon2 = cte2.GetLonMin();
-      if (lon1 == lon2) {
-        return i1 - i2;
-      } else
-        return (lon1 < lon2) ? -1 : 1;
-    } else
-      return (lat1 < lat2) ? 1 : -1;
-  } else
-    return cte1.GetScale() - cte2.GetScale();
+  // Primary: scale (smaller scale value means larger scale chart)
+  return cte1.GetScale() - cte2.GetScale();
 }
 static bool CompareScalesStd(int i1, int i2) {
   return CompareScales(i1, i2) < 0;


### PR DESCRIPTION
- Add size validation to ChartCanvas::UpdateShips() to prevent bitmap creation errors on zero-size DCs.
- Add null pointer check for cc->canvas in GetCanvasIndexUnderMouse().
- Rewrite CompareScales in quilt.cpp for deterministic, multi-criteria chart sorting by scale, latitude, longitude, and db index.

See: https://github.com/OpenCPN/OpenCPN/issues/5114