### PR TITLE
Drop macOS legacy build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,27 +73,6 @@ jobs:
       - checkout
       - run: ci/circleci-build-android-corelib-armhf.sh
 
-  build-macos:
-    macos:
-      xcode: "14.3.1"
-    environment:
-      - OCPN_TARGET: macos
-      - pkg_mod: 11
-      - MACOSX_DEPLOYMENT_TARGET: 11.0
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - macos-cache-v2-{{checksum "ci/generic-build-macos.sh"}}
-      - run: ci/generic-build-macos.sh
-      - save_cache:
-          key: macos-cache-v2-{{checksum "ci/generic-build-macos.sh"}}
-          paths:
-            - /usr/local/bin
-            - /usr/local/include
-            - /usr/local/lib
-      - run: ci/generic-upload.sh
-
   build-macos-universal:
     macos:
       xcode: "15.4.0"
@@ -111,35 +90,6 @@ jobs:
       - run: ci/macos-sign-cleanup.sh
       - save_cache:
           key: macos-cache-v2-universal-{{checksum "ci/macos-universal-deps.sh"}}-{{checksum "ci/universal-build-macos.sh"}}
-          paths:
-            - /usr/local/bin
-            - /usr/local/include
-            - /usr/local/lib
-      - run: ci/generic-upload.sh
-
-  build-macos-intel-legacy:
-    macos:
-      xcode: "14.3.1"
-    environment:
-      - OCPN_TARGET: macos
-      - pkg_mod: 11
-      - MACOSX_DEPLOYMENT_TARGET: 10.13
-      - OCPN_TARGET_TUPLE: darwin-wx32;10;x86_64
-      - ARCHS: x86_64
-      - ARCH: x86_64
-      - DEPS_BUNDLE_FILE: macos_deps_intel_legacy.tar.xz
-      - DEPS_BUNDLE_DEST: /tmp/ocpn_deps
-      - RELEASE: legacyintel
-    steps:
-      - checkout
-      - restore_cache:
-          keys:
-            - macos-cache-v2-intel-{{checksum "ci/macos-universal-deps.sh"}}-{{checksum "ci/universal-build-macos.sh"}}
-      - run: ci/macos-sign-setup.sh
-      - run: ci/universal-build-macos.sh
-      - run: ci/macos-sign-cleanup.sh
-      - save_cache:
-          key: macos-cache-v2-intel-{{checksum "ci/macos-universal-deps.sh"}}-{{checksum "ci/universal-build-macos.sh"}}
           paths:
             - /usr/local/bin
             - /usr/local/include
@@ -173,7 +123,4 @@ workflows:
           <<: *std-filters
 
       - build-macos-universal:
-          <<: *std-filters
-
-      - build-macos-intel-legacy:
           <<: *std-filters

--- a/manual/modules/ROOT/pages/mac-osx.adoc
+++ b/manual/modules/ROOT/pages/mac-osx.adoc
@@ -72,8 +72,7 @@ For local development the wxWidgets from Homebrew (or built locally) can be used
  $ brew install wxwidgets
 
 But to get results fully compatible with the official OpenCPN
-builds, which retain compatibility with older macOS versions, wxWidgets must be version 3.2.5 built manually.
-For very old Intel machines you may download the prebuilt binaries archive from https://dl.cloudsmith.io/public/nohal/opencpn-dependencies/raw/files/macos_deps_intel_legacy.tar.xz
+builds, which retain compatibility with older macOS versions, wxWidgets must be version 3.2.x (>=3.2.5)  built manually.
 For modern Macs, OpenCPN is built as a universal binary against set of prebuilt dependencies available from https://dl.cloudsmith.io/public/nohal/opencpn-dependencies/raw/files/macos_deps_universal-opencpn.tar.xz
 
 To build wxWidgets manually, you may use the following process:


### PR DESCRIPTION
It is time to part ways with the Intel-only macOS build.
This PR drops the CI job and removes mention of the legacy dependency bundle from the developer docs, when merged we no more care about being compatible with it past 5.14