### PR TITLE
Remove all _T() and wxT() macros from grib_pi source. They are no longer needed.

### DIFF
--- a/plugins/grib_pi/src/CursorData.cpp
+++ b/plugins/grib_pi/src/CursorData.cpp
@@ -144,15 +144,15 @@ void CursorData::PopulateTrackingControls(bool vertical) {
   // Get text controls sizing data
   wxFont *font = OCPNGetFont(_("Dialog"));
   int wn, wd, ws, wl;
-  GetTextExtent(_T("abcdefghihjk"), &wn, nullptr, 0, 0,
+  GetTextExtent("abcdefghihjk", &wn, nullptr, 0, 0,
                 font);  // normal width text control size
-  GetTextExtent(_T("abcdef"), &ws, nullptr, 0, 0,
+  GetTextExtent("abcdef", &ws, nullptr, 0, 0,
                 font);  // short width text control size for direction only
   GetTextExtent(
-      _T("abcdefghijklmopq"), &wd, nullptr, 0, 0,
+      "abcdefghijklmopq", &wd, nullptr, 0, 0,
       font);  // long width text control size for double unit wind display
   GetTextExtent(
-      _T("abcdefghijklm"), &wl, nullptr, 0, 0,
+      "abcdefghijklm", &wl, nullptr, 0, 0,
       font);  // long width text control size for double unit wave display
   //
   // create a dummy textCtrl to be used as a "space" in vertical display
@@ -293,29 +293,28 @@ void CursorData::PopulateTrackingControls(bool vertical) {
   lev = m_gparent.m_OverlaySettings.CalibrateValue(
       GribOverlaySettings::GEO_ALTITUDE,
       10);  // convert 10m in current altitude unit
-  t.Printf(
-      m_Altitude
-          ? m_gparent.m_OverlaySettings
-                .GetAltitudeFromIndex(
-                    m_Altitude, m_gparent.m_OverlaySettings
+  t.Printf(m_Altitude ? m_gparent.m_OverlaySettings
+                            .GetAltitudeFromIndex(
+                                m_Altitude,
+                                m_gparent.m_OverlaySettings
                                     .Settings[GribOverlaySettings::PRESSURE]
                                     .m_Units)
-                .Append(_T(" "))
-                .Append(m_gparent.m_OverlaySettings.GetUnitSymbol(
-                    GribOverlaySettings::PRESSURE))
-          : wxString::Format(_T("%1.*f "), lev == (int)lev ? 0 : 1, lev)
-                .Append(m_gparent.m_OverlaySettings.GetUnitSymbol(
-                    GribOverlaySettings::GEO_ALTITUDE)));
-  wxString pre = _T(" ");
+                            .Append(" ")
+                            .Append(m_gparent.m_OverlaySettings.GetUnitSymbol(
+                                GribOverlaySettings::PRESSURE))
+                      : wxString::Format("%1.*f ", lev == (int)lev ? 0 : 1, lev)
+                            .Append(m_gparent.m_OverlaySettings.GetUnitSymbol(
+                                GribOverlaySettings::GEO_ALTITUDE)));
+  wxString pre = " ";
   if (m_Altitude) {
     pre.Append(_("at Geopotential Height"));
-    pre.Append(_T(" "));
+    pre.Append(" ");
     m_tcAltitude->SetToolTip(_("Altitude") + t);
     m_tcTemp->SetToolTip(_("Temperature") + t);
     m_tcRelHumid->SetToolTip(_("Relative Humidity") + t);
   } else {
     pre.Append(_("at"));
-    pre.Append(_T(" "));
+    pre.Append(" ");
   }
   t.Prepend(pre);
 
@@ -323,13 +322,13 @@ void CursorData::PopulateTrackingControls(bool vertical) {
   m_tcWindSpeedBf->SetToolTip(_("Wind Speed in Bf") + t);
   m_tcWindDirection->SetToolTip(_("Wind Direction") + t);
 
-  t.Printf(_T(" %1.*f ") + m_gparent.m_OverlaySettings.GetUnitSymbol(
-                               GribOverlaySettings::GEO_ALTITUDE),
+  t.Printf(" %1.*f " + m_gparent.m_OverlaySettings.GetUnitSymbol(
+                           GribOverlaySettings::GEO_ALTITUDE),
            lev == (int)lev ? 0 : 1, lev);
   m_tcWindGust->SetToolTip(_("Wind Gust at") + t);
 
   if (m_gparent.m_pTimelineSet) {
-    wxString s[] = {_T(" "), _("Air Temperature at"), _("surface level"),
+    wxString s[] = {" ", _("Air Temperature at"), _("surface level"),
                     _("Sea Surface Temperature")};
 
     lev = m_gparent.m_OverlaySettings.CalibrateValue(
@@ -338,8 +337,8 @@ void CursorData::PopulateTrackingControls(bool vertical) {
     t.Printf(m_gparent.m_bGRIBActiveFile->m_GribIdxArray.Index(
                  1000 + NORWAY_METNO) != wxNOT_FOUND
                  ? s[0] + s[2]
-                 : _T(" %1.*f ") + m_gparent.m_OverlaySettings.GetUnitSymbol(
-                                       GribOverlaySettings::GEO_ALTITUDE),
+                 : " %1.*f " + m_gparent.m_OverlaySettings.GetUnitSymbol(
+                                   GribOverlaySettings::GEO_ALTITUDE),
              lev == (int)lev ? 0 : 1, lev);
     m_tcAirTemperature->SetToolTip(s[1] + t);
 
@@ -365,8 +364,8 @@ void CursorData::UpdateTrackingControls(void) {
         GribOverlaySettings::WIND, vkn);
 
     m_tcWindSpeed->SetValue(
-        wxString::Format(_T("%3d ") + m_gparent.m_OverlaySettings.GetUnitSymbol(
-                                          GribOverlaySettings::WIND),
+        wxString::Format("%3d " + m_gparent.m_OverlaySettings.GetUnitSymbol(
+                                      GribOverlaySettings::WIND),
                          (int)round(vk)));
 
     // wind is a special case: if current unit is not bf ==> double speed
@@ -375,16 +374,13 @@ void CursorData::UpdateTrackingControls(void) {
             .m_Units != GribOverlaySettings::BFS) {
       vk = m_gparent.m_OverlaySettings.GetmstobfFactor(vkn) * vkn;
       if (m_DialogStyle == SEPARATED_VERTICAL)
-        m_tcWindSpeedBf->SetValue(
-            wxString::Format(_T("%2d bf"), (int)round(vk)));
+        m_tcWindSpeedBf->SetValue(wxString::Format("%2d bf", (int)round(vk)));
       else
-        m_tcWindSpeed->SetValue(
-            m_tcWindSpeed->GetValue().Append(_T(" - ")).Append(
-                wxString::Format(_T("%2d bf"), (int)round(vk))));
+        m_tcWindSpeed->SetValue(m_tcWindSpeed->GetValue().Append(" - ").Append(
+            wxString::Format("%2d bf", (int)round(vk))));
     }
 
-    m_tcWindDirection->SetValue(
-        wxString::Format(_T("%03d%c"), (int)(ang), 0x00B0));
+    m_tcWindDirection->SetValue(wxString::Format("%03d%c", (int)(ang), 0x00B0));
   } else {
     m_tcWindSpeed->SetValue(_("N/A"));
     m_tcWindSpeedBf->SetValue(_("N/A"));
@@ -399,10 +395,10 @@ void CursorData::UpdateTrackingControls(void) {
     if (vkn != GRIB_NOTDEF) {
       vkn = m_gparent.m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::WIND_GUST, vkn);
-      m_tcWindGust->SetValue(wxString::Format(
-          _T("%2d ") + m_gparent.m_OverlaySettings.GetUnitSymbol(
-                           GribOverlaySettings::WIND_GUST),
-          (int)round(vkn)));
+      m_tcWindGust->SetValue(
+          wxString::Format("%2d " + m_gparent.m_OverlaySettings.GetUnitSymbol(
+                                        GribOverlaySettings::WIND_GUST),
+                           (int)round(vkn)));
     } else
       m_tcWindGust->SetValue(_("N/A"));
   }
@@ -420,10 +416,10 @@ void CursorData::UpdateTrackingControls(void) {
                .m_Units == 2)
               ? 2
               : 1;  // if PRESSURE & inHG = two decimals
-      m_tcPressure->SetValue(wxString::Format(
-          _T("%2.*f ") + m_gparent.m_OverlaySettings.GetUnitSymbol(
-                             GribOverlaySettings::PRESSURE),
-          p, (press)));
+      m_tcPressure->SetValue(
+          wxString::Format("%2.*f " + m_gparent.m_OverlaySettings.GetUnitSymbol(
+                                          GribOverlaySettings::PRESSURE),
+                           p, (press)));
     } else
       m_tcPressure->SetValue(_("N/A"));
   }
@@ -436,19 +432,19 @@ void CursorData::UpdateTrackingControls(void) {
     if (height != GRIB_NOTDEF) {
       height = m_gparent.m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::WAVE, height);
-      wxString w(wxString::Format(
-          _T("%4.1f ") + m_gparent.m_OverlaySettings.GetUnitSymbol(
-                             GribOverlaySettings::WAVE),
-          height));
+      wxString w(
+          wxString::Format("%4.1f " + m_gparent.m_OverlaySettings.GetUnitSymbol(
+                                          GribOverlaySettings::WAVE),
+                           height));
       if (RecordArray[Idx_WVPER]) {
         double period = RecordArray[Idx_WVPER]->getInterpolatedValue(
             m_cursor_lon, m_cursor_lat, true);
         if (period != GRIB_NOTDEF) {
           if (m_DialogStyle == SEPARATED_VERTICAL)
             m_tcWavePeriode->SetValue(
-                wxString::Format(_T("%01ds"), (int)round(period)));
+                wxString::Format("%01ds", (int)round(period)));
           else
-            w.Append(wxString::Format(_T(" - %01ds"), (int)round(period)));
+            w.Append(wxString::Format(" - %01ds", (int)round(period)));
         } else
           m_tcWavePeriode->SetValue(_("N/A"));
       } else
@@ -465,7 +461,7 @@ void CursorData::UpdateTrackingControls(void) {
         m_cursor_lon, m_cursor_lat, true, true);
     if (direction != GRIB_NOTDEF)
       m_tcWaveDirection->SetValue(
-          wxString::Format(_T("%03d%c"), (int)direction, 0x00B0));
+          wxString::Format("%03d%c", (int)direction, 0x00B0));
     else
       m_tcWaveDirection->SetValue(_("N/A"));
   }
@@ -484,13 +480,13 @@ void CursorData::UpdateTrackingControls(void) {
     vkn = m_gparent.m_OverlaySettings.CalibrateValue(
         GribOverlaySettings::CURRENT, vkn);
 
-    m_tcCurrentVelocity->SetValue(wxString::Format(
-        _T("%4.1f ") + m_gparent.m_OverlaySettings.GetUnitSymbol(
-                           GribOverlaySettings::CURRENT),
-        vkn));
+    m_tcCurrentVelocity->SetValue(
+        wxString::Format("%4.1f " + m_gparent.m_OverlaySettings.GetUnitSymbol(
+                                        GribOverlaySettings::CURRENT),
+                         vkn));
 
     m_tcCurrentDirection->SetValue(
-        wxString::Format(_T("%03d%c"), (int)(ang), 0x00B0));
+        wxString::Format("%03d%c", (int)(ang), 0x00B0));
   } else {
     m_tcCurrentVelocity->SetValue(_("N/A"));
     m_tcCurrentDirection->SetValue(_("N/A"));
@@ -510,10 +506,10 @@ void CursorData::UpdateTrackingControls(void) {
                        .m_Units == 1
                ? 1
                : 0;  // if PRESSURE & in = one decimal more
-      m_tcPrecipitation->SetValue(wxString::Format(
-          _T("%4.*f ") + m_gparent.m_OverlaySettings.GetUnitSymbol(
-                             GribOverlaySettings::PRECIPITATION),
-          p, precip));
+      m_tcPrecipitation->SetValue(
+          wxString::Format("%4.*f " + m_gparent.m_OverlaySettings.GetUnitSymbol(
+                                          GribOverlaySettings::PRECIPITATION),
+                           p, precip));
     } else
       m_tcPrecipitation->SetValue(_("N/A"));
   }
@@ -526,7 +522,7 @@ void CursorData::UpdateTrackingControls(void) {
     if (cloud != GRIB_NOTDEF) {
       cloud = m_gparent.m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::CLOUD, cloud);
-      wxString val(wxString::Format(_T("%5.0f "), cloud));
+      wxString val(wxString::Format("%5.0f ", cloud));
       m_tcCloud->SetValue(val + m_gparent.m_OverlaySettings.GetUnitSymbol(
                                     GribOverlaySettings::CLOUD));
     } else
@@ -541,10 +537,10 @@ void CursorData::UpdateTrackingControls(void) {
     if (temp != GRIB_NOTDEF) {
       temp = m_gparent.m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::AIR_TEMPERATURE, temp);
-      m_tcAirTemperature->SetValue(wxString::Format(
-          _T("%5.1f ") + m_gparent.m_OverlaySettings.GetUnitSymbol(
-                             GribOverlaySettings::AIR_TEMPERATURE),
-          temp));
+      m_tcAirTemperature->SetValue(
+          wxString::Format("%5.1f " + m_gparent.m_OverlaySettings.GetUnitSymbol(
+                                          GribOverlaySettings::AIR_TEMPERATURE),
+                           temp));
     } else
       m_tcAirTemperature->SetValue(_("N/A"));
   }
@@ -557,10 +553,10 @@ void CursorData::UpdateTrackingControls(void) {
     if (temp != GRIB_NOTDEF) {
       temp = m_gparent.m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::SEA_TEMPERATURE, temp);
-      m_tcSeaTemperature->SetValue(wxString::Format(
-          _T("%5.1f ") + m_gparent.m_OverlaySettings.GetUnitSymbol(
-                             GribOverlaySettings::SEA_TEMPERATURE),
-          temp));
+      m_tcSeaTemperature->SetValue(
+          wxString::Format("%5.1f " + m_gparent.m_OverlaySettings.GetUnitSymbol(
+                                          GribOverlaySettings::SEA_TEMPERATURE),
+                           temp));
     } else
       m_tcSeaTemperature->SetValue(_("N/A"));
   }
@@ -573,10 +569,10 @@ void CursorData::UpdateTrackingControls(void) {
     if (cape != GRIB_NOTDEF) {
       cape = m_gparent.m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::CAPE, cape);
-      m_tcCAPE->SetValue(wxString::Format(
-          _T("%5.0f ") + m_gparent.m_OverlaySettings.GetUnitSymbol(
-                             GribOverlaySettings::CAPE),
-          cape));
+      m_tcCAPE->SetValue(
+          wxString::Format("%5.0f " + m_gparent.m_OverlaySettings.GetUnitSymbol(
+                                          GribOverlaySettings::CAPE),
+                           cape));
     } else
       m_tcCAPE->SetValue(_("N/A"));
   }
@@ -587,10 +583,10 @@ void CursorData::UpdateTrackingControls(void) {
     if (c_refl != GRIB_NOTDEF) {
       c_refl = m_gparent.m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::COMP_REFL, c_refl);
-      m_tcReflC->SetValue(wxString::Format(
-          _T("%5.0f ") + m_gparent.m_OverlaySettings.GetUnitSymbol(
-                             GribOverlaySettings::COMP_REFL),
-          c_refl));
+      m_tcReflC->SetValue(
+          wxString::Format("%5.0f " + m_gparent.m_OverlaySettings.GetUnitSymbol(
+                                          GribOverlaySettings::COMP_REFL),
+                           c_refl));
     } else
       m_tcReflC->SetValue(_("N/A"));
   }
@@ -603,7 +599,7 @@ void CursorData::UpdateTrackingControls(void) {
     if (geop != GRIB_NOTDEF) {
       geop = m_gparent.m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::GEO_ALTITUDE, geop);
-      m_tcAltitude->SetValue(wxString::Format(_T("%5.0f "), geop) +
+      m_tcAltitude->SetValue(wxString::Format("%5.0f ", geop) +
                              m_gparent.m_OverlaySettings.GetUnitSymbol(
                                  GribOverlaySettings::GEO_ALTITUDE));
     } else
@@ -618,7 +614,7 @@ void CursorData::UpdateTrackingControls(void) {
     if (temp != GRIB_NOTDEF) {
       temp = m_gparent.m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::AIR_TEMPERATURE, temp);
-      m_tcTemp->SetValue(wxString::Format(_T("%5.1f "), temp) +
+      m_tcTemp->SetValue(wxString::Format("%5.1f ", temp) +
                          m_gparent.m_OverlaySettings.GetUnitSymbol(
                              GribOverlaySettings::AIR_TEMPERATURE));
     } else
@@ -632,7 +628,7 @@ void CursorData::UpdateTrackingControls(void) {
     if (humi != GRIB_NOTDEF) {
       humi = m_gparent.m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::REL_HUMIDITY, humi);
-      m_tcRelHumid->SetValue(wxString::Format(_T("%5.0f "), humi) +
+      m_tcRelHumid->SetValue(wxString::Format("%5.0f ", humi) +
                              m_gparent.m_OverlaySettings.GetUnitSymbol(
                                  GribOverlaySettings::REL_HUMIDITY));
     } else
@@ -739,7 +735,7 @@ void CursorData::OnMenuCallBack(wxMouseEvent &event) {
 }
 
 void CursorData::MenuAppend(wxMenu *menu, int id, wxString label, int setting) {
-  wxMenuItem *item = new wxMenuItem(menu, id, label, _T(""), wxITEM_CHECK);
+  wxMenuItem *item = new wxMenuItem(menu, id, label, "", wxITEM_CHECK);
 
 #ifdef __WXMSW__
   wxFont *qFont = OCPNGetFont(_("Menu"));

--- a/plugins/grib_pi/src/CustomGrid.cpp
+++ b/plugins/grib_pi/src/CustomGrid.cpp
@@ -50,10 +50,10 @@ CustomGrid::CustomGrid(wxWindow* parent, wxWindowID id, const wxPoint& pos,
   // init rows pref
   wxFileConfig* pConf = GetOCPNConfigObject();
   if (pConf) {
-    pConf->SetPath(_T("/Settings/GRIB"));
-    m_IsDigit = pConf->Read(_T("GribDataTableRowPref"), _T("XXX"));
+    pConf->SetPath("/Settings/GRIB");
+    m_IsDigit = pConf->Read("GribDataTableRowPref", "XXX");
   }
-  if (m_IsDigit.Len() != wxString(_T("XXX")).Len()) m_IsDigit = _T("XXX");
+  if (m_IsDigit.Len() != wxString("XXX").Len()) m_IsDigit = "XXX";
   // create structure for all numerical rows
   for (unsigned int i = 0; i < m_IsDigit.Len(); i++) {
     m_NumRow.push_back(wxNOT_FOUND);
@@ -64,17 +64,17 @@ CustomGrid::CustomGrid(wxWindow* parent, wxWindowID id, const wxPoint& pos,
   SetLabelFont(labelfont);
   wxColour colour = wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOW);
   if (colour.Red() > 128) {
-    GetGlobalColor(_T("DILG0"), &colour);
-    GetGlobalColor(_T("GREEN1"), &m_greenColour);
-    GetGlobalColor(_T("DILG1"), &m_greyColour);
+    GetGlobalColor("DILG0", &colour);
+    GetGlobalColor("GREEN1", &m_greenColour);
+    GetGlobalColor("DILG1", &m_greyColour);
   } else {
-    GetGlobalColor(_T("GREEN2"), &m_greenColour);
+    GetGlobalColor("GREEN2", &m_greenColour);
     m_greyColour = colour;
   }
   SetLabelBackgroundColour(colour);
   // set row label size
   int w;
-  GetTextExtent(_T("Ab"), &w, nullptr, 0, 0, &labelfont);
+  GetTextExtent("Ab", &w, nullptr, 0, 0, &labelfont);
   double x = (double)w * 6.5;
   SetRowLabelSize((int)x);
 
@@ -149,7 +149,7 @@ void CustomGrid::DrawRowLabel(wxDC& dc, int row) {
   dc.SetFont(m_labelFont);
   dc.SetPen(GetDefaultGridLinePen());
   dc.SetBrush(wxBrush(m_labelBackgroundColour, wxBRUSHSTYLE_SOLID));
-  int w = dc.GetTextExtent(_T("Speed")).x;
+  int w = dc.GetTextExtent("Speed").x;
   wxString label1, label2;
   label1 = GetRowLabelValue(row).BeforeFirst(',', &label2);
   bool pline = true;
@@ -157,7 +157,7 @@ void CustomGrid::DrawRowLabel(wxDC& dc, int row) {
   if (GetNumberRows() > row + 2 &&
       label1 == GetRowLabelValue(row + 2).BeforeFirst(',')) {
     pline = false;
-    if (IsRowVisible(row + 2)) label1 = _T(" ");
+    if (IsRowVisible(row + 2)) label1 = " ";
   }
   // row is the second of 3 or the first of 2
   else if (GetNumberRows() > row + 1 &&
@@ -165,16 +165,16 @@ void CustomGrid::DrawRowLabel(wxDC& dc, int row) {
     pline = false;
     if (row > 0 &&
         label1 == GetRowLabelValue(row - 1).BeforeFirst(',')) {  // second of 3
-      if (!IsRowVisible(row + 1)) label1 = _T(" ");
+      if (!IsRowVisible(row + 1)) label1 = " ";
     }
   }
   // row is the last of 3
   else if (row > 1 && label1 == GetRowLabelValue(row - 2).BeforeFirst(',')) {
-    if (IsRowVisible(row - 1)) label1 = _T(" ");
+    if (IsRowVisible(row - 1)) label1 = " ";
   }
   // row is the last of 2
   else if (row > 0 && label1 == GetRowLabelValue(row - 1).BeforeFirst(',')) {
-    if (IsRowVisible(row - 1)) label1 = _T(" ");
+    if (IsRowVisible(row - 1)) label1 = " ";
   }
   // draw first part of the label
   wxRect aRect(5, GetRowTop(row), m_rowLabelWidth - w, GetRowHeight(row));
@@ -201,7 +201,7 @@ void CustomGrid::DrawCornerLabel(wxDC& dc) {
   double hc = m_colLabelHeight;
   double hb = wxBitmap(now).GetHeight();
   double scfac = ((hc / hb) * 4) / 4;
-  wxBitmap bmp = m_gParent->GetScaledBitmap(wxBitmap(now), _T("now"), scfac);
+  wxBitmap bmp = m_gParent->GetScaledBitmap(wxBitmap(now), "now", scfac);
   // center bitmap
   int x = (m_rowLabelWidth - bmp.GetWidth()) / 2;
   int y = (m_colLabelHeight == bmp.GetHeight())
@@ -395,7 +395,7 @@ void CustomRenderer::Draw(wxGrid& grid, wxGridCellAttr& attr, wxDC& dc,
   dc.DrawRectangle(rect);
   if (m_IsDigit || m_dDir == GRIB_NOTDEF) {  // digital format
     wxString text(wxEmptyString);
-    if (m_dDir != GRIB_NOTDEF) text.Printf(_T("%03d%c"), (int)m_dDir, 0x00B0);
+    if (m_dDir != GRIB_NOTDEF) text.Printf("%03d%c", (int)m_dDir, 0x00B0);
     dc.DrawLabel(text, rect,
                  wxALIGN_CENTER_HORIZONTAL | wxALIGN_CENTER_VERTICAL);
   } else {  // graphical format

--- a/plugins/grib_pi/src/GribOverlayFactory.cpp
+++ b/plugins/grib_pi/src/GribOverlayFactory.cpp
@@ -93,14 +93,14 @@ static bool PointInLLBox(PlugIn_ViewPort *vp, double x, double y) {
 static wxString MToString( int DataCenterModel )
 {
     switch( DataCenterModel ) {
-    case NOAA_GFS: return  _T("NOAA_GFS");
-    case NOAA_NCEP_WW3: return  _T("NOAA_NCEP_WW3");
-    case NOAA_NCEP_SST: return  _T("NOAA_NCEP_SST");
-    case NOAA_RTOFS: return  _T("NOAA_RTOFS");
-    case FNMOC_WW3_GLB: return  _T("FNMOC_WW3");
-    case FNMOC_WW3_MED: return  _T("FNMOC_WW3");
-    case NORWAY_METNO: return  _T("NORWAY_METNO");
-    default : return  _T("OTHER_DATA_CENTER");
+    case NOAA_GFS: return  "NOAA_GFS";
+    case NOAA_NCEP_WW3: return  "NOAA_NCEP_WW3";
+    case NOAA_NCEP_SST: return  "NOAA_NCEP_SST";
+    case NOAA_RTOFS: return  "NOAA_RTOFS";
+    case FNMOC_WW3_GLB: return  "FNMOC_WW3";
+    case FNMOC_WW3_MED: return  "FNMOC_WW3";
+    case NORWAY_METNO: return  "NORWAY_METNO";
+    default : return  "OTHER_DATA_CENTER";
     }
 }
 #endif
@@ -594,22 +594,22 @@ bool GRIBOverlayFactory::DoRenderGribOverlay(PlugIn_ViewPort *vp) {
     }
   }
   if (m_Altitude) {
-    if (!m_Message_Hiden.IsEmpty()) m_Message_Hiden.Append(_T("\n"));
+    if (!m_Message_Hiden.IsEmpty()) m_Message_Hiden.Append("\n");
     m_Message_Hiden.Append(_("Warning : Data at Geopotential Height"))
-        .Append(_T(" "))
+        .Append(" ")
         .Append(m_Settings.GetAltitudeFromIndex(
             m_Altitude,
             m_Settings.Settings[GribOverlaySettings::PRESSURE].m_Units))
-        .Append(_T(" "))
+        .Append(" ")
         .Append(m_Settings.GetUnitSymbol(GribOverlaySettings::PRESSURE))
-        .Append(_T(" ! "));
+        .Append(" ! ");
   }
   if (m_dlg.ProjectionEnabled()) {
     int x, y;
     m_dlg.GetProjectedLatLon(x, y, vp);
     DrawProjectedPosition(x, y);
   }
-  if (!m_Message_Hiden.IsEmpty()) m_Message_Hiden.Append(_T("\n"));
+  if (!m_Message_Hiden.IsEmpty()) m_Message_Hiden.Append("\n");
   m_Message_Hiden.Append(m_Message);
   DrawMessageWindow(m_Message_Hiden, vp->pix_width, vp->pix_height,
                     m_Font_Message);
@@ -955,103 +955,85 @@ struct ColorMap {
 };
 
 static ColorMap CurrentMap[] = {
-    {0, _T("#d90000")},  {1, _T("#d92a00")},  {2, _T("#d96e00")},
-    {3, _T("#d9b200")},  {4, _T("#d4d404")},  {5, _T("#a6d906")},
-    {7, _T("#06d9a0")},  {9, _T("#00d9b0")},  {12, _T("#00d9c0")},
-    {15, _T("#00aed0")}, {18, _T("#0083e0")}, {21, _T("#0057e0")},
-    {24, _T("#0000f0")}, {27, _T("#0400f0")}, {30, _T("#1c00f0")},
-    {36, _T("#4800f0")}, {42, _T("#6900f0")}, {48, _T("#a000f0")},
-    {56, _T("#f000f0")}};
+    {0, "#d90000"},  {1, "#d92a00"},  {2, "#d96e00"},  {3, "#d9b200"},
+    {4, "#d4d404"},  {5, "#a6d906"},  {7, "#06d9a0"},  {9, "#00d9b0"},
+    {12, "#00d9c0"}, {15, "#00aed0"}, {18, "#0083e0"}, {21, "#0057e0"},
+    {24, "#0000f0"}, {27, "#0400f0"}, {30, "#1c00f0"}, {36, "#4800f0"},
+    {42, "#6900f0"}, {48, "#a000f0"}, {56, "#f000f0"}};
 
 static ColorMap GenericMap[] = {
-    {0, _T("#00d900")},  {1, _T("#2ad900")},  {2, _T("#6ed900")},
-    {3, _T("#b2d900")},  {4, _T("#d4d400")},  {5, _T("#d9a600")},
-    {7, _T("#d90000")},  {9, _T("#d90040")},  {12, _T("#d90060")},
-    {15, _T("#ae0080")}, {18, _T("#8300a0")}, {21, _T("#5700c0")},
-    {24, _T("#0000d0")}, {27, _T("#0400e0")}, {30, _T("#0800e0")},
-    {36, _T("#a000e0")}, {42, _T("#c004c0")}, {48, _T("#c008a0")},
-    {56, _T("#c0a008")}};
+    {0, "#00d900"},  {1, "#2ad900"},  {2, "#6ed900"},  {3, "#b2d900"},
+    {4, "#d4d400"},  {5, "#d9a600"},  {7, "#d90000"},  {9, "#d90040"},
+    {12, "#d90060"}, {15, "#ae0080"}, {18, "#8300a0"}, {21, "#5700c0"},
+    {24, "#0000d0"}, {27, "#0400e0"}, {30, "#0800e0"}, {36, "#a000e0"},
+    {42, "#c004c0"}, {48, "#c008a0"}, {56, "#c0a008"}};
 
 //    HTML colors taken from zygrib representation
 static ColorMap WindMap[] = {
-    {0, _T("#288CFF")},  {3, _T("#00AFFF")},  {6, _T("#00DCE1")},
-    {9, _T("#00F7B0")},  {12, _T("#00EA9C")}, {15, _T("#82F059")},
-    {18, _T("#F0F503")}, {21, _T("#FFED00")}, {24, _T("#FFDB00")},
-    {27, _T("#FFC700")}, {30, _T("#FFB400")}, {33, _T("#FF9800")},
-    {36, _T("#FF7E00")}, {39, _T("#F77800")}, {42, _T("#EC7814")},
-    {45, _T("#E4711E")}, {48, _T("#E06128")}, {51, _T("#DC5132")},
-    {54, _T("#D5453C")}, {57, _T("#CD3A46")}, {60, _T("#BE2C50")},
-    {63, _T("#B41A5A")}, {66, _T("#AA1464")}, {70, _T("#962878")},
-    {75, _T("#8C328C")}};
+    {0, "#288CFF"},  {3, "#00AFFF"},  {6, "#00DCE1"},  {9, "#00F7B0"},
+    {12, "#00EA9C"}, {15, "#82F059"}, {18, "#F0F503"}, {21, "#FFED00"},
+    {24, "#FFDB00"}, {27, "#FFC700"}, {30, "#FFB400"}, {33, "#FF9800"},
+    {36, "#FF7E00"}, {39, "#F77800"}, {42, "#EC7814"}, {45, "#E4711E"},
+    {48, "#E06128"}, {51, "#DC5132"}, {54, "#D5453C"}, {57, "#CD3A46"},
+    {60, "#BE2C50"}, {63, "#B41A5A"}, {66, "#AA1464"}, {70, "#962878"},
+    {75, "#8C328C"}};
 
 //    HTML colors taken from zygrib representation
 static ColorMap AirTempMap[] = {
-    {0, _T("#283282")},  {5, _T("#273c8c")},  {10, _T("#264696")},
-    {14, _T("#2350a0")}, {18, _T("#1f5aaa")}, {22, _T("#1a64b4")},
-    {26, _T("#136ec8")}, {29, _T("#0c78e1")}, {32, _T("#0382e6")},
-    {35, _T("#0091e6")}, {38, _T("#009ee1")}, {41, _T("#00a6dc")},
-    {44, _T("#00b2d7")}, {47, _T("#00bed2")}, {50, _T("#28c8c8")},
-    {53, _T("#78d2aa")}, {56, _T("#8cdc78")}, {59, _T("#a0eb5f")},
-    {62, _T("#c8f550")}, {65, _T("#f3fb02")}, {68, _T("#ffed00")},
-    {71, _T("#ffdd00")}, {74, _T("#ffc900")}, {78, _T("#ffab00")},
-    {82, _T("#ff8100")}, {86, _T("#f1780c")}, {90, _T("#e26a23")},
-    {95, _T("#d5453c")}, {100, _T("#b53c59")}};
+    {0, "#283282"},  {5, "#273c8c"},  {10, "#264696"}, {14, "#2350a0"},
+    {18, "#1f5aaa"}, {22, "#1a64b4"}, {26, "#136ec8"}, {29, "#0c78e1"},
+    {32, "#0382e6"}, {35, "#0091e6"}, {38, "#009ee1"}, {41, "#00a6dc"},
+    {44, "#00b2d7"}, {47, "#00bed2"}, {50, "#28c8c8"}, {53, "#78d2aa"},
+    {56, "#8cdc78"}, {59, "#a0eb5f"}, {62, "#c8f550"}, {65, "#f3fb02"},
+    {68, "#ffed00"}, {71, "#ffdd00"}, {74, "#ffc900"}, {78, "#ffab00"},
+    {82, "#ff8100"}, {86, "#f1780c"}, {90, "#e26a23"}, {95, "#d5453c"},
+    {100, "#b53c59"}};
 
 //  Color map similar to:
 //  https://www.ospo.noaa.gov/data/sst/contour/global.cf.gif
 static ColorMap SeaTempMap[] = {
-    {-2, _T("#cc04ae")}, {2, _T("#8f06e4")},  {6, _T("#486afa")},
-    {10, _T("#00ffff")}, {15, _T("#00d54b")}, {19, _T("#59d800")},
-    {23, _T("#f2fc00")}, {27, _T("#ff1500")}, {32, _T("#ff0000")},
-    {36, _T("#d80000")}, {40, _T("#a90000")}, {44, _T("#870000")},
-    {48, _T("#690000")}, {52, _T("#550000")}, {56, _T("#330000")}};
+    {-2, "#cc04ae"}, {2, "#8f06e4"},  {6, "#486afa"},  {10, "#00ffff"},
+    {15, "#00d54b"}, {19, "#59d800"}, {23, "#f2fc00"}, {27, "#ff1500"},
+    {32, "#ff0000"}, {36, "#d80000"}, {40, "#a90000"}, {44, "#870000"},
+    {48, "#690000"}, {52, "#550000"}, {56, "#330000"}};
 
 //    HTML colors taken from ZyGrib representation
 static ColorMap PrecipitationMap[] = {
-    {0, _T("#ffffff")},   {.01, _T("#c8f0ff")}, {.02, _T("#b4e6ff")},
-    {.05, _T("#8cd3ff")}, {.07, _T("#78caff")}, {.1, _T("#6ec1ff")},
-    {.2, _T("#64b8ff")},  {.5, _T("#50a6ff")},  {.7, _T("#469eff")},
-    {1.0, _T("#3c96ff")}, {2.0, _T("#328eff")}, {5.0, _T("#1e7eff")},
-    {7.0, _T("#1476f0")}, {10, _T("#0a6edc")},  {20, _T("#0064c8")},
-    {50, _T("#0052aa")}};
+    {0, "#ffffff"},   {.01, "#c8f0ff"}, {.02, "#b4e6ff"}, {.05, "#8cd3ff"},
+    {.07, "#78caff"}, {.1, "#6ec1ff"},  {.2, "#64b8ff"},  {.5, "#50a6ff"},
+    {.7, "#469eff"},  {1.0, "#3c96ff"}, {2.0, "#328eff"}, {5.0, "#1e7eff"},
+    {7.0, "#1476f0"}, {10, "#0a6edc"},  {20, "#0064c8"},  {50, "#0052aa"}};
 
 //    HTML colors taken from ZyGrib representation
-static ColorMap CloudMap[] = {
-    {0, _T("#ffffff")},  {1, _T("#f0f0e6")},  {10, _T("#e6e6dc")},
-    {20, _T("#dcdcd2")}, {30, _T("#c8c8b4")}, {40, _T("#aaaa8c")},
-    {50, _T("#969678")}, {60, _T("#787864")}, {70, _T("#646450")},
-    {80, _T("#5a5a46")}, {90, _T("#505036")}};
+static ColorMap CloudMap[] = {{0, "#ffffff"},  {1, "#f0f0e6"},  {10, "#e6e6dc"},
+                              {20, "#dcdcd2"}, {30, "#c8c8b4"}, {40, "#aaaa8c"},
+                              {50, "#969678"}, {60, "#787864"}, {70, "#646450"},
+                              {80, "#5a5a46"}, {90, "#505036"}};
 
-static ColorMap REFCMap[] = {
-    {0, _T("#ffffff")},  {5, _T("#06E8E4")},  {10, _T("#009BE9")},
-    {15, _T("#0400F3")}, {20, _T("#00F924")}, {25, _T("#06C200")},
-    {30, _T("#009100")}, {35, _T("#FAFB00")}, {40, _T("#EBB608")},
-    {45, _T("#FF9400")}, {50, _T("#FD0002")}, {55, _T("#D70000")},
-    {60, _T("#C20300")}, {65, _T("#F900FE")}, {70, _T("#945AC8")}};
+static ColorMap REFCMap[] = {{0, "#ffffff"},  {5, "#06E8E4"},  {10, "#009BE9"},
+                             {15, "#0400F3"}, {20, "#00F924"}, {25, "#06C200"},
+                             {30, "#009100"}, {35, "#FAFB00"}, {40, "#EBB608"},
+                             {45, "#FF9400"}, {50, "#FD0002"}, {55, "#D70000"},
+                             {60, "#C20300"}, {65, "#F900FE"}, {70, "#945AC8"}};
 
 static ColorMap CAPEMap[] = {
-    {0, _T("#0046c8")},    {5, _T("#0050f0")},    {10, _T("#005aff")},
-    {15, _T("#0069ff")},   {20, _T("#0078ff")},   {30, _T("#000cff")},
-    {45, _T("#00a1ff")},   {60, _T("#00b6fa")},   {100, _T("#00c9ee")},
-    {150, _T("#00e0da")},  {200, _T("#00e6b4")},  {300, _T("#82e678")},
-    {500, _T("#9bff3b")},  {700, _T("#ffdc00")},  {1000, _T("#ffb700")},
-    {1500, _T("#f37800")}, {2000, _T("#d4440c")}, {2500, _T("#c8201c")},
-    {3000, _T("#ad0430")},
+    {0, "#0046c8"},    {5, "#0050f0"},    {10, "#005aff"},   {15, "#0069ff"},
+    {20, "#0078ff"},   {30, "#000cff"},   {45, "#00a1ff"},   {60, "#00b6fa"},
+    {100, "#00c9ee"},  {150, "#00e0da"},  {200, "#00e6b4"},  {300, "#82e678"},
+    {500, "#9bff3b"},  {700, "#ffdc00"},  {1000, "#ffb700"}, {1500, "#f37800"},
+    {2000, "#d4440c"}, {2500, "#c8201c"}, {3000, "#ad0430"},
 };
 
 static ColorMap WindyMap[] = {
-    {0, _T("#6271B7")},  {3, _T("#3961A9")},  {6, _T("#4A94A9")},
-    {9, _T("#4D8D7B")},  {12, _T("#53A553")}, {15, _T("#53A553")},
-    {18, _T("#359F35")}, {21, _T("#A79D51")}, {24, _T("#9F7F3A")},
-    {27, _T("#A16C5C")}, {30, _T("#A16C5C")}, {33, _T("#813A4E")},
-    {36, _T("#AF5088")}, {39, _T("#AF5088")}, {42, _T("#754A93")},
-    {45, _T("#754A93")}, {48, _T("#6D61A3")}, {51, _T("#44698D")},
-    {54, _T("#44698D")}, {57, _T("#5C9098")}, {60, _T("#7D44A5")},
-    {63, _T("#7D44A5")}, {66, _T("#7D44A5")}, {69, _T("#E7D7D7")},
-    {72, _T("#E7D7D7")}, {75, _T("#E7D7D7")}, {78, _T("#DBD483")},
-    {81, _T("#DBD483")}, {84, _T("#DBD483")}, {87, _T("#CDC470")},
-    {90, _T("#CDC470")}, {93, _T("#CDC470")}, {96, _T("#CDC470")},
-    {99, _T("#808080")}};
+    {0, "#6271B7"},  {3, "#3961A9"},  {6, "#4A94A9"},  {9, "#4D8D7B"},
+    {12, "#53A553"}, {15, "#53A553"}, {18, "#359F35"}, {21, "#A79D51"},
+    {24, "#9F7F3A"}, {27, "#A16C5C"}, {30, "#A16C5C"}, {33, "#813A4E"},
+    {36, "#AF5088"}, {39, "#AF5088"}, {42, "#754A93"}, {45, "#754A93"},
+    {48, "#6D61A3"}, {51, "#44698D"}, {54, "#44698D"}, {57, "#5C9098"},
+    {60, "#7D44A5"}, {63, "#7D44A5"}, {66, "#7D44A5"}, {69, "#E7D7D7"},
+    {72, "#E7D7D7"}, {75, "#E7D7D7"}, {78, "#DBD483"}, {81, "#DBD483"},
+    {84, "#DBD483"}, {87, "#CDC470"}, {90, "#CDC470"}, {93, "#CDC470"},
+    {96, "#CDC470"}, {99, "#808080"}};
 
 #if 0
 static ColorMap *ColorMaps[] = {CurrentMap, GenericMap, WindMap, AirTempMap, SeaTempMap, PrecipitationMap, CloudMap};
@@ -1183,7 +1165,7 @@ wxColour GRIBOverlayFactory::GetGraphicColor(int settings, double val_in) {
 
 wxString GRIBOverlayFactory::getLabelString(double value, int settings) {
   int p;
-  wxString f = _T("%.*f");
+  wxString f = "%.*f";
 
   switch (settings) {
     case GribOverlaySettings::PRESSURE: /* 2 */
@@ -1193,7 +1175,7 @@ wxString GRIBOverlayFactory::getLabelString(double value, int settings) {
       else if (m_Settings.Settings[settings].m_Units == 0 &&
                m_Settings.Settings[settings].m_bAbbrIsoBarsNumbers) {
         value -= floor(value / 100.) * 100.;
-        f = _T("%02.*f");
+        f = "%02.*f";
       }
       break;
     case GribOverlaySettings::WAVE:            /* 3 */
@@ -1822,9 +1804,9 @@ void GRIBOverlayFactory::RenderGribOverlayMap(int settings, GribRecord **pGR,
           m_Message_Hiden.IsEmpty()
               ? m_Message_Hiden
                     .Append(_("Overlays too wide and can't be displayed:"))
-                    .Append(_T(" "))
+                    .Append(" ")
                     .Append(GribOverlaySettings::NameFromIndex(settings))
-              : m_Message_Hiden.Append(_T(",")).Append(
+              : m_Message_Hiden.Append(",").Append(
                     GribOverlaySettings::NameFromIndex(settings));
       }
 #endif
@@ -1853,9 +1835,9 @@ void GRIBOverlayFactory::RenderGribOverlayMap(int settings, GribRecord **pGR,
               ? m_Message_Hiden
                     .Append(_(
                         "Please Zoom or Scale Out to view invisible overlays:"))
-                    .Append(_T(" "))
+                    .Append(" ")
                     .Append(GribOverlaySettings::NameFromIndex(settings))
-              : m_Message_Hiden.Append(_T(",")).Append(
+              : m_Message_Hiden.Append(",").Append(
                     GribOverlaySettings::NameFromIndex(settings));
       }
     }
@@ -1892,7 +1874,7 @@ void GRIBOverlayFactory::RenderGribNumbers(int settings, GribRecord **pGR,
 
   // set an arbitrary width for numbers
   int wstring;
-  m_TexFontNumbers.GetTextExtent(_T("1234"), &wstring, nullptr);
+  m_TexFontNumbers.GetTextExtent(wxString("1234"), &wstring, nullptr);
 
   if (m_Settings.Settings[settings].m_bNumFixSpac) {  // fixed spacing
 

--- a/plugins/grib_pi/src/GribReader.cpp
+++ b/plugins/grib_pi/src/GribReader.cpp
@@ -39,7 +39,7 @@ GribReader::GribReader() {
 GribReader::GribReader(const wxString fname) {
   ok = false;
   dewpointDataStatus = NO_DATA_IN_FILE;
-  if (fname != _T("")) {
+  if (fname != "") {
     openFile(fname);
   } else {
     clean_all_vectors();

--- a/plugins/grib_pi/src/GribRecord.cpp
+++ b/plugins/grib_pi/src/GribRecord.cpp
@@ -434,7 +434,7 @@ std::string GribRecord::makeKey(
   //  levelValue); return std::string(ktmp);
 
   wxString k;
-  k.Printf(_T("%d-%d-%d"), dataType, levelType, levelValue);
+  k.Printf("%d-%d-%d", dataType, levelType, levelValue);
   return std::string(k.mb_str());
 }
 //-----------------------------------------

--- a/plugins/grib_pi/src/GribRequestDialog.cpp
+++ b/plugins/grib_pi/src/GribRequestDialog.cpp
@@ -201,13 +201,13 @@ void GribRequestSetting::InitRequestConfig() {
     int m;
     pConf->Read(_T( "MailRequestConfig" ), &m_RequestConfigBase,
                 _T( "000220XX........0" ));
-    pConf->Read(_T( "MailSenderAddress" ), &l, _T(""));
+    pConf->Read(_T( "MailSenderAddress" ), &l, "");
     m_pSenderAddress->ChangeValue(l);
     pConf->Read(_T( "MailRequestAddresses" ), &m_MailToAddresses,
-                _T("query@saildocs.com;gribauto@zygrib.org"));
-    pConf->Read(_T( "ZyGribLogin" ), &l, _T(""));
+                "query@saildocs.com;gribauto@zygrib.org");
+    pConf->Read(_T( "ZyGribLogin" ), &l, "");
     m_pLogin->ChangeValue(l);
-    pConf->Read(_T( "ZyGribCode" ), &l, _T(""));
+    pConf->Read(_T( "ZyGribCode" ), &l, "");
     m_pCode->ChangeValue(l);
     pConf->Read(_T( "SendMailMethod" ), &m_SendMethod, 0);
     pConf->Read(_T( "MovingGribSpeed" ), &m, 0);
@@ -241,24 +241,23 @@ void GribRequestSetting::InitRequestConfig() {
       m_RequestConfigBase = _T( "000220XX.............." );
   }
   // populate model, mail to, waves model choices
-  wxString s1[] = {_T("GFS"),  _T("COAMPS"), _T("RTOFS"),
-                   _T("HRRR"), _T("ICON"),   _T("ECMWF")};
+  wxString s1[] = {"GFS", "COAMPS", "RTOFS", "HRRR", "ICON", "ECMWF"};
   for (unsigned int i = 0; i < (sizeof(s1) / sizeof(wxString)); i++)
     m_pModel->Append(s1[i]);
-  wxString s2[] = {_T("Saildocs"), _T("zyGrib")};
+  wxString s2[] = {"Saildocs", "zyGrib"};
   for (unsigned int i = 0; i < (sizeof(s2) / sizeof(wxString)); i++)
     m_pMailTo->Append(s2[i]);
-  wxString s3[] = {_T("WW3-GLOBAL"), _T("WW3-MEDIT")};
+  wxString s3[] = {"WW3-GLOBAL", "WW3-MEDIT"};
   for (unsigned int i = 0; i < (sizeof(s3) / sizeof(wxString)); i++)
     m_pWModel->Append(s3[i]);
   m_rButtonYes->SetLabel(_("Send"));
   m_rButtonApply->SetLabel(_("OK"));
-  m_tResUnit->SetLabel(wxString::Format(_T("\u00B0")));
-  m_sCourseUnit->SetLabel(wxString::Format(_T("\u00B0")));
+  m_tResUnit->SetLabel(wxString::Format("\u00B0"));
+  m_sCourseUnit->SetLabel(wxString::Format("\u00B0"));
 
   // Set wxSpinCtrl sizing
   int w, h;
-  GetTextExtent(_T("-360"), &w, &h, 0, 0,
+  GetTextExtent("-360", &w, &h, 0, 0,
                 OCPNGetFont(_("Dialog")));  // optimal text control size
   w += 30;
   h += 4;
@@ -349,7 +348,7 @@ void GribRequestSetting::OnClose(wxCloseEvent &event) {
 void GribRequestSetting::SetRequestDialogSize() {
   int y;
   /*first let's size the mail display space*/
-  GetTextExtent(_T("abc"), nullptr, &y, 0, 0, OCPNGetFont(_("Dialog")));
+  GetTextExtent("abc", nullptr, &y, 0, 0, OCPNGetFont(_("Dialog")));
   m_MailImage->SetMinSize(
       wxSize(-1, ((y * m_MailImage->GetNumberOfLines()) + 10)));
 
@@ -722,8 +721,8 @@ void GribRequestSetting::FillTreeCtrl(wxJSONValue &data) {
       wxTreeItemId src_id = m_SourcesTreeCtrl1->AppendItem(
           root, source["source"].AsString(), -1, -1, info);
       if (source.HasMember("areas") && source["areas"].IsArray()) {
-        for (int j = 0; j < source[_T("areas")].Size(); j++) {
-          wxJSONValue area = source[_T("areas")][j];
+        for (int j = 0; j < source["areas"].Size(); j++) {
+          wxJSONValue area = source["areas"][j];
           auto info = new GribCatalogInfo(
               LocalSourceItem::AREA, area["name"].AsString(),
               source["description"].AsString(), source["url"].AsString(),
@@ -751,7 +750,7 @@ void GribRequestSetting::FillTreeCtrl(wxJSONValue &data) {
                   area["boundary"]["lon_max"].AsDouble());
               m_SourcesTreeCtrl1->AppendItem(
                   m_SourcesTreeCtrl1->GetLastChild(src_id),
-                  grib[_T("name")].AsString(), -1, -1, info);
+                  grib["name"].AsString(), -1, -1, info);
             }
           }
         }
@@ -1060,12 +1059,12 @@ void GribRequestSetting::ApplyRequestConfig(unsigned rs, unsigned it,
                                             unsigned tr) {
   // some useful  strings
   const wxString res[][RESOLUTIONS] = {
-      {_T("0.25"), _T("0.5"), _T("1.0"), _T("2.0")},
-      {_T("0.2"), _T("0.8"), _T("1.6"), wxEmptyString},
-      {_T("0.08"), _T("0.24"), _T("1.0"), wxEmptyString},         // RTOFS
-      {_T("0.03"), _T("0.24"), _T("1.0"), wxEmptyString},         // HRRR
-      {_T("0.0625"), _T("0.125"), wxEmptyString, wxEmptyString},  // ICON
-      {_T("0.4"), _T("1.0"), _T("2.0"), wxEmptyString}            // ECMWF
+      {"0.25", "0.5", "1.0", "2.0"},
+      {"0.2", "0.8", "1.6", wxEmptyString},
+      {"0.08", "0.24", "1.0", wxEmptyString},             // RTOFS
+      {"0.03", "0.24", "1.0", wxEmptyString},             // HRRR
+      {"0.0625", "0.125", wxEmptyString, wxEmptyString},  // ICON
+      {"0.4", "1.0", "2.0", wxEmptyString}                // ECMWF
   };
 
   IsZYGRIB = m_pMailTo->GetCurrentSelection() == ZYGRIB;
@@ -1098,7 +1097,7 @@ void GribRequestSetting::ApplyRequestConfig(unsigned rs, unsigned it,
 
   m_pInterval->Clear();
   for (unsigned i = l; i < m; i *= 2)
-    m_pInterval->Append(wxString::Format(_T("%d"), i));
+    m_pInterval->Append(wxString::Format("%d", i));
   m_pInterval->SetSelection(wxMin(it, m_pInterval->GetCount() - 1));
 
   // populate time range choice
@@ -1111,7 +1110,7 @@ void GribRequestSetting::ApplyRequestConfig(unsigned rs, unsigned it,
                 : 3;
   m_pTimeRange->Clear();
   for (unsigned i = 2; i < l + 1; i++)
-    m_pTimeRange->Append(wxString::Format(_T("%d"), i));
+    m_pTimeRange->Append(wxString::Format("%d", i));
   m_pTimeRange->SetSelection(wxMin(l - 2, tr));
 
   m_pModel->Enable(!IsZYGRIB);
@@ -1264,11 +1263,11 @@ bool GribRequestSetting::DoRenderZoneOverlay() {
   EstimateFileSize(&size);
 
   wxString label(_("Coord. "));
-  label.Append(toMailFormat(1, m_spMaxLat->GetValue()) + _T(" "));
-  label.Append(toMailFormat(0, m_spMinLon->GetValue()) + _T(" "));
-  label.Append(toMailFormat(1, m_spMinLat->GetValue()) + _T(" "));
-  label.Append(toMailFormat(0, m_spMaxLon->GetValue()) + _T("\n"));
-  label.Append(_T("Estim. Size "))
+  label.Append(toMailFormat(1, m_spMaxLat->GetValue()) + " ");
+  label.Append(toMailFormat(0, m_spMinLon->GetValue()) + " ");
+  label.Append(toMailFormat(1, m_spMinLat->GetValue()) + " ");
+  label.Append(toMailFormat(0, m_spMaxLon->GetValue()) + "\n");
+  label.Append("Estim. Size ")
       .Append((wxString::Format(_T("%1.2f " ), size) + _("MB")));
 
   if (m_pdc) {
@@ -1456,8 +1455,8 @@ void GribRequestSetting::OnOK(wxCommandEvent &event) {
                               (char)(m_pInterval->GetCurrentSelection() + '0'));
 
   wxString range;
-  range.Printf(_T("%x"), m_pTimeRange->GetCurrentSelection() +
-                             1);  // range max = 2 to 16 stored in hexa 1 to f
+  range.Printf("%x", m_pTimeRange->GetCurrentSelection() +
+                         1);  // range max = 2 to 16 stored in hexa 1 to f
   m_RequestConfigBase.SetChar(4, range.GetChar(0));
 
   if (IsZYGRIB && m_pWModel->IsShown())
@@ -1515,45 +1514,43 @@ wxString GribRequestSetting::WriteMail() {
 
   m_MailError_Nb = 0;
   // some useful strings
-  const wxString s[] = {_T(","), _T(" ")};  // separators
+  const wxString s[] = {",", " "};  // separators
   const wxString p[][11] = {
       // parameters GFS from Saildocs
-      {_T("APCP"), _T("TCDC"), _T("AIRTMP"), _T("HTSGW,WVPER,WVDIR"),
-       _T("SEATMP"), _T("GUST"), _T("CAPE"), wxEmptyString, wxEmptyString,
-       _T("WIND500,HGT500"), wxEmptyString},
+      {"APCP", "TCDC", "AIRTMP", "HTSGW,WVPER,WVDIR", "SEATMP", "GUST", "CAPE",
+       wxEmptyString, wxEmptyString, "WIND500,HGT500", wxEmptyString},
       {},  // COAMPS
       {},  // RTOFS
       {},  // HRRR = same parameters as GFS
       // parametres ICON
-      {_T(""), _T(""), _T("AIRTMP"), _T(""), _T("SFCTMP"), _T("GUST"), _T(""),
-       _T(""), _T(""), _T("WIND500,HGT500"), _T("")},
+      {"", "", "AIRTMP", "", "SFCTMP", "GUST", "", "", "", "WIND500,HGT500",
+       ""},
       // parametres ECMWF
-      {_T(""), _T(""), _T("TEMP"), _T("WAVES"), _T(""), _T(""), _T(""), _T(""),
-       _T(""), _T("WIND500,HGT500"), _T("")},
+      {"", "", "TEMP", "WAVES", "", "", "", "", "", "WIND500,HGT500", ""},
       // parameters GFS from zygrib
-      {_T("PRECIP"), _T("CLOUD"), _T("TEMP"), _T("WVSIG WVWIND"), wxEmptyString,
-       _T("GUST"), _T("CAPE"), _T("A850"), _T("A700"), _T("A500"), _T("A300")}};
+      {"PRECIP", "CLOUD", "TEMP", "WVSIG WVWIND", wxEmptyString, "GUST", "CAPE",
+       "A850", "A700", "A500", "A300"}};
 
   wxString r_topmess, r_parameters, r_zone;
   // write the top part of the mail
   switch (m_pMailTo->GetCurrentSelection()) {
     case SAILDOCS:  // Saildocs
-      r_zone = toMailFormat(1, m_spMaxLat->GetValue()) + _T(",") +
-               toMailFormat(1, m_spMinLat->GetValue()) + _T(",") +
-               toMailFormat(2, m_spMinLon->GetValue()) + _T(",") +
+      r_zone = toMailFormat(1, m_spMaxLat->GetValue()) + "," +
+               toMailFormat(1, m_spMinLat->GetValue()) + "," +
+               toMailFormat(2, m_spMinLon->GetValue()) + "," +
                toMailFormat(2, m_spMaxLon->GetValue());
-      r_topmess = wxT("send ");
-      r_topmess.Append(m_pModel->GetStringSelection() + _T(":"));
-      r_topmess.Append(r_zone + _T("|"));
+      r_topmess = "send ";
+      r_topmess.Append(m_pModel->GetStringSelection() + ":");
+      r_topmess.Append(r_zone + "|");
       r_topmess.Append(m_pResolution->GetStringSelection())
-          .Append(_T(","))
+          .Append(",")
           .Append(m_pResolution->GetStringSelection())
-          .Append(_T("|"));
+          .Append("|");
       double v;
       m_pInterval->GetStringSelection().ToDouble(&v);
-      r_topmess.Append(wxString::Format(_T("0,%d,%d"), (int)v, (int)v * 2));
+      r_topmess.Append(wxString::Format("0,%d,%d", (int)v, (int)v * 2));
       m_pTimeRange->GetStringSelection().ToDouble(&v);
-      r_topmess.Append(wxString::Format(_T("..%d"), (int)v * 24) + _T("|=\n"));
+      r_topmess.Append(wxString::Format("..%d", (int)v * 24) + "|=\n");
       break;
     case ZYGRIB:  // Zygrib
       double maxlon = (m_spMinLon->GetValue() > m_spMaxLon->GetValue() &&
@@ -1561,27 +1558,27 @@ wxString GribRequestSetting::WriteMail() {
                           ? m_spMaxLon->GetValue() + 360
                           : m_spMaxLon->GetValue();
       r_zone = toMailFormat(1, m_spMinLat->GetValue()) +
-               toMailFormat(2, m_spMinLon->GetValue()) + _T(" ") +
+               toMailFormat(2, m_spMinLon->GetValue()) + " " +
                toMailFormat(1, m_spMaxLat->GetValue()) +
                toMailFormat(2, maxlon);
-      r_topmess = wxT("login : ");
-      r_topmess.Append(m_pLogin->GetValue() + _T("\n"));
-      r_topmess.Append(wxT("code :"));
-      r_topmess.Append(m_pCode->GetValue() + _T("\n"));
-      r_topmess.Append(wxT("area : "));
-      r_topmess.append(r_zone + _T("\n"));
-      r_topmess.Append(wxT("resol : "));
-      r_topmess.append(m_pResolution->GetStringSelection() + _T("\n"));
-      r_topmess.Append(wxT("days : "));
-      r_topmess.append(m_pTimeRange->GetStringSelection() + _T("\n"));
-      r_topmess.Append(wxT("hours : "));
-      r_topmess.append(m_pInterval->GetStringSelection() + _T("\n"));
+      r_topmess = "login : ";
+      r_topmess.Append(m_pLogin->GetValue() + "\n");
+      r_topmess.Append("code :");
+      r_topmess.Append(m_pCode->GetValue() + "\n");
+      r_topmess.Append("area : ");
+      r_topmess.append(r_zone + "\n");
+      r_topmess.Append("resol : ");
+      r_topmess.append(m_pResolution->GetStringSelection() + "\n");
+      r_topmess.Append("days : ");
+      r_topmess.append(m_pTimeRange->GetStringSelection() + "\n");
+      r_topmess.Append("hours : ");
+      r_topmess.append(m_pInterval->GetStringSelection() + "\n");
       if (m_pWaves->IsChecked()) {
-        r_topmess.Append(wxT("waves : "));
-        r_topmess.append(m_pWModel->GetStringSelection() + _T("\n"));
+        r_topmess.Append("waves : ");
+        r_topmess.append(m_pWModel->GetStringSelection() + "\n");
       }
-      r_topmess.Append(wxT("meteo : "));
-      r_topmess.append(m_pModel->GetStringSelection() + _T("\n"));
+      r_topmess.Append("meteo : ");
+      r_topmess.append(m_pModel->GetStringSelection() + "\n");
       if (m_pLogin->GetValue().IsEmpty() || m_pCode->GetValue().IsEmpty())
         m_MailError_Nb = 6;
       break;
@@ -1590,8 +1587,8 @@ wxString GribRequestSetting::WriteMail() {
   int GFSZ = IsZYGRIB ? 6 : 0;
   switch (m_pModel->GetCurrentSelection()) {
     case GFS:  // GFS
-      r_parameters = wxT("WIND") + s[m_pMailTo->GetCurrentSelection()] +
-                     wxT("PRESS");  // the default minimum request parameters
+      r_parameters = "WIND" + s[m_pMailTo->GetCurrentSelection()] +
+                     "PRESS";  // the default minimum request parameters
       if (m_pRainfall->IsChecked())
         r_parameters.Append(s[m_pMailTo->GetCurrentSelection()] +
                             p[GFS + GFSZ][0]);
@@ -1628,16 +1625,16 @@ wxString GribRequestSetting::WriteMail() {
                               p[GFS + GFSZ][10]);
       }
       break;
-    case COAMPS:                         // COAMPS
-      r_parameters = wxT("WIND,PRMSL");  // the default parameters for this
-                                         // model
+    case COAMPS:                    // COAMPS
+      r_parameters = "WIND,PRMSL";  // the default parameters for this
+                                    // model
       break;
-    case RTOFS:                        // RTOFS
-      r_parameters = wxT("CUR,WTMP");  // the default parameters for this model
+    case RTOFS:                   // RTOFS
+      r_parameters = "CUR,WTMP";  // the default parameters for this model
       break;
-    case HRRR:                           // HRRR
-      r_parameters = wxT("WIND,PRMSL");  // the default parameters for this
-                                         // model
+    case HRRR:                      // HRRR
+      r_parameters = "WIND,PRMSL";  // the default parameters for this
+                                    // model
       if (m_pRainfall->IsChecked())
         r_parameters.Append(s[m_pMailTo->GetCurrentSelection()] + p[GFS][0]);
       if (m_pAirTemp->IsChecked())
@@ -1650,8 +1647,8 @@ wxString GribRequestSetting::WriteMail() {
         r_parameters.Append(s[m_pMailTo->GetCurrentSelection()] + p[GFS][6]);
       break;
     case ICON:
-      r_parameters = wxT("WIND,PRMSL");  // the default parameters for this
-                                         // model
+      r_parameters = "WIND,PRMSL";  // the default parameters for this
+                                    // model
       if (m_pAirTemp->IsChecked())
         r_parameters.Append(s[m_pMailTo->GetCurrentSelection()] + p[ICON][2]);
       if (m_pSeaTemp->IsChecked())
@@ -1664,7 +1661,7 @@ wxString GribRequestSetting::WriteMail() {
       }
       break;
     case ECMWF:
-      r_parameters = wxT("WIND,MSLP");  // the default parameters for this
+      r_parameters = "WIND,MSLP";  // the default parameters for this
       // model
       if (m_pAirTemp->IsChecked())
         r_parameters.Append(s[m_pMailTo->GetCurrentSelection()] + p[ECMWF][2]);
@@ -1678,8 +1675,8 @@ wxString GribRequestSetting::WriteMail() {
       break;
   }
   if (!IsZYGRIB && m_cMovingGribEnabled->IsChecked())  // moving grib
-    r_parameters.Append(wxString::Format(
-        _T("|%d,%d"), m_sMovingSpeed->GetValue(), m_sMovingCourse->GetValue()));
+    r_parameters.Append(wxString::Format("|%d,%d", m_sMovingSpeed->GetValue(),
+                                         m_sMovingCourse->GetValue()));
 
   // line lenth limitation
   int j = 0;
@@ -1689,9 +1686,8 @@ wxString GribRequestSetting::WriteMail() {
       j--;  // do not split Saildocs "moving" values
     if (r_parameters.GetChar(i) == c) j++;
     if (j > 6) {  // no more than 6 parameters on the same line
-      r_parameters.insert(i + 1, m_pMailTo->GetCurrentSelection() == SAILDOCS
-                                     ? _T("=\n")
-                                     : _T("\n"));
+      r_parameters.insert(
+          i + 1, m_pMailTo->GetCurrentSelection() == SAILDOCS ? "=\n" : "\n");
       break;
     }
   }
@@ -1702,9 +1698,8 @@ wxString GribRequestSetting::WriteMail() {
   m_tFileSize->SetLabel(wxString::Format(_T("%1.2f " ), size) + _("MB"));
 
   if (IsZYGRIB) {
-    m_tLimit->SetLabel(wxString(_T("( ")) + _("Max") +
-                       wxString::Format(_T(" %d "), limit) + _("MB") +
-                       _T(" )"));
+    m_tLimit->SetLabel(wxString("( ") + _("Max") +
+                       wxString::Format(" %d ", limit) + _("MB") + " )");
     if (size > limit) m_MailError_Nb += 2;
   } else
     m_tLimit->SetLabel(wxEmptyString);
@@ -1841,7 +1836,7 @@ void GribRequestSetting::OnSendMaiL(wxCommandEvent &event) {
   }
 
   const wxString error[] = {
-      _T("\n\n"),
+      "\n\n",
       _("Before sending an email to Zygrib you have to enter your Login and "
         "Code.\nPlease visit www.zygrib.org/ and follow instructions..."),
       _("Too big file! zyGrib limit is 2Mb!"),
@@ -1896,16 +1891,16 @@ void GribRequestSetting::OnSendMaiL(wxCommandEvent &event) {
   // weird, but real)
   wxMailMessage *message =
       new wxMailMessage((m_pMailTo->GetCurrentSelection() == SAILDOCS)
-                            ? _T("grib-request")
-                            : wxT("gribauto"),  // requested subject
+                            ? "grib-request"
+                            : "gribauto",  // requested subject
                         mailto,
                         EncodeURL(WriteMail()),  // message image
                         mailfrom);
 #else
   wxMailMessage *message =
       new wxMailMessage((m_pMailTo->GetCurrentSelection() == SAILDOCS)
-                            ? _T("grib-request")
-                            : wxT("gribauto"),  // requested subject
+                            ? "grib-request"
+                            : "gribauto",  // requested subject
                         mailto,
                         WriteMail(),  // message image
                         mailfrom);

--- a/plugins/grib_pi/src/GribSettingsDialog.cpp
+++ b/plugins/grib_pi/src/GribSettingsDialog.cpp
@@ -43,19 +43,19 @@ static const wxString *unit_names[] = {
     units0_names, units1_names, units2_names, units3_names, units4_names,
     units5_names, units6_names, units7_names, units8_names};
 
-static const wxString name_from_index[] = {_T("Wind"),
-                                           _T("WindGust"),
-                                           _T("Pressure"),
-                                           _T("Waves"),
-                                           _T("Current"),
-                                           _T("Rainfall"),
-                                           _T("CloudCover"),
-                                           _T("AirTemperature"),
-                                           _T("SeaTemperature"),
-                                           _T("CAPE"),
-                                           _T("CompositeReflectivity"),
-                                           _T("Altitude"),
-                                           _T("RelativeHumidity")};
+static const wxString name_from_index[] = {"Wind",
+                                           "WindGust",
+                                           "Pressure",
+                                           "Waves",
+                                           "Current",
+                                           "Rainfall",
+                                           "CloudCover",
+                                           "AirTemperature",
+                                           "SeaTemperature",
+                                           "CAPE",
+                                           "CompositeReflectivity",
+                                           "Altitude",
+                                           "RelativeHumidity"};
 static const wxString tname_from_index[] = {_("Wind"),
                                             _("Wind Gust"),
                                             _("Pressure"),
@@ -66,7 +66,7 @@ static const wxString tname_from_index[] = {_("Wind"),
                                             _("Air Temperature"),
                                             _("Sea Temperature"),
                                             _("CAPE"),
-                                            _T("Composite Reflectivity"),
+                                            "Composite Reflectivity",
                                             _("Altitude(Geopotential)"),
                                             _("Relative Humidity")};
 
@@ -77,9 +77,9 @@ static const int minuttes_from_index[] = {2,  5,   10,  20,  30,  60,
                                           90, 180, 360, 720, 1440};
 
 static const wxString altitude_from_index[3][5] = {
-    {_T("Std"), _T("850"), _T("700"), _T("500"), _T("300")},
-    {_T("Std"), _T("637"), _T("525"), _T("375"), _T("225")},
-    {_T("Std"), _T("25.2"), _T("20.7"), _T("14.8"), _T("8.9")}};
+    {"Std", "850", "700", "500", "300"},
+    {"Std", "637", "525", "375", "225"},
+    {"Std", "25.2", "20.7", "14.8", "8.9"}};
 
 #ifdef __ANDROID__
 
@@ -509,83 +509,83 @@ wxString GribOverlaySettings::GetUnitSymbol(int settings) {
     case 0:
       switch (Settings[settings].m_Units) {
         case KNOTS:
-          return _T("kts");
+          return "kts";
         case M_S:
-          return _T("m/s");
+          return "m/s";
         case MPH:
-          return _T("mph");
+          return "mph";
         case KPH:
-          return _T("km/h");
+          return "km/h";
         case BFS:
-          return _T("bf");
+          return "bf";
       }
       break;
     case 1:
       switch (Settings[settings].m_Units) {
         case MILLIBARS:
-          return _T("hPa");
+          return "hPa";
         case MMHG:
-          return _T("mmHg");
+          return "mmHg";
         case INHG:
-          return _T("inHg");
+          return "inHg";
       }
       break;
     case 2:
       switch (Settings[settings].m_Units) {
         case METERS:
-          return _T("m");
+          return "m";
         case FEET:
-          return _T("ft");
+          return "ft";
       }
       break;
     case 3:
       switch (Settings[settings].m_Units) {
         case CELCIUS:
-          return _T("\u00B0C");
+          return "\u00B0C";
         case FAHRENHEIT:
-          return _T("\u00B0F");
+          return "\u00B0F";
       }
       break;
     case 4:
       switch (Settings[settings].m_Units) {
         case MILLIMETERS:
-          return _T("mm");
+          return "mm";
         case INCHES:
-          return _T("in");
+          return "in";
       }
       break;
     case 5:
       switch (Settings[settings].m_Units) {
         case PERCENTAGE:
-          return _T("%");
+          return "%";
       }
       break;
     case 6:
       switch (Settings[settings].m_Units) {
         case JPKG:
-          return _T("j/kg");
+          return "j/kg";
       }
       break;
     case 7:
       switch (Settings[settings].m_Units) {
         case KNOTS:
-          return _T("kts");
+          return "kts";
         case M_S:
-          return _T("m/s");
+          return "m/s";
         case MPH:
-          return _T("mph");
+          return "mph";
         case KPH:
-          return _T("km/h");
+          return "km/h";
       }
       break;
     case 8:
       switch (Settings[settings].m_Units) {
         case DBZ:
-          return _T("dBZ");
+          return "dBZ";
       }
       break;
   }
-  return _T("");
+  return "";
 }
 
 double GribOverlaySettings::GetMin(int settings) {
@@ -656,31 +656,29 @@ GribSettingsDialog::GribSettingsDialog(GRIBUICtrlBar &parent,
   m_sSlicesPerUpdate->Clear();
   for (int i = 0; i < fileIntervalIndex + 1; i++) {
     int mn = m_Settings.GetMinFromIndex(i);
-    m_sSlicesPerUpdate->Append(wxString::Format(_T("%2d "), mn / 60) + _("h") +
-                               wxString::Format(_T(" %.2d "), mn % 60) +
-                               _("mn"));
+    m_sSlicesPerUpdate->Append(wxString::Format("%2d ", mn / 60) + _("h") +
+                               wxString::Format(" %.2d ", mn % 60) + _("mn"));
   }
   // Set Bitmap
-  m_biAltitude->SetBitmap(parent.GetScaledBitmap(
-      wxBitmap(altitude), _T("altitude"), parent.GetScaleFactor()));
-  m_biNow->SetBitmap(parent.GetScaledBitmap(wxBitmap(now), _T("now"),
-                                            parent.GetScaleFactor()));
-  m_biZoomToCenter->SetBitmap(parent.GetScaledBitmap(
-      wxBitmap(zoomto), _T("zoomto"), parent.GetScaleFactor()));
+  m_biAltitude->SetBitmap(parent.GetScaledBitmap(wxBitmap(altitude), "altitude",
+                                                 parent.GetScaleFactor()));
+  m_biNow->SetBitmap(
+      parent.GetScaledBitmap(wxBitmap(now), "now", parent.GetScaleFactor()));
+  m_biZoomToCenter->SetBitmap(parent.GetScaledBitmap(wxBitmap(zoomto), "zoomto",
+                                                     parent.GetScaleFactor()));
   m_biShowCursorData->SetBitmap(parent.GetScaledBitmap(
       parent.m_CDataIsShown ? wxBitmap(curdata) : wxBitmap(ncurdata),
-      parent.m_CDataIsShown ? _T("curdata") : _T("ncurdata"),
-      parent.GetScaleFactor()));
-  m_biPlay->SetBitmap(parent.GetScaledBitmap(wxBitmap(play), _T("play"),
-                                             parent.GetScaleFactor()));
-  m_biTimeSlider->SetBitmap(parent.GetScaledBitmap(
-      wxBitmap(slider), _T("slider"), parent.GetScaleFactor()));
-  m_biOpenFile->SetBitmap(parent.GetScaledBitmap(
-      wxBitmap(openfile), _T("openfile"), parent.GetScaleFactor()));
-  m_biSettings->SetBitmap(parent.GetScaledBitmap(
-      wxBitmap(setting), _T("setting"), parent.GetScaleFactor()));
-  m_biRequest->SetBitmap(parent.GetScaledBitmap(
-      wxBitmap(request), _T("request"), parent.GetScaleFactor()));
+      parent.m_CDataIsShown ? "curdata" : "ncurdata", parent.GetScaleFactor()));
+  m_biPlay->SetBitmap(
+      parent.GetScaledBitmap(wxBitmap(play), "play", parent.GetScaleFactor()));
+  m_biTimeSlider->SetBitmap(parent.GetScaledBitmap(wxBitmap(slider), "slider",
+                                                   parent.GetScaleFactor()));
+  m_biOpenFile->SetBitmap(parent.GetScaledBitmap(wxBitmap(openfile), "openfile",
+                                                 parent.GetScaleFactor()));
+  m_biSettings->SetBitmap(parent.GetScaledBitmap(wxBitmap(setting), "setting",
+                                                 parent.GetScaleFactor()));
+  m_biRequest->SetBitmap(parent.GetScaledBitmap(wxBitmap(request), "request",
+                                                parent.GetScaleFactor()));
   // read bookpage
   wxFileConfig *pConf = GetOCPNConfigObject();
   if (pConf) {
@@ -1001,13 +999,13 @@ void GribSettingsDialog::ShowFittingSettings(int settings) {
 
   wxString l = (m_lastdatatype == GribOverlaySettings::PRESSURE &&
                 m_cDataUnits->GetSelection() == GribOverlaySettings::INHG)
-                   ? _T("(0.03 " )
-                   : _T("(");
+                   ? "(0.03 "
+                   : "(";
   m_tIsoBarSpacing->SetLabel(
       wxString(_("Spacing"))
           .Append(l)
           .Append(m_Settings.GetUnitSymbol(m_lastdatatype))
-          .Append(_T(")")));
+          .Append(")"));
 }
 
 void GribSettingsDialog::ShowSettings(int params, bool show) {
@@ -1078,13 +1076,13 @@ void GribSettingsDialog::OnUnitChange(wxCommandEvent &event) {
   m_Settings.Settings[m_lastdatatype].m_Units = m_cDataUnits->GetSelection();
   wxString l = (m_lastdatatype == GribOverlaySettings::PRESSURE &&
                 m_cDataUnits->GetSelection() == GribOverlaySettings::INHG)
-                   ? _T("(0.03 " )
-                   : _T("(");
+                   ? "(0.03 "
+                   : "(";
   m_tIsoBarSpacing->SetLabel(
       wxString(_("Spacing"))
           .Append(l)
           .Append(m_Settings.GetUnitSymbol(m_lastdatatype))
-          .Append(_T(")")));
+          .Append(")"));
   SetSettingsDialogSize();
 }
 
@@ -1190,7 +1188,7 @@ wxString GribOverlaySettings::SettingsToJSON(wxString json) {
 
   for (int i = 0; i < SETTINGS_COUNT; i++) {
     wxString units;
-    units.Printf(_T("%d"), (int)Settings[i].m_Units);
+    units.Printf("%d", (int)Settings[i].m_Units);
     v[name_from_index[i] + _T ( "Units" )] = units;
 
     if (i == WIND) {

--- a/plugins/grib_pi/src/GribTable.cpp
+++ b/plugins/grib_pi/src/GribTable.cpp
@@ -53,7 +53,7 @@ void GRIBTable::InitGribTable(ArrayOfGribRecordSets *rsa, int NowIndex) {
   // populate "cursor position" display
   wxString l;
   l.Append(toSDMM_PlugIn(1, m_cursor_lat))
-      .Append(_T("   "))
+      .Append("   ")
       .Append(toSDMM_PlugIn(2, m_cursor_lon));
   m_pCursorPosition->SetLabel(l);
   m_pCursorPosition->SetFont(
@@ -253,11 +253,11 @@ void GRIBTable::SetTableSizePosition(int vpWidth, int vpHeight) {
   int x = -1, y = -1, w = -1, h = -1;
   wxFileConfig *pConf = GetOCPNConfigObject();
   if (pConf) {
-    pConf->SetPath(_T("/Settings/GRIB"));
-    pConf->Read(_T("GribDataTablePosition_x"), &x);
-    pConf->Read(_T("GribDataTablePosition_y"), &y);
-    pConf->Read(_T("GribDataTableWidth"), &w);
-    pConf->Read(_T("GribDataTableHeight"), &h);
+    pConf->SetPath("/Settings/GRIB");
+    pConf->Read("GribDataTablePosition_x", &x);
+    pConf->Read("GribDataTablePosition_y", &y);
+    pConf->Read("GribDataTableWidth", &w);
+    pConf->Read("GribDataTableHeight", &h);
   }
   wxPoint final_pos = GetOCPNCanvasWindow()->ClientToScreen(wxPoint(x, y));
   // set a default size & position if saved values are outside of limits
@@ -374,15 +374,15 @@ wxString GRIBTable::GetWind(GribRecord **recordarray, int datatype,
         m_pGDialog->pPlugIn->m_pGRIBOverlayFactory->GetGraphicColor(
             GribOverlaySettings::WIND, cvkn);
     skn.Printf(wxString::Format(
-        _T("%2d bf"),
+        "%2d bf",
         (int)wxRound(m_pGDialog->m_OverlaySettings.GetmstobfFactor(vkn) *
                      vkn)));
     if (datatype == 2) {  // wind speed unit other than bf
-      skn.Prepend(wxString::Format(
-                      _T("%2d ") + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
-                                       GribOverlaySettings::WIND),
-                      (int)wxRound(cvkn)) +
-                  _T(" - "));
+      skn.Prepend(
+          wxString::Format("%2d " + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
+                                        GribOverlaySettings::WIND),
+                           (int)wxRound(cvkn)) +
+          " - ");
     }
   }
   return skn;
@@ -401,16 +401,15 @@ wxString GRIBTable::GetWindGust(GribRecord **recordarray, int datatype) {
               GribOverlaySettings::WIND_GUST, cvkn);
 
       skn.Printf(wxString::Format(
-          _T("%2d bf"),
+          "%2d bf",
           (int)wxRound(m_pGDialog->m_OverlaySettings.GetmstobfFactor(vkn) *
                        vkn)));  // wind gust unit bf
       if (datatype == 1) {      // wind gust unit other than bf
-        skn.Prepend(
-            wxString::Format(
-                _T("%2d ") + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
-                                 GribOverlaySettings::WIND_GUST),
-                (int)wxRound(cvkn)) +
-            _T(" - " ));
+        skn.Prepend(wxString::Format(
+                        "%2d " + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
+                                     GribOverlaySettings::WIND_GUST),
+                        (int)wxRound(cvkn)) +
+                    _T(" - " ));
       }
     }
   }
@@ -432,8 +431,8 @@ wxString GRIBTable::GetPressure(GribRecord **recordarray) {
               ? 2
               : 0;  // if PRESSURE & inHG = two decimals
       skn.Printf(wxString::Format(
-          _T("%2.*f ") + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
-                             GribOverlaySettings::PRESSURE),
+          "%2.*f " + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
+                         GribOverlaySettings::PRESSURE),
           p, (press)));
     }
   }
@@ -453,8 +452,8 @@ wxString GRIBTable::GetWaves(GribRecord **recordarray, int datatype,
           double cheight = m_pGDialog->m_OverlaySettings.CalibrateValue(
               GribOverlaySettings::WAVE, height);
           skn.Printf(wxString::Format(
-              _T("%4.1f ") + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
-                                 GribOverlaySettings::WAVE),
+              "%4.1f " + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
+                             GribOverlaySettings::WAVE),
               cheight));
           m_pDataCellsColour =
               m_pGDialog->pPlugIn->m_pGRIBOverlayFactory->GetGraphicColor(
@@ -475,7 +474,7 @@ wxString GRIBTable::GetWaves(GribRecord **recordarray, int datatype,
         double period = recordarray[Idx_WVPER]->getInterpolatedValue(
             m_cursor_lon, m_cursor_lat, true);
         if (period != GRIB_NOTDEF)
-          skn.Printf(wxString::Format(_T("%01ds"), (int)(period + 0.5)));
+          skn.Printf(wxString::Format("%01ds", (int)(period + 0.5)));
       }
   }
   return skn;
@@ -490,8 +489,8 @@ wxString GRIBTable::GetRainfall(GribRecord **recordarray) {
     if (precip != GRIB_NOTDEF) {
       precip = m_pGDialog->m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::PRECIPITATION, precip);
-      skn.Printf(_T("%6.2f ") + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
-                                    GribOverlaySettings::PRECIPITATION),
+      skn.Printf("%6.2f " + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
+                                GribOverlaySettings::PRECIPITATION),
                  precip);
       m_pDataCellsColour =
           m_pGDialog->pPlugIn->m_pGRIBOverlayFactory->GetGraphicColor(
@@ -510,7 +509,7 @@ wxString GRIBTable::GetCloudCover(GribRecord **recordarray) {
     if (cloud != GRIB_NOTDEF) {
       cloud = m_pGDialog->m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::CLOUD, cloud);
-      skn.Printf(_T("%5.1f "), cloud);
+      skn.Printf("%5.1f ", cloud);
       skn.Append(m_pGDialog->m_OverlaySettings.GetUnitSymbol(
           GribOverlaySettings::CLOUD));
       m_pDataCellsColour =
@@ -530,8 +529,8 @@ wxString GRIBTable::GetAirTemp(GribRecord **recordarray) {
     if (temp != GRIB_NOTDEF) {
       temp = m_pGDialog->m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::AIR_TEMPERATURE, temp);
-      skn.Printf(_T("%5.1f ") + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
-                                    GribOverlaySettings::AIR_TEMPERATURE),
+      skn.Printf("%5.1f " + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
+                                GribOverlaySettings::AIR_TEMPERATURE),
                  temp);
       m_pDataCellsColour =
           m_pGDialog->pPlugIn->m_pGRIBOverlayFactory->GetGraphicColor(
@@ -550,8 +549,8 @@ wxString GRIBTable::GetSeaTemp(GribRecord **recordarray) {
     if (temp != GRIB_NOTDEF) {
       temp = m_pGDialog->m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::SEA_TEMPERATURE, temp);
-      skn.Printf(_T("%5.1f ") + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
-                                    GribOverlaySettings::SEA_TEMPERATURE),
+      skn.Printf("%5.1f " + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
+                                GribOverlaySettings::SEA_TEMPERATURE),
                  temp);
       m_pDataCellsColour =
           m_pGDialog->pPlugIn->m_pGRIBOverlayFactory->GetGraphicColor(
@@ -571,8 +570,8 @@ wxString GRIBTable::GetCAPE(GribRecord **recordarray) {
       cape = m_pGDialog->m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::CAPE, cape);
       skn.Printf(wxString::Format(
-          _T("%5.0f ") + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
-                             GribOverlaySettings::CAPE),
+          "%5.0f " + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
+                         GribOverlaySettings::CAPE),
           cape));
       m_pDataCellsColour =
           m_pGDialog->pPlugIn->m_pGRIBOverlayFactory->GetGraphicColor(
@@ -592,8 +591,8 @@ wxString GRIBTable::GetCompRefl(GribRecord **recordarray) {
       refl = m_pGDialog->m_OverlaySettings.CalibrateValue(
           GribOverlaySettings::COMP_REFL, refl);
       skn.Printf(wxString::Format(
-          _T("%5.0f ") + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
-                             GribOverlaySettings::COMP_REFL),
+          "%5.0f " + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
+                         GribOverlaySettings::COMP_REFL),
           refl));
       m_pDataCellsColour =
           m_pGDialog->pPlugIn->m_pGRIBOverlayFactory->GetGraphicColor(
@@ -617,10 +616,10 @@ wxString GRIBTable::GetCurrent(GribRecord **recordarray, int datatype,
     }
     vkn = m_pGDialog->m_OverlaySettings.CalibrateValue(
         GribOverlaySettings::CURRENT, vkn);
-    skn.Printf(wxString::Format(
-        _T("%4.1f ") + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
-                           GribOverlaySettings::CURRENT),
-        vkn));
+    skn.Printf(
+        wxString::Format("%4.1f " + m_pGDialog->m_OverlaySettings.GetUnitSymbol(
+                                        GribOverlaySettings::CURRENT),
+                         vkn));
     m_pDataCellsColour =
         m_pGDialog->pPlugIn->m_pGRIBOverlayFactory->GetGraphicColor(
             GribOverlaySettings::CURRENT, vkn);

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -352,7 +352,7 @@ GRIBUICtrlBar::~GRIBUICtrlBar() {
 
     for (unsigned int i = 0; i < m_file_names.GetCount(); i++) {
       wxString key;
-      key.Printf(_T("Filename%d"), i);
+      key.Printf("Filename%d", i);
       pConf->Write(key, m_file_names[i]);
     }
 
@@ -387,25 +387,25 @@ void GRIBUICtrlBar::SetScaledBitmap(double factor) {
   m_ScaledFactor = wxRound(factor * 4.0) / 4.0;
   // set buttons bitmap
   m_bpPrev->SetBitmapLabel(
-      GetScaledBitmap(wxBitmap(prev), _T("prev"), m_ScaledFactor));
+      GetScaledBitmap(wxBitmap(prev), "prev", m_ScaledFactor));
   m_bpNext->SetBitmapLabel(
-      GetScaledBitmap(wxBitmap(next), _T("next"), m_ScaledFactor));
+      GetScaledBitmap(wxBitmap(next), "next", m_ScaledFactor));
   m_bpAltitude->SetBitmapLabel(
-      GetScaledBitmap(wxBitmap(altitude), _T("altitude"), m_ScaledFactor));
+      GetScaledBitmap(wxBitmap(altitude), "altitude", m_ScaledFactor));
   m_bpNow->SetBitmapLabel(
-      GetScaledBitmap(wxBitmap(now), _T("now"), m_ScaledFactor));
+      GetScaledBitmap(wxBitmap(now), "now", m_ScaledFactor));
   m_bpZoomToCenter->SetBitmapLabel(
-      GetScaledBitmap(wxBitmap(zoomto), _T("zoomto"), m_ScaledFactor));
+      GetScaledBitmap(wxBitmap(zoomto), "zoomto", m_ScaledFactor));
   m_bpPlay->SetBitmapLabel(
-      GetScaledBitmap(wxBitmap(play), _T("play"), m_ScaledFactor));
-  m_bpShowCursorData->SetBitmapLabel(GetScaledBitmap(
-      wxBitmap(m_CDataIsShown ? curdata : ncurdata),
-      m_CDataIsShown ? _T("curdata") : _T("ncurdata"), m_ScaledFactor));
+      GetScaledBitmap(wxBitmap(play), "play", m_ScaledFactor));
+  m_bpShowCursorData->SetBitmapLabel(
+      GetScaledBitmap(wxBitmap(m_CDataIsShown ? curdata : ncurdata),
+                      m_CDataIsShown ? "curdata" : "ncurdata", m_ScaledFactor));
   if (m_bpOpenFile)
     m_bpOpenFile->SetBitmapLabel(
-        GetScaledBitmap(wxBitmap(openfile), _T("openfile"), m_ScaledFactor));
+        GetScaledBitmap(wxBitmap(openfile), "openfile", m_ScaledFactor));
   m_bpSettings->SetBitmapLabel(
-      GetScaledBitmap(wxBitmap(setting), _T("setting"), m_ScaledFactor));
+      GetScaledBitmap(wxBitmap(setting), "setting", m_ScaledFactor));
 
   SetRequestButtonBitmap(m_ZoneSelMode);
 
@@ -423,13 +423,13 @@ void GRIBUICtrlBar::SetScaledBitmap(double factor) {
 void GRIBUICtrlBar::SetRequestButtonBitmap(int type) {
   if (nullptr == m_bpRequest) return;
   m_bpRequest->SetBitmapLabel(
-      GetScaledBitmap(wxBitmap(request), _T("request"), m_ScaledFactor));
+      GetScaledBitmap(wxBitmap(request), "request", m_ScaledFactor));
   m_bpRequest->SetToolTip(_("Start a download request"));
 }
 
 void GRIBUICtrlBar::OpenFile(bool newestFile) {
   m_bpPlay->SetBitmapLabel(
-      GetScaledBitmap(wxBitmap(play), _T("play"), m_ScaledFactor));
+      GetScaledBitmap(wxBitmap(play), "play", m_ScaledFactor));
   m_cRecordForecast->Clear();
   pPlugIn->GetGRIBOverlayFactory()->ClearParticles();
   m_Altitude = 0;
@@ -652,7 +652,7 @@ wxArrayString GRIBUICtrlBar::GetFilesInDirectory() {
 
   //    Get an array of GRIB file names in the target directory, not descending
   //    into subdirs
-  wxRegEx pattern(_T(".+\\.gri?b2?(\\.(bz2|gz))?$"),
+  wxRegEx pattern(".+\\.gri?b2?(\\.(bz2|gz))?$",
                   wxRE_EXTENDED | wxRE_ICASE | wxRE_NOSUB);
   FileCollector collector(file_array, pattern);
   wxDir dir(m_grib_dir);
@@ -690,9 +690,9 @@ void GRIBUICtrlBar::UpdateTrackingControl() {
 
 void GRIBUICtrlBar::OnShowCursorData(wxCommandEvent &event) {
   m_CDataIsShown = !m_CDataIsShown;
-  m_bpShowCursorData->SetBitmapLabel(GetScaledBitmap(
-      wxBitmap(m_CDataIsShown ? curdata : ncurdata),
-      m_CDataIsShown ? _T("curdata") : _T("ncurdata"), m_ScaledFactor));
+  m_bpShowCursorData->SetBitmapLabel(
+      GetScaledBitmap(wxBitmap(m_CDataIsShown ? curdata : ncurdata),
+                      m_CDataIsShown ? "curdata" : "ncurdata", m_ScaledFactor));
   SetDialogsStyleSizePosition(true);
 }
 
@@ -816,7 +816,7 @@ void GRIBUICtrlBar::SetDialogsStyleSizePosition(bool force_recompute) {
         sFont = FindOrCreateFont_PlugIn(pointSize, wxFONTFAMILY_DEFAULT,
                                         wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL,
                                         FALSE);
-        dc.GetTextExtent(_T("W"), &width, &height, nullptr, nullptr, sFont);
+        dc.GetTextExtent("W", &width, &height, nullptr, nullptr, sFont);
         if (width <= target_char_width) bOK = true;
         pointSize--;
         if (pointSize <= 10) bOK = true;
@@ -932,7 +932,7 @@ void GRIBUICtrlBar::OnMenuEvent(wxMenuEvent &event) {
 void GRIBUICtrlBar::MenuAppend(wxMenu *menu, int id, wxString label,
                                wxItemKind kind, wxBitmap bitmap,
                                wxMenu *submenu) {
-  wxMenuItem *item = new wxMenuItem(menu, id, label, _T(""), kind);
+  wxMenuItem *item = new wxMenuItem(menu, id, label, "", kind);
   // add a submenu to this item if necessary
   if (submenu) {
     item->SetSubMenu(submenu);
@@ -984,33 +984,31 @@ void GRIBUICtrlBar::OnMouseEvent(wxMouseEvent &event) {
       smenu->Check(ID_CTRLALTITUDE + 1000 + m_Altitude, true);
       MenuAppend(
           xmenu, wxID_ANY, _("Select geopotential altitude"), wxITEM_NORMAL,
-          GetScaledBitmap(wxBitmap(altitude), _T("altitude"), m_ScaledFactor),
+          GetScaledBitmap(wxBitmap(altitude), "altitude", m_ScaledFactor),
           smenu);
     }
     MenuAppend(xmenu, ID_BTNNOW, _("Now"), wxITEM_NORMAL,
-               GetScaledBitmap(wxBitmap(now), _T("now"), m_ScaledFactor));
+               GetScaledBitmap(wxBitmap(now), "now", m_ScaledFactor));
     MenuAppend(xmenu, ID_BTNZOOMTC, _("Zoom To Center"), wxITEM_NORMAL,
-               GetScaledBitmap(wxBitmap(zoomto), _T("zoomto"), m_ScaledFactor));
+               GetScaledBitmap(wxBitmap(zoomto), "zoomto", m_ScaledFactor));
     MenuAppend(
         xmenu, ID_BTNSHOWCDATA,
         m_CDataIsShown ? _("Hide data at cursor") : _("Show data at cursor"),
         wxITEM_NORMAL,
         GetScaledBitmap(wxBitmap(m_CDataIsShown ? curdata : ncurdata),
-                        m_CDataIsShown ? _T("curdata") : _T("ncurdata"),
+                        m_CDataIsShown ? "curdata" : "ncurdata",
                         m_ScaledFactor));
     MenuAppend(
         xmenu, ID_BTNPLAY,
         m_tPlayStop.IsRunning() ? _("Stop play back") : _("Start play back"),
         wxITEM_NORMAL,
         GetScaledBitmap(wxBitmap(m_tPlayStop.IsRunning() ? stop : play),
-                        m_tPlayStop.IsRunning() ? _T("stop") : _T("play"),
+                        m_tPlayStop.IsRunning() ? "stop" : "play",
                         m_ScaledFactor));
-    MenuAppend(
-        xmenu, ID_BTNOPENFILE, _("Open a new file"), wxITEM_NORMAL,
-        GetScaledBitmap(wxBitmap(openfile), _T("openfile"), m_ScaledFactor));
-    MenuAppend(
-        xmenu, ID_BTNSETTING, _("Settings"), wxITEM_NORMAL,
-        GetScaledBitmap(wxBitmap(setting), _T("setting"), m_ScaledFactor));
+    MenuAppend(xmenu, ID_BTNOPENFILE, _("Open a new file"), wxITEM_NORMAL,
+               GetScaledBitmap(wxBitmap(openfile), "openfile", m_ScaledFactor));
+    MenuAppend(xmenu, ID_BTNSETTING, _("Settings"), wxITEM_NORMAL,
+               GetScaledBitmap(wxBitmap(setting), "setting", m_ScaledFactor));
     bool requeststate1 = m_ZoneSelMode == AUTO_SELECTION ||
                          m_ZoneSelMode == SAVED_SELECTION ||
                          m_ZoneSelMode == START_SELECTION;
@@ -1024,9 +1022,9 @@ void GRIBUICtrlBar::OnMouseEvent(wxMouseEvent &event) {
                GetScaledBitmap(wxBitmap(requeststate1   ? request
                                         : requeststate3 ? selzone
                                                         : request_end),
-                               requeststate1   ? _T("request")
-                               : requeststate3 ? _T("selzone")
-                                               : _T("request_end"),
+                               requeststate1   ? "request"
+                               : requeststate3 ? "selzone"
+                                               : "request_end",
                                m_ScaledFactor));
 
     PopupMenu(xmenu);
@@ -1235,14 +1233,14 @@ void GRIBUICtrlBar::OnCompositeDialog(wxCommandEvent &event) {
     return;
   }
 
-  v[_T("latMin")] = lat_min;
-  v[_T("latMax")] = lat_max;
-  v[_T("lonMin")] = lon_min;
-  v[_T("lonMax")] = lon_max;
+  v["latMin"] = lat_min;
+  v["latMax"] = lat_max;
+  v["lonMin"] = lon_min;
+  v["lonMax"] = lon_max;
 
   //  Clear the file name field, so that a retrieved or selected file name can
   //  be returned
-  v[_T("grib_file")] = _T("");
+  v["grib_file"] = "";
 
   wxJSONWriter w;
   wxString json_final;
@@ -1268,7 +1266,7 @@ void GRIBUICtrlBar::OpenFileFromJSON(wxString json) {
     return;
   }
 
-  wxString file = root[(_T("grib_file"))].AsString();
+  wxString file = root[("grib_file")].AsString();
 
   if (file.Length() && wxFileExists(file)) {
     wxFileName fn(file);
@@ -1284,7 +1282,7 @@ void GRIBUICtrlBar::OnPlayStop(wxCommandEvent &event) {
     StopPlayBack();
   } else {
     m_bpPlay->SetBitmapLabel(
-        GetScaledBitmap(wxBitmap(stop), _T("stop"), m_ScaledFactor));
+        GetScaledBitmap(wxBitmap(stop), "stop", m_ScaledFactor));
     m_bpPlay->SetToolTip(_("Stop play back"));
     m_tPlayStop.Start(3000 / m_OverlaySettings.m_UpdatesPerSecond,
                       wxTIMER_CONTINUOUS);
@@ -1324,7 +1322,7 @@ void GRIBUICtrlBar::StopPlayBack() {
   if (m_tPlayStop.IsRunning()) {
     m_tPlayStop.Stop();
     m_bpPlay->SetBitmapLabel(
-        GetScaledBitmap(wxBitmap(play), _T("play"), m_ScaledFactor));
+        GetScaledBitmap(wxBitmap(play), "play", m_ScaledFactor));
     m_bpPlay->SetToolTip(_("Start play back"));
   }
 }
@@ -1707,7 +1705,7 @@ void GRIBUICtrlBar::OnOpenFile(wxCommandEvent &event) {
 
   wxString file;
   int response = PlatformFileSelectorDialog(
-      nullptr, &file, _("Select a GRIB file"), m_grib_dir, _T(""), _T("*.*"));
+      nullptr, &file, _("Select a GRIB file"), m_grib_dir, "", "*.*");
 
   if (response == wxID_OK) {
     wxFileName fn(file);
@@ -2440,16 +2438,16 @@ bool CheckPendingJNIException() {
 wxString callActivityMethod_ss(const char *method, wxString parm) {
   if (!java_vm) {
     // qDebug() << "java_vm is nullptr.";
-    return _T("NOK");
+    return "NOK";
   }
 
-  if (CheckPendingJNIException()) return _T("NOK");
+  if (CheckPendingJNIException()) return "NOK";
 
   wxString return_string;
   QAndroidJniObject activity = QAndroidJniObject::callStaticObjectMethod(
       "org/qtproject/qt5/android/QtNative", "activity",
       "()Landroid/app/Activity;");
-  if (CheckPendingJNIException()) return _T("NOK");
+  if (CheckPendingJNIException()) return "NOK";
 
   if (!activity.isValid()) {
     // qDebug() << "Activity is not valid";
@@ -2471,7 +2469,7 @@ wxString callActivityMethod_ss(const char *method, wxString parm) {
 
   QAndroidJniObject data = activity.callObjectMethod(
       method, "(Ljava/lang/String;)Ljava/lang/String;", p);
-  if (CheckPendingJNIException()) return _T("NOK");
+  if (CheckPendingJNIException()) return "NOK";
 
   // qDebug() << "Back from method_ss";
 

--- a/plugins/grib_pi/src/GribUIDialogBase.cpp
+++ b/plugins/grib_pi/src/GribUIDialogBase.cpp
@@ -51,7 +51,7 @@ GRIBUICtrlBarBase::GRIBUICtrlBarBase(wxWindow* parent, wxWindowID id,
     fgSizer50->Add(m_bpPrev, 0, wxALL, 1);
 
     wxArrayString m_cRecordForecastChoices;
-    m_cRecordForecastChoices.Add(_T("Item0"));
+    m_cRecordForecastChoices.Add("Item0");
     m_cRecordForecast =
         new wxChoice(this, ID_CTRLTIME, wxDefaultPosition, wxDefaultSize,
                      m_cRecordForecastChoices, 0);
@@ -176,7 +176,7 @@ GRIBUICtrlBarBase::GRIBUICtrlBarBase(wxWindow* parent, wxWindowID id,
     fgSizer50->Add(m_bpPrev, 0, wxALL, 1);
 
     wxArrayString m_cRecordForecastChoices;
-    m_cRecordForecastChoices.Add(_T("Item0"));
+    m_cRecordForecastChoices.Add("Item0");
     m_cRecordForecast =
         new wxChoice(this, ID_CTRLTIME, wxDefaultPosition, wxDefaultSize,
                      m_cRecordForecastChoices, 0);
@@ -575,11 +575,11 @@ wxBitmap GRIBUICtrlBarBase::GetScaledBitmap(wxBitmap bitmap,
   h *= scale_factor;
 
 #ifdef ocpnUSE_SVG
-  wxString shareLocn = *GetpSharedDataLocation() + _T("plugins") +
-                       wxFileName::GetPathSeparator() + _T("grib_pi") +
-                       wxFileName::GetPathSeparator() + _T("data") +
+  wxString shareLocn = *GetpSharedDataLocation() + "plugins" +
+                       wxFileName::GetPathSeparator() + "grib_pi" +
+                       wxFileName::GetPathSeparator() + "data" +
                        wxFileName::GetPathSeparator();
-  wxString filename = shareLocn + svgFileName + _T(".svg");
+  wxString filename = shareLocn + svgFileName + ".svg";
 
   wxBitmap svgbm = GetBitmapFromSVGFile(filename, w, h);
   if (svgbm.GetWidth() > 0 && svgbm.GetHeight() > 0)
@@ -1182,7 +1182,7 @@ GribSettingsDialogBase::GribSettingsDialogBase(wxWindow* parent, wxWindowID id,
   fgSizer15->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
 
   wxArrayString m_cDataTypeChoices;
-  m_cDataTypeChoices.Add(_T("Item0"));
+  m_cDataTypeChoices.Add("Item0");
   m_cDataType = new wxChoice(m_scSetDataPanel, wxID_ANY, wxDefaultPosition,
                              wxDefaultSize, m_cDataTypeChoices, 0);
   m_cDataType->SetSelection(0);
@@ -1197,7 +1197,7 @@ GribSettingsDialogBase::GribSettingsDialogBase(wxWindow* parent, wxWindowID id,
   fgSizer15->Add(m_staticText12, 0, wxALL | wxEXPAND, 5);
 
   wxArrayString m_cDataUnitsChoices;
-  m_cDataUnitsChoices.Add(_T("Item0"));
+  m_cDataUnitsChoices.Add("Item0");
   m_cDataUnits = new wxChoice(m_scSetDataPanel, wxID_ANY, wxDefaultPosition,
                               wxDefaultSize, m_cDataUnitsChoices, 0);
   m_cDataUnits->SetSelection(0);
@@ -2413,11 +2413,11 @@ wxStaticBoxSizer* GribRequestSettingBase::createAreaSelectionSection(
       new wxBitmapToggleButton(this, ID_BTNREQUEST, wxNullBitmap,
                                wxDefaultPosition, wxDefaultSize, wxBU_AUTODRAW);
   m_bpManualSelection->SetBitmapLabel(GRIBUICtrlBarBase::GetScaledBitmap(
-      wxBitmap(selzone), _T("selzone"), ctrlBar->GetScaleFactor()));
+      wxBitmap(selzone), "selzone", ctrlBar->GetScaleFactor()));
   // Set the pressed state bitmap - use a darker/highlighted version of the same
   // bitmap
   wxBitmap pressedBitmap = GRIBUICtrlBarBase::GetScaledBitmap(
-      wxBitmap(selzone), _T("selzone"), ctrlBar->GetScaleFactor());
+      wxBitmap(selzone), "selzone", ctrlBar->GetScaleFactor());
   pressedBitmap =
       pressedBitmap.ConvertToDisabled();  // Creates a greyed version
   m_bpManualSelection->SetBitmapPressed(pressedBitmap);
@@ -3600,8 +3600,8 @@ GRIBTableBase::GRIBTableBase(wxWindow* parent, wxWindowID id,
   fgSizer20->SetFlexibleDirection(wxBOTH);
   fgSizer20->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_ALL);
 
-  m_pGribTable = new CustomGrid(this, wxID_ANY, wxDefaultPosition,
-                                wxSize(-1, 50), 0, _T(" "));
+  m_pGribTable =
+      new CustomGrid(this, wxID_ANY, wxDefaultPosition, wxSize(-1, 50), 0, " ");
 
   // Cell Defaults
   m_pGribTable->SetDefaultCellFont(
@@ -3679,7 +3679,7 @@ ProjectBoatPanel::ProjectBoatPanel(wxWindow* parent, wxWindowID id,
                             wxDefaultSize, 0);
   bSizerProjectBoat->Add(m_tSpeed, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);
 
-  m_stSpeedUnit = new wxStaticText(this, wxID_ANY, wxT("kt"), wxDefaultPosition,
+  m_stSpeedUnit = new wxStaticText(this, wxID_ANY, "kt", wxDefaultPosition,
                                    wxDefaultSize, 0);
   m_stSpeedUnit->Wrap(-1);
   bSizerProjectBoat->Add(m_stSpeedUnit, 0, wxALIGN_CENTER_VERTICAL | wxALL, 5);

--- a/plugins/grib_pi/src/email.cpp
+++ b/plugins/grib_pi/src/email.cpp
@@ -47,9 +47,8 @@
 bool wxEmail::Send(wxMailMessage& message, int sendMethod,
                    const wxString& profileName, const wxString& sendMail2,
                    const wxString& sendMail1, const wxString& sendMail0) {
-  wxString mailURL = _T("mailto:");
-  mailURL +=
-      message.m_to[0] + _T("?&subject=") + message.m_subject + _T("&body=");
+  wxString mailURL = "mailto:";
+  mailURL += message.m_to[0] + "?&subject=" + message.m_subject + "&body=";
   wxString msgBody = message.m_body;
   msgBody.Replace(" ", "%20");
   msgBody.Replace("\n", "%0A");
@@ -78,7 +77,7 @@ bool wxEmail::Send(wxMailMessage& message, int sendMethod,
 bool wxEmail::Send(wxMailMessage& message, int sendMethod,
                    const wxString& profileName, const wxString& sendMail2,
                    const wxString& sendMail1, const wxString& sendMail0) {
-  wxASSERT_MSG(!message.m_to.IsEmpty(), _T("no recipients to send mail to"));
+  wxASSERT_MSG(!message.m_to.IsEmpty(), "no recipients to send mail to");
 
   wxString from = message.m_from;
   if (from.empty()) {
@@ -105,8 +104,7 @@ bool wxEmail::Send(wxMailMessage& message, int sendMethod,
     else if (wxFileExists(sendMail1))
       sendmail << sendMail1;
     else {
-      wxLogMessage(
-          _T("MAIL Error: xdg-email is not installed on this computer!"));
+      wxLogMessage("MAIL Error: xdg-email is not installed on this computer!");
       return false;
     }
 
@@ -121,16 +119,16 @@ bool wxEmail::Send(wxMailMessage& message, int sendMethod,
     return true;
 
   } else {  // directly with sendmail
-    msg << wxT("To: ");
+    msg << "To: ";
     for (size_t rcpt = 0; rcpt < message.m_to.GetCount(); rcpt++) {
-      if (rcpt) msg << wxT(", ");
+      if (rcpt) msg << ", ";
       msg << message.m_to[rcpt];
     }
-    msg << wxT("\nFrom: ") << from << wxT("\nSubject: ") << message.m_subject;
-    msg << wxT("\n\n") << message.m_body;
+    msg << "\nFrom: " << from << "\nSubject: " << message.m_subject;
+    msg << "\n\n" << message.m_body;
 
     wxString filename;
-    filename.Printf(wxT("/tmp/msg-%ld-%ld-%ld.txt"), (long)getpid(),
+    filename.Printf("/tmp/msg-%ld-%ld-%ld.txt", (long)getpid(),
                     wxGetLocalTime(), (long)rand());
 
     wxFileOutputStream stream(filename);
@@ -143,7 +141,7 @@ bool wxEmail::Send(wxMailMessage& message, int sendMethod,
     sendmail << sendMail2;
 
     wxString cmd;
-    cmd << sendmail << wxT(" < ") << filename;
+    cmd << sendmail << " < " << filename;
 
     // TODO: check return code
     wxSystem(cmd.c_str());
@@ -156,7 +154,7 @@ bool wxEmail::Send(wxMailMessage& message, int sendMethod,
   return FALSE;
 }
 #else
-wxLogMessage(_T("Send eMail not yet implemented for this platform"));
+wxLogMessage("Send eMail not yet implemented for this platform");
 return false;
 // #error Send not yet implemented for this platform.
 #endif

--- a/plugins/grib_pi/src/email.h
+++ b/plugins/grib_pi/src/email.h
@@ -49,11 +49,9 @@ public:
   static bool Send(
       wxMailMessage& message, int sendMethod,
       const wxString& profileName = wxEmptyString,
-      const wxString& sendMail2 = wxT("/usr/sbin/sendmail -t"),  // sendmail
-      const wxString& sendMail1 =
-          wxT("/usr/bin/xdg-email"),  // xdg in bin folder
-      const wxString& sendMail0 =
-          wxT("/usr/sbin/xdg-email"));  // xdg in sbin folder
+      const wxString& sendMail2 = "/usr/sbin/sendmail -t",  // sendmail
+      const wxString& sendMail1 = "/usr/bin/xdg-email",     // xdg in bin folder
+      const wxString& sendMail0 = "/usr/sbin/xdg-email");  // xdg in sbin folder
 
 protected:
 };

--- a/plugins/grib_pi/src/grib_pi.cpp
+++ b/plugins/grib_pi/src/grib_pi.cpp
@@ -74,15 +74,15 @@ grib_pi::grib_pi(void *ppimgr) : opencpn_plugin_116(ppimgr) {
   // Create the PlugIn icons
   initialize_images();
 
-  wxString shareLocn = *GetpSharedDataLocation() + _T("plugins") +
-                       wxFileName::GetPathSeparator() + _T("grib_pi") +
-                       wxFileName::GetPathSeparator() + _T("data") +
+  wxString shareLocn = *GetpSharedDataLocation() + "plugins" +
+                       wxFileName::GetPathSeparator() + "grib_pi" +
+                       wxFileName::GetPathSeparator() + "data" +
                        wxFileName::GetPathSeparator();
-  wxImage panelIcon(shareLocn + _T("grib_panel_icon.png"));
+  wxImage panelIcon(shareLocn + "grib_panel_icon.png");
   if (panelIcon.IsOk())
     m_panelBitmap = wxBitmap(panelIcon);
   else
-    wxLogMessage(_T("    GRIB panel icon NOT loaded"));
+    wxLogMessage("    GRIB panel icon NOT loaded");
 
   m_pLastTimelineSet = nullptr;
   m_bShowGrib = false;
@@ -97,7 +97,7 @@ grib_pi::~grib_pi(void) {
 }
 
 int grib_pi::Init(void) {
-  AddLocaleCatalog(_T("opencpn-grib_pi"));
+  AddLocaleCatalog("opencpn-grib_pi");
 
   // Set some default private member parameters
   m_CtrlBarxy = wxPoint(0, 0);
@@ -125,9 +125,9 @@ int grib_pi::Init(void) {
   //      int m_height = GetChartbarHeight();
   //    This PlugIn needs a CtrlBar icon, so request its insertion if enabled
   //    locally
-  wxString shareLocn = *GetpSharedDataLocation() + _T("plugins") +
-                       wxFileName::GetPathSeparator() + _T("grib_pi") +
-                       wxFileName::GetPathSeparator() + _T("data") +
+  wxString shareLocn = *GetpSharedDataLocation() + "plugins" +
+                       wxFileName::GetPathSeparator() + "grib_pi" +
+                       wxFileName::GetPathSeparator() + "data" +
                        wxFileName::GetPathSeparator();
   // Initialize catalog file
   wxString local_grib_catalog = "sources.json";
@@ -142,22 +142,22 @@ int grib_pi::Init(void) {
     wxCopyFile(shareLocn + local_grib_catalog, m_local_sources_catalog);
   }
   if (m_bGRIBShowIcon) {
-    wxString normalIcon = shareLocn + _T("grib.svg");
-    wxString toggledIcon = shareLocn + _T("grib_toggled.svg");
-    wxString rolloverIcon = shareLocn + _T("grib_rollover.svg");
+    wxString normalIcon = shareLocn + "grib.svg";
+    wxString toggledIcon = shareLocn + "grib_toggled.svg";
+    wxString rolloverIcon = shareLocn + "grib_rollover.svg";
 
     //  For journeyman styles, we prefer the built-in raster icons which match
     //  the rest of the toolbar.
-    if (GetActiveStyleName().Lower() != _T("traditional")) {
-      normalIcon = _T("");
-      toggledIcon = _T("");
-      rolloverIcon = _T("");
+    if (GetActiveStyleName().Lower() != "traditional") {
+      normalIcon = "";
+      toggledIcon = "";
+      rolloverIcon = "";
     }
 
     wxLogMessage(normalIcon);
     m_leftclick_tool_id = InsertPlugInToolSVG(
-        _T(""), normalIcon, rolloverIcon, toggledIcon, wxITEM_CHECK, _("Grib"),
-        _T(""), nullptr, GRIB_TOOL_POSITION, 0, this);
+        "", normalIcon, rolloverIcon, toggledIcon, wxITEM_CHECK, _("Grib"), "",
+        nullptr, GRIB_TOOL_POSITION, 0, this);
   }
 
   if (!QualifyCtrlBarPosition(m_CtrlBarxy, m_CtrlBar_Sizexy)) {
@@ -197,7 +197,7 @@ int grib_pi::GetPlugInVersionMinor() { return PLUGIN_VERSION_MINOR; }
 
 wxBitmap *grib_pi::GetPlugInBitmap() { return &m_panelBitmap; }
 
-wxString grib_pi::GetCommonName() { return _T("GRIB"); }
+wxString grib_pi::GetCommonName() { return "GRIB"; }
 
 wxString grib_pi::GetShortDescription() { return _("GRIB PlugIn for OpenCPN"); }
 
@@ -445,7 +445,7 @@ void grib_pi::OnToolbarToolCallback(int id) {
                                        this, scale_factor);
     m_pGribCtrlBar->SetScaledBitmap(scale_factor);
 
-    wxMenu *dummy = new wxMenu(_T("Plugin"));
+    wxMenu *dummy = new wxMenu("Plugin");
     wxMenuItem *table =
         new wxMenuItem(dummy, wxID_ANY, wxString(_("Weather table")),
                        wxEmptyString, wxITEM_NORMAL);
@@ -640,98 +640,96 @@ void grib_pi::SetDialogFont(wxWindow *dialog, wxFont *font) {
 }
 
 void grib_pi::SetPluginMessage(wxString &message_id, wxString &message_body) {
-  if (message_id == _T("GRIB_VALUES_REQUEST")) {
+  if (message_id == "GRIB_VALUES_REQUEST") {
     if (!m_pGribCtrlBar) OnToolbarToolCallback(-1);
 
     // lat, lon, time, what
     wxJSONReader r;
     wxJSONValue v;
     r.Parse(message_body, &v);
-    if (!v.HasMember(_T("Day"))) {
+    if (!v.HasMember("Day")) {
       // bogus or loading grib
-      SendPluginMessage(wxString(_T("GRIB_VALUES")), _T(""));
+      SendPluginMessage(wxString("GRIB_VALUES"), "");
       return;
     }
-    wxDateTime time(v[_T("Day")].AsInt(),
-                    (wxDateTime::Month)v[_T("Month")].AsInt(),
-                    v[_T("Year")].AsInt(), v[_T("Hour")].AsInt(),
-                    v[_T("Minute")].AsInt(), v[_T("Second")].AsInt());
-    double lat = v[_T("lat")].AsDouble();
-    double lon = v[_T("lon")].AsDouble();
+    wxDateTime time(v["Day"].AsInt(), (wxDateTime::Month)v["Month"].AsInt(),
+                    v["Year"].AsInt(), v["Hour"].AsInt(), v["Minute"].AsInt(),
+                    v["Second"].AsInt());
+    double lat = v["lat"].AsDouble();
+    double lon = v["lon"].AsDouble();
 
     if (m_pGribCtrlBar) {
-      if (v.HasMember(_T("WIND SPEED"))) {
+      if (v.HasMember("WIND SPEED")) {
         double vkn, ang;
         if (m_pGribCtrlBar->getTimeInterpolatedValues(
                 vkn, ang, Idx_WIND_VX, Idx_WIND_VY, lon, lat, time) &&
             vkn != GRIB_NOTDEF) {
-          v[_T("Type")] = wxT("Reply");
-          v[_T("WIND SPEED")] = vkn;
-          v[_T("WIND DIR")] = ang;
+          v["Type"] = "Reply";
+          v["WIND SPEED"] = vkn;
+          v["WIND DIR"] = ang;
         } else {
-          v.Remove(_T("WIND SPEED"));
-          v.Remove(_T("WIND DIR"));
+          v.Remove("WIND SPEED");
+          v.Remove("WIND DIR");
         }
       }
-      if (v.HasMember(_T("CURRENT SPEED"))) {
+      if (v.HasMember("CURRENT SPEED")) {
         double vkn, ang;
         if (m_pGribCtrlBar->getTimeInterpolatedValues(
                 vkn, ang, Idx_SEACURRENT_VX, Idx_SEACURRENT_VY, lon, lat,
                 time) &&
             vkn != GRIB_NOTDEF) {
-          v[_T("Type")] = wxT("Reply");
-          v[_T("CURRENT SPEED")] = vkn;
-          v[_T("CURRENT DIR")] = ang;
+          v["Type"] = "Reply";
+          v["CURRENT SPEED"] = vkn;
+          v["CURRENT DIR"] = ang;
         } else {
-          v.Remove(_T("CURRENT SPEED"));
-          v.Remove(_T("CURRENT DIR"));
+          v.Remove("CURRENT SPEED");
+          v.Remove("CURRENT DIR");
         }
       }
-      if (v.HasMember(_T("GUST"))) {
+      if (v.HasMember("GUST")) {
         double vkn = m_pGribCtrlBar->getTimeInterpolatedValue(Idx_WIND_GUST,
                                                               lon, lat, time);
         if (vkn != GRIB_NOTDEF) {
-          v[_T("Type")] = wxT("Reply");
-          v[_T("GUST")] = vkn;
+          v["Type"] = "Reply";
+          v["GUST"] = vkn;
         } else
-          v.Remove(_T("GUST"));
+          v.Remove("GUST");
       }
-      if (v.HasMember(_T("SWELL"))) {
+      if (v.HasMember("SWELL")) {
         double vkn = m_pGribCtrlBar->getTimeInterpolatedValue(Idx_HTSIGW, lon,
                                                               lat, time);
         if (vkn != GRIB_NOTDEF) {
-          v[_T("Type")] = wxT("Reply");
-          v[_T("SWELL")] = vkn;
+          v["Type"] = "Reply";
+          v["SWELL"] = vkn;
         } else
-          v.Remove(_T("SWELL"));
+          v.Remove("SWELL");
       }
 
       wxJSONWriter w;
       wxString out;
       w.Write(v, out);
-      SendPluginMessage(wxString(_T("GRIB_VALUES")), out);
+      SendPluginMessage(wxString("GRIB_VALUES"), out);
     }
-  } else if (message_id == _T("GRIB_VERSION_REQUEST")) {
+  } else if (message_id == "GRIB_VERSION_REQUEST") {
     wxJSONValue v;
-    v[_T("GribVersionMinor")] = GetAPIVersionMinor();
-    v[_T("GribVersionMajor")] = GetAPIVersionMajor();
+    v["GribVersionMinor"] = GetAPIVersionMinor();
+    v["GribVersionMajor"] = GetAPIVersionMajor();
 
     wxJSONWriter w;
     wxString out;
     w.Write(v, out);
-    SendPluginMessage(wxString(_T("GRIB_VERSION")), out);
-  } else if (message_id == _T("GRIB_TIMELINE_REQUEST")) {
+    SendPluginMessage(wxString("GRIB_VERSION"), out);
+  } else if (message_id == "GRIB_TIMELINE_REQUEST") {
     // local time
     SendTimelineMessage(m_pGribCtrlBar ? m_pGribCtrlBar->TimelineTime()
                                        : wxDateTime::Now());
-  } else if (message_id == _T("GRIB_TIMELINE_RECORD_REQUEST")) {
+  } else if (message_id == "GRIB_TIMELINE_RECORD_REQUEST") {
     wxJSONReader r;
     wxJSONValue v;
     r.Parse(message_body, &v);
-    wxDateTime time(v[_T("Day")].AsInt(),
-                    (wxDateTime::Month)v[_T("Month")].AsInt(),
-                    v[_T("Year")].AsInt(), v[_T("Hour")].AsInt(),
-                    v[_T("Minute")].AsInt(), v[_T("Second")].AsInt());
+    wxDateTime time(v["Day"].AsInt(), (wxDateTime::Month)v["Month"].AsInt(),
+                    v["Year"].AsInt(), v["Hour"].AsInt(), v["Minute"].AsInt(),
+                    v["Second"].AsInt());
 
     if (!m_pGribCtrlBar) OnToolbarToolCallback(-1);
 
@@ -741,20 +739,20 @@ void grib_pi::SetPluginMessage(wxString &message_id, wxString &message_body) {
     char ptr[64];
     snprintf(ptr, sizeof ptr, "%p", set);
 
-    v[_T("GribVersionMajor")] = PLUGIN_VERSION_MAJOR;
-    v[_T("GribVersionMinor")] = PLUGIN_VERSION_MINOR;
-    v[_T("TimelineSetPtr")] = wxString::From8BitData(ptr);
+    v["GribVersionMajor"] = PLUGIN_VERSION_MAJOR;
+    v["GribVersionMinor"] = PLUGIN_VERSION_MINOR;
+    v["TimelineSetPtr"] = wxString::From8BitData(ptr);
 
     wxJSONWriter w;
     wxString out;
     w.Write(v, out);
-    SendPluginMessage(wxString(_T("GRIB_TIMELINE_RECORD")), out);
+    SendPluginMessage(wxString("GRIB_TIMELINE_RECORD"), out);
     delete m_pLastTimelineSet;
     m_pLastTimelineSet = set;
   }
 
-  else if (message_id == _T("GRIB_APPLY_JSON_CONFIG")) {
-    wxLogMessage(_T("Got GRIB_APPLY_JSON_CONFIG"));
+  else if (message_id == "GRIB_APPLY_JSON_CONFIG") {
+    wxLogMessage("Got GRIB_APPLY_JSON_CONFIG");
 
     if (m_pGribCtrlBar) {
       m_pGribCtrlBar->OpenFileFromJSON(message_body);
@@ -782,7 +780,7 @@ bool grib_pi::LoadConfig(void) {
   pConf->Read(_T( "CopyFirstCumulativeRecord" ), &m_bCopyFirstCumRec, 1);
   pConf->Read(_T( "CopyMissingWaveRecord" ), &m_bCopyMissWaveRec, 1);
 #ifdef __WXMSW__
-  pConf->Read(_T("GribIconsScaleFactor"), &m_GribIconsScaleFactor, 1);
+  pConf->Read("GribIconsScaleFactor", &m_GribIconsScaleFactor, 1);
 #endif
 
   m_CtrlBar_Sizexy.x = pConf->Read(_T ( "GRIBCtrlBarSizeX" ), 1400L);
@@ -816,7 +814,7 @@ bool grib_pi::SaveConfig(void) {
   pConf->Write(_T ( "DrawBarbedArrowHead" ), m_bDrawBarbedArrowHead);
   pConf->Write(_T ( "ZoomToCenterAtInit"), m_bZoomToCenterAtInit);
 #ifdef __WXMSW__
-  pConf->Write(_T("GribIconsScaleFactor"), m_GribIconsScaleFactor);
+  pConf->Write("GribIconsScaleFactor", m_GribIconsScaleFactor);
 #endif
 
   pConf->Write(_T ( "GRIBCtrlBarSizeX" ), m_CtrlBar_Sizexy.x);
@@ -844,24 +842,24 @@ void grib_pi::SendTimelineMessage(wxDateTime time) {
 
   wxJSONValue v;
   if (time.IsValid()) {
-    v[_T("Day")] = time.GetDay();
-    v[_T("Month")] = time.GetMonth();
-    v[_T("Year")] = time.GetYear();
-    v[_T("Hour")] = time.GetHour();
-    v[_T("Minute")] = time.GetMinute();
-    v[_T("Second")] = time.GetSecond();
+    v["Day"] = time.GetDay();
+    v["Month"] = time.GetMonth();
+    v["Year"] = time.GetYear();
+    v["Hour"] = time.GetHour();
+    v["Minute"] = time.GetMinute();
+    v["Second"] = time.GetSecond();
   } else {
-    v[_T("Day")] = -1;
-    v[_T("Month")] = -1;
-    v[_T("Year")] = -1;
-    v[_T("Hour")] = -1;
-    v[_T("Minute")] = -1;
-    v[_T("Second")] = -1;
+    v["Day"] = -1;
+    v["Month"] = -1;
+    v["Year"] = -1;
+    v["Hour"] = -1;
+    v["Minute"] = -1;
+    v["Second"] = -1;
   }
   wxJSONWriter w;
   wxString out;
   w.Write(v, out);
-  SendPluginMessage(wxString(_T("GRIB_TIMELINE")), out);
+  SendPluginMessage(wxString("GRIB_TIMELINE"), out);
 }
 
 void grib_pi::SetPositionFixEx(PlugIn_Position_Fix_Ex &pfix) {

--- a/plugins/grib_pi/src/jsonreader.cpp
+++ b/plugins/grib_pi/src/jsonreader.cpp
@@ -154,13 +154,13 @@
   wxJSONReader reader;
 
   // open a text file that contains the UTF-8 encoded JSON text
-  wxFFileInputStream jsonText( _T("filename.utf8"), _T("r"));
+  wxFFileInputStream jsonText( "filename.utf8", "r");
 
   // read the file
   int numErrors = reader.Parse( jsonText, &value );
 
   if ( numErrors > 0 )  {
-    ::MessageBox( _T("Error reading the input file"));
+    ::MessageBox( "Error reading the input file");
   }
  \endcode
 
@@ -174,8 +174,8 @@
 // WXTRACE=traceReader StoreComment
 // environment variable
 #if wxDEBUG_LEVEL > 0
-static const wxChar* traceMask = _T("traceReader");
-static const wxChar* storeTraceMask = _T("StoreComment");
+static const wxChar* traceMask = "traceReader";
+static const wxChar* storeTraceMask = "StoreComment";
 #endif
 
 //! Ctor
@@ -576,14 +576,14 @@ int wxJSONReader::DoRead(wxInputStream& is, wxJSONValue& parent) {
       case '{':
         if (parent.IsObject()) {
           if (key.empty()) {
-            AddError(_T("\'{\' is not allowed here (\'name\' is missing"));
+            AddError("\'{\' is not allowed here (\'name\' is missing");
           }
           if (value.IsValid()) {
-            AddError(_T("\'{\' cannot follow a \'value\'"));
+            AddError("\'{\' cannot follow a \'value\'");
           }
         } else if (parent.IsArray()) {
           if (value.IsValid()) {
-            AddError(_T("\'{\' cannot follow a \'value\' in JSON array"));
+            AddError("\'{\' cannot follow a \'value\' in JSON array");
           }
         } else {
           wxJSON_ASSERT(0);  // always fails
@@ -612,14 +612,14 @@ int wxJSONReader::DoRead(wxInputStream& is, wxJSONValue& parent) {
       case '[':
         if (parent.IsObject()) {
           if (key.empty()) {
-            AddError(_T("\'[\' is not allowed here (\'name\' is missing"));
+            AddError("\'[\' is not allowed here (\'name\' is missing");
           }
           if (value.IsValid()) {
-            AddError(_T("\'[\' cannot follow a \'value\' text"));
+            AddError("\'[\' cannot follow a \'value\' text");
           }
         } else if (parent.IsArray()) {
           if (value.IsValid()) {
-            AddError(_T("\'[\' cannot follow a \'value\'"));
+            AddError("\'[\' cannot follow a \'value\'");
           }
         } else {
           wxJSON_ASSERT(0);  // always fails
@@ -697,9 +697,9 @@ int wxJSONReader::DoRead(wxInputStream& is, wxJSONValue& parent) {
   // if we are here, the EOF condition was encontered so one or more
   // close-something characters are missing
   if (parent.IsArray()) {
-    AddWarning(wxJSONREADER_MISSING, _T("\']\' missing at end of file"));
+    AddWarning(wxJSONREADER_MISSING, "\']\' missing at end of file");
   } else if (parent.IsObject()) {
-    AddWarning(wxJSONREADER_MISSING, _T("\'}\' missing at end of file"));
+    AddWarning(wxJSONREADER_MISSING, "\'}\' missing at end of file");
   } else {
     wxJSON_ASSERT(0);
   }
@@ -732,9 +732,9 @@ void wxJSONReader::StoreValue(int ch, const wxString& key, wxJSONValue& value,
   //
   // if 'ch' == , (comma) value AND key (for TypeMap) cannot be empty
   //
-  wxLogTrace(traceMask, _T("(%s) ch=%d char=%c"), __PRETTY_FUNCTION__, ch,
+  wxLogTrace(traceMask, "(%s) ch=%d char=%c", __PRETTY_FUNCTION__, ch,
              (char)ch);
-  wxLogTrace(traceMask, _T("(%s) value=%s"), __PRETTY_FUNCTION__,
+  wxLogTrace(traceMask, "(%s) value=%s", __PRETTY_FUNCTION__,
              value.AsString().c_str());
 
   m_current = 0;
@@ -746,25 +746,25 @@ void wxJSONReader::StoreValue(int ch, const wxString& key, wxJSONValue& value,
     // OK, if the char read is a close-object or close-array
     if (ch == '}' || ch == ']') {
       m_lastStored = 0;
-      wxLogTrace(traceMask, _T("(%s) key and value are empty, returning"),
+      wxLogTrace(traceMask, "(%s) key and value are empty, returning",
                  __PRETTY_FUNCTION__);
     } else {
-      AddError(_T("key or value is missing for JSON value"));
+      AddError("key or value is missing for JSON value");
     }
   } else {
     // key or value are not empty
     if (parent.IsObject()) {
       if (!value.IsValid()) {
         AddError(
-            _T("cannot store the value: \'value\' is missing for JSON object ")
-            _T("type"));
+            "cannot store the value: \'value\' is missing for JSON object "
+            "type");
       } else if (key.empty()) {
         AddError(
-            _T("cannot store the value: \'key\' is missing for JSON object ")
-            _T("type"));
+            "cannot store the value: \'key\' is missing for JSON object "
+            "type");
       } else {
         // OK, adding the value to parent key/value map
-        wxLogTrace(traceMask, _T("(%s) adding value to key:%s"),
+        wxLogTrace(traceMask, "(%s) adding value to key:%s",
                    __PRETTY_FUNCTION__, key.c_str());
         parent[key] = value;
         m_lastStored = &(parent[key]);
@@ -773,16 +773,16 @@ void wxJSONReader::StoreValue(int ch, const wxString& key, wxJSONValue& value,
     } else if (parent.IsArray()) {
       if (!value.IsValid()) {
         AddError(
-            _T("cannot store the item: \'value\' is missing for JSON array ")
-            _T("type"));
+            "cannot store the item: \'value\' is missing for JSON array "
+            "type");
       }
       if (!key.empty()) {
         AddError(
-            _T("cannot store the item: \'key\' (\'%s\') is not permitted in ")
-            _T("JSON array type"),
+            "cannot store the item: \'key\' (\'%s\') is not permitted in "
+            "JSON array type",
             key);
       }
-      wxLogTrace(traceMask, _T("(%s) appending value to parent array"),
+      wxLogTrace(traceMask, "(%s) appending value to parent array",
                  __PRETTY_FUNCTION__);
       parent.Append(value);
       const wxJSONInternalArray* arr = parent.AsArray();
@@ -815,15 +815,14 @@ void wxJSONReader::StoreValue(int ch, const wxString& key, wxJSONValue& value,
 */
 void wxJSONReader::AddError(const wxString& msg) {
   wxString err;
-  err.Printf(_T("Error: line %d, col %d - %s"), m_lineNo, m_colNo, msg.c_str());
+  err.Printf("Error: line %d, col %d - %s", m_lineNo, m_colNo, msg.c_str());
 
-  wxLogTrace(traceMask, _T("(%s) %s"), __PRETTY_FUNCTION__, err.c_str());
+  wxLogTrace(traceMask, "(%s) %s", __PRETTY_FUNCTION__, err.c_str());
 
   if ((int)m_errors.size() < m_maxErrors) {
     m_errors.Add(err);
   } else if ((int)m_errors.size() == m_maxErrors) {
-    m_errors.Add(
-        _T("ERROR: too many error messages - ignoring further errors"));
+    m_errors.Add("ERROR: too many error messages - ignoring further errors");
   }
   // else if ( m_errors > m_maxErrors ) do nothing, thus ignore the error
   // message
@@ -880,12 +879,12 @@ void wxJSONReader::AddWarning(int type, const wxString& msg) {
   err.Printf(_T( "Warning: line %d, col %d - %s"), m_lineNo, m_colNo,
              msg.c_str());
 
-  wxLogTrace(traceMask, _T("(%s) %s"), __PRETTY_FUNCTION__, err.c_str());
+  wxLogTrace(traceMask, "(%s) %s", __PRETTY_FUNCTION__, err.c_str());
   if ((int)m_warnings.size() < m_maxErrors) {
     m_warnings.Add(err);
   } else if ((int)m_warnings.size() == m_maxErrors) {
     m_warnings.Add(
-        _T("Error: too many warning messages - ignoring further warnings"));
+        "Error: too many warning messages - ignoring further warnings");
   }
   // else do nothing, thus ignore the warning message
 }
@@ -908,7 +907,7 @@ int wxJSONReader::SkipWhiteSpace(wxInputStream& is) {
       break;
     }
   } while (ch == ' ' || ch == '\n' || ch == '\t');
-  wxLogTrace(traceMask, _T("(%s) end whitespaces line=%d col=%d"),
+  wxLogTrace(traceMask, "(%s) end whitespaces line=%d col=%d",
              __PRETTY_FUNCTION__, m_lineNo, m_colNo);
   return ch;
 }
@@ -927,8 +926,8 @@ int wxJSONReader::SkipWhiteSpace(wxInputStream& is) {
 */
 int wxJSONReader::SkipComment(wxInputStream& is) {
   static const wxChar* warn =
-      _T("Comments may be tolerated in JSON text but they are not part of ")
-      _T("JSON syntax");
+      "Comments may be tolerated in JSON text but they are not part of "
+      "JSON syntax";
 
   // if it is a comment, then a warning is added to the array
   // otherwise it is an error: values cannot start with a '/'
@@ -938,7 +937,7 @@ int wxJSONReader::SkipComment(wxInputStream& is) {
     return -1;
   }
 
-  wxLogTrace(storeTraceMask, _T("(%s) start comment line=%d col=%d"),
+  wxLogTrace(storeTraceMask, "(%s) start comment line=%d col=%d",
              __PRETTY_FUNCTION__, m_lineNo, m_colNo);
 
   // the temporary UTF-8/ANSI buffer that holds the comment string. This will be
@@ -1022,11 +1021,11 @@ int wxJSONReader::SkipComment(wxInputStream& is) {
     // read the next char that will be returned
     ch = ReadChar(is);
   }
-  wxLogTrace(traceMask, _T("(%s) end comment line=%d col=%d"),
+  wxLogTrace(traceMask, "(%s) end comment line=%d col=%d", __PRETTY_FUNCTION__,
+             m_lineNo, m_colNo);
+  wxLogTrace(storeTraceMask, "(%s) end comment line=%d col=%d",
              __PRETTY_FUNCTION__, m_lineNo, m_colNo);
-  wxLogTrace(storeTraceMask, _T("(%s) end comment line=%d col=%d"),
-             __PRETTY_FUNCTION__, m_lineNo, m_colNo);
-  wxLogTrace(storeTraceMask, _T("(%s) comment=%s"), __PRETTY_FUNCTION__,
+  wxLogTrace(storeTraceMask, "(%s) comment=%s", __PRETTY_FUNCTION__,
              m_comment.c_str());
   return ch;
 }
@@ -1180,11 +1179,10 @@ int wxJSONReader::ReadString(wxInputStream& is, wxJSONValue& val) {
 #endif
     }
   }
-  wxLogTrace(traceMask, _T("(%s) line=%d col=%d"), __PRETTY_FUNCTION__,
-             m_lineNo, m_colNo);
-  wxLogTrace(traceMask, _T("(%s) string read=%s"), __PRETTY_FUNCTION__,
-             s.c_str());
-  wxLogTrace(traceMask, _T("(%s) value=%s"), __PRETTY_FUNCTION__,
+  wxLogTrace(traceMask, "(%s) line=%d col=%d", __PRETTY_FUNCTION__, m_lineNo,
+             m_colNo);
+  wxLogTrace(traceMask, "(%s) string read=%s", __PRETTY_FUNCTION__, s.c_str());
+  wxLogTrace(traceMask, "(%s) value=%s", __PRETTY_FUNCTION__,
              val.AsString().c_str());
 
   // now assign the string to the JSON-value 'value'
@@ -1192,13 +1190,13 @@ int wxJSONReader::ReadString(wxInputStream& is, wxJSONValue& val) {
   //   'value'  is empty
   //   'value'  is a string; concatenate it but emit warning
   if (!val.IsValid()) {
-    wxLogTrace(traceMask, _T("(%s) assigning the string to value"),
+    wxLogTrace(traceMask, "(%s) assigning the string to value",
                __PRETTY_FUNCTION__);
     val = s;
   } else if (val.IsString()) {
     AddWarning(wxJSONREADER_MULTISTRING,
-               _T("Multiline strings are not allowed by JSON syntax"));
-    wxLogTrace(traceMask, _T("(%s) concatenate the string to value"),
+               "Multiline strings are not allowed by JSON syntax");
+    wxLogTrace(traceMask, "(%s) concatenate the string to value",
                __PRETTY_FUNCTION__);
     val.Cat(s);
   } else {
@@ -1250,9 +1248,9 @@ int wxJSONReader::ReadToken(wxInputStream& is, int ch, wxString& s) {
       case '\n':
       case '\r':
       case '\b':
-        wxLogTrace(traceMask, _T("(%s) line=%d col=%d"), __PRETTY_FUNCTION__,
+        wxLogTrace(traceMask, "(%s) line=%d col=%d", __PRETTY_FUNCTION__,
                    m_lineNo, m_colNo);
-        wxLogTrace(traceMask, _T("(%s) token read=%s"), __PRETTY_FUNCTION__,
+        wxLogTrace(traceMask, "(%s) token read=%s", __PRETTY_FUNCTION__,
                    s.c_str());
         return nextCh;
         break;
@@ -1263,9 +1261,9 @@ int wxJSONReader::ReadToken(wxInputStream& is, int ch, wxString& s) {
     // read the next character
     nextCh = ReadChar(is);
   }
-  wxLogTrace(traceMask, _T("(%s) EOF on line=%d col=%d"), __PRETTY_FUNCTION__,
+  wxLogTrace(traceMask, "(%s) EOF on line=%d col=%d", __PRETTY_FUNCTION__,
              m_lineNo, m_colNo);
-  wxLogTrace(traceMask, _T("(%s) EOF - token read=%s"), __PRETTY_FUNCTION__,
+  wxLogTrace(traceMask, "(%s) EOF - token read=%s", __PRETTY_FUNCTION__,
              s.c_str());
   return nextCh;
 }
@@ -1297,7 +1295,7 @@ int wxJSONReader::ReadToken(wxInputStream& is, int ch, wxString& s) {
 int wxJSONReader::ReadValue(wxInputStream& is, int ch, wxJSONValue& val) {
   wxString s;
   int nextCh = ReadToken(is, ch, s);
-  wxLogTrace(traceMask, _T("(%s) value=%s"), __PRETTY_FUNCTION__,
+  wxLogTrace(traceMask, "(%s) value=%s", __PRETTY_FUNCTION__,
              val.AsString().c_str());
 
   if (val.IsValid()) {
@@ -1318,32 +1316,32 @@ int wxJSONReader::ReadValue(wxInputStream& is, int ch, wxJSONValue& val) {
 #endif
 
   // first try the literal strings lowercase and nocase
-  if (s == _T("null")) {
+  if (s == "null") {
     val.SetType(wxJSONTYPE_NULL);
-    wxLogTrace(traceMask, _T("(%s) value = nullptr"), __PRETTY_FUNCTION__);
+    wxLogTrace(traceMask, "(%s) value = nullptr", __PRETTY_FUNCTION__);
     return nextCh;
   } else if (s.CmpNoCase(_T( "null" )) == 0) {
-    wxLogTrace(traceMask, _T("(%s) value = nullptr"), __PRETTY_FUNCTION__);
+    wxLogTrace(traceMask, "(%s) value = nullptr", __PRETTY_FUNCTION__);
     AddWarning(wxJSONREADER_CASE,
                _T( "the \'null\' literal must be lowercase" ));
     val.SetType(wxJSONTYPE_NULL);
     return nextCh;
-  } else if (s == _T("true")) {
-    wxLogTrace(traceMask, _T("(%s) value = TRUE"), __PRETTY_FUNCTION__);
+  } else if (s == "true") {
+    wxLogTrace(traceMask, "(%s) value = TRUE", __PRETTY_FUNCTION__);
     val = true;
     return nextCh;
   } else if (s.CmpNoCase(_T( "true" )) == 0) {
-    wxLogTrace(traceMask, _T("(%s) value = TRUE"), __PRETTY_FUNCTION__);
+    wxLogTrace(traceMask, "(%s) value = TRUE", __PRETTY_FUNCTION__);
     AddWarning(wxJSONREADER_CASE,
                _T( "the \'true\' literal must be lowercase" ));
     val = true;
     return nextCh;
-  } else if (s == _T("false")) {
-    wxLogTrace(traceMask, _T("(%s) value = FALSE"), __PRETTY_FUNCTION__);
+  } else if (s == "false") {
+    wxLogTrace(traceMask, "(%s) value = FALSE", __PRETTY_FUNCTION__);
     val = false;
     return nextCh;
   } else if (s.CmpNoCase(_T( "false" )) == 0) {
-    wxLogTrace(traceMask, _T("(%s) value = FALSE"), __PRETTY_FUNCTION__);
+    wxLogTrace(traceMask, "(%s) value = FALSE", __PRETTY_FUNCTION__);
     AddWarning(wxJSONREADER_CASE,
                _T( "the \'false\' literal must be lowercase" ));
     val = false;
@@ -1387,7 +1385,7 @@ int wxJSONReader::ReadValue(wxInputStream& is, int ch, wxJSONValue& val) {
   if (tSigned) {
 #if defined(wxJSON_64BIT_INT)
     r = Strtoll(s, &i64);
-    wxLogTrace(traceMask, _T("(%s) convert to wxInt64 result=%d"),
+    wxLogTrace(traceMask, "(%s) convert to wxInt64 result=%d",
                __PRETTY_FUNCTION__, r);
     if (r) {
       // store the value
@@ -1396,8 +1394,8 @@ int wxJSONReader::ReadValue(wxInputStream& is, int ch, wxJSONValue& val) {
     }
 #else
     r = s.ToLong(&l);
-    wxLogTrace(traceMask, _T("(%s) convert to int result=%d"),
-               __PRETTY_FUNCTION__, r);
+    wxLogTrace(traceMask, "(%s) convert to int result=%d", __PRETTY_FUNCTION__,
+               r);
     if (r) {
       // store the value
       val = (int)l;
@@ -1409,7 +1407,7 @@ int wxJSONReader::ReadValue(wxInputStream& is, int ch, wxJSONValue& val) {
   if (tUnsigned) {
 #if defined(wxJSON_64BIT_INT)
     r = Strtoull(s, &ui64);
-    wxLogTrace(traceMask, _T("(%s) convert to wxUint64 result=%d"),
+    wxLogTrace(traceMask, "(%s) convert to wxUint64 result=%d",
                __PRETTY_FUNCTION__, r);
     if (r) {
       // store the value
@@ -1418,8 +1416,8 @@ int wxJSONReader::ReadValue(wxInputStream& is, int ch, wxJSONValue& val) {
     }
 #else
     r = s.ToULong(&ul);
-    wxLogTrace(traceMask, _T("(%s) convert to int result=%d"),
-               __PRETTY_FUNCTION__, r);
+    wxLogTrace(traceMask, "(%s) convert to int result=%d", __PRETTY_FUNCTION__,
+               r);
     if (r) {
       // store the value
       val = (unsigned int)ul;
@@ -1430,7 +1428,7 @@ int wxJSONReader::ReadValue(wxInputStream& is, int ch, wxJSONValue& val) {
 
   if (tDouble) {
     r = s.ToDouble(&d);
-    wxLogTrace(traceMask, _T("(%s) convert to double result=%d"),
+    wxLogTrace(traceMask, "(%s) convert to double result=%d",
                __PRETTY_FUNCTION__, r);
     if (r) {
       // store the value
@@ -1512,7 +1510,7 @@ int wxJSONReader::AppendUES(wxMemoryBuffer& utf8Buff, const char* uesBuffer) {
     AddError(_T( "Invalid Unicode Escaped Sequence"));
     return -1;
   }
-  wxLogTrace(traceMask, _T("(%s) unicode sequence=%s code=%ld"),
+  wxLogTrace(traceMask, "(%s) unicode sequence=%s code=%ld",
              __PRETTY_FUNCTION__, uesBuffer, l);
 
   wchar_t ch = (wchar_t)l;
@@ -1558,14 +1556,14 @@ int wxJSONReader::AppendUES(wxMemoryBuffer& utf8Buff, const char* uesBuffer) {
  an error is reported (note: not a warning but an error).
 */
 void wxJSONReader::StoreComment(const wxJSONValue* parent) {
-  wxLogTrace(storeTraceMask, _T("(%s) m_comment=%s"), __PRETTY_FUNCTION__,
+  wxLogTrace(storeTraceMask, "(%s) m_comment=%s", __PRETTY_FUNCTION__,
              m_comment.c_str());
-  wxLogTrace(storeTraceMask, _T("(%s) m_flags=%d m_commentLine=%d"),
+  wxLogTrace(storeTraceMask, "(%s) m_flags=%d m_commentLine=%d",
              __PRETTY_FUNCTION__, m_flags, m_commentLine);
-  wxLogTrace(storeTraceMask, _T("(%s) m_current=%p"), __PRETTY_FUNCTION__,
+  wxLogTrace(storeTraceMask, "(%s) m_current=%p", __PRETTY_FUNCTION__,
              m_current);
-  wxLogTrace(storeTraceMask, _T("(%s) m_next=%p"), __PRETTY_FUNCTION__, m_next);
-  wxLogTrace(storeTraceMask, _T("(%s) m_lastStored=%p"), __PRETTY_FUNCTION__,
+  wxLogTrace(storeTraceMask, "(%s) m_next=%p", __PRETTY_FUNCTION__, m_next);
+  wxLogTrace(storeTraceMask, "(%s) m_lastStored=%p", __PRETTY_FUNCTION__,
              m_lastStored);
 
   // first check if the 'store comment' bit is on
@@ -1577,11 +1575,10 @@ void wxJSONReader::StoreComment(const wxJSONValue* parent) {
   // check if the comment is on the same line of one of the
   // 'current', 'next' or 'lastStored' value
   if (m_current != 0) {
-    wxLogTrace(storeTraceMask, _T("(%s) m_current->lineNo=%d"),
-               __PRETTY_FUNCTION__, m_current->GetLineNo());
+    wxLogTrace(storeTraceMask, "(%s) m_current->lineNo=%d", __PRETTY_FUNCTION__,
+               m_current->GetLineNo());
     if (m_current->GetLineNo() == m_commentLine) {
-      wxLogTrace(storeTraceMask,
-                 _T("(%s) comment added to \'m_current\' INLINE"),
+      wxLogTrace(storeTraceMask, "(%s) comment added to \'m_current\' INLINE",
                  __PRETTY_FUNCTION__);
       m_current->AddComment(m_comment, wxJSONVALUE_COMMENT_INLINE);
       m_comment.clear();
@@ -1589,10 +1586,10 @@ void wxJSONReader::StoreComment(const wxJSONValue* parent) {
     }
   }
   if (m_next != 0) {
-    wxLogTrace(storeTraceMask, _T("(%s) m_next->lineNo=%d"),
-               __PRETTY_FUNCTION__, m_next->GetLineNo());
+    wxLogTrace(storeTraceMask, "(%s) m_next->lineNo=%d", __PRETTY_FUNCTION__,
+               m_next->GetLineNo());
     if (m_next->GetLineNo() == m_commentLine) {
-      wxLogTrace(storeTraceMask, _T("(%s) comment added to \'m_next\' INLINE"),
+      wxLogTrace(storeTraceMask, "(%s) comment added to \'m_next\' INLINE",
                  __PRETTY_FUNCTION__);
       m_next->AddComment(m_comment, wxJSONVALUE_COMMENT_INLINE);
       m_comment.clear();
@@ -1600,11 +1597,11 @@ void wxJSONReader::StoreComment(const wxJSONValue* parent) {
     }
   }
   if (m_lastStored != 0) {
-    wxLogTrace(storeTraceMask, _T("(%s) m_lastStored->lineNo=%d"),
+    wxLogTrace(storeTraceMask, "(%s) m_lastStored->lineNo=%d",
                __PRETTY_FUNCTION__, m_lastStored->GetLineNo());
     if (m_lastStored->GetLineNo() == m_commentLine) {
       wxLogTrace(storeTraceMask,
-                 _T("(%s) comment added to \'m_lastStored\' INLINE"),
+                 "(%s) comment added to \'m_lastStored\' INLINE",
                  __PRETTY_FUNCTION__);
       m_lastStored->AddComment(m_comment, wxJSONVALUE_COMMENT_INLINE);
       m_comment.clear();
@@ -1620,33 +1617,30 @@ void wxJSONReader::StoreComment(const wxJSONValue* parent) {
   if (m_flags & wxJSONREADER_COMMENTS_AFTER) {  // comment AFTER
     if (m_current) {
       if (m_current == parent || !m_current->IsValid()) {
-        AddError(
-            _T("Cannot find a value for storing the comment (flag AFTER)"));
+        AddError("Cannot find a value for storing the comment (flag AFTER)");
       } else {
-        wxLogTrace(storeTraceMask,
-                   _T("(%s) comment added to m_current (AFTER)"),
+        wxLogTrace(storeTraceMask, "(%s) comment added to m_current (AFTER)",
                    __PRETTY_FUNCTION__);
         m_current->AddComment(m_comment, wxJSONVALUE_COMMENT_AFTER);
       }
     } else if (m_lastStored) {
-      wxLogTrace(storeTraceMask,
-                 _T("(%s) comment added to m_lastStored (AFTER)"),
+      wxLogTrace(storeTraceMask, "(%s) comment added to m_lastStored (AFTER)",
                  __PRETTY_FUNCTION__);
       m_lastStored->AddComment(m_comment, wxJSONVALUE_COMMENT_AFTER);
     } else {
       wxLogTrace(storeTraceMask,
-                 _T("(%s) cannot find a value for storing the AFTER comment"),
+                 "(%s) cannot find a value for storing the AFTER comment",
                  __PRETTY_FUNCTION__);
-      AddError(_T("Cannot find a value for storing the comment (flag AFTER)"));
+      AddError("Cannot find a value for storing the comment (flag AFTER)");
     }
   } else {  // comment BEFORE can only be added to the 'next' value
     if (m_next) {
-      wxLogTrace(storeTraceMask, _T("(%s) comment added to m_next (BEFORE)"),
+      wxLogTrace(storeTraceMask, "(%s) comment added to m_next (BEFORE)",
                  __PRETTY_FUNCTION__);
       m_next->AddComment(m_comment, wxJSONVALUE_COMMENT_BEFORE);
     } else {
       // cannot find a value for storing the comment
-      AddError(_T("Cannot find a value for storing the comment (flag BEFORE)"));
+      AddError("Cannot find a value for storing the comment (flag BEFORE)");
     }
   }
   m_comment.clear();
@@ -1844,11 +1838,11 @@ int wxJSONReader::ReadMemoryBuff(wxInputStream& is, wxJSONValue& val) {
   //   'value'  is invalid OR
   //   'value'  is a memory buffer; concatenate it
   if (!val.IsValid()) {
-    wxLogTrace(traceMask, _T("(%s) assigning the memory buffer to value"),
+    wxLogTrace(traceMask, "(%s) assigning the memory buffer to value",
                __PRETTY_FUNCTION__);
     val = buff;
   } else if (val.IsMemoryBuff()) {
-    wxLogTrace(traceMask, _T("(%s) concatenate memory buffer to value"),
+    wxLogTrace(traceMask, "(%s) concatenate memory buffer to value",
                __PRETTY_FUNCTION__);
     val.Cat(buff);
   } else {
@@ -2008,7 +2002,7 @@ bool wxJSONReader::DoStrto_ll(const wxString& str, wxUint64* ui64,
   // check the overflow: check the string length and the individual digits
   // of the string; the overflow is checked for unsigned long long
   if (strLen == maxDigits) {
-    wxString uLongMax(_T("18446744073709551615"));
+    wxString uLongMax("18446744073709551615");
     int j = 0;
     for (int i = index; i < strLen - 1; i++) {
       ch = str[i];

--- a/plugins/grib_pi/src/jsonval.cpp
+++ b/plugins/grib_pi/src/jsonval.cpp
@@ -39,10 +39,10 @@ WX_DEFINE_OBJARRAY(wxJSONInternalArray);
 #endif
 
 // the trace mask used in wxLogTrace() function
-// static const wxChar* traceMask = _T("jsonval");
+// static const wxChar* traceMask = "jsonval";
 #if wxDEBUG_LEVEL > 0
-static const wxChar* traceMask = _T("jsonval");
-static const wxChar* compareTraceMask = _T("sameas");
+static const wxChar* traceMask = "jsonval";
+static const wxChar* compareTraceMask = "sameas";
 static const wxChar* cowTraceMask = _T("traceCOW" );
 #endif
 
@@ -77,8 +77,8 @@ wxJSONRefData::wxJSONRefData() {
 #if defined(WXJSON_USE_VALUE_COUNTER)
   m_progr = sm_progr;
   ++sm_progr;
-  wxLogTrace(traceMask, _T("(%s) JSON refData ctor progr=%d"),
-             __PRETTY_FUNCTION__, m_progr);
+  wxLogTrace(traceMask, "(%s) JSON refData ctor progr=%d", __PRETTY_FUNCTION__,
+             m_progr);
 #endif
 }
 
@@ -214,7 +214,7 @@ wxJSONRefData* wxJSONValue::Init(wxJSONType type) {
 #if defined(WXJSON_USE_VALUE_COUNTER)
   m_progr = sm_progr;
   ++sm_progr;
-  wxLogTrace(cowTraceMask, _T("(%s) Init a new object progr=%d"),
+  wxLogTrace(cowTraceMask, "(%s) Init a new object progr=%d",
              __PRETTY_FUNCTION__, m_progr);
 #endif
   return data;
@@ -394,7 +394,7 @@ wxJSONValue::wxJSONValue(const wxJSONValue& other) {
 #if defined(WXJSON_USE_VALUE_COUNTER)
   m_progr = sm_progr;
   ++sm_progr;
-  wxLogTrace(cowTraceMask, _T("(%s) Copy ctor - progr=%d other progr=%d"),
+  wxLogTrace(cowTraceMask, "(%s) Copy ctor - progr=%d other progr=%d",
              __PRETTY_FUNCTION__, m_progr, other.m_progr);
 #endif
 }
@@ -883,25 +883,23 @@ wxString wxJSONValue::AsString() const {
       break;
     case wxJSONTYPE_INT:
 #if defined(wxJSON_64BIT_INT)
-      s.Printf(_T("%") compatibleLongLongFmtSpec _T("i"),
-               data->m_value.m_valInt64);
+      s.Printf("%" compatibleLongLongFmtSpec "i", data->m_value.m_valInt64);
 #else
-      s.Printf(_T("%ld"), data->m_value.m_valLong);
+      s.Printf("%ld", data->m_value.m_valLong);
 #endif
       break;
     case wxJSONTYPE_UINT:
 #if defined(wxJSON_64BIT_INT)
-      s.Printf(_T("%") compatibleLongLongFmtSpec _T("u"),
-               data->m_value.m_valUInt64);
+      s.Printf("%" compatibleLongLongFmtSpec "u", data->m_value.m_valUInt64);
 #else
-      s.Printf(_T("%lu"), data->m_value.m_valULong);
+      s.Printf("%lu", data->m_value.m_valULong);
 #endif
       break;
     case wxJSONTYPE_DOUBLE:
-      s.Printf(_T("%.10g"), data->m_value.m_valDouble);
+      s.Printf("%.10g", data->m_value.m_valDouble);
       break;
     case wxJSONTYPE_BOOL:
-      s.assign((data->m_value.m_valBool ? _T("true") : _T("false")));
+      s.assign((data->m_value.m_valBool ? "true" : "false"));
       break;
     case wxJSONTYPE_NULL:
       s.assign(_T( "null"));
@@ -910,10 +908,10 @@ wxString wxJSONValue::AsString() const {
       s.assign(_T( "<invalid>"));
       break;
     case wxJSONTYPE_ARRAY:
-      s.Printf(_T("[%d]"), size);
+      s.Printf("[%d]", size);
       break;
     case wxJSONTYPE_OBJECT:
-      s.Printf(_T("{%d}"), size);
+      s.Printf("{%d}", size);
       break;
     case wxJSONTYPE_MEMORYBUFF:
       s = MemoryBuffToString(*(data->m_memBuff), 5);
@@ -1628,10 +1626,10 @@ wxJSONValue& wxJSONValue::Item(unsigned index) {
  replaced by a map object.
 */
 wxJSONValue& wxJSONValue::Item(const wxString& key) {
-  wxLogTrace(traceMask, _T("(%s) searched key=\'%s\'"), __PRETTY_FUNCTION__,
+  wxLogTrace(traceMask, "(%s) searched key=\'%s\'", __PRETTY_FUNCTION__,
              key.c_str());
 #if !wxCHECK_VERSION(2, 9, 0)
-  wxLogTrace(traceMask, _T("(%s) actual object: %s"), __PRETTY_FUNCTION__,
+  wxLogTrace(traceMask, "(%s) actual object: %s", __PRETTY_FUNCTION__,
              GetInfo().c_str());
 #endif
 
@@ -1643,7 +1641,7 @@ wxJSONValue& wxJSONValue::Item(const wxString& key) {
     data = SetType(wxJSONTYPE_OBJECT);
     return data->m_valMap[key];
   }
-  wxLogTrace(traceMask, _T("(%s) searching key \'%s' in the actual object"),
+  wxLogTrace(traceMask, "(%s) searching key \'%s' in the actual object",
              __PRETTY_FUNCTION__, key.c_str());
   return data->m_valMap[key];
 }
@@ -1676,9 +1674,9 @@ wxJSONValue wxJSONValue::ItemAt(unsigned index) const {
  If \c key does not exist, an \b invalid value is returned.
 */
 wxJSONValue wxJSONValue::ItemAt(const wxString& key) const {
-  wxLogTrace(traceMask, _T("(%s) searched key=\'%s\'"), __PRETTY_FUNCTION__,
+  wxLogTrace(traceMask, "(%s) searched key=\'%s\'", __PRETTY_FUNCTION__,
              key.c_str());
-  wxLogTrace(traceMask, _T("(%s) actual object: %s"), __PRETTY_FUNCTION__,
+  wxLogTrace(traceMask, "(%s) actual object: %s", __PRETTY_FUNCTION__,
              GetInfo().c_str());
 
   wxJSONRefData* data = GetRefData();
@@ -2014,15 +2012,14 @@ wxString wxJSONValue::Dump(bool deep, int indent) const {
   wxString s1;
   wxString s2;
 #if defined(WXJSON_USE_VALUE_COUNTER)
-  s1.Printf(_T("Object: Progr=%d Type=%s Size=%d comments=%d\n"), m_progr,
+  s1.Printf("Object: Progr=%d Type=%s Size=%d comments=%d\n", m_progr,
             TypeToString(type).c_str(), Size(), data->m_comments.GetCount());
-  s2.Printf(_T("      : RefData=%p Progr=%d Num shares=%d\n"), data,
-            data->m_progr, data->GetRefCount());
-#else
-  s1.Printf(_T("Object: Type=%s Size=%d comments=%d\n"),
-            TypeToString(type).c_str(), Size(), data->m_comments.GetCount());
-  s2.Printf(_T("      : RefData=%p Num shares=%d\n"), data,
+  s2.Printf("      : RefData=%p Progr=%d Num shares=%d\n", data, data->m_progr,
             data->GetRefCount());
+#else
+  s1.Printf("Object: Type=%s Size=%d comments=%d\n", TypeToString(type).c_str(),
+            Size(), data->m_comments.GetCount());
+  s2.Printf("      : RefData=%p Num shares=%d\n", data, data->GetRefCount());
 #endif
   s.append(s1);
   if (indent > 0) {
@@ -2078,20 +2075,20 @@ wxString wxJSONValue::GetInfo() const {
 
   wxString s;
 #if defined(WXJSON_USE_VALUE_CONTER)
-  s.Printf(_T("Object: Progr=%d Type=%s Size=%d comments=%d\n"), data->m_progr,
+  s.Printf("Object: Progr=%d Type=%s Size=%d comments=%d\n", data->m_progr,
            wxJSONValue::TypeToString(data->m_type).c_str(), Size(),
            data->m_comments.GetCount());
 #else
-  s.Printf(_T("Object: Type=%s Size=%d comments=%d\n"),
+  s.Printf("Object: Type=%s Size=%d comments=%d\n",
            wxJSONValue::TypeToString(data->m_type).c_str(), Size(),
            data->m_comments.GetCount());
 #endif
   if (data->m_type == wxJSONTYPE_OBJECT) {
     wxArrayString arr = GetMemberNames();
     for (unsigned int i = 0; i < arr.size(); i++) {
-      s.append(_T("    Member name: "));
+      s.append("    Member name: ");
       s.append(arr[i]);
-      s.append(_T("\n"));
+      s.append("\n");
     }
   }
   return s;
@@ -2138,7 +2135,7 @@ bool wxJSONValue::IsSameAs(const wxJSONValue& other) const {
 
   if (data == otherData) {
     wxLogTrace(compareTraceMask,
-               _T("(%s) objects share the same referenced data - r=TRUE"),
+               "(%s) objects share the same referenced data - r=TRUE",
                __PRETTY_FUNCTION__);
     return true;
   }
@@ -2261,19 +2258,18 @@ bool wxJSONValue::IsSameAs(const wxJSONValue& other) const {
       break;
     case wxJSONTYPE_ARRAY:
       size = Size();
-      wxLogTrace(compareTraceMask,
-                 _T("(%s) Comparing an array object - size=%d"),
+      wxLogTrace(compareTraceMask, "(%s) Comparing an array object - size=%d",
                  __PRETTY_FUNCTION__, size);
 
       if (size != other.Size()) {
-        wxLogTrace(compareTraceMask, _T("(%s) Sizes does not match"),
+        wxLogTrace(compareTraceMask, "(%s) Sizes does not match",
                    __PRETTY_FUNCTION__);
         return false;
       }
       // compares every element in this object with the element of
       // the same index in the 'other' object
       for (int i = 0; i < size; i++) {
-        wxLogTrace(compareTraceMask, _T("(%s) Comparing array element=%d"),
+        wxLogTrace(compareTraceMask, "(%s) Comparing array element=%d",
                    __PRETTY_FUNCTION__, i);
         wxJSONValue v1 = ItemAt(i);
         wxJSONValue v2 = other.ItemAt(i);
@@ -2285,12 +2281,12 @@ bool wxJSONValue::IsSameAs(const wxJSONValue& other) const {
       break;
     case wxJSONTYPE_OBJECT:
       size = Size();
-      wxLogTrace(compareTraceMask, _T("(%s) Comparing a map obejct - size=%d"),
+      wxLogTrace(compareTraceMask, "(%s) Comparing a map obejct - size=%d",
                  __PRETTY_FUNCTION__, size);
 
       if (size != other.Size()) {
         wxLogTrace(compareTraceMask,
-                   _T("(%s) Comparison failed - sizes does not match"),
+                   "(%s) Comparison failed - sizes does not match",
                    __PRETTY_FUNCTION__);
         return false;
       }
@@ -2298,13 +2294,13 @@ bool wxJSONValue::IsSameAs(const wxJSONValue& other) const {
       // the other object. if 'key' does no exist, returns FALSE
       for (it = data->m_valMap.begin(); it != data->m_valMap.end(); it++) {
         wxString key = it->first;
-        wxLogTrace(compareTraceMask, _T("(%s) Comparing map object - key=%s"),
+        wxLogTrace(compareTraceMask, "(%s) Comparing map object - key=%s",
                    __PRETTY_FUNCTION__, key.c_str());
         wxJSONValue otherVal = other.ItemAt(key);
         bool isSame = it->second.IsSameAs(otherVal);
         if (!isSame) {
           wxLogTrace(compareTraceMask,
-                     _T("(%s) Comparison failed for the last object"),
+                     "(%s) Comparison failed for the last object",
                      __PRETTY_FUNCTION__);
           return false;
         }
@@ -2312,7 +2308,7 @@ bool wxJSONValue::IsSameAs(const wxJSONValue& other) const {
       break;
     default:
       // should never happen
-      wxFAIL_MSG(_T("wxJSONValue::IsSameAs() unexpected wxJSONType"));
+      wxFAIL_MSG("wxJSONValue::IsSameAs() unexpected wxJSONType");
       break;
   }
   return r;
@@ -2347,16 +2343,15 @@ int wxJSONValue::AddComment(const wxString& str, int position) {
   wxJSONRefData* data = COW();
   wxJSON_ASSERT(data);
 
-  wxLogTrace(traceMask, _T("(%s) comment=%s"), __PRETTY_FUNCTION__,
-             str.c_str());
+  wxLogTrace(traceMask, "(%s) comment=%s", __PRETTY_FUNCTION__, str.c_str());
   int r = -1;
   int len = str.length();
   if (len < 2) {
-    wxLogTrace(traceMask, _T("     error: len < 2"));
+    wxLogTrace(traceMask, "     error: len < 2");
     return -1;
   }
   if (str[0] != '/') {
-    wxLogTrace(traceMask, _T("     error: does not start with\'/\'"));
+    wxLogTrace(traceMask, "     error: does not start with\'/\'");
     return -1;
   }
   if (str[1] == '/') {  // a C++ comment: check that it ends with '\n'
@@ -2365,14 +2360,14 @@ int wxJSONValue::AddComment(const wxString& str, int position) {
       wxString temp(str);
       temp.append(1, '\n');
       data->m_comments.Add(temp);
-      wxLogTrace(traceMask, _T("     C++ comment: LF added"));
+      wxLogTrace(traceMask, "     C++ comment: LF added");
     } else {
       data->m_comments.Add(str);
     }
     r = data->m_comments.size();
   } else if (str[1] ==
              '*') {  // a C-style comment: check that it ends with '*/'
-    wxLogTrace(traceMask, _T("     C-style comment"));
+    wxLogTrace(traceMask, "     C-style comment");
     int lastPos = len - 1;
     wxChar ch = str.GetChar(lastPos);
     // skip leading whitespaces
@@ -2385,7 +2380,7 @@ int wxJSONValue::AddComment(const wxString& str, int position) {
       r = data->m_comments.size();
     }
   } else {
-    wxLogTrace(traceMask, _T("     error: is not a valid comment string"));
+    wxLogTrace(traceMask, "     error: is not a valid comment string");
     r = -1;
   }
   // if the comment was stored, store the position
@@ -2443,7 +2438,7 @@ int wxJSONValue::GetCommentCount() const {
   wxJSON_ASSERT(data);
 
   int d = data->m_comments.GetCount();
-  wxLogTrace(traceMask, _T("(%s) comment count=%d"), __PRETTY_FUNCTION__, d);
+  wxLogTrace(traceMask, "(%s) comment count=%d", __PRETTY_FUNCTION__, d);
   return d;
 }
 
@@ -2657,7 +2652,7 @@ void wxJSONValue::Ref(const wxJSONValue& clone) {
 */
 void wxJSONValue::UnRef() {
   if (m_refData) {
-    wxASSERT_MSG(m_refData->m_refCount > 0, _T("invalid ref data count"));
+    wxASSERT_MSG(m_refData->m_refCount > 0, "invalid ref data count");
 
     if (--m_refData->m_refCount == 0) {
       delete m_refData;
@@ -2727,7 +2722,7 @@ wxJSONRefData* wxJSONValue::CloneRefData(const wxJSONRefData* otherData) const {
     }
   }
 
-  wxLogTrace(cowTraceMask, _T("(%s) CloneRefData() PROGR: other=%d data=%d"),
+  wxLogTrace(cowTraceMask, "(%s) CloneRefData() PROGR: other=%d data=%d",
              __PRETTY_FUNCTION__, other->GetRefCount(), data->GetRefCount());
 
   return data;
@@ -2755,11 +2750,11 @@ wxJSONRefData* wxJSONValue::CreateRefData() const {
 */
 wxJSONRefData* wxJSONValue::COW() {
   wxJSONRefData* data = GetRefData();
-  wxLogTrace(cowTraceMask, _T("(%s) COW() START data=%p data->m_count=%d"),
+  wxLogTrace(cowTraceMask, "(%s) COW() START data=%p data->m_count=%d",
              __PRETTY_FUNCTION__, data, data->GetRefCount());
   UnShare();
   data = GetRefData();
-  wxLogTrace(cowTraceMask, _T("(%s) COW() END data=%p data->m_count=%d"),
+  wxLogTrace(cowTraceMask, "(%s) COW() END data=%p data->m_count=%d",
              __PRETTY_FUNCTION__, data, data->GetRefCount());
   return GetRefData();
 }
@@ -2779,7 +2774,7 @@ void wxJSONValue::AllocExclusive() {
   // else: ref count is 1, we are exclusive owners of m_refData anyhow
 
   wxASSERT_MSG(m_refData && m_refData->GetRefCount() == 1,
-               _T("wxObject::AllocExclusive() failed."));
+               "wxObject::AllocExclusive() failed.");
 }
 
 //! Convert memory buffer object to a string representation.
@@ -2836,7 +2831,7 @@ wxString wxJSONValue::MemoryBuffToString(const void* buff, size_t len,
   if (buffLen == (size_t)-1) {
     buffLen = len;
   }
-  s.Printf(_T("%p (%u) "), buff, buffLen);
+  s.Printf("%p (%u) ", buff, buffLen);
   unsigned char* ptr = (unsigned char*)buff;
   for (unsigned int i = 0; i < len; i++) {
     unsigned char c = *ptr;

--- a/plugins/grib_pi/src/jsonwriter.cpp
+++ b/plugins/grib_pi/src/jsonwriter.cpp
@@ -25,7 +25,7 @@
 #include <wx/log.h>
 
 #if wxDEBUG_LEVEL > 0
-static const wxChar* writerTraceMask = _T("traceWriter");
+static const wxChar* writerTraceMask = "traceWriter";
 #endif
 
 /*! \class wxJSONWriter
@@ -253,7 +253,7 @@ wxJSONWriter::~wxJSONWriter() {}
    writer.Write( root, mem );
    wxStreamError err = mem.GetLastError();
    if ( err != wxSTREAM_NO_ERROR )  {
-     MessageBox( _T("ERROR: cannot write the JSON text output"));
+     MessageBox( "ERROR: cannot write the JSON text output");
    }
 \endcode
 */
@@ -382,8 +382,8 @@ int wxJSONWriter::DoWrite(wxOutputStream& os, const wxJSONValue& value,
     case wxJSONTYPE_INVALID:
       WriteInvalid(os);
       wxFAIL_MSG(
-          _T("wxJSONWriter::WriteEmpty() cannot be called (not a valid JSON ")
-          _T("text"));
+          "wxJSONWriter::WriteEmpty() cannot be called (not a valid JSON "
+          "text");
       break;
 
     case wxJSONTYPE_INT:
@@ -506,7 +506,7 @@ int wxJSONWriter::DoWrite(wxOutputStream& os, const wxJSONValue& value,
 
     default:
       // a not yet defined wxJSONType: we FAIL
-      wxFAIL_MSG(_T("wxJSONWriter::DoWrite() undefined wxJSONType type"));
+      wxFAIL_MSG("wxJSONWriter::DoWrite() undefined wxJSONType type");
       break;
   }
 
@@ -811,8 +811,8 @@ int wxJSONWriter::WriteStringValue(wxOutputStream& os, const wxString& str) {
  The function converts the string \c str to UTF-8 and writes the buffer..
 */
 int wxJSONWriter::WriteString(wxOutputStream& os, const wxString& str) {
-  wxLogTrace(writerTraceMask, _T("(%s) string to write=%s"),
-             __PRETTY_FUNCTION__, str.c_str());
+  wxLogTrace(writerTraceMask, "(%s) string to write=%s", __PRETTY_FUNCTION__,
+             str.c_str());
   int lastChar = 0;
   char* writeBuff = nullptr;
 
@@ -846,8 +846,7 @@ int wxJSONWriter::WriteString(wxOutputStream& os, const wxString& str) {
     return -1;
   }
 
-  wxLogTrace(writerTraceMask, _T("(%s) result=%d"), __PRETTY_FUNCTION__,
-             lastChar);
+  wxLogTrace(writerTraceMask, "(%s) result=%d", __PRETTY_FUNCTION__, lastChar);
   return lastChar;
 }
 
@@ -887,7 +886,7 @@ int wxJSONWriter::WriteIntValue(wxOutputStream& os, const wxJSONValue& value) {
   // format specifier, we use the wxString's sprintf() function and then
   // convert to UTF-8 before writing to the stream
   wxString s;
-  s.Printf(_T("%") wxLongLongFmtSpec _T("d"), data->m_value.m_valInt64);
+  s.Printf("%" wxLongLongFmtSpec "d", data->m_value.m_valInt64);
   wxCharBuffer cb = s.ToUTF8();
   const char* cbData = cb.data();
   len = strlen(cbData);
@@ -938,7 +937,7 @@ int wxJSONWriter::WriteUIntValue(wxOutputStream& os, const wxJSONValue& value) {
   // format specifier, we use the wxString's sprintf() function and then
   // convert to UTF-8 before writing to the stream
   wxString s;
-  s.Printf(_T("%") wxLongLongFmtSpec _T("u"), data->m_value.m_valInt64);
+  s.Printf("%" wxLongLongFmtSpec "u", data->m_value.m_valInt64);
   wxCharBuffer cb = s.ToUTF8();
   const char* cbData = cb.data();
   len = strlen(cbData);
@@ -1015,7 +1014,7 @@ int wxJSONWriter::WriteBoolValue(wxOutputStream& os, const wxJSONValue& value) {
 
 //! Write the key of a key/value element to the output stream.
 int wxJSONWriter::WriteKey(wxOutputStream& os, const wxString& key) {
-  wxLogTrace(writerTraceMask, _T("(%s) key write=%s"), __PRETTY_FUNCTION__,
+  wxLogTrace(writerTraceMask, "(%s) key write=%s", __PRETTY_FUNCTION__,
              key.c_str());
 
   int lastChar = WriteStringValue(os, key);
@@ -1041,8 +1040,8 @@ int wxJSONWriter::WriteKey(wxOutputStream& os, const wxString& key) {
 */
 int wxJSONWriter::WriteInvalid(wxOutputStream& os) {
   wxFAIL_MSG(
-      _T("wxJSONWriter::WriteInvalid() cannot be called (not a valid JSON ")
-      _T("text"));
+      "wxJSONWriter::WriteInvalid() cannot be called (not a valid JSON "
+      "text");
   int lastChar = 0;
   os.Write("<invalid JSON value>", 9);
   return lastChar;

--- a/plugins/grib_pi/src/pi_TexFont.cpp
+++ b/plugins/grib_pi/src/pi_TexFont.cpp
@@ -62,9 +62,9 @@ void TexFont::Build(wxFont &font, bool blur) {
     wxCoord gw, gh;
     wxString text;
     if (i == DEGREE_GLYPH)
-      text = wxString::Format(_T("%c"), 0x00B0);  //_T("°");
+      text = wxString::Format("%c", 0x00B0);  //"°";
     else
-      text = wxString::Format(_T("%c"), i);
+      text = wxString::Format("%c", i);
     wxCoord descent, exlead;
     sdc.GetTextExtent(text, &gw, &gh, &descent, &exlead,
                       &font);  // measure the text
@@ -122,9 +122,9 @@ void TexFont::Build(wxFont &font, bool blur) {
 
     wxString text;
     if (i == DEGREE_GLYPH)
-      text = wxString::Format(_T("%c"), 0x00B0);  //_T("°");
+      text = wxString::Format("%c", 0x00B0);  //"°";
     else
-      text = wxString::Format(_T("%c"), i);
+      text = wxString::Format("%c", i);
 
     dc.DrawText(text, tgi[i].x, tgi[i].y);
 

--- a/plugins/grib_pi/src/pi_ocpndc.cpp
+++ b/plugins/grib_pi/src/pi_ocpndc.cpp
@@ -96,7 +96,7 @@ pi_ocpnDC::pi_ocpnDC(wxGLCanvas &canvas)
   pgc = nullptr;
 #endif
   m_textforegroundcolour = wxColour(0, 0, 0);
-  m_buseTex = false;  // GetLocaleCanonicalName().IsSameAs(_T("en_US"));
+  m_buseTex = false;  // GetLocaleCanonicalName().IsSameAs("en_US");
   workBuf = nullptr;
   workBufSize = 0;
   s_odc_tess_work_buf = nullptr;
@@ -131,7 +131,7 @@ pi_ocpnDC::pi_ocpnDC(wxDC &pdc)
   }
 #endif
   m_textforegroundcolour = wxColour(0, 0, 0);
-  m_buseTex = false;  // GetLocaleCanonicalName().IsSameAs(_T("en_US"));
+  m_buseTex = false;  // GetLocaleCanonicalName().IsSameAs("en_US");
   workBuf = nullptr;
   workBufSize = 0;
 #ifdef ocpnUSE_GL
@@ -149,7 +149,7 @@ pi_ocpnDC::pi_ocpnDC()
   pgc = nullptr;
 #endif
   m_textforegroundcolour = wxColour(0, 0, 0);
-  m_buseTex = false;  // GetLocaleCanonicalName().IsSameAs(_T("en_US"));
+  m_buseTex = false;  // GetLocaleCanonicalName().IsSameAs("en_US");
   workBuf = nullptr;
   workBufSize = 0;
 #ifdef ocpnUSE_GL
@@ -1605,7 +1605,7 @@ void APIENTRY ocpnDCvertexCallback(GLvoid *arg) {
 void APIENTRY ocpnDCerrorCallback(GLenum errorCode) {
   const GLubyte *estring;
   estring = gluErrorString(errorCode);
-  // wxLogMessage( _T("OpenGL Tessellation Error: %s"), (char *)estring );
+  // wxLogMessage( "OpenGL Tessellation Error: %s", (char *)estring );
 }
 
 void APIENTRY ocpnDCbeginCallback(GLenum type) { glBegin(type); }

--- a/plugins/grib_pi/src/smapi.cpp
+++ b/plugins/grib_pi/src/smapi.cpp
@@ -85,13 +85,13 @@ wxMapiSession::~wxMapiSession() {
 void wxMapiSession::Initialise() {
   // First make sure the "WIN.INI" entry for MAPI is present aswell
   // as the MAPI32 dll being present on the system
-  bool bMapiInstalled = (GetProfileInt(_T("MAIL"), _T("MAPI"), 0) != 0) &&
-                        (SearchPath(nullptr, _T("MAPI32.DLL"), nullptr, 0,
-                                    nullptr, nullptr) != 0);
+  bool bMapiInstalled =
+      (GetProfileInt(L"MAIL", L"MAPI", 0) != 0) &&
+      (SearchPath(nullptr, L"MAPI32.DLL", nullptr, 0, nullptr, nullptr) != 0);
 
   if (bMapiInstalled) {
     // Load up the MAPI dll and get the function pointers we are interested in
-    m_data->m_hMapi = ::LoadLibrary(_T("MAPI32.DLL"));
+    m_data->m_hMapi = ::LoadLibrary(L"MAPI32.DLL");
     if (m_data->m_hMapi) {
       m_data->m_lpfnMAPILogon =
           (LPMAPILOGON)GetProcAddress(m_data->m_hMapi, "MAPILogon");
@@ -111,8 +111,8 @@ void wxMapiSession::Initialise() {
           m_data->m_lpfnMAPIResolveName == nullptr ||
           m_data->m_lpfnMAPIFreeBuffer == nullptr) {
         wxLogMessage(
-            _T("MAIL Error: Failed to get one of the functions pointer in ")
-            _T("MAPI32.DLL\n"));
+            "MAIL Error: Failed to get one of the functions pointer in "
+            "MAPI32.DLL\n");
         Deinitialise();
       }
     }
@@ -199,8 +199,8 @@ bool wxMapiSession::Logon(const wxString& sProfileName,
       bSuccess = TRUE;
     } else {
       wxLogMessage(
-          _T("MAIL Error: Failed to logon to MAPI using a shared session, ")
-          _T("Error:%ld\n"),
+          "MAIL Error: Failed to logon to MAPI using a shared session, "
+          "Error:%ld\n",
           nError);
       m_data->m_nLastError = nError;
     }
@@ -229,7 +229,7 @@ bool wxMapiSession::Logoff() {
     // Call the MAPILogoff function
     ULONG nError = m_data->m_lpfnMAPILogoff(m_data->m_hSession, 0, 0, 0);
     if (nError != SUCCESS_SUCCESS) {
-      wxLogMessage(_T("MAIL Error: Failed in call to MapiLogoff, Error:%ld"),
+      wxLogMessage("MAIL Error: Failed in call to MapiLogoff, Error:%ld",
                    nError);
       m_data->m_nLastError = nError;
       bSuccess = TRUE;
@@ -262,7 +262,7 @@ bool wxMapiSession::Resolve(const wxString& sName, void* lppRecip1) {
   ULONG nError = m_data->m_lpfnMAPIResolveName(m_data->m_hSession, 0,
                                                lpszAsciiName, 0, 0, lppRecip);
   if (nError != SUCCESS_SUCCESS) {
-    wxLogMessage(_T("MAIL Error: Failed to resolve the name: %s, Error:%ld\n"),
+    wxLogMessage("MAIL Error: Failed to resolve the name: %s, Error:%ld\n",
                  sName.c_str(), nError);
     m_data->m_nLastError = nError;
   }
@@ -447,7 +447,7 @@ bool wxMapiSession::Send(wxMailMessage& message) {
     bSuccess = TRUE;
     m_data->m_nLastError = SUCCESS_SUCCESS;
   } else {
-    wxLogMessage(_T("MAIL Error: Failed to send mail message, Error:%ld\n"),
+    wxLogMessage("MAIL Error: Failed to send mail message, Error:%ld\n",
                  nError);
     m_data->m_nLastError = nError;
   }


### PR DESCRIPTION
To save many people having to do this on each unrelated commit, I just did it across the whole grib_pi source tree using a regex replace.  Hope this is helpful.

I could do this across the whole source tree, if that would be acceptable.  It only takes a minute.