### PR TITLE
Fix bug in type of integer time variable

### DIFF
--- a/plugins/chartdldr_pi/src/chartcatalog.cpp
+++ b/plugins/chartdldr_pi/src/chartcatalog.cpp
@@ -181,6 +181,10 @@ Chart::Chart(pugi::xml_node &xmldata) {
   zipfile_size = -1;
   zipfile_datetime = wxInvalidDateTime;
   zipfile_datetime_iso8601 = wxInvalidDateTime;
+  uadt = wxInvalidDateTime;
+  isdt = wxInvalidDateTime;
+  edtn = -1;
+  updn = -1;
   nm = NULL;
   lnm = NULL;
 
@@ -221,6 +225,16 @@ Chart::Chart(pugi::xml_node &xmldata) {
       zipfile_datetime_iso8601.MakeFromTimezone(wxDateTime::UTC);
     } else if (!strcmp(element.name(), "zipfile_size")) {
       zipfile_size = wxAtoi(wxString::FromUTF8(element.first_child().value()));
+    } else if (!strcmp(element.name(), "edtn")) {
+      edtn = wxAtoi(wxString::FromUTF8(element.first_child().value()));
+    } else if (!strcmp(element.name(), "updn")) {
+      updn = wxAtoi(wxString::FromUTF8(element.first_child().value()));
+    } else if (!strcmp(element.name(), "uadt")) {
+      uadt.ParseFormat(wxString::FromUTF8(element.first_child().value()),
+                       "%Y-%m-%d");
+    } else if (!strcmp(element.name(), "isdt")) {
+      isdt.ParseFormat(wxString::FromUTF8(element.first_child().value()),
+                       "%Y-%m-%d");
     } else if (!strcmp(element.name(), "cov")) {
       for (pugi::xml_node subElement = element.first_child(); subElement;
            subElement = subElement.next_sibling()) {

--- a/plugins/chartdldr_pi/src/chartcatalog.h
+++ b/plugins/chartdldr_pi/src/chartcatalog.h
@@ -100,6 +100,10 @@ public:
   wxDateTime zipfile_datetime;
   wxDateTime zipfile_datetime_iso8601;
   int zipfile_size;
+  int edtn;
+  int updn;
+  wxDateTime uadt;
+  wxDateTime isdt;
   wxString reference_file;
   wxString manual_download_url;
 

--- a/plugins/chartdldr_pi/src/chartdldr_pi.cpp
+++ b/plugins/chartdldr_pi/src/chartdldr_pi.cpp
@@ -830,14 +830,28 @@ bool ChartSource::IsNewerThanLocal(wxString chart_number, wxString filename,
                                    wxDateTime validDate) {
   wxStringTokenizer tk(filename, _T("."));
   wxString file = tk.GetNextToken().MakeLower();
+  time_t validTime = validDate.GetTicks();
   if (!m_update_data.empty()) {
-    if (m_update_data[std::string(chart_number.Lower().mbc_str())] <
-            validDate.GetTicks() &&
-        m_update_data[std::string(file.mbc_str())] < validDate.GetTicks())
-      return true;
-    else
-      return false;
+    time_t chartNumberTime =
+        m_update_data[std::string(chart_number.Lower().mbc_str())];
+    time_t updateFileTime = m_update_data[std::string(file.mbc_str())];
+    bool needsUpdate =
+        chartNumberTime < validTime && updateFileTime < validTime;
+    if (wxLOG_Debug <= wxLog::GetLogLevel()) {
+      // Show these only if user has selected loglevel debug, otherwise save a
+      // few cpu cycles
+      wxLogInfo("Latest Zip File Date: %sZ",
+                validDate.ToUTC().FormatISOCombined());
+      wxLogInfo("Local File: %s, Date: %sZ", filename,
+                wxDateTime(updateFileTime).ToUTC().FormatISOCombined());
+      wxLogInfo("Chart Number %s DOB: Date: %sZ", chart_number,
+                wxDateTime(chartNumberTime).ToUTC().FormatISOCombined());
+      wxLogInfo("Chart Number %s Needs update: %s", chart_number,
+                needsUpdate ? wxString("true") : wxString("false"));
+    }
+    return needsUpdate;
   }
+
   bool update_candidate = false;
 
   for (size_t i = 0; i < m_localfiles.Count(); i++) {
@@ -1133,7 +1147,7 @@ void ChartSource::LoadUpdateData() {
   std::ifstream infile(fn.mb_str());
 
   std::string key;
-  long value;
+  time_t value(0);
 
   while (infile >> key >> value) m_update_data[key] = value;
 


### PR DESCRIPTION
Refactored ChartSource::IsNewerThanLocal for clarity by using variables for timestamps, a boolean for update condition, and adding detailed debug logs. Also changed value type to time_t in LoadUpdateData for platform agnostic timestamp handling.

See #5259