### PR TITLE
Improve waypoint selection handling after list rebuild

### DIFF
--- a/gui/src/route_prop_dlg_impl.cpp
+++ b/gui/src/route_prop_dlg_impl.cpp
@@ -331,7 +331,6 @@ void RoutePropDlgImpl::RecalculateSize() {
 
 void RoutePropDlgImpl::UpdatePoints() {
   if (!m_pRoute) return;
-  wxDataViewItem selection = m_dvlcWaypoints->GetSelection();
   int selected_row = m_dvlcWaypoints->GetSelectedRow();
   m_dvlcWaypoints->DeleteAllItems();
 
@@ -466,9 +465,14 @@ void RoutePropDlgImpl::UpdatePoints() {
     data.clear();
     in++;
   }
-  if (selected_row > 0) {
-    m_dvlcWaypoints->SelectRow(selected_row);
-    m_dvlcWaypoints->EnsureVisible(selection);
+  // Restore the previous row selection after rebuilding the waypoint list.
+  // If the list now contains fewer rows than before, clamp the selection to
+  // the last valid row and scroll it into view so the user's context is kept.
+  int count = m_dvlcWaypoints->GetItemCount();
+  if (selected_row >= 0 && count > 0) {
+    m_dvlcWaypoints->SelectRow(selected_row < count ? selected_row : count - 1);
+    wxDataViewItem selection = m_dvlcWaypoints->GetSelection();
+    if (selection.IsOk()) m_dvlcWaypoints->EnsureVisible(selection);
   }
 }
 


### PR DESCRIPTION
Improve waypoint selection handling after list rebuild #5147

Ensure the previously selected row is restored after rebuilding the waypoint list, clamping to the last valid row if necessary. Only call EnsureVisible when the selection is valid to prevent errors and maintain user context when the number of waypoints changes.

Fixes: https://github.com/OpenCPN/OpenCPN/issues/5147