### PR TITLE
Cleanup iENCToolbar destruction and resource handling. Fixes #5212

### DIFF
--- a/gui/src/ienc_toolbar.cpp
+++ b/gui/src/ienc_toolbar.cpp
@@ -93,7 +93,10 @@ iENCToolbar::iENCToolbar(wxWindow *parent, wxPoint pos, long orient,
                 NULL, this);
 }
 
-iENCToolbar::~iENCToolbar() {}
+iENCToolbar::~iENCToolbar() {
+  m_state_timer.Stop();
+  delete m_pbmScratch;
+}
 
 void iENCToolbar::SetColorScheme(ColorScheme cs) {
   m_nDensity = -1;
@@ -286,7 +289,6 @@ void iENCToolbar::StateTimerEvent(wxTimerEvent &event) {
   if (ps52plib) {
     int nset = 1;
 
-    auto acc = top_frame::Get()->GetAbstractPrimaryCanvas();
     switch (acc->GetENCDisplayCategory()) {
       case (DISPLAYBASE):
         nset = 0;

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -1694,13 +1694,6 @@ void MyFrame::OnCloseWindow(wxCloseEvent &event) {
   // g_MainToolbar = NULL;
 #endif
 
-  if (g_iENCToolbar) {
-    // wxPoint locn = g_iENCToolbar->GetPosition();
-    // g_iENCToolbarPosY = locn.y;
-    // g_iENCToolbarPosX = locn.x;
-    // g_iENCToolbar->Destroy();
-  }
-
   if (g_pAISTargetList) {
     g_pAISTargetList->Disconnect_decoder();
     g_pAISTargetList->Destroy();
@@ -1828,6 +1821,10 @@ void MyFrame::OnCloseWindow(wxCloseEvent &event) {
   delete g_glTextureManager;
 #endif
   uninitIXNetSystem();
+
+  delete g_iENCToolbar;
+  g_iENCToolbar = NULL;
+
   this->Destroy();
   gFrame = NULL;
 


### PR DESCRIPTION
Improved resource management by stopping the state timer and deleting m_pbmScratch in iENCToolbar's destructor. Ensured g_iENCToolbar is deleted and set to NULL on window close. Removed obsolete commented code and cleaned up an unused variable in StateTimerEvent.