### PR TITLE
drivers: refactor circular buffer fifo - #5196

### DIFF
--- a/model/include/model/comm_buffers.h
+++ b/model/include/model/comm_buffers.h
@@ -18,22 +18,29 @@
 /**
  * \file
  *
- * Line-oriented input/output buffers.
+ * Various input/output buffers.
  */
 
 #ifndef COMM_BUFFERS_H_
 #define COMM_BUFFERS_H_
 
 #include <deque>
+#include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
 #ifdef _MSC_VER
 typedef unsigned __int8 uint8_t;
 #else
-#include <stdint.h>
+#include <cstdint>
 #endif
+
+class BufferError : public std::logic_error {
+public:
+  BufferError(const std::string& why) : logic_error(why) {};
+};
 
 /** Synchronized buffer for outbound, line oriented data. */
 class OutputBuffer {
@@ -93,6 +100,122 @@ private:
   std::deque<std::string> m_lines;
   std::vector<uint8_t> m_line;
   enum class State { PrefixWait, Data, CsDigit1, CsDigit2 } m_state;
+};
+
+/** Fixed size, synchronized FIFO buffer. Some methods throws BufferError. */
+template <class T>
+class CircularBuffer {
+public:
+  explicit CircularBuffer(size_t size)
+      : m_buf(std::unique_ptr<T[]>(new T[size])),
+        m_max_size(size),
+        m_head(0),
+        m_tail(0),
+        m_full(false) {}
+
+  /** Reset internal state, ditch possible contained data. */
+  void Reset() noexcept {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_head = 0;
+    m_tail = 0;
+    m_full = false;
+  }
+
+  /** Return buffer max size */
+  size_t Capacity() const noexcept { return m_max_size; }
+
+  /** Return actual size */
+  size_t Size() const noexcept {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    size_t size = m_max_size;
+    if (!m_full)
+      size = m_head >= m_tail ? m_head - m_tail : m_head + m_max_size - m_tail;
+    return size;
+  }
+
+  /** Return true if buffer is empty */
+  bool IsEmpty() const noexcept {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return (!m_full && (m_head == m_tail));
+  }
+
+  /** Return true if buffer is full. */
+  bool IsFull() const noexcept {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_full;
+  }
+
+  /**
+   * Add item to buffer without throwing exceptions.
+   * @return true if success i.e., buffer is not full.
+   */
+  bool SafePut(const T& item) noexcept {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_full) return false;
+    DoPut(item);
+    return true;
+  }
+
+  /** Add item to buffer; throw BufferError if full. */
+  void Put(const T& item) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_full) throw BufferError("Put(): full buffer");
+    DoPut(item);
+  }
+
+  /** Get item from buff; throw BufferError if empty. */
+  T Get() {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!m_full && m_head == m_tail) throw BufferError("Get(): empty buffer");
+    return DoGet();
+  }
+
+  /**
+   * Retrieve item from buffer without throwing exceptions.
+   * @return true if success i.e., buffer is not empty.
+   */
+  bool Get(T& item) noexcept {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!m_full && m_head == m_tail) return false;
+    item = DoGet();
+    return true;
+  }
+
+  const T& Peek() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!m_full && m_head == m_tail) throw BufferError("Peek(): empty buffer");
+    return m_buf[m_tail];
+  }
+
+  bool Peek(T& item) const noexcept {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!m_full && m_head == m_tail) return false;
+    item = m_buf[m_tail];
+    return true;
+  }
+
+private:
+  mutable std::mutex m_mutex;
+  std::unique_ptr<T[]> m_buf;
+  const size_t m_max_size;
+  size_t m_head;
+  size_t m_tail;
+  bool m_full;
+
+  void DoPut(const T& item) {
+    m_buf[m_head] = item;
+    if (m_full) m_tail = (m_tail + 1) % m_max_size;
+    m_head = (m_head + 1) % m_max_size;
+    m_full = m_head == m_tail;
+  }
+
+  // Read data and advance the tail (we now have a free space)
+  T DoGet() {
+    auto val = m_buf[m_tail];
+    m_full = false;
+    m_tail = (m_tail + 1) % m_max_size;
+    return val;
+  }
 };
 
 #endif  // COMM_BUFFERS_H_

--- a/model/include/model/comm_drv_n2k_net.h
+++ b/model/include/model/comm_drv_n2k_net.h
@@ -37,6 +37,7 @@
 
 #include <wx/datetime.h>
 
+#include "model/comm_buffers.h"
 #include "model/comm_can_util.h"
 #include "model/comm_drv_n2k.h"
 #include "model/comm_drv_n2k_net.h"
@@ -79,26 +80,6 @@ typedef enum { TX_FORMAT_YDEN = 0, TX_FORMAT_ACTISENSE } GW_TX_FORMAT;
 
 class MrqContainer;           // forward in .cpp file
 class CommDriverN2KNetEvent;  // Internal
-
-class circular_buffer {
-public:
-  circular_buffer(size_t size);
-  void reset();
-  size_t capacity() const;
-  size_t size() const;
-  bool empty() const;
-  bool full() const;
-  void put(unsigned char item);
-  unsigned char get();
-
-private:
-  std::mutex mutex_;
-  std::unique_ptr<unsigned char[]> buf_;
-  size_t head_ = 0;
-  size_t tail_ = 0;
-  const size_t max_size_;
-  bool full_ = 0;
-};
 
 class CommDriverN2KNet : public CommDriverN2K,
                          public wxEvtHandler,
@@ -226,7 +207,7 @@ private:
   int m_ib;
   bool m_bInMsg, m_bGotESC, m_bGotSOT;
 
-  circular_buffer* m_circle;
+  CircularBuffer<unsigned char> m_circle;
   unsigned char* rx_buffer;
   std::string m_sentence;
 

--- a/model/src/comm_drv_n0183_android_bt.cpp
+++ b/model/src/comm_drv_n0183_android_bt.cpp
@@ -120,58 +120,6 @@ wxEvent* CommDriverN0183AndroidBTEvent::Clone() const {
   return newevent;
 };
 
-template <class T>
-class circular_buffer {
-public:
-  explicit circular_buffer(size_t size)
-      : buf_(std::unique_ptr<T[]>(new T[size])), max_size_(size) {}
-
-  void reset();
-  size_t capacity() const;
-  size_t size() const;
-
-  bool empty() const {
-    // if head and tail are equal, we are empty
-    return (!full_ && (head_ == tail_));
-  }
-
-  bool full() const {
-    // If tail is ahead the head by 1, we are full
-    return full_;
-  }
-
-  void put(T item) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    buf_[head_] = item;
-    if (full_) tail_ = (tail_ + 1) % max_size_;
-
-    head_ = (head_ + 1) % max_size_;
-
-    full_ = head_ == tail_;
-  }
-
-  T get() {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    if (empty()) return T();
-
-    // Read data and advance the tail (we now have a free space)
-    auto val = buf_[tail_];
-    full_ = false;
-    tail_ = (tail_ + 1) % max_size_;
-
-    return val;
-  }
-
-private:
-  std::mutex mutex_;
-  std::unique_ptr<T[]> buf_;
-  size_t head_ = 0;
-  size_t tail_ = 0;
-  const size_t max_size_;
-  bool full_ = 0;
-};
-
 CommDriverN0183AndroidBT::CommDriverN0183AndroidBT(
     const ConnectionParams* params, DriverListener& listener)
     : CommDriverN0183(NavAddr::Bus::N0183, params->GetStrippedDSPort()),

--- a/model/src/comm_drv_n0183_android_int.cpp
+++ b/model/src/comm_drv_n0183_android_int.cpp
@@ -121,58 +121,6 @@ wxEvent* CommDriverN0183AndroidIntEvent::Clone() const {
   return newevent;
 };
 
-template <class T>
-class circular_buffer {
-public:
-  explicit circular_buffer(size_t size)
-      : buf_(std::unique_ptr<T[]>(new T[size])), max_size_(size) {}
-
-  void reset();
-  size_t capacity() const;
-  size_t size() const;
-
-  bool empty() const {
-    // if head and tail are equal, we are empty
-    return (!full_ && (head_ == tail_));
-  }
-
-  bool full() const {
-    // If tail is ahead the head by 1, we are full
-    return full_;
-  }
-
-  void put(T item) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    buf_[head_] = item;
-    if (full_) tail_ = (tail_ + 1) % max_size_;
-
-    head_ = (head_ + 1) % max_size_;
-
-    full_ = head_ == tail_;
-  }
-
-  T get() {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    if (empty()) return T();
-
-    // Read data and advance the tail (we now have a free space)
-    auto val = buf_[tail_];
-    full_ = false;
-    tail_ = (tail_ + 1) % max_size_;
-
-    return val;
-  }
-
-private:
-  std::mutex mutex_;
-  std::unique_ptr<T[]> buf_;
-  size_t head_ = 0;
-  size_t tail_ = 0;
-  const size_t max_size_;
-  bool full_ = 0;
-};
-
 CommDriverN0183AndroidInt::CommDriverN0183AndroidInt(
     const ConnectionParams* params, DriverListener& listener)
     : CommDriverN0183(NavAddr::Bus::N0183, params->GetStrippedDSPort()),

--- a/model/src/comm_drv_n2k_net.cpp
+++ b/model/src/comm_drv_n2k_net.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   Copyright (C) 2023 by David Register                                  *
- *   Copyright (C) 2023 Alec Leamas                                        *
+ *   Copyright (C) 2026 Alec Leamas                                        *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -83,54 +83,6 @@ public:
   }
 };
 
-// circular_buffer implementation
-
-circular_buffer::circular_buffer(size_t size)
-    : buf_(std::unique_ptr<unsigned char[]>(new unsigned char[size])),
-      max_size_(size) {}
-
-// void circular_buffer::reset()
-//{}
-
-// size_t circular_buffer::capacity() const
-//{}
-
-// size_t circular_buffer::size() const
-//{}
-
-bool circular_buffer::empty() const {
-  // if head and tail are equal, we are empty
-  return (!full_ && (head_ == tail_));
-}
-
-bool circular_buffer::full() const {
-  // If tail is ahead the head by 1, we are full
-  return full_;
-}
-
-void circular_buffer::put(unsigned char item) {
-  std::lock_guard<std::mutex> lock(mutex_);
-  buf_[head_] = item;
-  if (full_) tail_ = (tail_ + 1) % max_size_;
-
-  head_ = (head_ + 1) % max_size_;
-
-  full_ = head_ == tail_;
-}
-
-unsigned char circular_buffer::get() {
-  std::lock_guard<std::mutex> lock(mutex_);
-
-  if (empty()) return 0;
-
-  // Read data and advance the tail (we now have a free space)
-  auto val = buf_[tail_];
-  full_ = false;
-  tail_ = (tail_ + 1) % max_size_;
-
-  return val;
-}
-
 /// CAN v2.0 29 bit header as used by NMEA 2000
 CanHeader::CanHeader()
     : priority('\0'), source('\0'), destination('\0'), pgn(-1) {};
@@ -201,6 +153,7 @@ CommDriverN2KNet::CommDriverN2KNet(const ConnectionParams* params,
       m_io_select(params->IOSelect),
       m_connection_type(params->Type),
       m_bok(false),
+      m_circle(RX_BUFFER_SIZE_NET),
       m_TX_available(false) {
   m_addr.Hostname(params->NetworkAddress);
   m_addr.Service(params->NetworkPort);
@@ -230,7 +183,6 @@ CommDriverN2KNet::CommDriverN2KNet(const ConnectionParams* params,
   m_bGotESC = false;
   m_bGotSOT = false;
   rx_buffer = new unsigned char[RX_BUFFER_SIZE_NET + 1];
-  m_circle = new circular_buffer(RX_BUFFER_SIZE_NET);
 
   fast_messages = new FastMessageMap();
   m_order = 0;  // initialize the fast message sequence ID bits, for TX
@@ -246,7 +198,6 @@ CommDriverN2KNet::CommDriverN2KNet(const ConnectionParams* params,
 CommDriverN2KNet::~CommDriverN2KNet() {
   delete m_mrq_container;
   delete[] rx_buffer;
-  delete m_circle;
 
   Close();
 }
@@ -663,8 +614,8 @@ bool CommDriverN2KNet::ProcessActisense_N2K(std::vector<unsigned char> packet) {
   bool bGotESC = false;
   bool bGotSOT = false;
 
-  while (!m_circle->empty()) {
-    uint8_t next_byte = m_circle->get();
+  while (!m_circle.IsEmpty()) {
+    uint8_t next_byte = m_circle.Get();
 
     if (bInMsg) {
       if (bGotESC) {
@@ -777,8 +728,8 @@ bool CommDriverN2KNet::ProcessActisense_RAW(std::vector<unsigned char> packet) {
   bool bGotESC = false;
   bool bGotSOT = false;
 
-  while (!m_circle->empty()) {
-    uint8_t next_byte = m_circle->get();
+  while (!m_circle.IsEmpty()) {
+    uint8_t next_byte = m_circle.Get();
 
     if (bInMsg) {
       if (bGotESC) {
@@ -852,8 +803,8 @@ bool CommDriverN2KNet::ProcessActisense_NGT(std::vector<unsigned char> packet) {
   bool bGotESC = false;
   bool bGotSOT = false;
 
-  while (!m_circle->empty()) {
-    uint8_t next_byte = m_circle->get();
+  while (!m_circle.IsEmpty()) {
+    uint8_t next_byte = m_circle.Get();
 
     if (bInMsg) {
       if (bGotESC) {
@@ -913,8 +864,8 @@ bool CommDriverN2KNet::ProcessActisense_ASCII_RAW(
     std::vector<unsigned char> packet) {
   can_frame frame;
 
-  while (!m_circle->empty()) {
-    char b = m_circle->get();
+  while (!m_circle.IsEmpty()) {
+    char b = m_circle.Get();
     if ((b != 0x0a) && (b != 0x0d)) {
       m_sentence += b;
     }
@@ -963,8 +914,8 @@ bool CommDriverN2KNet::ProcessActisense_ASCII_N2K(
   // A001001.732 04FF6 1FA03 C8FBA80329026400
   std::string sentence;
 
-  while (!m_circle->empty()) {
-    char b = m_circle->get();
+  while (!m_circle.IsEmpty()) {
+    char b = m_circle.Get();
     if ((b != 0x0a) && (b != 0x0d)) {
       sentence += b;
     }
@@ -1034,8 +985,8 @@ bool CommDriverN2KNet::ProcessActisense_ASCII_N2K(
 }
 
 bool CommDriverN2KNet::ProcessSeaSmart(std::vector<unsigned char> packet) {
-  while (!m_circle->empty()) {
-    char b = m_circle->get();
+  while (!m_circle.IsEmpty()) {
+    char b = m_circle.Get();
     if ((b != 0x0a) && (b != 0x0d)) {
       m_sentence += b;
     }
@@ -1199,8 +1150,8 @@ bool CommDriverN2KNet::ProcessMiniPlex(std::vector<unsigned char> packet) {
   $MXPGN,01F200,2816,FFFF7FFFFF43F800*10\r\n
   $MXPGN,01F205,2816,FF050D3A1D4CFC00*19\r\n"
   */
-  while (!m_circle->empty()) {
-    char b = m_circle->get();
+  while (!m_circle.IsEmpty()) {
+    char b = m_circle.Get();
     if ((b != 0x0a) && (b != 0x0d)) {
       m_sentence += b;
     }
@@ -1300,7 +1251,7 @@ void CommDriverN2KNet::OnSocketEvent(wxSocketEvent& event) {
       bool done = false;
       if (newdata > 0) {
         for (int i = 0; i < newdata; i++) {
-          m_circle->put(data[i]);
+          if (!m_circle.IsFull()) m_circle.Put(data[i]);
           // printf("%c", data.at(i));
         }
       }

--- a/model/src/comm_drv_n2k_serial.cpp
+++ b/model/src/comm_drv_n2k_serial.cpp
@@ -34,6 +34,7 @@
 
 #include <wx/log.h>
 
+#include "model/comm_buffers.h"
 #include "model/comm_drv_n2k_serial.h"
 #include "model/comm_navmsg_bus.h"
 #include "model/comm_drv_registry.h"
@@ -56,91 +57,6 @@ static unsigned char NGT_STARTUP_SEQ[] = {
 };
 
 static std::vector<unsigned char> BufferToActisenseFormat(tN2kMsg& msg);
-
-template <typename T>
-class n2k_atomic_queue {
-public:
-  size_t size() {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    return m_queque.size();
-  }
-
-  bool empty() {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    return m_queque.empty();
-  }
-
-  const T& front() {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    return m_queque.front();
-  }
-
-  void push(const T& value) {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    m_queque.push(value);
-  }
-
-  void pop() {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    m_queque.pop();
-  }
-
-private:
-  std::queue<T> m_queque;
-  mutable std::mutex m_mutex;
-};
-
-template <class T>
-class circular_buffer {
-public:
-  explicit circular_buffer(size_t size)
-      : buf_(std::unique_ptr<T[]>(new T[size])), max_size_(size) {}
-
-  void reset();
-  size_t capacity() const;
-  size_t size() const;
-
-  bool empty() const {
-    // if head and tail are equal, we are empty
-    return (!full_ && (head_ == tail_));
-  }
-
-  bool full() const {
-    // If tail is ahead the head by 1, we are full
-    return full_;
-  }
-
-  void put(T item) {
-    std::lock_guard<std::mutex> lock(mutex_);
-    buf_[head_] = item;
-    if (full_) tail_ = (tail_ + 1) % max_size_;
-
-    head_ = (head_ + 1) % max_size_;
-
-    full_ = head_ == tail_;
-  }
-
-  T get() {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    if (empty()) return T();
-
-    // Read data and advance the tail (we now have a free space)
-    auto val = buf_[tail_];
-    full_ = false;
-    tail_ = (tail_ + 1) % max_size_;
-
-    return val;
-  }
-
-private:
-  std::mutex mutex_;
-  std::unique_ptr<T[]> buf_;
-  size_t head_ = 0;
-  size_t tail_ = 0;
-  const size_t max_size_;
-  bool full_ = 0;
-};
 
 class CommDriverN2KSerialEvent;  // fwd
 
@@ -179,7 +95,7 @@ private:
   int m_baud;
   int m_n_timeout;
 
-  n2k_atomic_queue<std::vector<unsigned char>> out_que;
+  CircularBuffer<std::vector<unsigned char>> m_out_que;
   DriverStats m_driver_stats;
   mutable std::mutex m_stats_mutex;
 #ifdef __WXMSW__
@@ -606,7 +522,8 @@ void CommDriverN2KSerial::AddTxPGN(int pgn) {
 
 CommDriverN2KSerialThread::CommDriverN2KSerialThread(
     CommDriverN2KSerial* Launcher, const wxString& PortName,
-    const wxString& strBaudRate) {
+    const wxString& strBaudRate)
+    : m_out_que(OUT_QUEUE_LENGTH) {
   m_pParentDriver = Launcher;  // This thread's immediate "parent"
 
   m_PortName = PortName;
@@ -704,8 +621,8 @@ size_t CommDriverN2KSerialThread::WriteComPortPhysical(unsigned char* msg,
 
 bool CommDriverN2KSerialThread::SetOutMsg(
     const std::vector<unsigned char>& msg) {
-  if (out_que.size() < OUT_QUEUE_LENGTH) {
-    out_que.push(msg);
+  if (!m_out_que.IsFull()) {
+    m_out_que.Put(msg);
     return true;
   }
   return false;
@@ -717,7 +634,7 @@ void* CommDriverN2KSerialThread::Entry() {
   bool nl_found = false;
   wxString msg;
   uint8_t rdata[2000];
-  circular_buffer<uint8_t> circle(DS_RX_BUFFER_SIZE);
+  CircularBuffer<uint8_t> circle(DS_RX_BUFFER_SIZE);
   int ib = 0;
 
   //    Request the com port from the comm manager
@@ -793,13 +710,13 @@ void* CommDriverN2KSerialThread::Entry() {
       m_driver_stats.rx_count += newdata;
 
       for (int i = 0; i < newdata; i++) {
-        circle.put(rdata[i]);
+        circle.Put(rdata[i]);
       }
     }
 
-    while (!circle.empty()) {
+    while (!circle.IsEmpty()) {
       if (ib >= DS_RX_BUFFER_SIZE) ib = 0;
-      uint8_t next_byte = circle.get();
+      uint8_t next_byte = circle.Get();
 
       if (bInMsg) {
         if (bGotESC) {
@@ -863,12 +780,11 @@ void* CommDriverN2KSerialThread::Entry() {
 
     //      Check for any pending output message
 #if 1
-    bool b_qdata = !out_que.empty();
+    bool b_qdata = !m_out_que.IsEmpty();
 
     while (b_qdata) {
       //  Take a copy of message
-      std::vector<unsigned char> qmsg = out_que.front();
-      out_que.pop();
+      std::vector<unsigned char> qmsg = m_out_que.Get();
 
       if (static_cast<size_t>(-1) == WriteComPortPhysical(qmsg) &&
           10 < retries++) {
@@ -878,7 +794,7 @@ void* CommDriverN2KSerialThread::Entry() {
         CloseComPortPhysical();
       }
 
-      b_qdata = !out_que.empty();
+      b_qdata = !m_out_que.IsEmpty();
     }  // while b_qdata
 
 #endif
@@ -900,7 +816,7 @@ void* CommDriverN2KSerialThread::Entry() {
   bool not_done = true;
   bool nl_found = false;
   wxString msg;
-  circular_buffer<uint8_t> circle(DS_RX_BUFFER_SIZE);
+  CircularBuffer<uint8_t> circle(DS_RX_BUFFER_SIZE);
 
   //    Request the com port from the comm manager
   if (!OpenComPortPhysical(m_PortName, m_baud)) {
@@ -967,12 +883,12 @@ void* CommDriverN2KSerialThread::Entry() {
 
     if (newdata > 0) {
       for (int i = 0; i < newdata; i++) {
-        circle.put(rdata[i]);
+        circle.Put(rdata[i]);
       }
     }
 
-    while (!circle.empty()) {
-      uint8_t next_byte = circle.get();
+    while (!circle.IsEmpty()) {
+      uint8_t next_byte = circle.Get();
 
       if (1) {
         if (bInMsg) {
@@ -1052,12 +968,11 @@ void* CommDriverN2KSerialThread::Entry() {
     }  // while
 
     //      Check for any pending output message
-    bool b_qdata = !out_que.empty();
+    bool b_qdata = !m_out_que.IsEmpty();
 
-    while (b_qdata) {
+    while (!m_out_que.IsEmpty()) {
       //  Take a copy of message
-      std::vector<unsigned char> qmsg = out_que.front();
-      out_que.pop();
+      std::vector<unsigned char> qmsg = m_out_que.Get();
 
       if (static_cast<size_t>(-1) == WriteComPortPhysical(qmsg) &&
           10 < retries++) {
@@ -1068,9 +983,7 @@ void* CommDriverN2KSerialThread::Entry() {
       }
       std::lock_guard lock(m_stats_mutex);
       m_driver_stats.tx_count += qmsg.size();
-
-      b_qdata = !out_que.empty();
-    }  // while b_qdata
+    }
   }  // while ((not_done)
 
   // thread_exit:

--- a/test/buffer_tests.cpp
+++ b/test/buffer_tests.cpp
@@ -5,20 +5,11 @@
 #include <string>
 #include <thread>
 
-#if (defined(OCPN_GHC_FILESYSTEM) || \
-     (defined(__clang_major__) && (__clang_major__ < 15)))
-#include <ghc/filesystem.hpp>
-namespace fs = ghc::filesystem;
-#else
-#include <filesystem>
-#include <utility>
-namespace fs = std::filesystem;
-#endif
-
 #include <wx/app.h>
 
 #include <gtest/gtest.h>
 
+#include "std_filesystem.h"
 #include "model/base_platform.h"
 #include "model/comm_buffers.h"
 #include "model/comm_drv_registry.h"
@@ -165,4 +156,37 @@ TEST(N0183Nuffer, Basic) {
   for (char c : input1) n0183_buffer.Put(c);
   EXPECT_TRUE(n0183_buffer.HasSentence());
   EXPECT_EQ(n0183_buffer.GetSentence(), ocpn::rtrim(input2));
+}
+
+TEST(CircularBuffer, Basic) {
+  CircularBuffer<char> buff(10);
+  for (int i = 0; i < 10; i++) buff.Put(static_cast<char>('a' + i));
+  EXPECT_TRUE(buff.IsFull());
+  EXPECT_FALSE(buff.IsEmpty());
+  EXPECT_EQ(buff.Size(), 10);
+  EXPECT_THROW(buff.Put('z'), BufferError);
+
+  for (int i = 0; i < 5; i++) buff.Get();
+  EXPECT_EQ(buff.Size(), 5);
+  EXPECT_FALSE(buff.IsFull());
+  EXPECT_FALSE(buff.IsEmpty());
+  for (int i = 5; i < 9; i++) EXPECT_EQ(buff.Get(), static_cast<char>('a' + i));
+  char c = buff.Peek();
+  EXPECT_EQ(c, 'a' + 9);
+  EXPECT_TRUE(buff.Peek(c));
+  EXPECT_EQ(c, 'a' + 9);
+  EXPECT_TRUE(buff.Get(c));
+  EXPECT_EQ(c, 'a' + 9);
+  EXPECT_EQ(buff.Size(), 0);
+  EXPECT_THROW(buff.Get(), BufferError);
+  EXPECT_THROW(buff.Peek(), BufferError);
+  EXPECT_FALSE(buff.Peek(c));
+  EXPECT_FALSE(buff.Get(c));
+
+  for (int i = 0; i < 10; i++)
+    EXPECT_TRUE(buff.SafePut(static_cast<char>('a' + i)));
+  EXPECT_TRUE(buff.IsFull());
+  EXPECT_FALSE(buff.IsEmpty());
+  EXPECT_EQ(buff.Size(), 10);
+  EXPECT_THROW(buff.Put('z'), BufferError);
 }


### PR DESCRIPTION
Refactor current circular buffer handling in  drivers:

  - Make usage DRY
  - Fix some concurrency possible errors due to missing locks
  - Make exception conditions Put() in full buffer and Get() from empty buffer properly defined.
  - Make creation logic well defined.