### PR TITLE
Connections: Warning for two on same interface - #5119

### DIFF
--- a/gui/src/connections_dlg.cpp
+++ b/gui/src/connections_dlg.cpp
@@ -88,6 +88,9 @@ the only transmitted messages.
 )---")
                                .c_str();
 
+static const char* kInterfaceExistsMessage =
+    _("Warning: A driver using this interface already exists.").c_str();
+
 static bool IsWindows() {
   return wxPlatformInfo::Get().GetOperatingSystemId() & wxOS_WINDOWS;
 }
@@ -108,6 +111,37 @@ static std::string BitsToDottedMask(const unsigned bits) {
   ss << ((mask & 0x0000ff00) >> 8) << ".";
   ss << (mask & 0x000000ff);
   return ss.str();
+}
+
+static ConnectionParams* FindConnectionByIface(ConnectionParams* new_cp) {
+  for (const auto& cp : TheConnectionParams()) {
+    if (cp->Type != new_cp->Type) continue;
+    switch (cp->Type) {
+      case SERIAL:
+        if (cp->Port != new_cp->Port) continue;
+        return cp;
+        break;
+      case NETWORK:
+        if (cp->NetProtocol != new_cp->NetProtocol) continue;
+        if (cp->NetworkAddress != new_cp->NetworkAddress) continue;
+        if (cp->NetworkPort != new_cp->NetworkPort) continue;
+        return cp;
+        break;
+      case INTERNAL_GPS:
+        return cp;
+        break;
+      case INTERNAL_BT:
+        return cp;
+        break;
+      case SOCKETCAN:
+        if (cp->socketCAN_port != new_cp->socketCAN_port) continue;
+        return cp;
+        break;
+      default:
+        continue;
+    }
+  }
+  return nullptr;
 }
 
 /** Standard icons bitmaps: settings gear, trash bin, etc. */
@@ -1220,6 +1254,12 @@ public:
     //  OK from NEW mode
     else {
       if (ConnectionParams* cp = m_edit_panel->GetParamsFromControls()) {
+        if (FindConnectionByIface(cp)) {
+          wxMessageDialog dialog(this, kInterfaceExistsMessage,
+                                 _("Driver creation warning"),
+                                 wxOK | wxCENTRE | wxICON_WARNING);
+          dialog.ShowModal();
+        }
         if (cp->GetValidPort()) {
           cp->b_IsSetup = false;  // Trigger new stream
           TheConnectionParams().push_back(cp);


### PR DESCRIPTION
Connections: Disallow multiple connections on same iface -  #5119
    
Creating multiple connections on the same interface is basically undefined, what drivers do in such scenarios is hard to define in a meaningful way.
    
 Add a test when creating connections which blocks such connections.
    
Closes: #5119
