### PR TITLE
Fix 2 crash scenarios: click replay and null checks in event logic

### DIFF
--- a/gui/include/gui/chcanv.h
+++ b/gui/include/gui/chcanv.h
@@ -964,6 +964,9 @@ private:
   bool m_bIsInRadius;
   bool m_bMayToggleMenuBar;
 
+  // True only while replaying delayed single-click timer event.
+  bool m_isReplayingClickEvent = false;
+
   RoutePoint *m_pRoutePointEditTarget;
   RoutePoint *m_lastRoutePointEditTarget;
   SelectItem *m_pFoundPoint;

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -7724,7 +7724,13 @@ ChartCanvas::GetCanvasContextAtPoint(int x, int y) {
 }
 
 void ChartCanvas::MouseTimedEvent(wxTimerEvent &event) {
-  if (singleClickEventIsValid) MouseEvent(singleClickEvent);
+  if (singleClickEventIsValid) {
+    const bool wasReplaying = m_isReplayingClickEvent;
+    m_isReplayingClickEvent = true;
+    MouseEvent(singleClickEvent);
+    m_isReplayingClickEvent = wasReplaying;
+  }
+
   singleClickEventIsValid = false;
   m_DoubleClickTimer->Stop();
 }
@@ -7913,8 +7919,11 @@ bool ChartCanvas::MouseEventSetup(wxMouseEvent &event, bool b_handle_dclick) {
 
 #ifdef __WXMSW__
   // TODO Test carefully in other platforms, remove ifdef....
-  if (event.ButtonDown() && !HasCapture()) CaptureMouse();
-  if (event.ButtonUp() && HasCapture()) ReleaseMouse();
+  // Avoid capture release on delayed/replayed timer events.
+  if (!m_isReplayingClickEvent) {
+    if (event.ButtonDown() && !HasCapture()) CaptureMouse();
+    if (event.ButtonUp() && HasCapture()) ReleaseMouse();
+  }
 #endif
 
   event.SetEventObject(this);

--- a/gui/src/senc_manager.cpp
+++ b/gui/src/senc_manager.cpp
@@ -153,8 +153,10 @@ void SENCThreadManager::StartTopJob() {
 
   if (nRunning) {
     wxString count;
-    count.Printf("  %ld", ticket_list.size());
-    top_frame::Get()->SetAlertString(_("Preparing vector chart ") + count);
+    count.Printf("  %ld", static_cast<long>(ticket_list.size()));
+    if (auto tfPtr = top_frame::Get()) {
+      tfPtr->SetAlertString(_("Preparing vector chart ") + count);
+    }
   }
 }
 
@@ -183,10 +185,14 @@ void SENCThreadManager::FinishJob(SENCJobTicket *ticket) {
 
   if (nRunning) {
     wxString count;
-    count.Printf("  %ld", ticket_list.size());
-    top_frame::Get()->SetAlertString(_("Preparing vector chart ") + count);
+    count.Printf("  %ld", static_cast<long>(ticket_list.size()));
+    if (auto tfPtr = top_frame::Get()) {
+      tfPtr->SetAlertString(_("Preparing vector chart ") + count);
+    }
   } else {
-    top_frame::Get()->SetAlertString("");
+    if (auto tfPtr = top_frame::Get()) {
+      tfPtr->SetAlertString("");
+    }
   }
 #endif
 }


### PR DESCRIPTION
Add m_isReplayingClickEvent to ChartCanvas to track replayed single-click timer events and skip mouse capture/release during these.

In SENCThreadManager, add null checks for top_frame::Get() before calling SetAlertString and cast ticket_list size to long for formatting.