### PR TITLE
Remove outdated known issues link from Safe Start dialog

### DIFF
--- a/gui/src/safe_mode_gui.cpp
+++ b/gui/src/safe_mode_gui.cpp
@@ -42,9 +42,7 @@ namespace safe_mode {
 static const char* LAST_RUN_ERROR_MSG =
     _("<p>The last opencpn run seems to have failed. Do you want to run\n"
       "in safe mode without plugins and other possibly problematic\n"
-      "features?\n</p><br/></br><p>You may consider visiting the <a "
-      "href=\"https://github.com/OpenCPN/OpenCPN/wiki/"
-      "OpenCPN-5.10-known-issues\">list of known issues</a>.</p>");
+      "features?\n</p>");
 
 /**
  * Check if the last start failed, possibly invoke user dialog and set


### PR DESCRIPTION
The existing link is to a page referring to known issues in v5.10, which was last updated by @nohal in Feb 2025, and is no longer relevant. 
The equivalent links for 5.12, 5.13, 5.14, 5.15 etc refer to empty pages, which also don't seem useful.

@nohal Any better suggestions than simply deleting the link?  I'm not clear on what the original intention was here.
Would it perhaps be useful to link to https://github.com/OpenCPN/OpenCPN/issues instead? Or perhaps that's too cluttered with issues that don't apply to a particular released version. That could potentially be addressed using labels (i.e. if an issue applies to version 5.14, label it as such).

Any thoughts?