### PR TITLE
Use llvm-ar for arm64, as the armhf branch already does

### DIFF
--- a/buildandroid/build_android.cmake
+++ b/buildandroid/build_android.cmake
@@ -9,7 +9,7 @@ SET(CMAKE_SYSTEM_PROCESSOR arm)
 # specify the cross compilers and tools
 
 if ("${OCPN_TARGET_TUPLE}" MATCHES "Android-arm64")
-  set(CMAKE_AR ${tool_base}/bin/aarch64-linux-android-ar)
+  set(CMAKE_AR ${tool_base}/bin/llvm-ar)
   set(CMAKE_CXX_COMPILER ${tool_base}/bin/aarch64-linux-android21-clang++)
   set(CMAKE_C_COMPILER ${tool_base}/bin/aarch64-linux-android21-clang)
 else ()


### PR DESCRIPTION
build_android.cmake picks the archiver per arch:

    if ("${OCPN_TARGET_TUPLE}" MATCHES "Android-arm64")
      set(CMAKE_AR ${tool_base}/bin/aarch64-linux-android-ar)
      ...
    else ()
      set(CMAKE_AR ${tool_base}/bin/llvm-ar)

NDK r23 dropped the per-triple GNU binutils; r26 ships only llvm-ar/llvm-ranlib, and the aarch64-linux-android-* names exist solely as the per-API-level clang wrappers. So the arm64 archiver does not exist and the first static library to be linked dies with a diagnostic that never names the missing file:

    aarch64-linux-android-ar qc libplutovg.a ...
    Error running link command: No such file or directory

The armhf branch was already moved to llvm-ar; arm64 was left behind, which is consistent with armhf being the arch that actually gets built. llvm-ar is target-agnostic (it is the same binary armhf has been using all along), so this is the same one-line fix, not a workaround.

CMAKE_RANLIB needs no change: nothing sets it here, and cmake's own detection already resolves it to llvm-ranlib for both arches.

NOTE when applying to an existing build tree: cmake caches toolchain/compiler detection in <build>/CMakeFiles/<cmake-version>/CMakeCXXCompiler.cmake and does not re-derive it on reconfigure -- that cached file re-sets CMAKE_AR to the old value *after* the toolchain file runs, so a plain rebuild silently keeps using the broken path. Delete that directory (or the whole build dir) once:

    rm -rf dist/android-arm64/CMakeFiles/<cmake-version>


Fixes #5317 