### PR TITLE
s52plib: handle connector segments in ComputeWinding()

### DIFF
--- a/libs/s52plib/src/s52plib.cpp
+++ b/libs/s52plib/src/s52plib.cpp
@@ -5767,6 +5767,11 @@ int s52plib::ComputeWinding(ObjRazRules *rzRules, Rules *rules) {
         ppt = (float *)(vbo_point + ls->pedge->vbo_offset);
         nPoints = ls->pedge->nCount;
         if (ls->ls_type == TYPE_EE_REV) idir = -1;
+
+      } else {
+        ppt = (float *)(vbo_point + ls->pcs->vbo_offset);
+        nPoints = 2;
+        bcon = true;
       }
 
       int vbo_index = 0;


### PR DESCRIPTION
ComputeWinding() walks a chain of line_segment_elements and, for each, fetches the vertex pointer and count before transcribing the points. It only ever handles the edge cases:

    int nPoints;
    ...
    if ((ls->ls_type == TYPE_EE) || (ls->ls_type == TYPE_EE_REV)) {
      ppt = (float *)(vbo_point + ls->pedge->vbo_offset);
      nPoints = ls->pedge->nCount;
      ...
    }
    // <- no else
    for (int ip = 0; ip < nPoints; ip++)   // nPoints/ppt garbage for TYPE_C*

SegmentType also has TYPE_CE, TYPE_CC and TYPE_EC — the connector segments, which carry their vertices in ls->pcs rather than ls->pedge. For those, nPoints and ppt are read uninitialized, so the loop runs a garbage number of times over a garbage pointer.

This is a copy/paste omission, not a deliberate skip: every sibling loop over the same structure has the else branch, including the immediately following block in this same function, which inspects ls->next:

      } else {
        ppt = (float *)(vbo_point + lsn->pcs->vbo_offset);
        nPoints_next = 2;
        bcona = true;
      }

The branch added here is that same idiom (see also RenderLC at ~5601). bcon is already declared and consumed below by the reversal logic, and was likewise only ever left false.

Not Android-specific, but it breaks the Android build specifically: OpenCPN compiles -Werror, and clang's -Wsometimes-uninitialized catches it where gcc on the desktop builds does not.

    error: variable 'nPoints' is used uninitialized whenever 'if' condition is
    false [-Werror,-Wsometimes-uninitialized]

Fixes #5313 