### PR TITLE
grib_pi: add GRIB merge utility

### DIFF
--- a/plugins/grib_pi/CMakeLists.txt
+++ b/plugins/grib_pi/CMakeLists.txt
@@ -103,6 +103,8 @@ set(SRC_GRIB
     src/GribSettingsDialog.h
     src/GribRequestDialog.cpp
     src/GribRequestDialog.h
+    src/GribMerge.cpp
+    src/GribMerge.h
     src/XyGribPanel.h
     src/XyGribPanel.cpp
     src/XyGribModelDef.h

--- a/plugins/grib_pi/po/POTFILES.in
+++ b/plugins/grib_pi/po/POTFILES.in
@@ -2,6 +2,8 @@ src/msg.h
 src/GribRecordSet.h
 src/zuFile.cpp
 src/GribUIDialog.cpp
+src/GribMerge.cpp
+src/GribMerge.h
 src/GribOverlayFactory.h
 src/GribReader.cpp
 src/email.h

--- a/plugins/grib_pi/src/GribMerge.cpp
+++ b/plugins/grib_pi/src/GribMerge.cpp
@@ -1,0 +1,481 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by the OpenCPN Authors                             *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ ***************************************************************************/
+
+#include "GribMerge.h"
+
+#include <wx/file.h>
+#include <wx/filefn.h>
+#include <wx/filename.h>
+
+#include <algorithm>
+#include <limits>
+
+namespace {
+
+const wxFileOffset MAX_GRIB_MERGE_FILE_SIZE = 512LL * 1024LL * 1024LL;
+
+uint32_t ReadUint24(const std::vector<unsigned char> &data, size_t pos) {
+  return ((uint32_t)data[pos] << 16) | ((uint32_t)data[pos + 1] << 8) |
+         (uint32_t)data[pos + 2];
+}
+
+uint32_t ReadUint16(const std::vector<unsigned char> &data, size_t pos) {
+  return ((uint32_t)data[pos] << 8) | (uint32_t)data[pos + 1];
+}
+
+uint32_t ReadUint32(const std::vector<unsigned char> &data, size_t pos) {
+  return ((uint32_t)data[pos] << 24) | ((uint32_t)data[pos + 1] << 16) |
+         ((uint32_t)data[pos + 2] << 8) | (uint32_t)data[pos + 3];
+}
+
+uint64_t ReadUint64(const std::vector<unsigned char> &data, size_t pos) {
+  uint64_t value = 0;
+  for (int i = 0; i < 8; i++) value = (value << 8) | data[pos + i];
+  return value;
+}
+
+int32_t ReadInt32(const std::vector<unsigned char> &data, size_t pos) {
+  return (int32_t)ReadUint32(data, pos);
+}
+
+int32_t ReadInt24Grib1(const std::vector<unsigned char> &data, size_t pos) {
+  uint32_t value = ReadUint24(data, pos);
+  if (value & 0x800000) return -(int32_t)(value & 0x7fffff);
+  return (int32_t)value;
+}
+
+double NormaliseLon(double lon) {
+  while (lon > 180.0) lon -= 360.0;
+  while (lon < -180.0) lon += 360.0;
+  return lon;
+}
+
+bool IsGribAt(const std::vector<unsigned char> &data, size_t pos) {
+  return pos + 4 <= data.size() && data[pos] == 'G' && data[pos + 1] == 'R' &&
+         data[pos + 2] == 'I' && data[pos + 3] == 'B';
+}
+
+bool EndsWith7777(const std::vector<unsigned char> &data, size_t end) {
+  return end >= 4 && data[end - 4] == '7' && data[end - 3] == '7' &&
+         data[end - 2] == '7' && data[end - 1] == '7';
+}
+
+bool AddTimeDelta(wxDateTime &time, int unit, uint32_t value) {
+  switch (unit) {
+    case 0:
+      time += wxTimeSpan::Minutes(value);
+      return true;
+    case 1:
+      time += wxTimeSpan::Hours(value);
+      return true;
+    case 2:
+      time += wxTimeSpan::Days(value);
+      return true;
+    case 10:
+      time += wxTimeSpan::Hours(3 * value);
+      return true;
+    case 11:
+      time += wxTimeSpan::Hours(6 * value);
+      return true;
+    case 12:
+      time += wxTimeSpan::Hours(12 * value);
+      return true;
+    case 13:
+      time += wxTimeSpan::Seconds(value);
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool SetUtcTime(wxDateTime &time, int year, int month, int day, int hour,
+                int minute, int second) {
+  if (month < 1 || month > 12) return false;
+
+  time.Set((wxDateTime::wxDateTime_t)day, (wxDateTime::Month)(month - 1),
+           year, hour, minute, second);
+  if (!time.IsValid()) return false;
+
+  time.MakeFromTimezone(wxDateTime::UTC);
+  return true;
+}
+
+void AddValidTime(GribMergeSummary &summary, const wxDateTime &time) {
+  if (!time.IsValid()) return;
+  if (!summary.hasValidTimes) {
+    summary.firstValidTime = time;
+    summary.lastValidTime = time;
+    summary.hasValidTimes = true;
+    return;
+  }
+  if (time < summary.firstValidTime) summary.firstValidTime = time;
+  if (time > summary.lastValidTime) summary.lastValidTime = time;
+}
+
+void AddCoverage(GribMergeSummary &summary, double lat1, double lon1,
+                 double lat2, double lon2) {
+  double latMin = std::min(lat1, lat2);
+  double latMax = std::max(lat1, lat2);
+  double lonMin = std::min(lon1, lon2);
+  double lonMax = std::max(lon1, lon2);
+
+  if (!summary.hasCoverage) {
+    summary.latMin = latMin;
+    summary.latMax = latMax;
+    summary.lonMin = lonMin;
+    summary.lonMax = lonMax;
+    summary.hasCoverage = true;
+    return;
+  }
+
+  summary.latMin = std::min(summary.latMin, latMin);
+  summary.latMax = std::max(summary.latMax, latMax);
+  summary.lonMin = std::min(summary.lonMin, lonMin);
+  summary.lonMax = std::max(summary.lonMax, lonMax);
+}
+
+void ParseGrib1Meta(const std::vector<unsigned char> &data,
+                    const GribMergeMessage &msg, GribMergeSummary &summary) {
+  size_t pdsStart = msg.start + 8;
+  if (pdsStart + 3 > msg.start + msg.length) return;
+
+  uint32_t pdsLength = ReadUint24(data, pdsStart);
+  if (pdsLength < 25 || pdsStart + pdsLength > msg.start + msg.length) return;
+
+  unsigned char flags = data[pdsStart + 7];
+  int year = data[pdsStart + 12];
+  int month = data[pdsStart + 13];
+  int day = data[pdsStart + 14];
+  int hour = data[pdsStart + 15];
+  int minute = data[pdsStart + 16];
+  int timeUnit = data[pdsStart + 17];
+  int p1 = data[pdsStart + 18];
+  int p2 = data[pdsStart + 19];
+  int timeRange = data[pdsStart + 20];
+  int century = data[pdsStart + 24];
+  int fullYear = (century - 1) * 100 + year;
+
+  wxDateTime validTime;
+  if (SetUtcTime(validTime, fullYear, month, day, hour, minute, 0)) {
+    uint32_t step = ((timeRange >= 2 && timeRange <= 5) && p2) ? p2 : p1;
+    AddTimeDelta(validTime, timeUnit, step);
+    AddValidTime(summary, validTime);
+  }
+
+  if (!(flags & 0x80)) return;
+
+  size_t gdsStart = pdsStart + pdsLength;
+  if (gdsStart + 28 > msg.start + msg.length) return;
+
+  uint32_t gdsLength = ReadUint24(data, gdsStart);
+  if (gdsLength < 28 || gdsStart + gdsLength > msg.start + msg.length) return;
+
+  if (data[gdsStart + 5] == 0) {
+    double lat1 = ReadInt24Grib1(data, gdsStart + 10) / 1000.0;
+    double lon1 = NormaliseLon(ReadInt24Grib1(data, gdsStart + 13) / 1000.0);
+    double lat2 = ReadInt24Grib1(data, gdsStart + 17) / 1000.0;
+    double lon2 = NormaliseLon(ReadInt24Grib1(data, gdsStart + 20) / 1000.0);
+    AddCoverage(summary, lat1, lon1, lat2, lon2);
+  }
+}
+
+void ParseGrib2Meta(const std::vector<unsigned char> &data,
+                    const GribMergeMessage &msg, GribMergeSummary &summary) {
+  size_t end = msg.start + msg.length;
+  size_t pos = msg.start + 16;
+  wxDateTime refTime;
+
+  while (pos + 5 <= end - 4) {
+    uint32_t sectionLength = ReadUint32(data, pos);
+    if (sectionLength < 5 || pos + sectionLength > end) return;
+
+    int sectionNumber = data[pos + 4];
+    if (sectionNumber == 1 && sectionLength >= 21) {
+      int year = ReadUint16(data, pos + 12);
+      int month = data[pos + 14];
+      int day = data[pos + 15];
+      int hour = data[pos + 16];
+      int minute = data[pos + 17];
+      int second = data[pos + 18];
+      SetUtcTime(refTime, year, month, day, hour, minute, second);
+    } else if (sectionNumber == 3 && sectionLength >= 72) {
+      uint32_t gridTemplate = ReadUint16(data, pos + 12);
+      if (gridTemplate == 0) {
+        uint32_t basicAngle = ReadUint32(data, pos + 38);
+        uint32_t subdivisions = ReadUint32(data, pos + 42);
+        double scale =
+            (basicAngle == 0 || subdivisions == 0)
+                ? 1e-6
+                : (double)basicAngle / (double)subdivisions;
+        double lat1 = ReadInt32(data, pos + 46) * scale;
+        double lon1 = NormaliseLon(ReadInt32(data, pos + 50) * scale);
+        double lat2 = ReadInt32(data, pos + 55) * scale;
+        double lon2 = NormaliseLon(ReadInt32(data, pos + 59) * scale);
+        AddCoverage(summary, lat1, lon1, lat2, lon2);
+      }
+    } else if (sectionNumber == 4 && sectionLength >= 22 &&
+               refTime.IsValid()) {
+      wxDateTime validTime = refTime;
+      int timeUnit = data[pos + 17];
+      uint32_t forecastTime = ReadUint32(data, pos + 18);
+      if (AddTimeDelta(validTime, timeUnit, forecastTime))
+        AddValidTime(summary, validTime);
+    }
+
+    pos += sectionLength;
+  }
+}
+
+bool ScanMessages(const wxString &path, const std::vector<unsigned char> &data,
+                  std::vector<GribMergeMessage> &messages, wxString &error) {
+  size_t pos = 0;
+
+  while (pos < data.size()) {
+    size_t start = data.size();
+    for (size_t i = pos; i + 4 <= data.size(); i++) {
+      if (IsGribAt(data, i)) {
+        start = i;
+        break;
+      }
+    }
+
+    if (start == data.size()) break;
+
+    if (start + 8 > data.size()) {
+      error.Printf(_("%s: truncated GRIB header at byte %llu"),
+                   wxFileName(path).GetFullName(), (unsigned long long)start);
+      return false;
+    }
+
+    int edition = data[start + 7];
+    uint64_t length = 0;
+    if (edition == 1) {
+      length = ReadUint24(data, start + 4);
+    } else if (edition == 2) {
+      if (start + 16 > data.size()) {
+        error.Printf(_("%s: truncated GRIB2 header at byte %llu"),
+                     wxFileName(path).GetFullName(),
+                     (unsigned long long)start);
+        return false;
+      }
+      length = ReadUint64(data, start + 8);
+    } else {
+      error.Printf(_("%s: unsupported GRIB edition %d at byte %llu"),
+                   wxFileName(path).GetFullName(), edition,
+                   (unsigned long long)start);
+      return false;
+    }
+
+    if (length == 0 || length > std::numeric_limits<size_t>::max()) {
+      error.Printf(_("%s: invalid GRIB message length at byte %llu"),
+                   wxFileName(path).GetFullName(), (unsigned long long)start);
+      return false;
+    }
+
+    size_t end = start + (size_t)length;
+    if (end < start || end > data.size()) {
+      error.Printf(_("%s: GRIB message at byte %llu is truncated"),
+                   wxFileName(path).GetFullName(), (unsigned long long)start);
+      return false;
+    }
+
+    if (!EndsWith7777(data, end)) {
+      error.Printf(_("%s: GRIB message at byte %llu does not end with 7777"),
+                   wxFileName(path).GetFullName(), (unsigned long long)start);
+      return false;
+    }
+
+    GribMergeMessage msg;
+    msg.start = start;
+    msg.length = (size_t)length;
+    msg.edition = edition;
+    messages.push_back(msg);
+    pos = end;
+  }
+
+  if (messages.empty()) {
+    error.Printf(_("%s: no GRIB messages were found"),
+                 wxFileName(path).GetFullName());
+    return false;
+  }
+
+  return true;
+}
+
+wxString FormatTime(const wxDateTime &time) {
+  return time.Format("%Y-%m-%d %H:%M", wxDateTime::UTC) + " UTC";
+}
+
+}  // namespace
+
+bool GribMerge::ReadAndValidate(const wxString &path, GribMergeFile &file,
+                                wxString &error) {
+  wxFile input(path);
+  if (!input.IsOpened()) {
+    error.Printf(_("Unable to open %s"), path);
+    return false;
+  }
+
+  wxFileOffset length = input.Length();
+  if (length <= 0) {
+    error = _("The selected file is empty.");
+    return false;
+  }
+
+  if (length > MAX_GRIB_MERGE_FILE_SIZE) {
+    error = _("The selected file is too large to process.");
+    return false;
+  }
+
+  file.path = path;
+  file.data.assign((size_t)length, 0);
+  if (input.Read(file.data.data(), (size_t)length) != length) {
+    error.Printf(_("Unable to read %s"), path);
+    return false;
+  }
+
+  file.messages.clear();
+  if (!ScanMessages(path, file.data, file.messages, error)) return false;
+
+  GribMergeSummary summary;
+  summary.fileName = wxFileName(path).GetFullName();
+  summary.fileSize = file.data.size();
+  summary.messageCount = file.messages.size();
+  summary.grib1Count = 0;
+  summary.grib2Count = 0;
+  summary.hasValidTimes = false;
+  summary.hasCoverage = false;
+  summary.latMin = summary.latMax = summary.lonMin = summary.lonMax = 0.0;
+
+  for (size_t i = 0; i < file.messages.size(); i++) {
+    const GribMergeMessage &msg = file.messages[i];
+    if (msg.edition == 1) {
+      summary.grib1Count++;
+      ParseGrib1Meta(file.data, msg, summary);
+    } else if (msg.edition == 2) {
+      summary.grib2Count++;
+      ParseGrib2Meta(file.data, msg, summary);
+    }
+  }
+
+  file.summary = summary;
+  return true;
+}
+
+bool GribMerge::WriteMerged(const GribMergeFile &first,
+                            const GribMergeFile &second,
+                            const wxString &outputPath, wxString &error) {
+  wxFileName outputName(outputPath);
+  wxString tempPrefix = outputName.GetPathWithSep() + "." +
+                        outputName.GetFullName() + ".tmp";
+  wxString tempPath = wxFileName::CreateTempFileName(tempPrefix);
+
+  if (tempPath.IsEmpty()) {
+    error.Printf(_("Unable to create a temporary file for %s"), outputPath);
+    return false;
+  }
+
+  wxFile output(tempPath, wxFile::write);
+  if (!output.IsOpened()) {
+    wxRemoveFile(tempPath);
+    error.Printf(_("Unable to create a temporary file for %s"), outputPath);
+    return false;
+  }
+
+  const GribMergeFile *files[2] = {&first, &second};
+  for (int fileIndex = 0; fileIndex < 2; fileIndex++) {
+    const GribMergeFile &file = *files[fileIndex];
+    for (size_t i = 0; i < file.messages.size(); i++) {
+      const GribMergeMessage &msg = file.messages[i];
+      const unsigned char *buffer = file.data.data() + msg.start;
+      if (output.Write(buffer, msg.length) != msg.length) {
+        output.Close();
+        wxRemoveFile(tempPath);
+        error.Printf(_("Unable to write %s"), outputPath);
+        return false;
+      }
+    }
+  }
+
+  if (!output.Close()) {
+    wxRemoveFile(tempPath);
+    error.Printf(_("Unable to write %s"), outputPath);
+    return false;
+  }
+
+  if (!wxRenameFile(tempPath, outputPath, true)) {
+    wxRemoveFile(tempPath);
+    error.Printf(_("Unable to replace %s"), outputPath);
+    return false;
+  }
+
+  return true;
+}
+
+wxString GribMerge::FormatSummary(const wxString &label,
+                                  const GribMergeSummary &summary) {
+  wxString text;
+  text << label << "\n";
+  text << wxString::Format(_("  File: %s\n"), summary.fileName);
+  text << wxString::Format(_("  Messages: %llu\n"),
+                           (unsigned long long)summary.messageCount);
+  text << wxString::Format(_("  Editions: GRIB1: %llu, GRIB2: %llu\n"),
+                           (unsigned long long)summary.grib1Count,
+                           (unsigned long long)summary.grib2Count);
+
+  if (summary.hasValidTimes) {
+    text << wxString::Format(_("  Valid time: %s to %s\n"),
+                             FormatTime(summary.firstValidTime),
+                             FormatTime(summary.lastValidTime));
+  } else {
+    text << _("  Valid time: unavailable\n");
+  }
+
+  if (summary.hasCoverage) {
+    text << wxString::Format(_("  Coverage: lat %.4f to %.4f, lon %.4f to %.4f\n"),
+                             summary.latMin, summary.latMax, summary.lonMin,
+                             summary.lonMax);
+  } else {
+    text << _("  Coverage: unavailable\n");
+  }
+
+  return text;
+}
+
+wxString GribMerge::FormatOverlap(const GribMergeSummary &current,
+                                  const GribMergeSummary &weather) {
+  wxString text;
+  text << _("Wind and ocean current data overlap:") << "\n";
+
+  if (!current.hasValidTimes || !weather.hasValidTimes) {
+    text << _("unavailable") << "\n";
+    text << _("Outside this overlap, the merged file may contain weather data "
+              "without ocean current data.");
+    return text;
+  }
+
+  wxDateTime start =
+      current.firstValidTime > weather.firstValidTime ? current.firstValidTime
+                                                      : weather.firstValidTime;
+  wxDateTime end =
+      current.lastValidTime < weather.lastValidTime ? current.lastValidTime
+                                                    : weather.lastValidTime;
+
+  if (start <= end) {
+    text << wxString::Format(_("%s to %s"), FormatTime(start),
+                             FormatTime(end));
+  } else {
+    text << _("none");
+  }
+
+  text << "\n";
+  text << _("Outside this overlap, the merged file may contain weather data "
+            "without ocean current data.");
+  return text;
+}

--- a/plugins/grib_pi/src/GribMerge.h
+++ b/plugins/grib_pi/src/GribMerge.h
@@ -1,0 +1,65 @@
+/***************************************************************************
+ *   Copyright (C) 2026 by the OpenCPN Authors                             *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ ***************************************************************************/
+
+#ifndef __GRIBMERGE_H__
+#define __GRIBMERGE_H__
+
+#include "wx/wxprec.h"
+
+#ifndef WX_PRECOMP
+#include "wx/wx.h"
+#endif
+
+#include <stdint.h>
+
+#include <vector>
+
+struct GribMergeMessage {
+  size_t start;
+  size_t length;
+  int edition;
+};
+
+struct GribMergeSummary {
+  wxString fileName;
+  size_t fileSize;
+  size_t messageCount;
+  size_t grib1Count;
+  size_t grib2Count;
+  bool hasValidTimes;
+  wxDateTime firstValidTime;
+  wxDateTime lastValidTime;
+  bool hasCoverage;
+  double latMin;
+  double latMax;
+  double lonMin;
+  double lonMax;
+};
+
+struct GribMergeFile {
+  wxString path;
+  std::vector<unsigned char> data;
+  std::vector<GribMergeMessage> messages;
+  GribMergeSummary summary;
+};
+
+class GribMerge {
+public:
+  static bool ReadAndValidate(const wxString &path, GribMergeFile &file,
+                              wxString &error);
+  static bool WriteMerged(const GribMergeFile &first,
+                          const GribMergeFile &second,
+                          const wxString &outputPath, wxString &error);
+  static wxString FormatSummary(const wxString &label,
+                                const GribMergeSummary &summary);
+  static wxString FormatOverlap(const GribMergeSummary &current,
+                                const GribMergeSummary &weather);
+};
+
+#endif

--- a/plugins/grib_pi/src/GribUIDialog.cpp
+++ b/plugins/grib_pi/src/GribUIDialog.cpp
@@ -29,8 +29,10 @@
 #include "wx/sound.h"
 #include <wx/wfstream.h>
 #include <wx/dir.h>
+#include <wx/filefn.h>
 #include <wx/filename.h>
 #include <wx/debug.h>
+#include <wx/filepicker.h>
 #include <wx/graphics.h>
 #include <wx/regex.h>
 
@@ -43,6 +45,7 @@
 #include "ocpn_plugin.h"
 #include "grib_pi.h"
 #include "GribTable.h"
+#include "GribMerge.h"
 #include "email.h"
 #include "folder.xpm"
 #include "GribUIDialog.h"
@@ -51,6 +54,130 @@
 #ifdef __ANDROID__
 #include "android_jvm.h"
 #endif
+
+namespace {
+
+enum {
+  ID_GRIB_OPEN_FILE_MENU = wxID_HIGHEST + 1800,
+  ID_GRIB_MERGE_MENU
+};
+
+class GribMergeDialog : public wxDialog {
+public:
+  GribMergeDialog(wxWindow *parent, const wxString &gribDir)
+      : wxDialog(parent, wxID_ANY, _("Merge GRIBs"), wxDefaultPosition,
+                 wxDefaultSize,
+                 wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+        m_gribDir(gribDir) {
+    wxBoxSizer *topSizer = new wxBoxSizer(wxVERTICAL);
+    wxFlexGridSizer *gridSizer = new wxFlexGridSizer(0, 2, 6, 8);
+    gridSizer->AddGrowableCol(1);
+
+    m_gribWildcard =
+        _("Grib files") +
+        " (*.grb;*.grib;*.grib2;*.grb2)|*.grb;*.grib;*.grib2;*.grb2|" +
+        _("All files") + " (*.*)|*.*";
+
+    gridSizer->Add(
+        new wxStaticText(this, wxID_ANY, _("Ocean current GRIB file")), 0,
+        wxALIGN_CENTER_VERTICAL);
+    m_currentPicker =
+        new wxFilePickerCtrl(this, wxID_ANY, wxEmptyString,
+                             _("Select ocean current GRIB file"), m_gribWildcard,
+                             wxDefaultPosition, wxDefaultSize,
+                             wxFLP_OPEN | wxFLP_FILE_MUST_EXIST);
+    m_currentPicker->SetInitialDirectory(gribDir);
+    gridSizer->Add(m_currentPicker, 1, wxEXPAND);
+
+    gridSizer->Add(new wxStaticText(this, wxID_ANY, _("Weather/Wind GRIB file")),
+                   0, wxALIGN_CENTER_VERTICAL);
+    m_weatherPicker =
+        new wxFilePickerCtrl(this, wxID_ANY, wxEmptyString,
+                             _("Select weather or wind GRIB file"),
+                             m_gribWildcard, wxDefaultPosition, wxDefaultSize,
+                             wxFLP_OPEN | wxFLP_FILE_MUST_EXIST);
+    m_weatherPicker->SetInitialDirectory(gribDir);
+    gridSizer->Add(m_weatherPicker, 1, wxEXPAND);
+
+    gridSizer->Add(new wxStaticText(this, wxID_ANY, _("Output GRIB file")), 0,
+                   wxALIGN_CENTER_VERTICAL);
+    wxBoxSizer *outputSizer = new wxBoxSizer(wxHORIZONTAL);
+    m_outputPath =
+        new wxTextCtrl(this, wxID_ANY, DefaultOutputPath(gribDir),
+                       wxDefaultPosition, wxDefaultSize);
+    outputSizer->Add(m_outputPath, 1, wxALIGN_CENTER_VERTICAL | wxRIGHT, 6);
+    wxButton *browseOutput = new wxButton(this, wxID_ANY, _("Browse..."));
+    outputSizer->Add(browseOutput, 0, wxALIGN_CENTER_VERTICAL);
+    gridSizer->Add(outputSizer, 1, wxEXPAND);
+    browseOutput->Bind(wxEVT_BUTTON, &GribMergeDialog::OnBrowseOutput, this);
+
+    topSizer->Add(gridSizer, 0, wxEXPAND | wxALL, 12);
+
+    wxString orderChoices[] = {_("Ocean current file first"),
+                               _("Weather/Wind file first")};
+    m_order = new wxRadioBox(this, wxID_ANY, _("Merge order"),
+                             wxDefaultPosition, wxDefaultSize, 2, orderChoices,
+                             1, wxRA_SPECIFY_COLS);
+    m_order->SetSelection(0);
+    topSizer->Add(m_order, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 12);
+
+    wxStaticText *orderNote = new wxStaticText(
+        this, wxID_ANY,
+        _("Some workflows require ocean current records to be read before "
+          "weather records."));
+    orderNote->Wrap(560);
+    topSizer->Add(orderNote, 0, wxLEFT | wxRIGHT | wxBOTTOM | wxEXPAND, 12);
+
+    wxStdDialogButtonSizer *buttonSizer = new wxStdDialogButtonSizer();
+    buttonSizer->AddButton(new wxButton(this, wxID_OK, _("Merge")));
+    buttonSizer->AddButton(new wxButton(this, wxID_CANCEL));
+    buttonSizer->Realize();
+    topSizer->Add(buttonSizer, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 12);
+
+    SetSizerAndFit(topSizer);
+    SetMinSize(wxSize(620, GetBestSize().GetHeight()));
+    CentreOnParent();
+  }
+
+  wxString GetCurrentPath() const { return m_currentPicker->GetPath(); }
+  wxString GetWeatherPath() const { return m_weatherPicker->GetPath(); }
+  wxString GetOutputPath() const {
+    wxFileName output(m_outputPath->GetValue());
+    if (output.GetFullName().IsEmpty()) return wxEmptyString;
+    if (output.GetPath().IsEmpty()) output.SetPath(m_gribDir);
+    if (output.GetExt().IsEmpty()) output.SetExt("grb");
+    return output.GetFullPath();
+  }
+  bool CurrentFirst() const { return m_order->GetSelection() == 0; }
+
+private:
+  static wxString DefaultOutputPath(const wxString &gribDir) {
+    wxString stamp = wxDateTime::UNow().Format("%Y%m%d-%H%MZ", wxDateTime::UTC);
+    wxFileName output(gribDir, "merged_grib_" + stamp + ".grb");
+    return output.GetFullPath();
+  }
+
+  void OnBrowseOutput(wxCommandEvent &event) {
+    wxFileName currentPath(GetOutputPath());
+    wxFileDialog dialog(this, _("Select output GRIB file"),
+                        currentPath.GetPath(), currentPath.GetFullName(),
+                        m_gribWildcard, wxFD_SAVE);
+    if (dialog.ShowModal() != wxID_OK) return;
+
+    wxFileName output(dialog.GetPath());
+    if (output.GetExt().IsEmpty()) output.SetExt("grb");
+    m_outputPath->SetValue(output.GetFullPath());
+  }
+
+  wxString m_gribDir;
+  wxString m_gribWildcard;
+  wxFilePickerCtrl *m_currentPicker;
+  wxFilePickerCtrl *m_weatherPicker;
+  wxTextCtrl *m_outputPath;
+  wxRadioBox *m_order;
+};
+
+}  // namespace
 
 // general variables
 double m_cursor_lat, m_cursor_lon;
@@ -1670,6 +1797,25 @@ void GRIBUICtrlBar::OnOpenFile(wxCommandEvent &event) {
   if (m_tPlayStop.IsRunning())
     return;  // do nothing when play back is running !
 
+  wxMenu menu;
+  menu.Append(ID_GRIB_OPEN_FILE_MENU, _("Open GRIB file..."));
+#ifndef __OCPN__ANDROID__
+  menu.Append(ID_GRIB_MERGE_MENU, _("Merge GRIBs..."));
+#endif
+
+  Bind(wxEVT_MENU, &GRIBUICtrlBar::OnOpenGribFile, this,
+       ID_GRIB_OPEN_FILE_MENU);
+  Bind(wxEVT_MENU, &GRIBUICtrlBar::OnMergeGribs, this, ID_GRIB_MERGE_MENU);
+  PopupMenu(&menu);
+  Unbind(wxEVT_MENU, &GRIBUICtrlBar::OnOpenGribFile, this,
+         ID_GRIB_OPEN_FILE_MENU);
+  Unbind(wxEVT_MENU, &GRIBUICtrlBar::OnMergeGribs, this, ID_GRIB_MERGE_MENU);
+}
+
+void GRIBUICtrlBar::OnOpenGribFile(wxCommandEvent &event) {
+  if (m_tPlayStop.IsRunning())
+    return;  // do nothing when play back is running !
+
 #ifndef __OCPN__ANDROID__
 
   wxStandardPathsBase &path = wxStandardPaths::Get();
@@ -1713,6 +1859,125 @@ void GRIBUICtrlBar::OnOpenFile(wxCommandEvent &event) {
     m_file_names.Clear();
     m_file_names.Add(file);
     OpenFile();
+    SetDialogsStyleSizePosition(true);
+  }
+#endif
+}
+
+void GRIBUICtrlBar::OnMergeGribs(wxCommandEvent &event) {
+#ifdef __OCPN__ANDROID__
+  wxMessageBox(_("GRIB merging is not available on this platform."),
+               _("Merge GRIBs"), wxOK | wxICON_INFORMATION, this);
+#else
+  if (m_tPlayStop.IsRunning())
+    return;  // do nothing when play back is running !
+
+  if (!wxDir::Exists(m_grib_dir)) {
+    wxStandardPathsBase &path = wxStandardPaths::Get();
+    m_grib_dir = path.GetDocumentsDir();
+  }
+
+  GribMergeDialog dialog(this, m_grib_dir);
+  if (dialog.ShowModal() != wxID_OK) return;
+
+  wxString currentPath = dialog.GetCurrentPath();
+  wxString weatherPath = dialog.GetWeatherPath();
+  wxString outputPath = dialog.GetOutputPath();
+  if (currentPath.IsEmpty() || weatherPath.IsEmpty() || outputPath.IsEmpty()) {
+    wxMessageBox(_("Select an ocean current GRIB file, a weather/wind GRIB "
+                   "file, and an output file."),
+                 _("Merge GRIBs"), wxOK | wxICON_WARNING, this);
+    return;
+  }
+
+  if (currentPath == weatherPath) {
+    wxMessageBox(_("The ocean current and weather/wind inputs must be "
+                   "different files."),
+                 _("Merge GRIBs"), wxOK | wxICON_WARNING, this);
+    return;
+  }
+
+  if (outputPath == currentPath || outputPath == weatherPath) {
+    wxMessageBox(_("The output file must be different from the input files."),
+                 _("Merge GRIBs"), wxOK | wxICON_WARNING, this);
+    return;
+  }
+
+  if (wxFileExists(outputPath)) {
+    wxMessageDialog overwriteDialog(
+        this,
+        _("The output file already exists. Replace it with the merged GRIB "
+          "file?"),
+        _("Merge GRIBs"), wxYES_NO | wxNO_DEFAULT | wxICON_WARNING);
+    if (overwriteDialog.ShowModal() != wxID_YES) return;
+  }
+
+  wxString error;
+  GribMergeFile currentFile;
+  GribMergeFile weatherFile;
+  {
+    wxBusyCursor wait;
+    if (!GribMerge::ReadAndValidate(currentPath, currentFile, error) ||
+        !GribMerge::ReadAndValidate(weatherPath, weatherFile, error)) {
+      wxMessageBox(error, _("Merge GRIBs"), wxOK | wxICON_ERROR, this);
+      return;
+    }
+  }
+
+  bool currentFirst = dialog.CurrentFirst();
+  const GribMergeFile &first = currentFirst ? currentFile : weatherFile;
+  const GribMergeFile &second = currentFirst ? weatherFile : currentFile;
+
+  wxString summary;
+  summary << GribMerge::FormatSummary(_("Ocean current GRIB"),
+                                      currentFile.summary)
+          << "\n";
+  summary << GribMerge::FormatSummary(_("Weather/Wind GRIB"),
+                                      weatherFile.summary)
+          << "\n";
+  summary << GribMerge::FormatOverlap(currentFile.summary, weatherFile.summary)
+          << "\n\n";
+  summary << wxString::Format(_("Merge order: %s\n"),
+                              currentFirst ? _("Ocean current file first")
+                                           : _("Weather/Wind file first"));
+  summary << wxString::Format(_("Output: %s\n\n"), outputPath);
+  summary << _("Create the merged GRIB file?");
+
+  wxMessageDialog confirm(this, summary, _("Merge GRIBs"),
+                          wxYES_NO | wxNO_DEFAULT | wxICON_QUESTION);
+  if (confirm.ShowModal() != wxID_YES) return;
+
+  {
+    wxBusyCursor wait;
+    if (!GribMerge::WriteMerged(first, second, outputPath, error)) {
+      wxMessageBox(error, _("Merge GRIBs"), wxOK | wxICON_ERROR, this);
+      return;
+    }
+  }
+
+  GribMergeFile mergedFile;
+  wxString mergedSummary;
+  if (GribMerge::ReadAndValidate(outputPath, mergedFile, error)) {
+    mergedSummary = GribMerge::FormatSummary(_("Merged GRIB"),
+                                             mergedFile.summary);
+  } else {
+    mergedSummary = _("Merged GRIB file was created, but the summary could not "
+                      "be generated.");
+  }
+
+  wxString done;
+  done << _("Merged GRIB file created.") << "\n\n" << mergedSummary << "\n";
+  done << _("Open the merged GRIB file now?");
+
+  wxMessageDialog openDialog(this, done, _("Merge GRIBs"),
+                             wxYES_NO | wxYES_DEFAULT | wxICON_INFORMATION);
+  if (openDialog.ShowModal() == wxID_YES) {
+    wxFileName outputName(outputPath);
+    m_grib_dir = outputName.GetPath();
+    m_file_names.Clear();
+    m_file_names.Add(outputPath);
+    OpenFile();
+    if (g_pi && g_pi->m_bZoomToCenterAtInit) DoZoomToCenter();
     SetDialogsStyleSizePosition(true);
   }
 #endif

--- a/plugins/grib_pi/src/GribUIDialog.h
+++ b/plugins/grib_pi/src/GribUIDialog.h
@@ -354,6 +354,8 @@ private:
   }
   void OnAltitude(wxCommandEvent &event);
   void OnOpenFile(wxCommandEvent &event);
+  void OnOpenGribFile(wxCommandEvent &event);
+  void OnMergeGribs(wxCommandEvent &event);
   /** Callback invoked when user clicks download/request forecast data. */
   void OnRequestForecastData(wxCommandEvent &event);
   void createRequestDialog();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -44,9 +44,11 @@ set(MODEL_SRC_DIR ${CMAKE_SOURCE_DIR}/model/src)
 set(SRC
   datetime_tests.cpp
   tests.cpp filter_tests.cpp
+  grib_merge_tests.cpp
   navutil_base_tests.cpp
   route_point_tests.cpp
   ${CMAKE_SOURCE_DIR}/cli/api_shim.cpp
+  ${CMAKE_SOURCE_DIR}/plugins/grib_pi/src/GribMerge.cpp
 )
 
 if ("${OCPN_WX_VERSION}" GREATER_EQUAL 32)
@@ -86,6 +88,7 @@ target_compile_definitions(tests
     UNIT_TESTS
 )
 add_dependencies(tests config_tests)
+target_include_directories(tests PRIVATE ${CMAKE_SOURCE_DIR}/plugins/grib_pi/src)
 
 target_link_libraries(tests PRIVATE ocpn::model-src ocpn::gtest win32_libs)
 if (NOT "${ENABLE_SANITIZER}" STREQUAL "none")

--- a/test/grib_merge_tests.cpp
+++ b/test/grib_merge_tests.cpp
@@ -1,0 +1,142 @@
+#include <gtest/gtest.h>
+
+#include <wx/file.h>
+#include <wx/filename.h>
+
+#include "GribMerge.h"
+
+#include <vector>
+
+namespace {
+
+wxString WriteTempFile(const std::vector<unsigned char> &data) {
+  wxString path = wxFileName::CreateTempFileName("ocpn_grib_merge_test");
+  wxFile file(path, wxFile::write);
+  EXPECT_TRUE(file.IsOpened());
+  if (!data.empty()) EXPECT_EQ(file.Write(data.data(), data.size()), data.size());
+  file.Close();
+  return path;
+}
+
+std::vector<unsigned char> Grib1Message() {
+  return {'G', 'R', 'I', 'B', 0x00, 0x00, 0x0c, 0x01,
+          '7', '7', '7', '7'};
+}
+
+std::vector<unsigned char> Grib2Message() {
+  return {'G', 'R', 'I', 'B', 0x00, 0x00, 0x00, 0x02, 0x00, 0x00,
+          0x00, 0x00, 0x00, 0x00, 0x00, 0x14, '7',  '7',  '7',  '7'};
+}
+
+}  // namespace
+
+TEST(GribMerge, ValidatesMixedEditionMessages) {
+  std::vector<unsigned char> data = Grib1Message();
+  std::vector<unsigned char> grib2 = Grib2Message();
+  data.insert(data.end(), grib2.begin(), grib2.end());
+
+  wxString path = WriteTempFile(data);
+  GribMergeFile file;
+  wxString error;
+
+  EXPECT_TRUE(GribMerge::ReadAndValidate(path, file, error)) << error;
+  EXPECT_EQ(file.messages.size(), 2U);
+  EXPECT_EQ(file.summary.messageCount, 2U);
+  EXPECT_EQ(file.summary.grib1Count, 1U);
+  EXPECT_EQ(file.summary.grib2Count, 1U);
+
+  wxRemoveFile(path);
+}
+
+TEST(GribMerge, ValidatesGrib1Message) {
+  wxString path = WriteTempFile(Grib1Message());
+  GribMergeFile file;
+  wxString error;
+
+  EXPECT_TRUE(GribMerge::ReadAndValidate(path, file, error)) << error;
+  EXPECT_EQ(file.messages.size(), 1U);
+  EXPECT_EQ(file.summary.grib1Count, 1U);
+  EXPECT_EQ(file.summary.grib2Count, 0U);
+
+  wxRemoveFile(path);
+}
+
+TEST(GribMerge, ValidatesGrib2Message) {
+  wxString path = WriteTempFile(Grib2Message());
+  GribMergeFile file;
+  wxString error;
+
+  EXPECT_TRUE(GribMerge::ReadAndValidate(path, file, error)) << error;
+  EXPECT_EQ(file.messages.size(), 1U);
+  EXPECT_EQ(file.summary.grib1Count, 0U);
+  EXPECT_EQ(file.summary.grib2Count, 1U);
+
+  wxRemoveFile(path);
+}
+
+TEST(GribMerge, RejectsMessageWithout7777Terminator) {
+  std::vector<unsigned char> data = Grib1Message();
+  data[10] = '0';
+
+  wxString path = WriteTempFile(data);
+  GribMergeFile file;
+  wxString error;
+
+  EXPECT_FALSE(GribMerge::ReadAndValidate(path, file, error));
+  EXPECT_TRUE(error.Contains("7777"));
+
+  wxRemoveFile(path);
+}
+
+TEST(GribMerge, RejectsEmptyFile) {
+  std::vector<unsigned char> data;
+  wxString path = WriteTempFile(data);
+  GribMergeFile file;
+  wxString error;
+
+  EXPECT_FALSE(GribMerge::ReadAndValidate(path, file, error));
+  EXPECT_TRUE(error.Contains("empty"));
+
+  wxRemoveFile(path);
+}
+
+TEST(GribMerge, WritesMixedEditionMerge) {
+  wxString grib1Path = WriteTempFile(Grib1Message());
+  wxString grib2Path = WriteTempFile(Grib2Message());
+  wxString outputPath = wxFileName::CreateTempFileName("ocpn_grib_merge_out");
+
+  GribMergeFile grib1File;
+  GribMergeFile grib2File;
+  GribMergeFile mergedFile;
+  wxString error;
+
+  EXPECT_TRUE(GribMerge::ReadAndValidate(grib1Path, grib1File, error))
+      << error;
+  EXPECT_TRUE(GribMerge::ReadAndValidate(grib2Path, grib2File, error))
+      << error;
+  EXPECT_TRUE(GribMerge::WriteMerged(grib1File, grib2File, outputPath, error))
+      << error;
+  EXPECT_TRUE(GribMerge::ReadAndValidate(outputPath, mergedFile, error))
+      << error;
+  EXPECT_EQ(mergedFile.summary.messageCount, 2U);
+  EXPECT_EQ(mergedFile.summary.grib1Count, 1U);
+  EXPECT_EQ(mergedFile.summary.grib2Count, 1U);
+
+  wxRemoveFile(grib1Path);
+  wxRemoveFile(grib2Path);
+  wxRemoveFile(outputPath);
+}
+
+TEST(GribMerge, RejectsTruncatedMessage) {
+  std::vector<unsigned char> data = Grib1Message();
+  data[6] = 0x0d;
+
+  wxString path = WriteTempFile(data);
+  GribMergeFile file;
+  wxString error;
+
+  EXPECT_FALSE(GribMerge::ReadAndValidate(path, file, error));
+  EXPECT_TRUE(error.Contains("truncated"));
+
+  wxRemoveFile(path);
+}


### PR DESCRIPTION
Adds a local-file “Merge GRIBs…” utility to the internal `grib_pi` plugin.

This is intended for workflows where users have separate GRIB files for weather/wind data and ocean-current data, and need a single merged GRIB file for display and Weather Routing.

**What this adds**

- Adds a “Merge GRIBs…” action to the GRIB plugin UI.
- Lets the user select:
  - Ocean current GRIB file
  - Weather/Wind GRIB file
  - Output GRIB file
  - Merge order
- Supports GRIB1 and GRIB2 message streams.
- Validates complete GRIB messages before writing.
- Rejects empty, unreadable, malformed, truncated, unsupported, or too-large files.
- Writes complete GRIB message byte ranges only.
- Does not decode, resample, interpolate, modify, or convert weather/ocean data.
- Shows message counts, GRIB edition counts, valid-time ranges, coverage, and wind/current overlap window when available.
- Offers to open the merged GRIB after creation.

**Testing**

Tested locally on Arch Linux with OpenCPN 5.15.0 built from source.

Manual testing included:

- Confirmed the modified `grib_pi` plugin loads.
- Merged a GRIB1 ocean-current file with a GRIB2 weather/wind file.
- Confirmed the merged GRIB opens in the GRIB plugin.
- Confirmed wind and ocean-current fields display together.
- Confirmed Weather Routing uses the merged data where wind/current time ranges overlap.
- Confirmed routes outside the ocean-current time range still calculate using available weather data.

This PR intentionally does not add provider-specific download logic, URLs, credentials, or regional presets. It only merges local GRIB files selected by the user.