### PR TITLE
comm_drv_n2k_net: Handle various warnings, peephole optimization

### DIFF
--- a/model/include/model/comm_drv_n2k_net.h
+++ b/model/include/model/comm_drv_n2k_net.h
@@ -45,7 +45,7 @@
 #include "model/conn_params.h"
 
 #ifdef __WXGTK__
-// newer versions of glib define its own GSocket but we unfortunately use this
+// newer versions of glib define its own GSocket, but we unfortunately use this
 // name in our own (semi-)public header and so can't change it -- rename glib
 // one instead
 #define GSocket GlibGSocket
@@ -60,9 +60,6 @@
 #define ESCAPE 0x10
 #define STARTOFTEXT 0x02
 #define ENDOFTEXT 0x03
-
-#define MsgTypeN2kData 0x93
-#define MsgTypeN2kRequest 0x94
 
 typedef enum {
   N2KFormat_Undefined = 0,
@@ -88,7 +85,7 @@ public:
   CommDriverN2KNet();
   CommDriverN2KNet(const ConnectionParams* params, DriverListener& listener);
 
-  virtual ~CommDriverN2KNet();
+  ~CommDriverN2KNet() override;
 
   DriverStats GetDriverStats() const override { return m_driver_stats; }
 
@@ -108,7 +105,6 @@ public:
   void OpenNetworkUDP(unsigned int addr);
   void OnSocketReadWatchdogTimer(wxTimerEvent& event);
   void HandleResume();
-
   bool SendMessage(std::shared_ptr<const NavMsg> msg,
                    std::shared_ptr<const NavAddr> addr) override;
   wxSocketBase* GetSock() const { return m_sock; }
@@ -134,7 +130,7 @@ private:
 
   NetworkProtocol GetProtocol() { return m_net_protocol; }
   void SetBrxConnectEvent(bool event) { m_brx_connect_event = event; }
-  bool GetBrxConnectEvent() { return m_brx_connect_event; }
+  bool GetBrxConnectEvent() const { return m_brx_connect_event; }
 
   void SetConnectTime(wxDateTime time) { m_connect_time = time; }
   wxDateTime GetConnectTime() { return m_connect_time; }
@@ -144,11 +140,11 @@ private:
 
   std::vector<unsigned char> PushFastMsgFragment(const CanHeader& header,
                                                  int position);
-  std::vector<unsigned char> PushCompleteMsg(const CanHeader header,
+  std::vector<unsigned char> PushCompleteMsg(const CanHeader& header,
                                              int position,
-                                             const can_frame frame);
+                                             const can_frame& frame);
 
-  void HandleCanFrameInput(can_frame frame);
+  void HandleCanFrameInput(const can_frame& frame);
 
   ConnectionType GetConnectionType() const { return m_connection_type; }
 
@@ -156,26 +152,27 @@ private:
   void SetOk(bool ok) { m_bok = ok; };
 
   N2K_Format DetectFormat(const std::vector<unsigned char>& packet);
-  bool ProcessActisense_ASCII_RAW(std::vector<unsigned char> packet);
-  bool ProcessActisense_ASCII_N2K(std::vector<unsigned char> packet);
-  bool ProcessActisense_N2K(std::vector<unsigned char> packet);
-  bool ProcessActisense_RAW(std::vector<unsigned char> packet);
-  bool ProcessActisense_NGT(std::vector<unsigned char> packet);
-  bool ProcessSeaSmart(std::vector<unsigned char> packet);
-  bool ProcessMiniPlex(std::vector<unsigned char> packet);
+  bool ProcessActisense_ASCII_RAW(const std::vector<unsigned char>& packet);
+  bool ProcessActisense_ASCII_N2K(const std::vector<unsigned char>& packet);
+  bool ProcessActisense_N2K(const std::vector<unsigned char>& packet);
+  bool ProcessActisense_RAW(const std::vector<unsigned char>& packet);
+  bool ProcessActisense_NGT(const std::vector<unsigned char>& packet);
+  bool ProcessSeaSmart(const std::vector<unsigned char>& packet);
+  bool ProcessMiniPlex(const std::vector<unsigned char>& packet);
 
-  bool SendN2KNetwork(std::shared_ptr<const Nmea2000Msg>& msg,
-                      std::shared_ptr<const NavAddr2000> dest_addr);
+  bool SendN2KNetwork(const std::shared_ptr<const Nmea2000Msg>& msg,
+                      const std::shared_ptr<const NavAddr2000>& dest_addr);
 
   std::vector<std::vector<unsigned char>> GetTxVector(
       const std::shared_ptr<const Nmea2000Msg>& msg,
-      std::shared_ptr<const NavAddr2000> dest_addr);
-  bool SendSentenceNetwork(std::vector<std::vector<unsigned char>> payload);
-  bool HandleMgntMsg(uint64_t pgn, std::vector<unsigned char>& payload);
+      const std::shared_ptr<const NavAddr2000>& dest_addr);
+  bool SendSentenceNetwork(
+      const std::vector<std::vector<unsigned char>>& payload);
+  bool HandleMgntMsg(uint64_t pgn, const std::vector<unsigned char>& payload);
   bool PrepareForTX();
   std::vector<unsigned char> PrepareLogPayload(
-      std::shared_ptr<const Nmea2000Msg>& msg,
-      std::shared_ptr<const NavAddr2000> addr);
+      const std::shared_ptr<const Nmea2000Msg>& msg,
+      const std::shared_ptr<const NavAddr2000>& addr);
   void OnProdInfoTimer(wxTimerEvent& ev);
 
   StatsTimer m_stats_timer;
@@ -204,7 +201,6 @@ private:
   wxTimer m_socketread_watchdog_timer;
 
   bool m_bok;
-  int m_ib;
   bool m_bInMsg, m_bGotESC, m_bGotSOT;
 
   CircularBuffer<unsigned char> m_circle;
@@ -223,4 +219,4 @@ private:
   DECLARE_EVENT_TABLE()
 };
 
-#endif  // guard
+#endif

--- a/model/include/model/comm_drv_n2k_net.h
+++ b/model/include/model/comm_drv_n2k_net.h
@@ -213,6 +213,7 @@ private:
   char m_TX_flag;
   bool m_TX_available;
   wxTimer m_prodinfo_timer;
+  int m_detect_count;  //  should we invoke DetectFormat?
 
   ObsListener resume_listener;
 

--- a/model/src/comm_drv_n2k_net.cpp
+++ b/model/src/comm_drv_n2k_net.cpp
@@ -178,7 +178,6 @@ CommDriverN2KNet::CommDriverN2KNet(const ConnectionParams* params,
       this);
 
   m_mrq_container = new MrqContainer;
-  m_ib = 0;
   m_bInMsg = false;
   m_bGotESC = false;
   m_bGotSOT = false;
@@ -209,8 +208,8 @@ typedef struct {
 
 std::unordered_map<uint8_t, product_info> prod_info_map;
 
-bool CommDriverN2KNet::HandleMgntMsg(uint64_t pgn,
-                                     std::vector<unsigned char>& payload) {
+bool CommDriverN2KNet::HandleMgntMsg(
+    uint64_t pgn, const std::vector<unsigned char>& payload) {
   // Process a few N2K network management messages
   auto name = PayloadToName(payload);
   auto msg =
@@ -456,8 +455,8 @@ bool CommDriverN2KNet::SendMessage(std::shared_ptr<const NavMsg> msg,
 }
 
 std::vector<unsigned char> CommDriverN2KNet::PrepareLogPayload(
-    std::shared_ptr<const Nmea2000Msg>& msg,
-    std::shared_ptr<const NavAddr2000> addr) {
+    const std::shared_ptr<const Nmea2000Msg>& msg,
+    const std::shared_ptr<const NavAddr2000>& addr) {
   std::vector<unsigned char> data;
   data.push_back(0x94);
   data.push_back(0x13);
@@ -474,7 +473,7 @@ std::vector<unsigned char> CommDriverN2KNet::PrepareLogPayload(
 }
 
 std::vector<unsigned char> CommDriverN2KNet::PushCompleteMsg(
-    const CanHeader header, int position, const can_frame frame) {
+    const CanHeader& header, int position, const can_frame& frame) {
   std::vector<unsigned char> data;
   data.push_back(0x93);
   data.push_back(0x13);
@@ -523,7 +522,7 @@ std::vector<unsigned char> CommDriverN2KNet::PushFastMsgFragment(
  * layers. Otherwise, the fast message fragment is stored waiting for
  * next fragment.
  */
-void CommDriverN2KNet::HandleCanFrameInput(can_frame frame) {
+void CommDriverN2KNet::HandleCanFrameInput(const can_frame& frame) {
   int position = -1;
   bool ready = true;
 
@@ -606,7 +605,8 @@ N2K_Format CommDriverN2KNet::DetectFormat(
   return N2KFormat_Undefined;
 }
 
-bool CommDriverN2KNet::ProcessActisense_N2K(std::vector<unsigned char> packet) {
+bool CommDriverN2KNet::ProcessActisense_N2K(
+    const std::vector<unsigned char>& packet) {
   // 1002 d0 1500ff0401f80900684c1b00a074eb14f89052d288 1003
 
   std::vector<unsigned char> data;
@@ -718,7 +718,8 @@ bool CommDriverN2KNet::ProcessActisense_N2K(std::vector<unsigned char> packet) {
   return true;
 }
 
-bool CommDriverN2KNet::ProcessActisense_RAW(std::vector<unsigned char> packet) {
+bool CommDriverN2KNet::ProcessActisense_RAW(
+    const std::vector<unsigned char>& packet) {
   // 1002 95 0e15870402f8094b  fc e6 20 00 00 ff ff 6f 1003
 
   can_frame frame;
@@ -797,7 +798,8 @@ bool CommDriverN2KNet::ProcessActisense_RAW(std::vector<unsigned char> packet) {
   return true;
 }
 
-bool CommDriverN2KNet::ProcessActisense_NGT(std::vector<unsigned char> packet) {
+bool CommDriverN2KNet::ProcessActisense_NGT(
+    const std::vector<unsigned char>& packet) {
   std::vector<unsigned char> data;
   bool bInMsg = false;
   bool bGotESC = false;
@@ -861,7 +863,7 @@ bool CommDriverN2KNet::ProcessActisense_NGT(std::vector<unsigned char> packet) {
 }
 
 bool CommDriverN2KNet::ProcessActisense_ASCII_RAW(
-    std::vector<unsigned char> packet) {
+    const std::vector<unsigned char>& packet) {
   can_frame frame;
 
   while (!m_circle.IsEmpty()) {
@@ -910,7 +912,7 @@ bool CommDriverN2KNet::ProcessActisense_ASCII_RAW(
 }
 
 bool CommDriverN2KNet::ProcessActisense_ASCII_N2K(
-    std::vector<unsigned char> packet) {
+    const std::vector<unsigned char>& packet) {
   // A001001.732 04FF6 1FA03 C8FBA80329026400
   std::string sentence;
 
@@ -984,7 +986,8 @@ bool CommDriverN2KNet::ProcessActisense_ASCII_N2K(
   return true;
 }
 
-bool CommDriverN2KNet::ProcessSeaSmart(std::vector<unsigned char> packet) {
+bool CommDriverN2KNet::ProcessSeaSmart(
+    const std::vector<unsigned char>& packet) {
   while (!m_circle.IsEmpty()) {
     char b = m_circle.Get();
     if ((b != 0x0a) && (b != 0x0d)) {
@@ -1055,7 +1058,8 @@ bool CommDriverN2KNet::ProcessSeaSmart(std::vector<unsigned char> packet) {
   return true;
 }
 
-bool CommDriverN2KNet::ProcessMiniPlex(std::vector<unsigned char> packet) {
+bool CommDriverN2KNet::ProcessMiniPlex(
+    const std::vector<unsigned char>& packet) {
   /*
   $MXPGN – NMEA 2000 PGN Data
   This sentence transports NMEA 2000/CAN frames in NMEA 0183 format. The
@@ -1516,7 +1520,7 @@ std::vector<unsigned char> MakeSimpleOutMsg(
 
 std::vector<std::vector<unsigned char>> CommDriverN2KNet::GetTxVector(
     const std::shared_ptr<const Nmea2000Msg>& msg,
-    std::shared_ptr<const NavAddr2000> dest_addr) {
+    const std::shared_ptr<const NavAddr2000>& dest_addr) {
   std::vector<std::vector<unsigned char>> tx_vector;
 
   // Branch based on detected network data format currently in use
@@ -1875,8 +1879,9 @@ bool CommDriverN2KNet::PrepareForTX() {
   return false;
 }
 
-bool CommDriverN2KNet::SendN2KNetwork(std::shared_ptr<const Nmea2000Msg>& msg,
-                                      std::shared_ptr<const NavAddr2000> addr) {
+bool CommDriverN2KNet::SendN2KNetwork(
+    const std::shared_ptr<const Nmea2000Msg>& msg,
+    const std::shared_ptr<const NavAddr2000>& addr) {
   PrepareForTX();
 
   std::vector<std::vector<unsigned char>> out_data = GetTxVector(msg, addr);
@@ -1892,7 +1897,7 @@ bool CommDriverN2KNet::SendN2KNetwork(std::shared_ptr<const Nmea2000Msg>& msg,
 };
 
 bool CommDriverN2KNet::SendSentenceNetwork(
-    std::vector<std::vector<unsigned char>> payload) {
+    const std::vector<std::vector<unsigned char>>& payload) {
   if (m_txenter)
     return false;  // do not allow recursion, could happen with non-blocking
                    // sockets
@@ -1902,7 +1907,7 @@ bool CommDriverN2KNet::SendSentenceNetwork(
   wxDatagramSocket* udp_socket;
   switch (GetProtocol()) {
     case TCP:
-      for (std::vector<unsigned char>& v : payload) {
+      for (const std::vector<unsigned char>& v : payload) {
         if (GetSock() && GetSock()->IsOk()) {
           m_driver_stats.available = true;
           // printf("---%s", v.data());

--- a/model/src/comm_drv_n2k_net.cpp
+++ b/model/src/comm_drv_n2k_net.cpp
@@ -154,7 +154,8 @@ CommDriverN2KNet::CommDriverN2KNet(const ConnectionParams* params,
       m_connection_type(params->Type),
       m_bok(false),
       m_circle(RX_BUFFER_SIZE_NET),
-      m_TX_available(false) {
+      m_TX_available(false),
+      m_detect_count(-1) {
   m_addr.Hostname(params->NetworkAddress);
   m_addr.Service(params->NetworkPort);
 
@@ -1259,8 +1260,9 @@ void CommDriverN2KNet::OnSocketEvent(wxSocketEvent& event) {
           // printf("%c", data.at(i));
         }
       }
-
-      m_n2k_format = DetectFormat(data);
+      // Only invoke DetectFormat() on every tenth message:
+      m_detect_count = ++m_detect_count % 10;
+      if (m_detect_count <= 0) m_n2k_format = DetectFormat(data);
 
       switch (m_n2k_format) {
         case N2KFormat_Actisense_RAW_ASCII:


### PR DESCRIPTION
Avoid unnecessary allocations  causing warnings, fix some clang-tidy warnings

Only run DetectFormat for every tenth message -- there is no reason to think the format will change, and the detection is a bit expensive.

Closes: #5196