### PR TITLE
Make meaning of bnew_view consistent

### DIFF
--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -5628,7 +5628,8 @@ void MyFrame::OnFrameTimer1(wxTimerEvent &event) {
     gCog = 0.0;  // say speed is zero to kill ownship predictor
   }
 
-  //      Update the chart database and displayed chart
+  // Update the chart database and displayed chart
+  // bnew_view is true if Refresh(false) was called
   bool bnew_view = false;
   if (!g_btenhertz) bnew_view = DoChartUpdate();
 
@@ -5672,7 +5673,7 @@ void MyFrame::OnFrameTimer1(wxTimerEvent &event) {
           (!isnan(gHdt) && (gHdt != m_last_hdt))) {
         if (!g_bopengl) cc->UpdateShips();
 
-        bnew_view = true;  // force a full Refresh()
+        bnew_view = false;  // force a full Refresh()
       }
     }
   }
@@ -5689,7 +5690,7 @@ void MyFrame::OnFrameTimer1(wxTimerEvent &event) {
       PlugInContainer *pic = pplugin_array->Item(i);
       if (pic->m_enabled && pic->m_init_state) {
         if (pic->m_cap_flag & WANTS_DYNAMIC_OPENGL_OVERLAY_CALLBACK) {
-          bnew_view = true;
+          bnew_view = false;
           break;
         }
       }
@@ -5697,7 +5698,7 @@ void MyFrame::OnFrameTimer1(wxTimerEvent &event) {
   }
 
   //  Make sure we get a redraw and alert sound on AnchorWatch excursions.
-  if (AnchorAlertOn1 || AnchorAlertOn2) bnew_view = true;
+  if (AnchorAlertOn1 || AnchorAlertOn2) bnew_view = false;
 
   // For each canvas....
   for (unsigned int i = 0; i < g_canvasArray.GetCount(); i++) {
@@ -5712,7 +5713,7 @@ void MyFrame::OnFrameTimer1(wxTimerEvent &event) {
             if ((!g_btenhertz)) {
               if (cc->m_bFollow) {
                 cc->DoCanvasUpdate();
-                if (bnew_view)
+                if (!bnew_view)
                   cc->Refresh(false);  // honor ownship state update
               } else
                 cc->Refresh(false);

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -5683,20 +5683,17 @@ void MyFrame::OnFrameTimer1(wxTimerEvent &event) {
 
   //    If any PlugIn requested dynamic overlay callbacks, force a full canvas
   //    refresh thus, ensuring at least 1 Hz. callback.
-  bool brq_dynamic = false;
   if (g_pi_manager) {
     auto *pplugin_array = PluginLoader::GetInstance()->GetPlugInArray();
     for (unsigned int i = 0; i < pplugin_array->GetCount(); i++) {
       PlugInContainer *pic = pplugin_array->Item(i);
       if (pic->m_enabled && pic->m_init_state) {
         if (pic->m_cap_flag & WANTS_DYNAMIC_OPENGL_OVERLAY_CALLBACK) {
-          brq_dynamic = true;
+          bnew_view = true;
           break;
         }
       }
     }
-
-    if (brq_dynamic) bnew_view = true;
   }
 
   //  Make sure we get a redraw and alert sound on AnchorWatch excursions.


### PR DESCRIPTION
IMHO, there is an inconsistency in the usage of bnew_view in ocpn_frame.cpp `MyFrame::OnFrameTimer1()`. This is the situation in the original code:
```
bool bnew_view = false;
if (!g_btenhertz) bnew_view = DoChartUpdate();
```

This means that `bnew_view` is set to true if `Refresh(false)` is called in `DoChartUpdate()`. This is consistent with (at the end of the function):

`if (!bnew_view) {  // There has not been a Refresh() yet.....`

But in between, we have the following code, which seems to imply that `bnew_view = true` is meant to force a `Refresh(false) `call:

```
bnew_view = true;  // force a full Refresh()
//  Make sure we get a redraw and alert sound on AnchorWatch excursions.
 if (AnchorAlertOn1 || AnchorAlertOn2) bnew_view = true;

 if (bnew_view)
    cc->Refresh(false);  // honor ownship state update
```

The pull request attempts to make the meaning of bnew_view consistent over the whole function.