### PR TITLE
VERSION.cmake: Add automatic git date variables - #5253

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -102,3 +102,6 @@ Langstrings_*.nsh.in text eol=crlf
 .gitattributes export-ignore
 .gitignore     export-ignore
 .gitkeep       export-ignore
+
+# Define keyword substitution for VERSION.cmake
+VERSION.cmake filter=filter_date

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -506,8 +506,29 @@ set(PREFIX_LIB "${CMAKE_INSTALL_FULL_LIBDIR}")
 #
 include(${CMAKE_SOURCE_DIR}/VERSION.cmake)
 
-string(TIMESTAMP VERSION_DATE "%Y-%m-%d")
-string(TIMESTAMP UNIX_TIMESTAMP "%s")
+set(VERSION_DATE ${VERSION_GIT_DATE})
+set(UNIX_TIMESTAMP ${VERSION_GIT_STAMP})
+if (${VERSION_DATE} STREQUAL "%git_date%")
+  message(STATUS
+    "Commit date cannot be determined, using current last commit"
+  )
+  execute_process(
+    COMMAND "git" "log" "-1" "--pretty=format:%cs"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE VERSION_DATE
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  execute_process(
+    COMMAND "git" "log" "-1" "--pretty=format:%ct"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE UNIX_TIMESTAMP
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+  message(STATUS
+    "Using commit date: ${VERSION_DATE}, stamp: ${UNIX_TIMESTAMP}"
+  )
+endif ()
+
 if (OCPN_CI_BUILD)
   include(Utils)
   commit_id(COMMIT)

--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,4 +1,7 @@
+# filtered, see .gitattributes
 SET(VERSION_MAJOR "5")
 SET(VERSION_MINOR "15")
 SET(VERSION_PATCH "0")
 SET(VERSION_DATE "2026-04-17")
+SET(VERSION_GIT_DATE %git_date%)
+SET(VERSION_GIT_STAMP %git_stamp%)

--- a/tools/configure_git_filters
+++ b/tools/configure_git_filters
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# Set up configuration of GIT_COMMIT_DATE and GIT_COMMIT_STAMP
+# in VERSION.cmake, see .gitattributes
+
+srcdir=$(git rev-parse --show-toplevel)
+git config --local filter.filter_date.clean \
+    "$srcdir/tools/filter_date.sh clean"
+git config --local filter.filter_date.smudge \
+    "$srcdir/tools/filter_date.sh smudge"
+git config --local filter.filter_date.required  true

--- a/tools/filter_date.sh
+++ b/tools/filter_date.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+#
+# Handle substitution of VERSION_GIT_DATE and VERSION_GIT_COMMIT
+#
+# Usage filter_date [-i srcfile] <smudge|clean>
+#
+# Arguments
+#     smudge  Use actual commit dates in VERSION.cmake
+#     clean   Use %git_date% and %git_stamp% keywords in VERSION.cmake
+# Options
+#     -i      Update srcfile in place rather than work as a filter.
+
+function filter {
+    if [ "$1" = "clean" ]; then
+        sed -e 's/GIT_DATE.*/GIT_DATE %git_date%)/' \
+            -e 's/GIT_STAMP.*/GIT_STAMP %git_stamp%)/'
+    elif [ "$1" = "smudge" ]; then
+        sed -e "s/%git_date%/$(git log -1 --pretty=format:%cs)/" \
+            -e "s/%git_stamp%/$(git log -1 --pretty=format:%ct)/"
+    else
+        echo 'Illegal or missing <clean|smudge> argument' >&2
+        exit 1
+    fi
+}
+
+if [ "$1" = "-i" ]; then
+    shift
+    version_cmake=$1
+    shift
+    tmpfile=$(mktemp)
+    filter $1 < $version_cmake > $tmpfile \
+        && cp $tmpfile $version_cmake && rm $tmpfile
+else
+    filter $1
+fi


### PR DESCRIPTION
In order to create reproducible builds we need to use last commit date rather than today's date to mark the build.

Git, being what it is, requires using filters for this. Furthermore, there is no way to define random filters for other users (security reasons).

In order for this to work all commiters need to run the tools/configure_git_filters script. This sets up the filtering which is applied to VERSION.cmake only.

If a commit is done without filters we fall back to the old behaviour using today instead of the git commit date.
