### PR TITLE
SignalK network driver:  major overhaul - #5119

### DIFF
--- a/model/include/model/comm_drv_signalk_net.h
+++ b/model/include/model/comm_drv_signalk_net.h
@@ -26,7 +26,9 @@
 #ifndef SigNaLK_nEt_h_
 #define SigNaLK_nEt_h_
 
+#include <memory>
 #include <string>
+#include <thread>
 
 #include <wx/wxprec.h>
 
@@ -34,44 +36,15 @@
 #include <wx/wx.h>
 #endif
 
-#include <wx/socket.h>
-
-#include "ixwebsocket/IXWebSocket.h"
+#include <wx/event.h>
+#include <wx/string.h>
+#include <wx/timer.h>
 
 #include "model/conn_params.h"
 #include "model/comm_drv_signalk.h"
-#include "model/thread_ctrl.h"
 #include "comm_drv_stats.h"
 
-constexpr int kSignalkSocketId = 5011;
 constexpr int kDogTimeoutSeconds = 5;
-constexpr int kDogTimeoutReconnectSeconds = 10;
-
-constexpr double kMsToKnotFactor = 1.9438444924406;
-
-class CommDrvSignalkNetEvt;  // Forward in .cpp file
-
-class WebSocketThread : public ThreadCtrl {
-public:
-  WebSocketThread(const std::string& iface, const wxIPV4address& address,
-                  wxEvtHandler* consumer, const std::string& token);
-
-  ~WebSocketThread() override = default;
-
-  void* Run();
-
-  DriverStats GetStats() const;
-
-private:
-  wxIPV4address m_address;
-  wxEvtHandler* m_consumer;
-  const std::string m_iface;
-  std::string m_token;
-  ix::WebSocket m_ws;
-  ObsListener m_resume_listener;
-  DriverStats m_driver_stats;
-  mutable std::mutex m_stats_mutex;
-};
 
 class CommDriverSignalKNet : public CommDriverSignalK,
                              public wxEvtHandler,
@@ -80,24 +53,38 @@ public:
   CommDriverSignalKNet(const ConnectionParams* params, DriverListener& l);
   ~CommDriverSignalKNet() override;
 
-  static void initIXNetSystem();
-  static void uninitIXNetSystem();
-
-  static bool DiscoverSKServer(const std::string& serviceIdent, wxString& ip,
-                               int& port, int tSec);
+  /** \internal */
+  class InputEvt;
 
   DriverStats GetDriverStats() const override;
 
+  /** ix::initIXNetSystem wrapper */
+  static void initIXNetSystem();
+
+  /** ix::uninitIXNetSystem wrapper */
+  static void uninitIXNetSystem();
+
+  /**
+   * Scan for a SignalK server on local network using mDNS.
+   *
+   * @param service_ident   mDNS service to scan for
+   * @param ip On successful return found server IP address
+   * @param port On successful return found server IP port.
+   * @param tSec Scan timeout (seconds).
+   * @return true if a server is found, else false.
+   */
+  static bool DiscoverSkServer(const std::string& service_ident, wxString& ip,
+                               int& port, int tSec);
+
 private:
+  class IoThread;
+
   ConnectionParams m_params;
   DriverListener& m_listener;
-  std::string m_context;
-  std::string m_self;
   int m_dog_value;
   wxTimer m_socketread_watchdog_timer;
-  std::string m_token;
   std::thread m_std_thread;
-  WebSocketThread m_ws_thread;
+  std::unique_ptr<IoThread> m_io_thread;
   StatsTimer m_stats_timer;
   DriverStats m_driver_stats;
 
@@ -109,7 +96,8 @@ private:
   wxTimer* GetSocketThreadWatchdogTimer() {
     return &m_socketread_watchdog_timer;
   }
-  void HandleSkSentence(const CommDrvSignalkNetEvt& event);
+
+  void HandleSkSentence(const InputEvt& event);
 
   void ResetWatchdog() { m_dog_value = kDogTimeoutSeconds; }
   void SetWatchdog(int n) { m_dog_value = n; }

--- a/model/src/comm_drv_signalk_net.cpp
+++ b/model/src/comm_drv_signalk_net.cpp
@@ -23,15 +23,14 @@
  */
 
 #include <chrono>
-#include <memory>
 #include <mutex>  // std::mutex
-#include <queue>  // std::queue
-#include <thread>
-#include <vector>
+
+#include <wx/socket.h>
 
 #include "rapidjson/document.h"
 #include "ixwebsocket/IXNetSystem.h"
 #include "ixwebsocket/IXSocketTLSOptions.h"
+#include "ixwebsocket/IXWebSocket.h"
 #include "observable.h"
 
 #include "model/comm_drv_signalk_net.h"
@@ -39,16 +38,41 @@
 #include "model/geodesic.h"
 #include "model/logger.h"
 #include "model/sys_events.h"
+#include "model/thread_ctrl.h"
 #include "wxServDisc.h"
 
 using namespace std::literals::chrono_literals;
 
 constexpr int kTimerSocket = 9006;
+constexpr int kSignalkSocketId = 5011;
+constexpr int kDogTimeoutReconnectSeconds = 10;
 
-class CommDrvSignalkNetEvt;  // fwd
+constexpr double kMsToKnotFactor = 1.9438444924406;
+
+class CommDriverSignalKNet::IoThread : public ThreadCtrl {
+public:
+  IoThread(const std::string& iface, const wxIPV4address& address,
+           wxEvtHandler* consumer, const std::string& token);
+
+  ~IoThread() override = default;
+
+  void Run();
+
+  DriverStats GetStats() const;
+
+private:
+  wxIPV4address m_address;
+  wxEvtHandler* m_consumer;
+  const std::string m_iface;
+  std::string m_token;
+  ix::WebSocket m_ws;
+  ObsListener m_resume_listener;
+  DriverStats m_driver_stats;
+  mutable std::mutex m_stats_mutex;
+};
 
 // i. e. wxDEFINE_EVENT(), avoiding the evil macro.
-static const wxEventTypeTag<CommDrvSignalkNetEvt> SignalkEvtType(
+static const wxEventTypeTag<CommDriverSignalKNet::InputEvt> SignalkEvtType(
     wxNewEventType());
 
 static wxIPV4address ParamsIpAddress(const ConnectionParams& params) {
@@ -58,29 +82,27 @@ static wxIPV4address ParamsIpAddress(const ConnectionParams& params) {
   return addr;
 }
 
-class CommDrvSignalkNetEvt : public wxEvent {
+class CommDriverSignalKNet::InputEvt : public wxEvent {
 public:
-  explicit CommDrvSignalkNetEvt(std::string payload)
+  explicit InputEvt(std::string payload)
       : wxEvent(0, SignalkEvtType), m_payload(std::move(payload)) {};
-
-  ~CommDrvSignalkNetEvt() override = default;
 
   std::string GetPayload() const { return m_payload; }
 
   // required for sending with wxPostEvent()
-  [[nodiscard]] wxEvent* Clone() const override {
-    return new CommDrvSignalkNetEvt(m_payload);
-  };
+  wxEvent* Clone() const override { return new InputEvt(m_payload); };
 
 private:
   const std::string m_payload;
 };
 
-//      WebSocket implementation
-WebSocketThread::WebSocketThread(const std::string& iface,
-                                 const wxIPV4address& address,
-                                 wxEvtHandler* consumer,
-                                 const std::string& token)
+//========================================================================
+//      IoThread implementation
+//
+CommDriverSignalKNet::IoThread::IoThread(const std::string& iface,
+                                         const wxIPV4address& address,
+                                         wxEvtHandler* consumer,
+                                         const std::string& token)
     : m_address(address), m_consumer(consumer), m_iface(iface), m_token(token) {
   m_resume_listener.Init(SystemEvents::GetInstance().evt_resume,
                          [&](ObservedEvt& ev) {
@@ -90,24 +112,27 @@ WebSocketThread::WebSocketThread(const std::string& iface,
                          });
 }
 
-void* WebSocketThread::Run() {
+void CommDriverSignalKNet::IoThread::Run() {
   using namespace std::chrono_literals;
 
+  {
+    std::lock_guard lock(m_stats_mutex);
+    m_driver_stats.driver_bus = NavAddr::Bus::Signalk;
+    m_driver_stats.driver_iface = m_iface;
+    m_driver_stats.available = false;
+  }
+
+  // Craft the address strings
   wxString host = m_address.IPAddress();
   int port = m_address.Service();
-
-  // Craft the address string
   std::stringstream wsAddress;
   wsAddress << "ws://" << host << ":" << port
             << "/signalk/v1/stream?subscribe=all&sendCachedValues=false";
+  if (!m_token.empty()) wsAddress << "&token=" << m_token;
   std::stringstream wssAddress;
   wssAddress << "wss://" << host << ":" << port
              << "/signalk/v1/stream?subscribe=all&sendCachedValues=false";
-
-  if (!m_token.empty()) {
-    wsAddress << "&token=" << m_token;
-    wssAddress << "&token=" << m_token;
-  }
+  if (!m_token.empty()) wssAddress << "&token=" << m_token;
 
   m_ws.setUrl(wssAddress.str());
   ix::SocketTLSOptions opt;
@@ -118,7 +143,7 @@ void* WebSocketThread::Run() {
 
   auto message_callback = [&](const ix::WebSocketMessagePtr& msg) {
     if (msg->type == ix::WebSocketMessageType::Message) {
-      m_consumer->QueueEvent(new CommDrvSignalkNetEvt(msg->str));
+      m_consumer->QueueEvent(new InputEvt(msg->str));
       m_driver_stats.rx_count++;
     } else if (msg->type == ix::WebSocketMessageType::Open) {
       wxLogDebug("websocket: Connection to %s established",
@@ -137,15 +162,7 @@ void* WebSocketThread::Run() {
                                        : m_ws.setUrl(wsAddress.str());
     }
   };
-
   m_ws.setOnMessageCallback(message_callback);
-
-  {
-    std::lock_guard lock(m_stats_mutex);
-    m_driver_stats.driver_bus = NavAddr::Bus::Signalk;
-    m_driver_stats.driver_iface = m_iface;
-    m_driver_stats.available = false;
-  }
 
   m_ws.start();
   while (KeepGoing()) {
@@ -153,22 +170,17 @@ void* WebSocketThread::Run() {
   }
   m_ws.stop();
   SignalExit();
-  {
-    std::lock_guard lock(m_stats_mutex);
-    m_driver_stats.available = false;
-  }
-
-  return nullptr;
-}
-
-DriverStats WebSocketThread::GetStats() const {
   std::lock_guard lock(m_stats_mutex);
-  return m_driver_stats;
+  m_driver_stats.available = false;
 }
 
 //========================================================================
-/*    CommDriverSignalKNet implementation
- * */
+//    CommDriverSignalKNet implementation
+//
+DriverStats CommDriverSignalKNet::IoThread::GetStats() const {
+  std::lock_guard lock(m_stats_mutex);
+  return m_driver_stats;
+}
 
 CommDriverSignalKNet::CommDriverSignalKNet(const ConnectionParams* params,
                                            DriverListener& listener)
@@ -176,13 +188,13 @@ CommDriverSignalKNet::CommDriverSignalKNet(const ConnectionParams* params,
       m_params(*params),
       m_listener(listener),
       m_dog_value(kDogTimeoutSeconds),
-      m_ws_thread(params->GetStrippedDSPort(), ParamsIpAddress(*params), this,
-                  params->AuthToken.ToStdString()),
+      m_io_thread(std::make_unique<IoThread>(params->GetStrippedDSPort(),
+                                             ParamsIpAddress(*params), this,
+                                             params->AuthToken.ToStdString())),
       m_stats_timer(*this, 2s) {
   // Prepare the wxEventHandler to accept events from the actual hardware thread
   Bind(SignalkEvtType, &CommDriverSignalKNet::HandleSkSentence, this);
 
-  m_token = params->AuthToken;
   m_socketread_watchdog_timer.SetOwner(this, kTimerSocket);
 
   // Dummy Driver Stats, may be polled before worker thread is active
@@ -197,7 +209,7 @@ CommDriverSignalKNet::~CommDriverSignalKNet() { Close(); }
 
 DriverStats CommDriverSignalKNet::GetDriverStats() const {
   if (m_std_thread.joinable())
-    return m_ws_thread.GetStats();
+    return m_io_thread->GetStats();
   else
     return m_driver_stats;
 }
@@ -217,10 +229,10 @@ void CommDriverSignalKNet::Open() {
 }
 void CommDriverSignalKNet::Close() { CloseWebSocket(); }
 
-bool CommDriverSignalKNet::DiscoverSKServer(const std::string& serviceIdent,
+bool CommDriverSignalKNet::DiscoverSkServer(const std::string& service_ident,
                                             wxString& ip, int& port, int tSec) {
   auto servscan = std::make_unique<wxServDisc>(
-      nullptr, wxString(serviceIdent.c_str()), QTYPE_PTR);
+      nullptr, wxString(service_ident.c_str()), QTYPE_PTR);
   for (int i = 0; i < 10; i++) {
     if (servscan->getResultCount()) {
       auto result = servscan->getResults().at(0);
@@ -260,7 +272,7 @@ bool CommDriverSignalKNet::DiscoverSKServer(const std::string& serviceIdent,
 void CommDriverSignalKNet::OpenWebSocket() {
   wxLogMessage("Opening Signal K WebSocket client: %s",
                m_params.GetDSPort().c_str());
-  m_std_thread = std::thread([&] { m_ws_thread.Run(); });
+  m_std_thread = std::thread([&] { m_io_thread->Run(); });
   if (!m_std_thread.joinable()) {
     wxLogError("Can't create WebSocketThread!");
     return;
@@ -271,12 +283,12 @@ void CommDriverSignalKNet::OpenWebSocket() {
 
 void CommDriverSignalKNet::CloseWebSocket() {
   if (m_std_thread.joinable()) {
-    if (m_ws_thread.IsRunning()) {
+    if (m_io_thread->IsRunning()) {
       wxLogMessage("Stopping Secondary SignalK Thread");
       m_stats_timer.Stop();
-      m_ws_thread.RequestStop();
+      m_io_thread->RequestStop();
       std::chrono::milliseconds stop_delay;
-      bool stop_ok = m_ws_thread.WaitUntilStopped(10s, stop_delay);
+      bool stop_ok = m_io_thread->WaitUntilStopped(10s, stop_delay);
       if (stop_ok)
         MESSAGE_LOG << "Stopped in" << stop_delay.count() << " msec.";
       else
@@ -289,7 +301,7 @@ void CommDriverSignalKNet::CloseWebSocket() {
   }
 }
 
-void CommDriverSignalKNet::HandleSkSentence(const CommDrvSignalkNetEvt& event) {
+void CommDriverSignalKNet::HandleSkSentence(const InputEvt& event) {
   rapidjson::Document root;
 
   std::string msg = event.GetPayload();
@@ -313,24 +325,26 @@ void CommDriverSignalKNet::HandleSkSentence(const CommDrvSignalkNetEvt& event) {
     vers << (root["version"].GetString());
     wxLogMessage(vers);
   }
+  std::string self;
   if (root.HasMember("self")) {
     if (strncmp(root["self"].GetString(), "vessels.", 8) == 0)
-      m_self = (root["self"].GetString());  // for java server, and OpenPlotter
-                                            // node.js server 1.20
+      self = (root["self"].GetString());  // for java server, and OpenPlotter
+                                          // node.js server 1.20
     else
-      m_self = std::string("vessels.")
-                   .append(root["self"].GetString());  // for Node.js server
+      self = std::string("vessels.")
+                 .append(root["self"].GetString());  // for Node.js server
   }
+  std::string context;
   if (root.HasMember("context") && root["context"].IsString()) {
-    m_context = root["context"].GetString();
+    context = root["context"].GetString();
   }
 
   // Notify all listeners
   auto pos = iface.find(':');
   std::string comm_interface;
   if (pos != std::string::npos) comm_interface = iface.substr(pos + 1);
-  auto navmsg = std::make_shared<const SignalkMsg>(m_self, m_context, msg,
-                                                   comm_interface);
+  auto navmsg =
+      std::make_shared<const SignalkMsg>(self, context, msg, comm_interface);
   m_listener.Notify(std::move(navmsg));
 }
 


### PR DESCRIPTION
Working with  #5119 it turns out that the comm_drv_signalk_net driver needs an overhaul. Basic parts:
- Remove dead code
- Update confusing lack of consistent naming
- Remove raw pointers, using unique_ptr and stack allocation to avoid possible corner case crashes
- Clean up dependencies between driver thread and driver  replacing the circular driver <-> thread dep with a clean driver->thread one. Uses the ThreadCtrl mixin which is much faster when tearing down things.
- Various clean up.

For me, this solves #5119. However, these changes are IMHO too big to be merged into the 5.14 branch. I will add a simple check which blocks creation of multiple drivers with the same interface. This should close the bug in 5.14.