### PR TITLE
Do not discard user-supplied CMAKE_CXX_FLAGS on Android

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -448,8 +448,8 @@ if (QT_ANDROID)
   add_definitions(-D__OCPN__ANDROID__)
   add_definitions(-DANDROID)
   add_definitions(-DNOASSERT)
-  set(CMAKE_CXX_FLAGS "-pthread -fPIC -g -O2")
-  set(CMAKE_C_FLAGS "-pthread -fPIC -g -O2")
+  set(CMAKE_CXX_FLAGS "-pthread -fPIC -g -O2 ${CMAKE_CXX_FLAGS}")
+  set(CMAKE_C_FLAGS "-pthread -fPIC -g -O2 ${CMAKE_C_FLAGS}")
 
   add_compile_options(
     "-Wno-inconsistent-missing-override"


### PR DESCRIPTION
The QT_ANDROID branch assigns CMAKE_CXX_FLAGS/CMAKE_C_FLAGS outright, so any value passed on the configure line (-DCMAKE_CXX_FLAGS=...) or inherited from the CXXFLAGS environment is silently dropped. Android is the one platform branch in this file where the caller cannot add a compiler flag at all.

That matters here because OpenCPN builds with -Werror and wxWidgets 3.2 emits a

    #warning "Custom mb/wchar conv. only works for ASCII, see Android NDK notes"

which fails the build on the first file compiled. The wx limitation is real and permanent, so the build has to silence the diagnostic (-Wno-#warnings) rather than fix it -- but with the assignment below there is nowhere to put that flag. scripts/build.sh passes it via -DCMAKE_CXX_FLAGS.

Appending keeps the defaults this branch wants while letting the caller win, as CMake's flag precedence normally guarantees.

Fixes #5315 