### PR TITLE
Pluginmsg: Activate and use existing plugin-msg driver - #5143

### DIFF
--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -1556,6 +1556,7 @@ void MyApp::BuildMainFrame() {
     }
   }
   MakeLoopbackDriver();
+  MakeInternalDriver();
 
   // Load and initialize plugins
   auto style = g_StyleManager->GetCurrentStyle();

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -6463,9 +6463,9 @@ GetAttributes(DriverHandle handle);
  * Send a non-NMEA2000 message. The call is not blocking.
  * @param handle Obtained from GetActiveDrivers()
  * @param payload Message data, for example a complete Nmea0183 message.<br/>
- *        From 1.19: if the handle "protocol" attribute is "internal" it is
+ *        From 5.16.1: if the handle "protocol" attribute is "internal" it is
  *        parsed as <id><space><message> where the id is used when listening/
- *        subscribing to message.<br/>
+ *        subscribing, message the json payload .<br/>
  *        From 5.12.4: if handle "protocol" attribute is "loopback" it is
  *        parsed as one of
  *          - "signalk" <source> <context_self> <json payload>

--- a/model/include/model/comm_drv_factory.h
+++ b/model/include/model/comm_drv_factory.h
@@ -45,6 +45,9 @@ void MakeCommDriver(const ConnectionParams* params);
 /** Create and register the loopback driver. */
 void MakeLoopbackDriver();
 
+/** Create and register the internal driver. */
+void MakeInternalDriver();
+
 void initIXNetSystem();
 void uninitIXNetSystem();
 

--- a/model/src/comm_drv_factory.cpp
+++ b/model/src/comm_drv_factory.cpp
@@ -43,6 +43,7 @@
 #include "model/comm_drv_signalk_net.h"
 #include "model/comm_drv_n0183_android_int.h"
 #include "model/comm_drv_n0183_android_bt.h"
+#include "model/comm_drv_internal.h"
 #include "model/comm_navmsg_bus.h"
 #include "model/comm_drv_registry.h"
 
@@ -73,6 +74,11 @@ public:
 
 void MakeLoopbackDriver() {
   auto driver = std::make_unique<LoopbackDriver>(NavMsgBus::GetInstance());
+  CommDriverRegistry::GetInstance().Activate(std::move(driver));
+}
+
+void MakeInternalDriver() {
+  auto driver = std::make_unique<CommDriverInternal>(NavMsgBus::GetInstance());
   CommDriverRegistry::GetInstance().Activate(std::move(driver));
 }
 

--- a/model/src/comm_drv_internal.cpp
+++ b/model/src/comm_drv_internal.cpp
@@ -44,6 +44,7 @@ CommDriverInternal::CommDriverInternal(DriverListener& listener)
     : AbstractCommDriver(NavAddr::Bus::Plugin, "internal"),
       m_listener(listener) {
   this->attributes["commPort"] = "internal";
+  this->attributes["protocol"] = "internal";
   this->attributes["ioDirection"] = "OUT";
 }
 

--- a/model/src/comm_drv_internal.cpp
+++ b/model/src/comm_drv_internal.cpp
@@ -32,13 +32,15 @@
 #include <wx/log.h>
 #include <wx/string.h>
 
+#include "observable.h"
+#include "wx/jsonreader.h"
+
 #include "config.h"
 #include "model/comm_drv_internal.h"
 #include "model/comm_drv_registry.h"
 #include "model/comm_navmsg_bus.h"
 #include "model/logger.h"
-
-#include "observable.h"
+#include "model/plugin_comm.h"
 
 CommDriverInternal::CommDriverInternal(DriverListener& listener)
     : AbstractCommDriver(NavAddr::Bus::Plugin, "internal"),
@@ -50,11 +52,19 @@ CommDriverInternal::CommDriverInternal(DriverListener& listener)
 
 bool CommDriverInternal::SendMessage(std::shared_ptr<const NavMsg> msg,
                                      std::shared_ptr<const NavAddr> addr) {
-  auto msg_plugin = std::dynamic_pointer_cast<const PluginMsg>(msg);
-  if (!msg_plugin) {
-    WARNING_LOG << " CommDriverInternal::SendMessage::Illegal message type";
+  auto plugin_msg = std::dynamic_pointer_cast<const PluginMsg>(msg);
+  if (!plugin_msg) {
+    WARNING_LOG << "SendMessage(): Illegal message type";
     return false;
   }
-  NavMsgBus::GetInstance().Notify(msg_plugin);
+  wxJSONValue root;
+  wxJSONReader json_reader;
+  int num_errors = json_reader.Parse(plugin_msg->message, &root);
+  if (num_errors > 0) {
+    WARNING_LOG << "SendMessage(): cannot parse json: "
+                << plugin_msg->message.substr(0, 30);
+    return false;
+  }
+  m_listener.Notify(plugin_msg);
   return true;
 }


### PR DESCRIPTION
The missing driver at the core of #5143 does actually exist and even has a basic test, but is not activated from some reason. Activate the driver so it becomes visible in the  WriteCommDriver API function