### PR TITLE
Replace HideTooltip with KillTooltip for tool click

### DIFF
--- a/gui/include/gui/ocpn_frame.h
+++ b/gui/include/gui/ocpn_frame.h
@@ -317,6 +317,10 @@ public:
   }
   void OnToolLeftClick(wxCommandEvent& event) override;
 
+  bool DisableTbarTooltips();
+  void EnableTbarTooltips();
+  void HideTbarTooltip();
+
   void SetENCDisplayCategory(ChartCanvas* cc, enum _DisCat nset);
   void ToggleQuiltMode(ChartCanvas* cc);
 

--- a/gui/include/gui/toolbar.h
+++ b/gui/include/gui/toolbar.h
@@ -305,7 +305,7 @@ public:
   void HideTooltip();
   void KillTooltip();
   void EnableTooltips();
-  void DisableTooltips();
+  bool DisableTooltips();
 
 protected:
   // common part of all ctors
@@ -437,8 +437,9 @@ public:
   void EnableTooltips() {
     if (m_ptoolbar) m_ptoolbar->EnableTooltips();
   }
-  void DisableTooltips() {
-    if (m_ptoolbar) m_ptoolbar->DisableTooltips();
+  bool DisableTooltips() {
+    if (m_ptoolbar) return m_ptoolbar->DisableTooltips();
+    return false;
   }
   void UpdateRecoveryWindow(bool b_toolbarEnable);
   void EnableTool(int toolid, bool enable);

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -2332,9 +2332,29 @@ void MyFrame::RefreshGroupIndices() {
   }
 }
 
-void MyFrame::OnToolLeftClick(wxCommandEvent &event) {
-  if (g_MainToolbar) g_MainToolbar->HideTooltip();
+bool MyFrame::DisableTbarTooltips() {
+  if (g_MainToolbar) {
+    g_MainToolbar->HideTooltip();
+    return g_MainToolbar->DisableTooltips();
+  }
+  wxLogWarning("Global g_MainToolbar has not been created.");
+  return false;
+}
 
+void MyFrame::EnableTbarTooltips() {
+  if (g_MainToolbar) {
+    g_MainToolbar->EnableTooltips();
+  }
+}
+
+void MyFrame::HideTbarTooltip() {
+  if (g_MainToolbar) {
+    g_MainToolbar->HideTooltip();
+  }
+}
+
+void MyFrame::OnToolLeftClick(wxCommandEvent &event) {
+  HideTbarTooltip();
   switch (event.GetId()) {
     case ID_MENU_SCALE_OUT:
       DoStackDelta(GetPrimaryCanvas(), 1);
@@ -2490,7 +2510,7 @@ void MyFrame::OnToolLeftClick(wxCommandEvent &event) {
 
     case wxID_PREFERENCES:
     case ID_SETTINGS: {
-      if (g_MainToolbar) g_MainToolbar->HideTooltip();
+      HideTbarTooltip();
       DoSettings();
       break;
     }
@@ -2515,7 +2535,7 @@ void MyFrame::OnToolLeftClick(wxCommandEvent &event) {
     case ID_MENU_SETTINGS_BASIC: {
 #ifdef __ANDROID__
       androidDisableFullScreen();
-      if (g_MainToolbar) g_MainToolbar->HideTooltip();
+      HideTbarTooltip();
       DoAndroidPreferences();
 #else
       DoSettings();
@@ -2724,7 +2744,7 @@ void MyFrame::OnToolLeftClick(wxCommandEvent &event) {
       //        If found, make the callback.
       //        TODO Modify this to allow multiple tools per plugin
       if (g_pi_manager) {
-        if (g_MainToolbar) g_MainToolbar->HideTooltip();
+        HideTbarTooltip();
 
         ArrayOfPlugInToolbarTools tool_array =
             g_pi_manager->GetPluginToolbarToolArray();
@@ -2756,7 +2776,7 @@ void MyFrame::OnToolLeftClick(wxCommandEvent &event) {
 bool MyFrame::SetGlobalToolbarViz(bool viz) {
   bool viz_now = g_bmasterToolbarFull;
 
-  if (g_MainToolbar) g_MainToolbar->HideTooltip();
+  HideTbarTooltip();
   wxString tip = _("Show Toolbar");
   if (viz) {
     tip = _("Hide Toolbar");
@@ -6102,7 +6122,13 @@ void MyFrame::DoPrint(void) {
   auto &printer = PrintDialog::GetInstance();
   printer.Initialize(wxLANDSCAPE);
   printer.EnablePageNumbers(false);
+  // Disable/hide the tooltips during print because they can interfere with the
+  // print dialog
+  bool tooltips_were_enabled = DisableTbarTooltips();
   printer.Print(this, &printout);
+  if (tooltips_were_enabled) {
+    EnableTbarTooltips();
+  }
 
   // Pass two printout objects: for preview, and possible printing.
   /*

--- a/gui/src/toolbar.cpp
+++ b/gui/src/toolbar.cpp
@@ -850,7 +850,7 @@ void ocpnToolBarSimple::Init() {
   m_last_plugin_down_id = -1;
   m_leftDown = false;
   m_nShowTools = 0;
-  m_btooltip_show = false;
+  DisableTooltips();
 #ifndef __ANDROID__
   EnableTooltips();
 #endif
@@ -1015,14 +1015,16 @@ void ocpnToolBarSimple::EnableTooltips() {
 #endif
 }
 
-void ocpnToolBarSimple::DisableTooltips() {
+bool ocpnToolBarSimple::DisableTooltips() {
 #ifndef __ANDROID__
+  bool ret = ocpnToolBarSimple::m_btooltip_show;
   ocpnToolBarSimple::m_btooltip_show = false;
+  return ret;
 #endif
 }
 
 void ocpnToolBarSimple::KillTooltip() {
-  m_btooltip_show = false;
+  DisableTooltips();
 
   TooltipManager::Get().HideTooltip();
   m_tooltip_timer.Stop();


### PR DESCRIPTION
Added KillTooltip() to the toolbar class and updated MyFrame::OnToolLeftClick() to use it, ensuring tooltips are forcefully killed instead of just hidden.

Addresses focus problems with toolbar tooltips #5300 