### PR TITLE
Rename waypoint arrival label

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ tags
 
 # Ignore Build Dependency files
 *build-deps*
+/.cache

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -2257,7 +2257,7 @@ void options::CreatePanel_Routes(size_t parent, int border_size,
   routeSizer->Add(pRouteGrid, 0, wxALL | wxEXPAND, border_size);
 
   wxStaticText* raText = new wxStaticText(
-      itemPanelRoutes, wxID_STATIC, _("Waypoint Arrival Circle Radius (NMi)"));
+      itemPanelRoutes, wxID_STATIC, _("Waypoint Arrival Distance (NMi)"));
   pRouteGrid->Add(raText, 1, wxEXPAND | wxALL, group_item_spacing);
 
   m_pText_ACRadius = new wxTextCtrl(itemPanelRoutes, -1, "TEXT  ");

--- a/gui/src/options.cpp
+++ b/gui/src/options.cpp
@@ -2256,8 +2256,8 @@ void options::CreatePanel_Routes(size_t parent, int border_size,
   pRouteGrid->AddGrowableCol(1);
   routeSizer->Add(pRouteGrid, 0, wxALL | wxEXPAND, border_size);
 
-  wxStaticText* raText = new wxStaticText(
-      itemPanelRoutes, wxID_STATIC, _("Waypoint Arrival Distance (NMi)"));
+  wxStaticText* raText = new wxStaticText(itemPanelRoutes, wxID_STATIC,
+                                          _("Waypoint Arrival Distance (NMi)"));
   pRouteGrid->Add(raText, 1, wxEXPAND | wxALL, group_item_spacing);
 
   m_pText_ACRadius = new wxTextCtrl(itemPanelRoutes, -1, "TEXT  ");


### PR DESCRIPTION
Change static text from "Waypoint Arrival Circle Radius (NMi)" to "Waypoint Arrival Distance (NMi)" to better reflect the setting behavior because there is no arrival circle (waypoint is completed when boat crosses the perpendicular line to the waypoint  and NormalRange <= Arrival Distance)

explained here : https://github.com/OpenCPN/OpenCPN/issues/4881