### PR TITLE
Fix bug that showed the URL twice

### DIFF
--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -5297,7 +5297,7 @@ _OCPN_DLStatus OCPN_downloadFile(const wxString& url,
   wxFileName tfn = wxFileName::CreateTempFileName(outputFile);
   wxFileOutputStream output(tfn.GetFullPath());
 
-  wxCurlDownloadDialog ddlg(url, &output, title, message + url, bitmap, parent,
+  wxCurlDownloadDialog ddlg(url, &output, title, message, bitmap, parent,
                             style);
   wxCurlDialogReturnFlag ret = ddlg.RunModal();
   output.Close();


### PR DESCRIPTION
The download dialog now shows the URL only when flag OCPN_DLDS_URL is set. Before it always appended the URL to the message. With flag OCPN_DLDS_URL it was thus shown twice.