### PR TITLE
Accept XDR "Pitch" and "Roll" IDs in dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .idea
 .vs
 .vscode
+.qtcreator/CMakeLists.txt.user
 build
 buildwin/NSIS_Unicode/Include/Langstrings_*.nsh
 buildwin/crashrpt/CrashRpt1402.dll

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -1840,8 +1840,9 @@ void dashboard_pi::SetNMEASentence(wxString &sentence) {
           if (m_NMEA0183.Xdr.TransducerInfo[i].TransducerType == _T("A")) {
             if (m_NMEA0183.Xdr.TransducerInfo[i].TransducerName.Contains(
                     _T("PTCH")) ||
-                m_NMEA0183.Xdr.TransducerInfo[i].TransducerName.Contains(
-                    _T("PITCH"))) {
+                m_NMEA0183.Xdr.TransducerInfo[i]
+                    .TransducerName.MakeUpper()
+                    .Contains(_T("PITCH"))) {
               if (mPriPitchRoll >= 3) {
                 if (m_NMEA0183.Xdr.TransducerInfo[i].MeasurementData > 0) {
                   xdrunit = _T("\u00B0\u2191") + _("Up");
@@ -1860,8 +1861,9 @@ void dashboard_pi::SetNMEASentence(wxString &sentence) {
               }
             }
             // XDR Heel
-            if (m_NMEA0183.Xdr.TransducerInfo[i].TransducerName.Contains(
-                    "ROLL")) {
+            if (m_NMEA0183.Xdr.TransducerInfo[i]
+                    .TransducerName.MakeUpper()
+                    .Contains("ROLL")) {
               if (mPriPitchRoll >= 3) {
                 if (m_NMEA0183.Xdr.TransducerInfo[i].MeasurementData > 0) {
                   xdrunit = _T("\u00B0\u003E") + _("Stbd");

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -1786,7 +1786,7 @@ void dashboard_pi::SetNMEASentence(wxString &sentence) {
           // XDR Airtemp
           if (m_NMEA0183.Xdr.TransducerInfo[i].TransducerType == _T("C")) {
             if (m_NMEA0183.Xdr.TransducerInfo[i]
-                    .TransducerName.MakeUpper()
+                    .TransducerName.Upper()
                     .Contains(_T("AIR")) ||
                 m_NMEA0183.Xdr.TransducerInfo[i].TransducerName == _T("Te") ||
                 m_NMEA0183.Xdr.TransducerInfo[i].TransducerName ==
@@ -1804,7 +1804,7 @@ void dashboard_pi::SetNMEASentence(wxString &sentence) {
               }
             }  // Water temp
             if (m_NMEA0183.Xdr.TransducerInfo[i]
-                    .TransducerName.MakeUpper()
+                    .TransducerName.Upper()
                     .Contains("WATER") ||
                 m_NMEA0183.Xdr.TransducerInfo[i].TransducerName == "WTHI") {
               if (mPriWTP >= 3) {
@@ -1823,7 +1823,7 @@ void dashboard_pi::SetNMEASentence(wxString &sentence) {
           // XDR Pressure
           if (m_NMEA0183.Xdr.TransducerInfo[i].TransducerType == "P") {
             if (m_NMEA0183.Xdr.TransducerInfo[i]
-                    .TransducerName.MakeUpper()
+                    .TransducerName.Upper()
                     .Contains(_T("BARO")) &&
                 mPriMDA >= 4) {
               if (m_NMEA0183.Xdr.TransducerInfo[i].UnitOfMeasurement == "B") {
@@ -1841,7 +1841,7 @@ void dashboard_pi::SetNMEASentence(wxString &sentence) {
             if (m_NMEA0183.Xdr.TransducerInfo[i].TransducerName.Contains(
                     _T("PTCH")) ||
                 m_NMEA0183.Xdr.TransducerInfo[i]
-                    .TransducerName.MakeUpper()
+                    .TransducerName.Upper()
                     .Contains(_T("PITCH"))) {
               if (mPriPitchRoll >= 3) {
                 if (m_NMEA0183.Xdr.TransducerInfo[i].MeasurementData > 0) {
@@ -1862,7 +1862,7 @@ void dashboard_pi::SetNMEASentence(wxString &sentence) {
             }
             // XDR Heel
             if (m_NMEA0183.Xdr.TransducerInfo[i]
-                    .TransducerName.MakeUpper()
+                    .TransducerName.Upper()
                     .Contains("ROLL")) {
               if (mPriPitchRoll >= 3) {
                 if (m_NMEA0183.Xdr.TransducerInfo[i].MeasurementData > 0) {
@@ -1883,7 +1883,7 @@ void dashboard_pi::SetNMEASentence(wxString &sentence) {
             }
             // XDR Rudder Angle
             if (m_NMEA0183.Xdr.TransducerInfo[i]
-                    .TransducerName.MakeUpper()
+                    .TransducerName.Upper()
                     .Contains("RUDDER")) {
               if (mPriRSA > 4) {
                 SendSentenceToAllInstruments(OCPN_DBP_STC_RSA, xdrdata,

--- a/plugins/dashboard_pi/src/dashboard_pi.cpp
+++ b/plugins/dashboard_pi/src/dashboard_pi.cpp
@@ -1787,12 +1787,12 @@ void dashboard_pi::SetNMEASentence(wxString &sentence) {
           if (m_NMEA0183.Xdr.TransducerInfo[i].TransducerType == _T("C")) {
             if (m_NMEA0183.Xdr.TransducerInfo[i]
                     .TransducerName.Upper()
-                    .Contains(_T("AIR")) ||
+                    .Contains("AIR") ||
                 m_NMEA0183.Xdr.TransducerInfo[i].TransducerName == _T("Te") ||
                 m_NMEA0183.Xdr.TransducerInfo[i].TransducerName ==
-                    _T("ENV_OUTAIR_T") ||
+                    "ENV_OUTAIR_T" ||
                 m_NMEA0183.Xdr.TransducerInfo[i].TransducerName ==
-                    _T("ENV_OUTSIDE_T")) {
+                    "ENV_OUTSIDE_T") {
               if (mPriATMP >= 4) {
                 mPriATMP = 4;
                 SendSentenceToAllInstruments(
@@ -1824,7 +1824,7 @@ void dashboard_pi::SetNMEASentence(wxString &sentence) {
           if (m_NMEA0183.Xdr.TransducerInfo[i].TransducerType == "P") {
             if (m_NMEA0183.Xdr.TransducerInfo[i]
                     .TransducerName.Upper()
-                    .Contains(_T("BARO")) &&
+                    .Contains("BARO") &&
                 mPriMDA >= 4) {
               if (m_NMEA0183.Xdr.TransducerInfo[i].UnitOfMeasurement == "B") {
                 xdrdata *= 1000;
@@ -1839,10 +1839,10 @@ void dashboard_pi::SetNMEASentence(wxString &sentence) {
           // XDR Pitch (=Nose up/down) or Heel (stb/port)
           if (m_NMEA0183.Xdr.TransducerInfo[i].TransducerType == _T("A")) {
             if (m_NMEA0183.Xdr.TransducerInfo[i].TransducerName.Contains(
-                    _T("PTCH")) ||
+                    "PTCH") ||
                 m_NMEA0183.Xdr.TransducerInfo[i]
                     .TransducerName.Upper()
-                    .Contains(_T("PITCH"))) {
+                    .Contains("PITCH")) {
               if (mPriPitchRoll >= 3) {
                 if (m_NMEA0183.Xdr.TransducerInfo[i].MeasurementData > 0) {
                   xdrunit = _T("\u00B0\u2191") + _("Up");


### PR DESCRIPTION
Added MakeUpper() to TransducerName to accept "Pitch" and "Roll" IDs which is the new standard in NMEA0183 revision 4.11