### PR TITLE
Fix SENCThreadManager threading and event-handling crashes

### DIFF
--- a/gui/include/gui/senc_manager.h
+++ b/gui/include/gui/senc_manager.h
@@ -68,10 +68,9 @@ public:
   double ref_lat, ref_lon;
   double m_LOD_meters;
 
-  SENCBuildThread *m_thread;
-
   SENCThreadStatus m_status;
   EVENTSENCResult m_SENCResult;
+  bool m_completion_posted;
 };
 
 //----------------------------------------------------------------------------
@@ -97,6 +96,10 @@ private:
  * Manages the creation of SENC (Simplified Electronic Navigational Chart) files
  * from S57 charts using background threads. Handles scheduling and executing
  * SENC build jobs.
+ *
+ * Worker threads post exactly one completion event to this manager via
+ * QueueEvent(). OnEvtThread() performs queue bookkeeping and forwards a single
+ * copy to the main frame for UI work. The frame deletes the ticket.
  */
 class SENCThreadManager : public wxEvtHandler {
 public:
@@ -110,11 +113,24 @@ public:
   void StartTopJob();
   bool IsChartInTicketlist(s57chart *chart);
   bool SetChartPointer(s57chart *chart, void *new_ptr);
+  void InvalidateChartPointer(s57chart *chart);
+  void ReleaseCompletedTicket(SENCJobTicket *ticket);
+  void ClearJobList();
   int GetJobCount();
+  int GetRunningJobCount();
+  bool IsShuttingDown() const;
 
   int m_max_jobs;
 
   std::vector<SENCJobTicket *> ticket_list;
+
+private:
+  void UpdateAlertString();
+  void NotifyFrame(OCPN_BUILDSENC_ThreadEvent &event);
+
+  std::vector<SENCJobTicket *> completing_list;
+  wxCriticalSection m_list_mutex;
+  bool m_shutting_down;
 };
 
 //----------------------------------------------------------------------------
@@ -127,7 +143,6 @@ public:
 
   wxString m_FullPath000;
   wxString m_SENCFileName;
-  s57chart *m_chart;
   SENCThreadManager *m_manager;
   SENCJobTicket *m_ticket;
 };

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -822,10 +822,15 @@ void MyFrame::OnSENCEvtThread(OCPN_BUILDSENC_ThreadEvent &event) {
       }
 
       ReloadAllVP();
+      if (g_SencThreadManager)
+        g_SencThreadManager->ReleaseCompletedTicket(event.m_ticket);
       delete event.m_ticket;
       break;
     case SENC_BUILD_DONE_ERROR:
-      // printf("Myframe SENC build done ERROR\n");
+      wxLogDebug("SENC build done: SENC_BUILD_DONE_ERROR");
+      if (g_SencThreadManager)
+        g_SencThreadManager->ReleaseCompletedTicket(event.m_ticket);
+      delete event.m_ticket;
       break;
     default:
       break;

--- a/gui/src/s57chart.cpp
+++ b/gui/src/s57chart.cpp
@@ -309,12 +309,8 @@ s57chart::~s57chart() {
     if (::wxFileExists(m_TempFilePath)) wxRemoveFile(m_TempFilePath);
   }
 
-  //  Check the SENCThreadManager to see if this chart is queued or active
-  if (g_SencThreadManager) {
-    if (g_SencThreadManager->IsChartInTicketlist(this)) {
-      g_SencThreadManager->SetChartPointer(this, NULL);
-    }
-  }
+  //  Detach this chart from any queued or completing SENC jobs.
+  if (g_SencThreadManager) g_SencThreadManager->InvalidateChartPointer(this);
 }
 
 void s57chart::GetValidCanvasRegion(const ViewPort &VPoint,

--- a/gui/src/senc_manager.cpp
+++ b/gui/src/senc_manager.cpp
@@ -40,12 +40,18 @@
 
 SENCThreadManager *g_SencThreadManager;
 
+namespace {
+constexpr int kThreadWaitSeconds = 5;
+}
+
 //----------------------------------------------------------------------------------
 //      SENCJobTicket Implementation
 //----------------------------------------------------------------------------------
 SENCJobTicket::SENCJobTicket() {
+  m_chart = nullptr;
   m_SENCResult = SENC_BUILD_INACTIVE;
   m_status = THREAD_INACTIVE;
+  m_completion_posted = false;
 }
 
 const wxEventType wxEVT_OCPN_BUILDSENCTHREAD = wxNewEventType();
@@ -57,6 +63,7 @@ OCPN_BUILDSENC_ThreadEvent::OCPN_BUILDSENC_ThreadEvent(wxEventType commandType,
                                                        int id)
     : wxEvent(id, commandType) {
   stat = 0;
+  m_ticket = nullptr;
 }
 
 OCPN_BUILDSENC_ThreadEvent::~OCPN_BUILDSENC_ThreadEvent() {}
@@ -73,183 +80,227 @@ wxEvent *OCPN_BUILDSENC_ThreadEvent::Clone() const {
 //----------------------------------------------------------------------------------
 //      SENCThreadManager Implementation
 //----------------------------------------------------------------------------------
-SENCThreadManager::SENCThreadManager() {
-  // ideally we would use the cpu count -1, and only launch jobs
-  // when the idle load average is sufficient (greater than 1)
+SENCThreadManager::SENCThreadManager() : m_shutting_down(false) {
   int nCPU = wxMax(1, wxThread::GetCPUCount());
   if (g_nCPUCount > 0) nCPU = g_nCPUCount;
 
-  // obviously there's at least one CPU!
   if (nCPU < 1) nCPU = 1;
 
   m_max_jobs = wxMax(nCPU - 1, 1);
-  // m_max_jobs = 1;
 
   wxLogDebug("SENC: nCPU: %d    m_max_jobs :%d\n", nCPU, m_max_jobs);
 
-  //  Create/connect a dynamic event handler slot for messages from the worker
-  //  threads
   Connect(
       wxEVT_OCPN_BUILDSENCTHREAD,
       (wxObjectEventFunction)(wxEventFunction)&SENCThreadManager::OnEvtThread);
-
-  //     m_timer.Connect(wxEVT_TIMER, wxTimerEventHandler(
-  //     glTextureManager::OnTimer ), NULL, this); m_timer.Start(500);
 }
 
-SENCThreadManager::~SENCThreadManager() {
-  //    ClearJobList();
+SENCThreadManager::~SENCThreadManager() { ClearJobList(); }
+
+bool SENCThreadManager::IsShuttingDown() const { return m_shutting_down; }
+
+int SENCThreadManager::GetRunningJobCount() {
+  wxCriticalSectionLocker lock(m_list_mutex);
+  int nRunning = 0;
+  for (SENCJobTicket *ticket : ticket_list) {
+    if (ticket->m_status == THREAD_STARTED) nRunning++;
+  }
+  return nRunning;
+}
+
+void SENCThreadManager::UpdateAlertString() {
+  int nRunning = 0;
+  size_t jobCount = 0;
+  {
+    wxCriticalSectionLocker lock(m_list_mutex);
+    jobCount = ticket_list.size();
+    for (SENCJobTicket *ticket : ticket_list) {
+      if (ticket->m_status == THREAD_STARTED) nRunning++;
+    }
+  }
+
+  if (auto tfPtr = top_frame::Get()) {
+    if (nRunning) {
+      wxString count;
+      count.Printf("  %ld", static_cast<long>(jobCount));
+      tfPtr->SetAlertString(_("Preparing vector chart ") + count);
+    } else {
+      tfPtr->SetAlertString("");
+    }
+  }
+}
+
+void SENCThreadManager::ClearJobList() {
+  m_shutting_down = true;
+
+  wxDateTime end = wxDateTime::Now();
+  end.Add(wxTimeSpan::Seconds(kThreadWaitSeconds));
+
+  while (wxDateTime::Now() < end && GetRunningJobCount() > 0) {
+    wxSleep(1);
+    wxYield();
+  }
+
+  std::vector<SENCJobTicket *> tickets_to_delete;
+  {
+    wxCriticalSectionLocker lock(m_list_mutex);
+    auto collect = [&](std::vector<SENCJobTicket *> &list) {
+      for (SENCJobTicket *ticket : list) tickets_to_delete.push_back(ticket);
+      list.clear();
+    };
+    collect(ticket_list);
+    collect(completing_list);
+  }
+
+  for (SENCJobTicket *ticket : tickets_to_delete) delete ticket;
 }
 
 SENCThreadStatus SENCThreadManager::ScheduleJob(SENCJobTicket *ticket) {
-  //  Do not add a job if there is already a job pending for this chart, by name
-  for (size_t i = 0; i < ticket_list.size(); i++) {
-    if (ticket_list[i]->m_FullPath000 == ticket->m_FullPath000)
-      return THREAD_PENDING;
+  if (m_shutting_down) return THREAD_INACTIVE;
+
+  {
+    wxCriticalSectionLocker lock(m_list_mutex);
+
+    for (SENCJobTicket *queued : ticket_list) {
+      if (queued->m_FullPath000 == ticket->m_FullPath000) return THREAD_PENDING;
+    }
+
+    ticket->m_status = THREAD_PENDING;
+    ticket->m_completion_posted = false;
+    ticket_list.push_back(ticket);
   }
 
-  ticket->m_status = THREAD_PENDING;
-  ticket_list.push_back(ticket);
-
-  // printf("Scheduling job:  %s\n", (const
-  // char*)ticket->m_FullPath000.mb_str()); printf("Job count:  %d\n",
-  // ticket_list.size());
   StartTopJob();
   return THREAD_PENDING;
 }
 
 void SENCThreadManager::StartTopJob() {
-  SENCJobTicket *startCandidate;
-  // Get the running job count
-  int nRunning = 0;
-  for (size_t i = 0; i < ticket_list.size(); i++) {
-    if (ticket_list[i]->m_status == THREAD_STARTED) nRunning++;
-  }
+  if (m_shutting_down) return;
 
-  // OK to start one?
-  if (nRunning < m_max_jobs) {
-    // Find the first eligible
-    startCandidate = NULL;
-    for (size_t i = 0; i < ticket_list.size(); i++) {
-      if (ticket_list[i]->m_status == THREAD_PENDING) {
-        startCandidate = ticket_list[i];
-        break;
+  bool started_job = false;
+  do {
+    started_job = false;
+
+    {
+      wxCriticalSectionLocker lock(m_list_mutex);
+
+      int nRunning = 0;
+      for (SENCJobTicket *ticket : ticket_list) {
+        if (ticket->m_status == THREAD_STARTED) nRunning++;
       }
-    }
 
-    // Found one?
-    if (startCandidate) {
-      // printf("Starting job:  %s\n", (const
-      // char*)startCandidate->m_FullPath000.mb_str());
+      if (nRunning >= m_max_jobs) break;
+
+      SENCJobTicket *startCandidate = nullptr;
+      for (SENCJobTicket *ticket : ticket_list) {
+        if (ticket->m_status == THREAD_PENDING) {
+          startCandidate = ticket;
+          break;
+        }
+      }
+
+      if (!startCandidate) break;
 
       SENCBuildThread *thread = new SENCBuildThread(startCandidate, this);
-      startCandidate->m_thread = thread;
       startCandidate->m_status = THREAD_STARTED;
       thread->SetPriority(20);
-      thread->Run();
-      nRunning++;
-    }
-  }
+      if (thread->Run() != wxTHREAD_NO_ERROR) {
+        startCandidate->m_status = THREAD_PENDING;
+        delete thread;
+        break;
+      }
 
-  if (nRunning) {
-    wxString count;
-    count.Printf("  %ld", static_cast<long>(ticket_list.size()));
-    if (auto tfPtr = top_frame::Get()) {
-      tfPtr->SetAlertString(_("Preparing vector chart ") + count);
+      started_job = true;
     }
-  }
+  } while (started_job);
+
+  UpdateAlertString();
 }
 
 void SENCThreadManager::FinishJob(SENCJobTicket *ticket) {
-  // printf("Finishing job:  %s\n", (const
-  // char*)ticket->m_FullPath000.mb_str());
+  {
+    wxCriticalSectionLocker lock(m_list_mutex);
 
-  // Find and remove the ticket from the list
-  for (size_t i = 0; i < ticket_list.size(); i++) {
-    if (ticket_list[i] == ticket) {
-      // printf("   Removing job:  %s\n", (const
-      // char*)ticket->m_FullPath000.mb_str());
-
-      ticket_list.erase(ticket_list.begin() + i);
-      // printf("Job count:  %d\n", ticket_list.size());
-
-      break;
+    for (size_t i = 0; i < ticket_list.size(); i++) {
+      if (ticket_list[i] == ticket) {
+        ticket->m_status = THREAD_FINISHED;
+        completing_list.push_back(ticket);
+        ticket_list.erase(ticket_list.begin() + i);
+        break;
+      }
     }
   }
 
-#if 1
-  int nRunning = 0;
-  for (size_t i = 0; i < ticket_list.size(); i++) {
-    if (ticket_list[i]->m_status == THREAD_STARTED) nRunning++;
-  }
-
-  if (nRunning) {
-    wxString count;
-    count.Printf("  %ld", static_cast<long>(ticket_list.size()));
-    if (auto tfPtr = top_frame::Get()) {
-      tfPtr->SetAlertString(_("Preparing vector chart ") + count);
-    }
-  } else {
-    if (auto tfPtr = top_frame::Get()) {
-      tfPtr->SetAlertString("");
-    }
-  }
-#endif
+  UpdateAlertString();
 }
 
-int SENCThreadManager::GetJobCount() { return ticket_list.size(); }
+int SENCThreadManager::GetJobCount() {
+  wxCriticalSectionLocker lock(m_list_mutex);
+  return static_cast<int>(ticket_list.size());
+}
 
 bool SENCThreadManager::IsChartInTicketlist(s57chart *chart) {
-  for (size_t i = 0; i < ticket_list.size(); i++) {
-    if (ticket_list[i]->m_chart == chart) return true;
+  wxCriticalSectionLocker lock(m_list_mutex);
+  for (SENCJobTicket *ticket : ticket_list) {
+    if (ticket->m_chart == chart) return true;
+  }
+  for (SENCJobTicket *ticket : completing_list) {
+    if (ticket->m_chart == chart) return true;
   }
   return false;
 }
 
 bool SENCThreadManager::SetChartPointer(s57chart *chart, void *new_ptr) {
-  // Find the ticket
-  for (size_t i = 0; i < ticket_list.size(); i++) {
-    if (ticket_list[i]->m_chart == chart) {
-      ticket_list[i]->m_chart = (s57chart *)new_ptr;
-      return true;
+  wxCriticalSectionLocker lock(m_list_mutex);
+  auto update = [&](std::vector<SENCJobTicket *> &list) {
+    for (SENCJobTicket *ticket : list) {
+      if (ticket->m_chart == chart) {
+        ticket->m_chart = static_cast<s57chart *>(new_ptr);
+        return true;
+      }
     }
-  }
-  return false;
+    return false;
+  };
+
+  if (update(ticket_list)) return true;
+  return update(completing_list);
 }
 
-#define NBAR_LENGTH 40
+void SENCThreadManager::InvalidateChartPointer(s57chart *chart) {
+  SetChartPointer(chart, nullptr);
+}
+
+void SENCThreadManager::ReleaseCompletedTicket(SENCJobTicket *ticket) {
+  wxCriticalSectionLocker lock(m_list_mutex);
+  for (size_t i = 0; i < completing_list.size(); i++) {
+    if (completing_list[i] == ticket) {
+      completing_list.erase(completing_list.begin() + i);
+      break;
+    }
+  }
+}
+
+void SENCThreadManager::NotifyFrame(OCPN_BUILDSENC_ThreadEvent &event) {
+  if (!top_frame::Get()) return;
+
+  OCPN_BUILDSENC_ThreadEvent frame_event(wxEVT_OCPN_BUILDSENCTHREAD, 0);
+  frame_event.stat = event.stat;
+  frame_event.type = event.type;
+  frame_event.m_ticket = event.m_ticket;
+  top_frame::Get()->GetEventHandler()->AddPendingEvent(frame_event);
+}
 
 void SENCThreadManager::OnEvtThread(OCPN_BUILDSENC_ThreadEvent &event) {
-  OCPN_BUILDSENC_ThreadEvent Sevent(wxEVT_OCPN_BUILDSENCTHREAD, 0);
-
   switch (event.type) {
-    case SENC_BUILD_STARTED:
-      // printf("SENC build started\n");
-      Sevent.type = SENC_BUILD_STARTED;
-      Sevent.m_ticket = event.m_ticket;
-
-      break;
     case SENC_BUILD_DONE_NOERROR:
-      // printf("SENC build done no error\n");
-      Sevent.type = SENC_BUILD_DONE_NOERROR;
-      Sevent.m_ticket = event.m_ticket;
-      FinishJob(event.m_ticket);
-      StartTopJob();
-
-      break;
     case SENC_BUILD_DONE_ERROR:
-      // printf("SENC build done ERROR\n");
-      Sevent.type = SENC_BUILD_DONE_ERROR;
-      Sevent.m_ticket = event.m_ticket;
       FinishJob(event.m_ticket);
       StartTopJob();
-
+      NotifyFrame(event);
       break;
     default:
       break;
   }
-  if (top_frame::Get())
-    top_frame::Get()->GetEventHandler()->AddPendingEvent(Sevent);
 }
 
 //----------------------------------------------------------------------------------
@@ -257,28 +308,20 @@ void SENCThreadManager::OnEvtThread(OCPN_BUILDSENC_ThreadEvent &event) {
 //----------------------------------------------------------------------------------
 
 SENCBuildThread::SENCBuildThread(SENCJobTicket *ticket,
-                                 SENCThreadManager *manager) {
+                                 SENCThreadManager *manager)
+    : wxThread(wxTHREAD_DETACHED), m_manager(manager), m_ticket(ticket) {
   m_FullPath000 = ticket->m_FullPath000;
   m_SENCFileName = ticket->m_SENCFileName;
-  m_manager = manager;
-  m_ticket = ticket;
-
   Create();
 }
 
 void *SENCBuildThread::Entry() {
-  // #ifdef __MSVC__
-  //   _set_se_translator(my_translate);
+  EVENTSENCResult result = SENC_BUILD_DONE_ERROR;
+  int stat = -1;
 
-  //  On Windows, if anything in this thread produces a SEH exception (like
-  //  access violation) we handle the exception locally, and simply alow the
-  //  thread to exit smoothly with no results. Upstream will notice that nothing
-  //  got done, and maybe try again later.
+  if (!m_manager || m_manager->IsShuttingDown()) return nullptr;
 
-  try
-  // #endif
-  {
-    // Start the SENC build
+  try {
     Osenc senc;
 
     senc.setRegistrar(g_poRegistrar);
@@ -287,46 +330,29 @@ void *SENCBuildThread::Entry() {
     senc.setNoErrDialog(true);
 
     m_ticket->m_SENCResult = SENC_BUILD_STARTED;
-    OCPN_BUILDSENC_ThreadEvent Sevent(wxEVT_OCPN_BUILDSENCTHREAD, 0);
-    Sevent.stat = 0;
-    Sevent.type = SENC_BUILD_STARTED;
-    Sevent.m_ticket = m_ticket;
-    if (m_manager) m_manager->QueueEvent(Sevent.Clone());
 
-    int ret = senc.createSenc200(m_FullPath000, m_SENCFileName, false);
-
-    OCPN_BUILDSENC_ThreadEvent Nevent(wxEVT_OCPN_BUILDSENCTHREAD, 0);
-    Nevent.stat = ret;
-    Nevent.m_ticket = m_ticket;
-    if (ret == ERROR_INGESTING000)
-      Nevent.type = SENC_BUILD_DONE_ERROR;
-    else
-      Nevent.type = SENC_BUILD_DONE_NOERROR;
-
-    m_ticket->m_SENCResult = Sevent.type;
-    if (m_manager) m_manager->QueueEvent(Nevent.Clone());
-
-    // if(ret == ERROR_INGESTING000)
-    //  return BUILD_SENC_NOK_PERMANENT;
-    // else
-    //  return ret;
-
-    return 0;
-  }  // try
-
-  // #ifdef __MSVC__
-  catch (const std::exception &e /*SE_Exception e*/) {
-    const char *msg = e.what();
-    if (m_manager) {
-      //             OCPN_CompressionThreadEvent
-      //             Nevent(wxEVT_OCPN_COMPRESSIONTHREAD, 0);
-      //             m_ticket->b_isaborted = true;
-      //             Nevent.SetTicket(m_ticket);
-      //             Nevent.type = 0;
-      //             m_manager->QueueEvent(Nevent.Clone());
-    }
-
-    return 0;
+    stat = senc.createSenc200(m_FullPath000, m_SENCFileName, false);
+    result = (stat == ERROR_INGESTING000) ? SENC_BUILD_DONE_ERROR
+                                          : SENC_BUILD_DONE_NOERROR;
+  } catch (const std::exception &e) {
+    wxLogMessage("SENC build thread exception: %s", e.what());
+    result = SENC_BUILD_DONE_ERROR;
+    stat = -1;
   }
-  // #endif
+
+  // Post exactly one completion event to the manager.
+  if (!m_manager || m_manager->IsShuttingDown() ||
+      m_ticket->m_completion_posted)
+    return nullptr;
+
+  m_ticket->m_completion_posted = true;
+  m_ticket->m_SENCResult = result;
+
+  OCPN_BUILDSENC_ThreadEvent event(wxEVT_OCPN_BUILDSENCTHREAD, 0);
+  event.stat = stat;
+  event.type = result;
+  event.m_ticket = m_ticket;
+  m_manager->QueueEvent(event.Clone());
+
+  return nullptr;
 }


### PR DESCRIPTION
SENC background builds were unsafe under chart unload, concurrent GUI activity, and shutdown. The worker relayed multiple events per job (STARTED + DONE), and completion/error paths could post more than once, so the frame could process the same ticket twice and double-delete it. ticket_list was also accessed without synchronization and tickets were removed from the active queue before the frame finished with them, leaving dangling chart pointers.

Rework the worker/manager/frame flow to match the glTextureManager pattern:

- Post exactly one completion event from each worker thread
- Handle queue bookkeeping only in SENCThreadManager::OnEvtThread
- Forward a single DONE event to the main frame for UI work
- Guard against duplicate completion posts with m_completion_posted
- Use wxTHREAD_DETACHED and stop Wait()/delete during event handling
- Protect ticket_list and completing_list with wxCriticalSection
- Keep finished tickets in completing_list until the frame deletes them
- Add InvalidateChartPointer() so chart destruction clears queued refs
- Add ClearJobList() shutdown drain in the manager destructor
- Delete tickets on both success and error paths in MyFrame

Tested with extended pan/zoom and shutdown while SENC jobs were still queued; no crashes observed.