### PR TITLE
Add links to log and config files to Safe Restart dialog. Fixes #5215

### DIFF
--- a/gui/src/safe_mode_gui.cpp
+++ b/gui/src/safe_mode_gui.cpp
@@ -30,6 +30,7 @@
 #include <wx/filename.h>
 #include <wx/sizer.h>
 
+#include "model/base_platform.h"
 #include "model/cmdline.h"
 #include "model/ocpn_utils.h"
 #include "model/safe_mode.h"
@@ -70,6 +71,11 @@ void check_last_start() {
   std::stringstream html;
   html << "<html><body>";
   html << LAST_RUN_ERROR_MSG;
+  html << "<p>" << "Logfile location: " << g_BasePlatform->GetLogFileName()
+       << "</p>";
+  html << "<p>"
+       << "Config file location: " << g_BasePlatform->GetConfigFileName()
+       << "</p>";
   html << "</body></html>";
   dlg.AddHtmlContent(html);
 


### PR DESCRIPTION
See #5215

There is no standard location for crash reports, and as far as I know they are not generated across platforms, but at least directing the user to the local log file and config file after a crash should help them both to diagnose the problem themselves, as well as more easily file a sensible bug report. 