### PR TITLE
Fix:  tides table selection list

### DIFF
--- a/gui/include/gui/chcanv.h
+++ b/gui/include/gui/chcanv.h
@@ -992,6 +992,8 @@ private:
   bool bShowingCurrent;
   bool bShowingTide;
 
+  Select *pSelectTC;
+
   /**
    * Display-specific scale factor in logical pixels per meter for the physical
    * screen.

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -668,6 +668,15 @@ ChartCanvas::ChartCanvas(wxFrame *frame, int canvasIndex, wxWindow *nmea_log)
   }
 #endif
 
+  // Init the Selectable Tide/Current Items List
+  pSelectTC = new Select();
+  //  Increase the select radius for tide/current stations
+  pSelectTC->SetSelectPixelRadius(25);
+  if (g_btouch) {
+    int SelectPixelRadius = 50;
+    pSelectTC->SetSelectPixelRadius(wxMax(25, SelectPixelRadius));
+  }
+
   // Listen for notification events
   auto &noteman = NotificationManager::GetInstance();
 
@@ -734,6 +743,8 @@ ChartCanvas::~ChartCanvas() {
   delete m_pos_image_user_yellow_day;
   delete m_pos_image_user_yellow_dusk;
   delete m_pos_image_user_yellow_night;
+
+  delete pSelectTC;
 
   delete undo;
 #ifdef ocpnUSE_GL

--- a/gui/src/cm93.cpp
+++ b/gui/src/cm93.cpp
@@ -804,18 +804,20 @@ bool cm93_dictionary::LoadDictionary(const wxString &dictionary_dir) {
             if (a == 0x0a) break;
           }
 
-          if (line[0] != ';') {
-            wxStringTokenizer tkz(line, "|");
-            if (tkz.CountTokens()) {
-              //  6 attribute label
-              wxString class_name = tkz.GetNextToken();
+          if (!line.IsEmpty()) {
+            if (line[0] != ';') {
+              wxStringTokenizer tkz(line, "|");
+              if (tkz.CountTokens()) {
+                //  6 attribute label
+                wxString class_name = tkz.GetNextToken();
 
-              //  attribute number, ascii
-              wxString token = tkz.GetNextToken();
-              long liattr;
-              token.ToLong(&liattr);
-              int iattr = liattr;
-              if (iattr > iattr_max) iattr_max = iattr;
+                //  attribute number, ascii
+                wxString token = tkz.GetNextToken();
+                long liattr;
+                token.ToLong(&liattr);
+                int iattr = liattr;
+                if (iattr > iattr_max) iattr_max = iattr;
+              }
             }
           }
         }
@@ -844,40 +846,42 @@ bool cm93_dictionary::LoadDictionary(const wxString &dictionary_dir) {
             if (a == 0x0a) break;
           }
 
-          if (line[0] != ';') {
-            wxStringTokenizer tkz(line, "|\r\n");
-            if (tkz.CountTokens() >= 3) {
-              //  6 char class name
-              wxString attr_name = tkz.GetNextToken();
+          if (!line.IsEmpty()) {
+            if (line[0] != ';') {
+              wxStringTokenizer tkz(line, "|\r\n");
+              if (tkz.CountTokens() >= 3) {
+                //  6 char class name
+                wxString attr_name = tkz.GetNextToken();
 
-              //  class number, ascii
-              wxString token = tkz.GetNextToken();
-              long liattr;
-              token.ToLong(&liattr);
-              int iattr = liattr;
+                //  class number, ascii
+                wxString token = tkz.GetNextToken();
+                long liattr;
+                token.ToLong(&liattr);
+                int iattr = liattr;
 
-              m_AttrArray->Insert(attr_name, iattr);
-              m_AttrArray->RemoveAt(iattr + 1);
+                m_AttrArray->Insert(attr_name, iattr);
+                m_AttrArray->RemoveAt(iattr + 1);
 
-              token = tkz.GetNextToken().Trim();
+                token = tkz.GetNextToken().Trim();
 
-              char atype = '?';
-              if (token.IsSameAs("aFLOAT"))
-                atype = 'R';
-              else if (token.IsSameAs("aBYTE"))
-                atype = 'B';
-              else if (token.IsSameAs("aSTRING"))
-                atype = 'S';
-              else if (token.IsSameAs("aCMPLX"))
-                atype = 'C';
-              else if (token.IsSameAs("aLIST"))
-                atype = 'L';
-              else if (token.IsSameAs("aWORD10"))
-                atype = 'W';
-              else if (token.IsSameAs("aLONG"))
-                atype = 'G';
+                char atype = '?';
+                if (token.IsSameAs("aFLOAT"))
+                  atype = 'R';
+                else if (token.IsSameAs("aBYTE"))
+                  atype = 'B';
+                else if (token.IsSameAs("aSTRING"))
+                  atype = 'S';
+                else if (token.IsSameAs("aCMPLX"))
+                  atype = 'C';
+                else if (token.IsSameAs("aLIST"))
+                  atype = 'L';
+                else if (token.IsSameAs("aWORD10"))
+                  atype = 'W';
+                else if (token.IsSameAs("aLONG"))
+                  atype = 'G';
 
-              m_ValTypeArray[iattr] = atype;
+                m_ValTypeArray[iattr] = atype;
+              }
             }
           }
         }

--- a/gui/src/gl_chart_canvas.cpp
+++ b/gui/src/gl_chart_canvas.cpp
@@ -539,7 +539,7 @@ void glChartCanvas::OnSize(wxSizeEvent &event) {
                      2.0 / (float)vp->pix_width, -2.0 / (float)vp->pix_height,
                      1.0);
   mat4x4_translate_in_place((float(*)[4])vp->vp_matrix_transform,
-                            -vp->pix_width / 2, -vp->pix_height / 2, 0);
+                            -vp->pix_width / 2.0f, -vp->pix_height / 2.0f, 0);
 }
 
 void glChartCanvas::MouseEvent(wxMouseEvent &event) {

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -937,11 +937,6 @@ bool MyApp::OnInit() {
   pSelect = new Select();
   pSelect->SetSelectPixelRadius(12);
 
-  //      Init the Selectable Tide/Current Items List
-  pSelectTC = new Select();
-  //  Increase the select radius for tide/current stations
-  pSelectTC->SetSelectPixelRadius(25);
-
   //      Init the Selectable AIS Target List
   pSelectAIS = new Select();
   pSelectAIS->SetSelectPixelRadius(12);
@@ -1072,7 +1067,6 @@ bool MyApp::OnInit() {
     int SelectPixelRadius = 50;
 
     pSelect->SetSelectPixelRadius(SelectPixelRadius);
-    pSelectTC->SetSelectPixelRadius(wxMax(25, SelectPixelRadius));
     pSelectAIS->SetSelectPixelRadius(SelectPixelRadius);
   }
 
@@ -1803,7 +1797,6 @@ int MyApp::OnExit() {
 
   delete pConfig;
   delete pSelect;
-  delete pSelectTC;
   delete pSelectAIS;
 
   delete ps52plib;

--- a/model/include/model/select.h
+++ b/model/include/model/select.h
@@ -42,8 +42,7 @@
 
 class Select;  // forward
 
-extern Select *pSelect;    ///< Global instance
-extern Select *pSelectTC;  ///< Global instance
+extern Select *pSelect;  ///< Global instance
 
 struct SelectCtx {
   const bool show_nav_objects;

--- a/model/src/select.cpp
+++ b/model/src/select.cpp
@@ -34,7 +34,6 @@
 #include "vector2D.h"
 
 Select *pSelect;
-Select *pSelectTC;
 
 Select::Select() {
   pSelectList = new SelectableItemList;


### PR DESCRIPTION
This problem occurs when double-clicking on a tide station while using dual charts: the station will not open the tide window if the charts are updated frequently. The problem occurs consistently across multiple systems that I've tested it on.

This fix moves the tides table selection list from a global scope to a local scope for each chart. Previously, the tides table was global, which caused issues when trying to display a tide station with two charts showing different areas.

I’m not entirely sure why the tides table was global in the first place, so this change may not be the perfect solution in the end. 

I have attached a video showing the problem, where I can select the tide station on chart 2, but it is impossible to do so on chart 1.

https://github.com/user-attachments/assets/1a76237a-64fd-47b7-a07d-225fc2c0e02e
