### PR TITLE
Signal K network driver: bugfix.

### DIFF
--- a/model/include/model/comm_drv_signalk_net.h
+++ b/model/include/model/comm_drv_signalk_net.h
@@ -95,10 +95,6 @@ private:
   void OpenWebSocket();
   void CloseWebSocket();
 
-  wxTimer* GetSocketThreadWatchdogTimer() {
-    return &m_socketread_watchdog_timer;
-  }
-
   void HandleSkSentence(const InputEvt& event);
 
   void ResetWatchdog() { m_dog_value = kDogTimeoutSeconds; }

--- a/model/include/model/comm_drv_signalk_net.h
+++ b/model/include/model/comm_drv_signalk_net.h
@@ -87,6 +87,8 @@ private:
   std::unique_ptr<IoThread> m_io_thread;
   StatsTimer m_stats_timer;
   DriverStats m_driver_stats;
+  std::string m_context;
+  std::string m_self;
 
   void Open();
   void Close();

--- a/model/src/comm_drv_signalk_net.cpp
+++ b/model/src/comm_drv_signalk_net.cpp
@@ -278,7 +278,7 @@ void CommDriverSignalKNet::OpenWebSocket() {
     return;
   }
   ResetWatchdog();
-  GetSocketThreadWatchdogTimer()->Start(1000, wxTIMER_ONE_SHOT);
+  m_socketread_watchdog_timer.Start(1000, wxTIMER_ONE_SHOT);
 }
 
 void CommDriverSignalKNet::CloseWebSocket() {

--- a/model/src/comm_drv_signalk_net.cpp
+++ b/model/src/comm_drv_signalk_net.cpp
@@ -325,26 +325,24 @@ void CommDriverSignalKNet::HandleSkSentence(const InputEvt& event) {
     vers << (root["version"].GetString());
     wxLogMessage(vers);
   }
-  std::string self;
   if (root.HasMember("self")) {
     if (strncmp(root["self"].GetString(), "vessels.", 8) == 0)
-      self = (root["self"].GetString());  // for java server, and OpenPlotter
-                                          // node.js server 1.20
+      m_self = (root["self"].GetString());  // for java server, and OpenPlotter
+                                            // node.js server 1.20
     else
-      self = std::string("vessels.")
-                 .append(root["self"].GetString());  // for Node.js server
+      m_self = std::string("vessels.")
+                   .append(root["self"].GetString());  // for Node.js server
   }
-  std::string context;
   if (root.HasMember("context") && root["context"].IsString()) {
-    context = root["context"].GetString();
+    m_context = root["context"].GetString();
   }
 
   // Notify all listeners
   auto pos = iface.find(':');
   std::string comm_interface;
   if (pos != std::string::npos) comm_interface = iface.substr(pos + 1);
-  auto navmsg =
-      std::make_shared<const SignalkMsg>(self, context, msg, comm_interface);
+  auto navmsg = std::make_shared<const SignalkMsg>(m_self, m_context, msg,
+                                                   comm_interface);
   m_listener.Notify(std::move(navmsg));
 }
 


### PR DESCRIPTION
comm_drv_signalk_net: store context and self - #5132
    
Restore class state variables tracking SignalK "self" and "context", fixing bug introduced in 40b72631e  - comm_drv_signalk_net: Refactor interface, comments.

While on it, make some more interface clean up.
    
Closes: #5132
