### PR TITLE
PlugInAISDrawGL() cannot render AIS targets due to null ChartCanvas

### DIFF
--- a/gui/src/ais.cpp
+++ b/gui/src/ais.cpp
@@ -1932,32 +1932,30 @@ void AISDraw(ocpnDC &dc, ViewPort &vp, ChartCanvas *cp) {
   }
   delete[] Array;
 
-  if (cp != NULL) {
-    //    Draw all targets in three pass loop, sorted on SOG, GPSGate & DSC on
-    //    top This way, fast targets are not obscured by slow/stationary targets
-    for (const auto &it : current_targets) {
-      auto td = it.second;
-      if ((td->SOG < g_SOGminCOG_kts) &&
-          !((td->Class == AIS_GPSG_BUDDY) || (td->Class == AIS_DSC))) {
-        AISDrawTarget(td.get(), dc, vp, cp);
-      }
+  //    Draw all targets in three pass loop, sorted on SOG, GPSGate & DSC on
+  //    top This way, fast targets are not obscured by slow/stationary targets
+  for (const auto &it : current_targets) {
+    auto td = it.second;
+    if ((td->SOG < g_SOGminCOG_kts) &&
+        !((td->Class == AIS_GPSG_BUDDY) || (td->Class == AIS_DSC))) {
+      AISDrawTarget(td.get(), dc, vp, cp);
     }
+  }
 
-    for (const auto &it : current_targets) {
-      auto td = it.second;
-      if ((td->SOG >= g_SOGminCOG_kts) &&
-          !((td->Class == AIS_GPSG_BUDDY) || (td->Class == AIS_DSC))) {
-        AISDrawTarget(td.get(), dc, vp,
-                      cp);  // yes this is a doubling of code;(
-        if (td->importance > 0) AISDrawTarget(td.get(), dc, vp, cp);
-      }
+  for (const auto &it : current_targets) {
+    auto td = it.second;
+    if ((td->SOG >= g_SOGminCOG_kts) &&
+        !((td->Class == AIS_GPSG_BUDDY) || (td->Class == AIS_DSC))) {
+      AISDrawTarget(td.get(), dc, vp,
+                    cp);  // yes this is a doubling of code;(
+      if (td->importance > 0) AISDrawTarget(td.get(), dc, vp, cp);
     }
+  }
 
-    for (const auto &it : current_targets) {
-      auto td = it.second;
-      if ((td->Class == AIS_GPSG_BUDDY) || (td->Class == AIS_DSC))
-        AISDrawTarget(td.get(), dc, vp, cp);
-    }
+  for (const auto &it : current_targets) {
+    auto td = it.second;
+    if ((td->Class == AIS_GPSG_BUDDY) || (td->Class == AIS_DSC))
+      AISDrawTarget(td.get(), dc, vp, cp);
   }
 }
 


### PR DESCRIPTION
The API function PlugInAISDrawGL() becomes unusable for rendering AIS targets because it internally calls AISDraw() with ChartCanvas set to NULL. Since AISDraw() checks for a non-null ChartCanvas, the rendering is skipped, making it impossible for a plugin to draw AIS targets using this pathway.

Steps to reproduce
I have noticed this in the radar plugin that use PlugInAISDrawGL() to draw AIS targets on the radar PPI.
If I enable “Show AIS/ARPA on PPI” in the Radar PI plugin menu, no AIS targets are displayed on the PPI.

Suggested fix
The null check in the drawing loops of AISDraw() may be unnecessary, as the underlying AISDrawTarget() function can safely handle a NULL ChartCanvas.
Removing the null check will allow plugins to successfully render AIS targets on the PPI.

I do not know the full usage of AISDraw() maybe it is not the correct approach but I have tested it for som hours with radar_pi without any issues.
 