### PR TITLE
Replace wxJSON with nlohmann::json  - #5347

### DIFF
--- a/gui/src/api_122.cpp
+++ b/gui/src/api_122.cpp
@@ -26,6 +26,11 @@
 
 #include "ocpn_plugin.h"
 
+#include "nlohmann/json.hpp"
+#include "observable/observable.h"
+
+#include "model/comm_navmsg.h"
+
 // FIXME (leamas) find new home.
 std::unique_ptr<HostApi> GetHostApi() {
   auto impl = dynamic_cast<Api122Impl*>(wxTheApp);
@@ -38,4 +43,13 @@ void HostApi122::RegisterApiEventCallback(
   auto impl = dynamic_cast<Api122Impl*>(wxTheApp);
   assert(impl && "wxTheApp does not implement Api122Impl");
   impl->RegisterApiEventCallback(plugin_name, callback);
+}
+
+std::string HostApi122::GetSignalkPayload(ObservedEvt ev) {
+  auto msg = obs::UnpackEvtPointer<SignalkMsg>(ev);
+  nlohmann::json root;
+  root["Data"] = msg->raw_message;
+  root["Context"] = msg->context;
+  root["ContextSelf"] = msg->context_self;
+  return root.dump();
 }

--- a/gui/src/canvas_menu.cpp
+++ b/gui/src/canvas_menu.cpp
@@ -37,6 +37,8 @@
 #include <wx/listbook.h>
 #include <wx/menu.h>
 
+#include "nlohmann/json.hpp"
+
 #include "model/ais_decoder.h"
 #include "model/ais_state_vars.h"
 #include "model/ais_target_data.h"
@@ -1367,10 +1369,9 @@ void CanvasMenuHandler::PopupMenuHandler(wxCommandEvent &event) {
         g_AW2GUID.Clear();
       }
       if (!guid.IsEmpty()) {
-        wxJSONValue v;
+        nlohmann::json v;
         v["GUID"] = guid;
-        wxString msg_id("OCPN_ANCHOR_WATCH_CLEARED");
-        SendJSONMessageToAllPlugins(msg_id, v);
+        SendJsonMessageToAllPlugins("OCPN_ANCHOR_WATCH_CLEARED", v);
       }
       break;
     }
@@ -1399,10 +1400,9 @@ void CanvasMenuHandler::PopupMenuHandler(wxCommandEvent &event) {
         }
       }
       if (!guid.IsEmpty()) {
-        wxJSONValue v;
+        nlohmann::json v;
         v["GUID"] = guid;
-        wxString msg_id("OCPN_ANCHOR_WATCH_SET");
-        SendJSONMessageToAllPlugins(msg_id, v);
+        SendJsonMessageToAllPlugins("OCPN_ANCHOR_WATCH_SET", v);
       }
       break;
     }

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -11247,7 +11247,7 @@ void pupHandler_PasteTrack() {
 }
 
 bool ChartCanvas::InvokeCanvasMenu(int x, int y, int seltype) {
-  wxJSONValue v;
+  nlohmann::json v;
   v["CanvasIndex"] = GetCanvasIndexUnderMouse();
   v["CursorPosition_x"] = x;
   v["CursorPosition_y"] = y;
@@ -11257,12 +11257,10 @@ bool ChartCanvas::InvokeCanvasMenu(int x, int y, int seltype) {
   if (seltype & SELTYPE_ROUTEPOINT) v["SelectionType"] = "RoutePoint";
   if (seltype & SELTYPE_AISTARGET) v["SelectionType"] = "AISTarget";
 
-  wxJSONWriter w;
-  wxString out;
-  w.Write(v, out);
+  std::string out = v.dump();
   SendMessageToAllPlugins("OCPN_CONTEXT_CLICK", out);
 
-  json_msg.Notify(std::make_shared<wxJSONValue>(v), "OCPN_CONTEXT_CLICK");
+  json_msg.Notify(std::make_shared<nlohmann::json>(v), "OCPN_CONTEXT_CLICK");
 
 #if 0
 #define SELTYPE_UNKNOWN 0x0001

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -11936,7 +11936,7 @@ void ChartCanvas::UpdateCanvasS52PLIBConfig() {
   }
 
   if (bSendPlibState) {
-    wxJSONValue v;
+    nlohmann::json v;
     v["OpenCPN Version Major"] = VERSION_MAJOR;
     v["OpenCPN Version Minor"] = VERSION_MINOR;
     v["OpenCPN Version Patch"] = VERSION_PATCH;
@@ -11977,12 +11977,10 @@ void ChartCanvas::UpdateCanvasS52PLIBConfig() {
         g_Platform->GetChartScaleFactorExp(g_ChartScaleFactor);
     v["OpenCPN Display Width"] = (int)g_display_size_mm;
 
-    wxJSONWriter w;
-    wxString out;
-    w.Write(v, out);
+    const std::string out = v.dump();
 
     if (!g_lastS52PLIBPluginMessage.IsSameAs(out)) {
-      SendMessageToAllPlugins(wxString("OpenCPN Config"), out);
+      SendMessageToAllPlugins("OpenCPN Config", out);
       g_lastS52PLIBPluginMessage = out;
     }
   }

--- a/gui/src/gl_chart_canvas.cpp
+++ b/gui/src/gl_chart_canvas.cpp
@@ -44,7 +44,6 @@
 #include <wx/gdicmn.h>
 #include <wx/glcanvas.h>
 #include <wx/image.h>
-#include <wx/jsonval.h>
 #include <wx/log.h>
 #include <wx/pen.h>
 #include <wx/progdlg.h>
@@ -53,6 +52,8 @@
 #include <wx/tokenzr.h>
 #include <wx/utils.h>
 #include <wx/window.h>
+
+#include "nlohmann/json.hpp"
 
 #include "model/base_platform.h"
 #include "model/config_vars.h"
@@ -1229,7 +1230,7 @@ void glChartCanvas::SetupOpenGL() {
 
 void glChartCanvas::SendJSONConfigMessage() {
   if (g_pi_manager) {
-    wxJSONValue v;
+    nlohmann::json v;
     v["setupComplete"] = m_bsetup;
     v["useStencil"] = s_b_useStencil;
     v["useStencilAP"] = s_b_useStencilAP;
@@ -1237,8 +1238,7 @@ void glChartCanvas::SendJSONConfigMessage() {
     v["useFBO"] = s_b_useFBO;
     v["useVBO"] = g_b_EnableVBO;
     v["TextureRectangleFormat"] = g_texture_rectangle_format;
-    wxString msg_id("OCPN_OPENGL_CONFIG");
-    SendJSONMessageToAllPlugins(msg_id, v);
+    SendJsonMessageToAllPlugins("OCPN_OPENGL_CONFIG", v);
   }
 }
 void glChartCanvas::SetupCompression() {

--- a/gui/src/initwiz/wiz_ui.cpp
+++ b/gui/src/initwiz/wiz_ui.cpp
@@ -33,6 +33,8 @@
 
 #include "gl_headers.h"  // Must be included before anything using GL stuff
 
+#include <sstream>
+
 #include <wx/wxprec.h>
 #ifndef WX_PRECOMP
 #include <wx/wx.h>
@@ -41,17 +43,20 @@
 #include <regex>
 #include <wx/sckaddr.h>
 #include <wx/socket.h>
-#include <wx/jsonval.h>
-#include <wx/jsonreader.h>
+
+#include "nlohmann/json.hpp"
+
 #include "wiz_ui.h"
-#include "ocpn_platform.h"
+
 #include "model/comm_drv_signalk_net.h"
 #include "model/comm_drv_n2k_net.h"
 #include "model/conn_params.h"
 #include "model/logger.h"
 #include "model/mdns_query.h"
-#include "navutil.h"
 #include "model/svg_utils.h"
+
+#include "navutil.h"
+#include "ocpn_platform.h"
 #ifndef __ANDROID__
 #include "serial/serial.h"
 #include "dnet.h"
@@ -563,26 +568,22 @@ void FirstUseWizImpl::EnumerateCAN() {
     return;
   }
 
-  wxString fis;
+  std::stringstream ss;
   for (const auto& l : output) {
-    fis.Append(l);
+    ss << l;
   }
-  wxJSONReader reader;
-  wxJSONValue root;
-  reader.Parse(fis, &root);
-  if (reader.GetErrorCount() > 0) {
-    DEBUG_LOG << "Failed to parse JSON output from ip.";
-    for (const auto& l : reader.GetErrors()) {
-      DEBUG_LOG << " - " << l;
-    }
+  nlohmann::json root;
+  try {
+    root = nlohmann::json::parse(ss.str());
+  } catch (nlohmann::json::exception& e) {
+    DEBUG_LOG << "Failed to parse JSON output from ip: " << e.what();
     return;
   }
-  if (root.IsArray()) {
-    for (int i = 0; i < root.Size(); i++) {
-      const wxJSONValue iface = root[i];
-      if (iface.HasMember("ifname") && iface.HasMember("link_type")) {
-        wxString ifname = iface.Get("ifname", "").AsString();
-        wxString link_type = iface.Get("link_type", "").AsString();
+  if (root.is_array()) {
+    for (const auto& iface : root) {
+      if (iface.contains("ifname") && iface.contains("link_type")) {
+        std::string ifname = iface["ifname"].get<std::string>();
+        std::string link_type = iface["link_type"].get<std::string>();
         if (link_type == "can") {
           DEBUG_LOG << "Found CAN interface: " << ifname;
           ConnectionParams params;

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -100,7 +100,6 @@ void gdk_window_set_override_redirect(GdkWindow *window,
 #include <wx/image.h>
 #include <wx/intl.h>
 #include <wx/ipc.h>
-#include <wx/jsonreader.h>
 #include <wx/listctrl.h>
 #include <wx/power.h>
 #include <wx/printdlg.h>

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -3099,10 +3099,9 @@ void MyFrame::ActivateMOB() {
     if (g_pRouteMan->GetpActiveRoute()) g_pRouteMan->DeactivateRoute();
     g_pRouteMan->ActivateRoute(temp_route, pWP_MOB);
 
-    wxJSONValue v;
+    nlohmann::json v;
     v["GUID"] = temp_route->m_GUID;
-    wxString msg_id("OCPN_MAN_OVERBOARD");
-    SendJSONMessageToAllPlugins(msg_id, v);
+    SendJsonMessageToAllPlugins("OCPN_MAN_OVERBOARD", v);
   }
 
   if (RouteManagerDialog::getInstanceFlag()) {
@@ -3150,7 +3149,7 @@ void MyFrame::TrackOn() {
     }
   }
 
-  wxJSONValue v;
+  nlohmann::json v;
   wxString name = g_pActiveTrack->GetName();
   if (name.IsEmpty()) {
     TrackPoint *tp = g_pActiveTrack->GetPoint(0);
@@ -3162,20 +3161,18 @@ void MyFrame::TrackOn() {
   }
   v["Name"] = name;
   v["GUID"] = g_pActiveTrack->m_GUID;
-  wxString msg_id("OCPN_TRK_ACTIVATED");
-  SendJSONMessageToAllPlugins(msg_id, v);
-  g_FlushNavobjChangesTimeout =
-      30;  // Every thirty seconds, consider flushing navob changes
+  SendJsonMessageToAllPlugins("OCPN_TRK_ACTIVATED", v);
+  // Every thirty seconds, consider flushing navob changes
+  g_FlushNavobjChangesTimeout = 30;
 }
 
 Track *MyFrame::TrackOff(bool do_add_point) {
   Track *return_val = g_pActiveTrack;
 
   if (g_pActiveTrack) {
-    wxJSONValue v;
-    wxString msg_id("OCPN_TRK_DEACTIVATED");
+    nlohmann::json v;
     v["GUID"] = g_pActiveTrack->m_GUID;
-    SendJSONMessageToAllPlugins(msg_id, v);
+    SendJsonMessageToAllPlugins("OCPN_TRK_DEACTIVATED", v);
 
     g_pActiveTrack->Stop(do_add_point);
 
@@ -5828,14 +5825,14 @@ double MyFrame::GetMag(double a, double lat, double lon) {
 bool MyFrame::SendJSON_WMM_Var_Request(double lat, double lon,
                                        wxDateTime date) {
   if (g_pi_manager) {
-    wxJSONValue v;
+    nlohmann::json v;
     v["Lat"] = lat;
     v["Lon"] = lon;
     v["Year"] = date.GetYear();
     v["Month"] = date.GetMonth();
     v["Day"] = date.GetDay();
 
-    SendJSONMessageToAllPlugins("WMM_VARIATION_REQUEST", v);
+    SendJsonMessageToAllPlugins("WMM_VARIATION_REQUEST", v);
     return true;
   } else
     return false;
@@ -6253,16 +6250,17 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
     }
   }
   if (message_ID == "OCPN_TRACK_REQUEST") {
-    wxJSONValue root;
-    wxJSONReader reader;
-    wxString trk_id = wxEmptyString;
+    nlohmann::json root;
+    wxString trk_id = "";
 
-    int numErrors = reader.Parse(message_JSONText, &root);
-    if (numErrors > 0) return;
+    try {
+      root = nlohmann::json::parse(message_JSONText);
+    } catch (nlohmann::json::exception &) {
+      return;
+    }
+    if (root.contains("Track_ID")) trk_id = root["Track_ID"].get<std::string>();
 
-    if (root.HasMember("Track_ID")) trk_id = root["Track_ID"].AsString();
-
-    wxJSONValue v;
+    nlohmann::json v;
     v["Track_ID"] = trk_id;
     for (Track *ptrack : g_TrackList) {
       wxString name = wxEmptyString;
@@ -6288,15 +6286,12 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
           v["lon"] = tp->m_lon;
           v["NodeNr"] = i;
           i++;
-          wxString msg_id("OCPN_TRACKPOINTS_COORDS");
-          SendJSONMessageToAllPlugins(msg_id, v);
+          SendJsonMessageToAllPlugins("OCPN_TRACKPOINTS_COORDS", v);
         }
         return;
       }
       v["error"] = true;
-
-      wxString msg_id("OCPN_TRACKPOINTS_COORDS");
-      SendJSONMessageToAllPlugins(msg_id, v);
+      SendJsonMessageToAllPlugins("OCPN_TRACKPOINTS_COORDS", v);
     }
   } else if (message_ID == "OCPN_ROUTE_REQUEST") {
     wxJSONValue root;
@@ -6310,7 +6305,7 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
 
     if (root.HasMember("GUID")) guid = root["GUID"].AsString();
 
-    wxJSONValue v;
+    nlohmann::json v;
     v["GUID"] = guid;
     for (auto it = pRouteList->begin(); it != pRouteList->end(); ++it) {
       wxString name = wxEmptyString;
@@ -6321,7 +6316,7 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
 
         v["Name"] = name;
         v["error"] = false;
-        wxJSONValue w;
+        nlohmann::json w;
         int i = 0;
         for (RoutePointList::iterator itp = (*it)->pRoutePointList->begin();
              itp != (*it)->pRoutePointList->end(); itp++) {
@@ -6346,29 +6341,25 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
           i++;
         }
         v["waypoints"] = w;
-        wxString msg_id("OCPN_ROUTE_RESPONSE");
-        SendJSONMessageToAllPlugins(msg_id, v);
+        SendJsonMessageToAllPlugins("OCPN_ROUTE_RESPONSE", v);
         return;
       }
     }
 
     v["error"] = true;
-
-    wxString msg_id("OCPN_ROUTE_RESPONSE");
-    SendJSONMessageToAllPlugins(msg_id, v);
+    SendJsonMessageToAllPlugins("OCPN_ROUTE_RESPONSE", v);
   } else if (message_ID == "OCPN_ROUTELIST_REQUEST") {
-    wxJSONValue root;
-    wxJSONReader reader;
+    nlohmann::json root;
     bool route = true;
+    try {
+      root = nlohmann::json::parse(message_JSONText);
+    } catch (nlohmann::json::exception &) {
+      return;
+    }
+    if (root.contains("mode")) {
+      if (root["mode"].get<std::string>() == "Track") route = false;
 
-    int numErrors = reader.Parse(message_JSONText, &root);
-    if (numErrors > 0) return;
-
-    if (root.HasMember("mode")) {
-      wxString str = root["mode"].AsString();
-      if (str == "Track") route = false;
-
-      wxJSONValue v;
+      nlohmann::json v;
       int i = 1;
       if (route) {
         for (RouteList::iterator it = pRouteList->begin();
@@ -6400,16 +6391,14 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
           i++;
         }
       }
-      wxString msg_id("OCPN_ROUTELIST_RESPONSE");
-      SendJSONMessageToAllPlugins(msg_id, v);
+      SendJsonMessageToAllPlugins("OCPN_ROUTELIST_RESPONSE", v);
     } else {
-      wxJSONValue v;
+      nlohmann::json v;
       v[0]["error"] = true;
-      wxString msg_id("OCPN_ROUTELIST_RESPONSE");
-      SendJSONMessageToAllPlugins(msg_id, v);
+      SendJsonMessageToAllPlugins("OCPN_ROUTELIST_RESPONSE", v);
     }
   } else if (message_ID == "OCPN_ACTIVE_ROUTELEG_REQUEST") {
-    wxJSONValue v;
+    nlohmann::json v;
     v[0]["error"] = true;
     if (g_pRouteMan->GetpActiveRoute()) {
       if (g_pRouteMan->m_bDataValid) {
@@ -6424,8 +6413,7 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
             g_pRouteMan->GetpActiveRoute()->m_pRouteActivePoint->GetLongitude();
       }
     }
-    wxString msg_id("OCPN_ACTIVE_ROUTELEG_RESPONSE");
-    SendJSONMessageToAllPlugins(msg_id, v);
+    SendJsonMessageToAllPlugins("OCPN_ACTIVE_ROUTELEG_RESPONSE", v);
   }
 }
 
@@ -6579,10 +6567,9 @@ void MyFrame::ActivateAISMOBRoute(const AisTargetData *ptarget) {
   if (g_pRouteMan->GetpActiveRoute()) g_pRouteMan->DeactivateRoute();
   //       g_pRouteMan->ActivateRoute( pAISMOBRoute, pWP_MOB );
 
-  wxJSONValue v;
+  nlohmann::json v;
   v["GUID"] = pAISMOBRoute->m_GUID;
-  wxString msg_id("OCPN_MAN_OVERBOARD");
-  SendJSONMessageToAllPlugins(msg_id, v);
+  SendJsonMessageToAllPlugins("OCPN_MAN_OVERBOARD", v);
   //}
 
   if (RouteManagerDialog::getInstanceFlag()) {

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -2721,15 +2721,14 @@ void MyFrame::OnToolLeftClick(wxCommandEvent &event) {
     case ID_CMD_POST_JSON_TO_PLUGINS: {
       // Extract the Message ID which is embedded in the JSON string passed in
       // the event
-      wxJSONValue root;
-      wxJSONReader reader;
-
-      int numErrors = reader.Parse(event.GetString(), &root);
-      if (numErrors == 0) {
-        if (root["MessageID"].IsString()) {
-          wxString MsgID = root["MessageID"].AsString();
-          SendPluginMessage(MsgID, event.GetString());  // Send to all PlugIns
+      nlohmann::json root;
+      try {
+        root = nlohmann::json::parse(event.GetString().ToStdString());
+        if (root["MessageID"].is_string()) {
+          std::string msg_id = root["MessageID"].get<std::string>();
+          SendPluginMessage(msg_id, event.GetString());  // Send to all PlugIns
         }
+      } catch (nlohmann::json::exception &) {
       }
 
       break;
@@ -6167,44 +6166,29 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
   //  present, active, and we have no other source of Variation
   if (!g_bVAR_Rx) {
     if (message_ID == "WMM_VARIATION_BOAT") {
-      // construct the JSON root object
-      wxJSONValue root;
-      // construct a JSON parser
-      wxJSONReader reader;
-
-      // now read the JSON text and store it in the 'root' structure
-      // check for errors before retreiving values...
-      int numErrors = reader.Parse(message_JSONText, &root);
-      if (numErrors > 0) {
-        //              const wxArrayString& errors = reader.GetErrors();
+      nlohmann::json root;
+      try {
+        root = nlohmann::json::parse(message_JSONText);
+      } catch (nlohmann::json::exception &) {
         return;
       }
-
       // get the DECL value from the JSON message
-      wxString decl = root["Decl"].AsString();
-      double decl_val;
-      decl.ToDouble(&decl_val);
-
-      gVar = decl_val;
+      try {
+        gVar = root["Decl"].get<double>();
+      } catch (nlohmann::json::exception &) {
+        return;
+      }
     }
   }
 
   if (message_ID == "WMM_VARIATION") {
-    // construct the JSON root object
-    wxJSONValue root;
-    // construct a JSON parser
-    wxJSONReader reader;
-
-    // now read the JSON text and store it in the 'root' structure
-    // check for errors before retreiving values...
-    int numErrors = reader.Parse(message_JSONText, &root);
-    if (numErrors > 0) {
-      //              const wxArrayString& errors = reader.GetErrors();
+    nlohmann::json root;
+    try {
+      root = nlohmann::json::parse(message_JSONText);
+    } catch (nlohmann::json::exception &) {
       return;
     }
-
-    // get the DECL value from the JSON message
-    wxString decl = root["Decl"].AsString();
+    wxString decl = root["Decl"].get<std::string>();
     double decl_val;
     decl.ToDouble(&decl_val);
 
@@ -6212,25 +6196,23 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
   }
 
   if (message_ID == "GRIB_TIMELINE") {
-    wxJSONReader r;
-    wxJSONValue v;
-    int numErrors = r.Parse(message_JSONText, &v);
-
-    if (numErrors > 0) {
+    nlohmann::json v;
+    try {
+      v = nlohmann::json::parse(message_JSONText);
+    } catch (nlohmann::json::exception &) {
       wxLogMessage("GRIB_TIMELINE: JSON parse error");
       return;
     }
-
-    // Store old time source for comparison
     wxDateTime oldTimeSource = gTimeSource;
 
-    if (v["Day"].AsInt() == -1) {
+    if (v["Day"].get<int>() == -1) {
       gTimeSource = wxInvalidDateTime;
       wxLogMessage("GRIB_TIMELINE: Reset to system time");
     } else {
-      gTimeSource.Set(v["Day"].AsInt(), (wxDateTime::Month)v["Month"].AsInt(),
-                      v["Year"].AsInt(), v["Hour"].AsInt(), v["Minute"].AsInt(),
-                      v["Second"].AsInt());
+      gTimeSource.Set(v["Day"].get<int>(),
+                      (wxDateTime::Month)v["Month"].get<int>(),
+                      v["Year"].get<int>(), v["Hour"].get<int>(),
+                      v["Minute"].get<int>(), v["Second"].get<int>());
     }
 
     // Refresh tide displays if time source changed
@@ -6294,16 +6276,15 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
       SendJsonMessageToAllPlugins("OCPN_TRACKPOINTS_COORDS", v);
     }
   } else if (message_ID == "OCPN_ROUTE_REQUEST") {
-    wxJSONValue root;
-    wxJSONReader reader;
-    wxString guid = wxEmptyString;
-
-    int numErrors = reader.Parse(message_JSONText, &root);
-    if (numErrors > 0) {
+    nlohmann::json root;
+    wxString guid = "";
+    try {
+      root = nlohmann::json::parse(message_JSONText);
+    } catch (nlohmann::json::exception &) {
       return;
     }
 
-    if (root.HasMember("GUID")) guid = root["GUID"].AsString();
+    if (root.contains("GUID")) guid = root["GUID"].get<std::string>();
 
     nlohmann::json v;
     v["GUID"] = guid;

--- a/gui/src/ocpn_platform.cpp
+++ b/gui/src/ocpn_platform.cpp
@@ -22,6 +22,7 @@
  */
 
 #include <cstdlib>
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -52,10 +53,9 @@
 #include <wx/filename.h>
 #include <wx/tokenzr.h>
 #include <wx/textfile.h>
-#include <wx/jsonval.h>
-#include <wx/jsonreader.h>
 
 #include "config.h"
+#include "nlohmann/json.hpp"
 
 #include "model/ais_decoder.h"
 #include "model/ais_state_vars.h"
@@ -610,12 +610,12 @@ void OCPNPlatform::OnExit_2() {
 
 #ifdef ocpnUSE_GL
 
-bool HasGLExt(wxJSONValue &glinfo, const std::string ext) {
-  if (!glinfo.HasMember("GL_EXTENSIONS")) {
+static bool HasGLExt(const nlohmann::json &glinfo, const std::string &ext) {
+  if (glinfo.count("GL_EXTENSIONS") <= 0) {
     return false;
   }
-  for (int i = 0; i < glinfo["GL_EXTENSIONS"].Size(); i++) {
-    if (glinfo["GL_EXTENSIONS"][i].AsString() == ext) {
+  for (const auto &extension : glinfo["GL_EXTENSIONS"]) {
+    if (extension.get<std::string>() == ext) {
       return true;
     }
   }
@@ -660,41 +660,43 @@ bool OCPNPlatform::BuildGLCaps(void *pbuf) {
     }
     return false;
   }
-
-  wxFileInputStream fis(gl_json);
-  wxJSONReader reader;
-  wxJSONValue root;
-  reader.Parse(fis, &root);
-  if (reader.GetErrorCount() > 0) {
+  nlohmann::json root;
+  std::ifstream f(gl_json);
+  try {
+    root = nlohmann::json::parse(f);
+  } catch (nlohmann::json::exception &e) {
     wxLogMessage("Failed to parse JSON output from OpenGL test utility.");
-    for (const auto &l : reader.GetErrors()) {
-      wxLogMessage(l);
-    }
+    wxLogMessage(e.what());
     return false;
   }
 
-  OCPN_GLCaps *pcaps = (OCPN_GLCaps *)pbuf;
-
-  if (root.HasMember("GL_RENDERER")) {
-    pcaps->Renderer = root["GL_RENDERER"].AsString();
+  auto *pcaps = static_cast<OCPN_GLCaps *>(pbuf);
+  if (root.contains("GL_RENDERER")) {
+    pcaps->Renderer = root["GL_RENDERER"].get<std::string>();
   } else {
     wxLogMessage("GL_RENDERER not found.");
     return false;
   }
-  if (root.HasMember("GL_VERSION")) {
-    pcaps->Version = root["GL_VERSION"].AsString();
+  if (root.contains("GL_VERSION")) {
+    pcaps->Version = root["GL_VERSION"].get<std::string>();
   } else {
     wxLogMessage("GL_VERSION not found.");
     return false;
   }
-  if (root.HasMember("GL_SHADING_LANGUAGE_VERSION")) {
-    pcaps->GLSL_Version = root["GL_SHADING_LANGUAGE_VERSION"].AsString();
+  if (root.contains("GL_SHADING_LANGUAGE_VERSION")) {
+    pcaps->GLSL_Version =
+        root["GL_SHADING_LANGUAGE_VERSION"].get<std::string>();
   } else {
     wxLogMessage("GL_SHADING_LANGUAGE_VERSION not found.");
     return false;
   }
-  if (root.HasMember("GL_USABLE")) {
-    if (!root["GL_USABLE"].AsBool()) {
+  if (root.contains("GL_USABLE")) {
+    if (!root["GL_USABLE"].get<bool>()) {
+      wxLogMessage("OpenGL test utility reports that OpenGL is not usable.");
+      return false;
+    }
+  } else if (root.contains("\"GL_USABLE\"")) {
+    if (!root["\"GL_USABLE\""].get<bool>()) {
       wxLogMessage("OpenGL test utility reports that OpenGL is not usable.");
       return false;
     }
@@ -729,10 +731,10 @@ bool OCPNPlatform::BuildGLCaps(void *pbuf) {
     pcaps->bCanDoFBO = false;
   }
 
-  pcaps->bCanDoVBO = HasGLExt(
-      root, "GL_ARB_vertex_buffer_object");  // TODO: Or the old way where we
-                                             // enable it without querying the
-                                             // extension is right?
+  pcaps->bCanDoVBO = HasGLExt(root, "GL_ARB_vertex_buffer_object");
+  // TODO: Or the old way where we enable it without querying the
+  // extension is right?
+
   top_frame::Get()->Show();
   return true;
 #else

--- a/gui/src/ocpn_plugin_gui.cpp
+++ b/gui/src/ocpn_plugin_gui.cpp
@@ -363,7 +363,7 @@ ArrayOfPlugIn_AIS_Targets* GetAISTargetArray() {
 wxAuiManager* GetFrameAuiManager() { return g_pauimgr; }
 
 void SendPluginMessage(wxString message_id, wxString message_body) {
-  SendMessageToAllPlugins(message_id, message_body);
+  SendMessageToAllPlugins(message_id.ToStdString(), message_body.ToStdString());
 
   //  We will send an event to the main application frame (gFrame)
   //  for informational purposes.

--- a/gui/src/peer_client_dlg.cpp
+++ b/gui/src/peer_client_dlg.cpp
@@ -28,8 +28,6 @@
 #include "gl_headers.h"  // Must come before anything using GL stuff
 
 #include <wx/fileconf.h>
-#include <wx/json_defs.h>
-#include <wx/jsonreader.h>
 #include <wx/tokenzr.h>
 
 #include <curl/curl.h>

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -200,36 +200,36 @@ static void SendAisJsonMessage(std::shared_ptr<const AisTargetData> pTarget) {
   if (!GetJSONMessageTargetCount()) return;
 
   // Do JSON message to all Plugin to inform of target
-  wxJSONValue jMsg;
+  nlohmann::json jMsg;
 
   wxLongLong t = ::wxGetLocalTimeMillis();
 
-  jMsg[wxS("Source")] = wxS("AisDecoder");
+  jMsg["Source"] = "AisDecoder";
   jMsg["Type"] = "Information";
-  jMsg["Msg"] = wxS("AIS Target");
+  jMsg["Msg"] = "AIS Target";
   jMsg["MsgId"] = t.GetValue();
-  jMsg[wxS("lat")] = pTarget->Lat;
-  jMsg[wxS("lon")] = pTarget->Lon;
-  jMsg[wxS("sog")] = pTarget->SOG;
-  jMsg[wxS("cog")] = pTarget->COG;
-  jMsg[wxS("hdg")] = pTarget->HDG;
-  jMsg[wxS("mmsi")] = pTarget->MMSI;
-  jMsg[wxS("class")] = pTarget->Class;
-  jMsg[wxS("ownship")] = pTarget->b_OwnShip;
-  jMsg[wxS("active")] = pTarget->b_active;
-  jMsg[wxS("lost")] = pTarget->b_lost;
+  jMsg["lat"] = pTarget->Lat;
+  jMsg["lon"] = pTarget->Lon;
+  jMsg["sog"] = pTarget->SOG;
+  jMsg["cog"] = pTarget->COG;
+  jMsg["hdg"] = pTarget->HDG;
+  jMsg["mmsi"] = pTarget->MMSI;
+  jMsg["class"] = pTarget->Class;
+  jMsg["ownship"] = pTarget->b_OwnShip;
+  jMsg["active"] = pTarget->b_active;
+  jMsg["lost"] = pTarget->b_lost;
   wxString l_ShipName = wxString::FromUTF8(pTarget->ShipName);
   for (size_t i = 0; i < l_ShipName.Len(); i++) {
     if (l_ShipName.GetChar(i) == '@') l_ShipName.SetChar(i, '\n');
   }
-  jMsg[wxS("shipname")] = l_ShipName;
+  jMsg["shipname"] = l_ShipName.ToStdString();
   wxString l_CallSign = wxString::FromUTF8(pTarget->CallSign);
   for (size_t i = 0; i < l_CallSign.Len(); i++) {
     if (l_CallSign.GetChar(i) == '@') l_CallSign.SetChar(i, '\n');
   }
-  jMsg[wxS("callsign")] = l_CallSign;
-  jMsg[wxS("removed")] = pTarget->b_removed;
-  SendJSONMessageToAllPlugins("AIS", jMsg);
+  jMsg["callsign"] = l_CallSign.ToStdString();
+  jMsg["removed"] = pTarget->b_removed;
+  SendJsonMessageToAllPlugins("AIS", jMsg);
 }
 
 static bool ReloadLocale() {
@@ -910,8 +910,8 @@ PlugInManager::PlugInManager(AbstractTopFrame* parent) {
   evt_json_to_all_plugins_listener.Listen(g_pRouteMan->json_msg, this,
                                           EVT_JSON_TO_ALL_PLUGINS);
   Bind(EVT_JSON_TO_ALL_PLUGINS, [&](ObservedEvt& ev) {
-    auto json = std::static_pointer_cast<const wxJSONValue>(ev.GetSharedPtr());
-    SendJSONMessageToAllPlugins(ev.GetString(), *json);
+    auto json = std::static_pointer_cast<const nlohmann::json>(ev.GetSharedPtr());
+    SendJsonMessageToAllPlugins(ev.GetString().ToStdString(), *json);
   });
 
   wxDEFINE_EVENT(EVT_LEGINFO_TO_ALL_PLUGINS, ObservedEvt);
@@ -992,14 +992,16 @@ void PlugInManager::HandleN0183(std::shared_ptr<const Nmea0183Msg> n0183_msg) {
 void PlugInManager::HandleSignalK(std::shared_ptr<const SignalkMsg> sK_msg) {
   g_ownshipMMSI_SK = sK_msg->context_self;
 
-  wxJSONReader jsonReader;
-  wxJSONValue root;
+  nlohmann::json root;
 
   std::string msgTerminated = sK_msg->raw_message;
-  ;
-
-  int errors = jsonReader.Parse(msgTerminated, &root);
-  if (errors == 0) SendJSONMessageToAllPlugins("OCPN_CORE_SIGNALK", root);
+  bool failed = false;
+  try {
+    root = nlohmann::json::parse(msgTerminated);
+  } catch (nlohmann::json::exception&) {
+    failed = true;
+  }
+  if (!failed) SendJsonMessageToAllPlugins("OCPN_CORE_SIGNALK", root);
 }
 
 /**

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -195,41 +195,41 @@ private:
   std::string m_key;
 };
 
-static void SendAisJsonMessage(std::shared_ptr<const AisTargetData> pTarget) {
+static void SendAisJsonMessage(std::shared_ptr<const AisTargetData> target) {
   //  Only send messages if someone is listening...
   if (!GetJSONMessageTargetCount()) return;
 
   // Do JSON message to all Plugin to inform of target
-  nlohmann::json jMsg;
+  nlohmann::json json_msg;
 
   wxLongLong t = ::wxGetLocalTimeMillis();
 
-  jMsg["Source"] = "AisDecoder";
-  jMsg["Type"] = "Information";
-  jMsg["Msg"] = "AIS Target";
-  jMsg["MsgId"] = t.GetValue();
-  jMsg["lat"] = pTarget->Lat;
-  jMsg["lon"] = pTarget->Lon;
-  jMsg["sog"] = pTarget->SOG;
-  jMsg["cog"] = pTarget->COG;
-  jMsg["hdg"] = pTarget->HDG;
-  jMsg["mmsi"] = pTarget->MMSI;
-  jMsg["class"] = pTarget->Class;
-  jMsg["ownship"] = pTarget->b_OwnShip;
-  jMsg["active"] = pTarget->b_active;
-  jMsg["lost"] = pTarget->b_lost;
-  wxString l_ShipName = wxString::FromUTF8(pTarget->ShipName);
+  json_msg["Source"] = "AisDecoder";
+  json_msg["Type"] = "Information";
+  json_msg["Msg"] = "AIS Target";
+  json_msg["MsgId"] = t.GetValue();
+  json_msg["lat"] = target->Lat;
+  json_msg["lon"] = target->Lon;
+  json_msg["sog"] = target->SOG;
+  json_msg["cog"] = target->COG;
+  json_msg["hdg"] = target->HDG;
+  json_msg["mmsi"] = target->MMSI;
+  json_msg["class"] = target->Class;
+  json_msg["ownship"] = target->b_OwnShip;
+  json_msg["active"] = target->b_active;
+  json_msg["lost"] = target->b_lost;
+  wxString l_ShipName = wxString::FromUTF8(target->ShipName);
   for (size_t i = 0; i < l_ShipName.Len(); i++) {
     if (l_ShipName.GetChar(i) == '@') l_ShipName.SetChar(i, '\n');
   }
-  jMsg["shipname"] = l_ShipName.ToStdString();
-  wxString l_CallSign = wxString::FromUTF8(pTarget->CallSign);
+  json_msg["shipname"] = l_ShipName.ToStdString();
+  wxString l_CallSign = wxString::FromUTF8(target->CallSign);
   for (size_t i = 0; i < l_CallSign.Len(); i++) {
     if (l_CallSign.GetChar(i) == '@') l_CallSign.SetChar(i, '\n');
   }
-  jMsg["callsign"] = l_CallSign.ToStdString();
-  jMsg["removed"] = pTarget->b_removed;
-  SendJsonMessageToAllPlugins("AIS", jMsg);
+  json_msg["callsign"] = l_CallSign.ToStdString();
+  json_msg["removed"] = target->b_removed;
+  SendJsonMessageToAllPlugins("AIS", json_msg);
 }
 
 static bool ReloadLocale() {
@@ -907,10 +907,11 @@ PlugInManager::PlugInManager(AbstractTopFrame* parent) {
   m_blacklist_ui = std::unique_ptr<BlacklistUI>(new BlacklistUI());
 
   wxDEFINE_EVENT(EVT_JSON_TO_ALL_PLUGINS, ObservedEvt);
-  evt_json_to_all_plugins_listener.Listen(g_pRouteMan->json_msg, this,
+  evt_json_to_all_plugins_listener.Listen(g_pRouteMan->json_msg_evt, this,
                                           EVT_JSON_TO_ALL_PLUGINS);
   Bind(EVT_JSON_TO_ALL_PLUGINS, [&](ObservedEvt& ev) {
-    auto json = std::static_pointer_cast<const nlohmann::json>(ev.GetSharedPtr());
+    auto json =
+        std::static_pointer_cast<const nlohmann::json>(ev.GetSharedPtr());
     SendJsonMessageToAllPlugins(ev.GetString().ToStdString(), *json);
   });
 
@@ -1058,16 +1059,17 @@ void PlugInManager::HandlePluginLoaderEvents() {
   Bind(EVT_PLUGIN_LOADALL_FINALIZE,
        [&](wxCommandEvent& ev) { FinalizePluginLoadall(); });
 
-  evt_ais_json_listener.Listen(g_pAIS->plugin_msg, this, EVT_PLUGMGR_AIS_MSG);
-  evt_routeman_json_listener.Listen(g_pRouteMan->json_msg, this,
+  evt_ais_json_listener.Listen(g_pAIS->plugin_msg_evt, this,
+                               EVT_PLUGMGR_AIS_MSG);
+  evt_routeman_json_listener.Listen(g_pRouteMan->json_msg_evt, this,
                                     EVT_PLUGMGR_ROUTEMAN_MSG);
   Bind(EVT_PLUGMGR_AIS_MSG, [&](ObservedEvt& ev) {
-    auto pTarget = obs::UnpackEvtPointer<AisTargetData>(ev);
-    SendAisJsonMessage(pTarget);
+    auto target = obs::UnpackEvtPointer<AisTargetData>(ev);
+    SendAisJsonMessage(target);
   });
   Bind(EVT_PLUGMGR_ROUTEMAN_MSG, [&](ObservedEvt& ev) {
-    auto msg = obs::UnpackEvtPointer<wxJSONValue>(ev);
-    SendJSONMessageToAllPlugins(ev.GetString(), *msg);
+    auto msg = obs::UnpackEvtPointer<nlohmann::json>(ev);
+    SendJsonMessageToAllPlugins(ev.GetString().ToStdString(), *msg);
   });
 }
 

--- a/gui/src/pluginmanager.cpp
+++ b/gui/src/pluginmanager.cpp
@@ -72,8 +72,6 @@
 #include <wx/filename.h>
 #include <wx/hashmap.h>
 #include <wx/hashset.h>
-#include <wx/jsonreader.h>
-#include <wx/jsonval.h>
 #include <wx/listimpl.cpp>
 #include <wx/platinfo.h>
 #include <wx/popupwin.h>
@@ -1739,17 +1737,15 @@ void PlugInManager::PrepareAllPluginContextMenus() {
 
 void PlugInManager::SendSKConfigToAllPlugIns() {
   // Send the current ownship MMSI, encoded as sK,  to all PlugIns
-  wxJSONValue v;
+  nlohmann::json v;
   v["self"] = g_ownshipMMSI_SK;
-  wxJSONWriter w;
-  wxString out;
-  w.Write(v, out);
-  SendMessageToAllPlugins(wxString("OCPN_CORE_SIGNALK"), out);
+  std::string out = v.dump();
+  SendMessageToAllPlugins("OCPN_CORE_SIGNALK", out);
 }
 
 void PlugInManager::SendBaseConfigToAllPlugIns() {
   // Send the current run-time configuration to all PlugIns
-  wxJSONValue v;
+  nlohmann::json v;
   v["OpenCPN Version Major"] = VERSION_MAJOR;
   v["OpenCPN Version Minor"] = VERSION_MINOR;
   v["OpenCPN Version Patch"] = VERSION_PATCH;
@@ -1773,15 +1769,13 @@ void PlugInManager::SendBaseConfigToAllPlugIns() {
   v["OpenCPN Content Scale Factor"] = OCPN_GetDisplayContentScaleFactor();
   v["OpenCPN Display DIP Scale Factor"] = OCPN_GetWinDIPScaleFactor();
 
-  wxJSONWriter w;
-  wxString out;
-  w.Write(v, out);
-  SendMessageToAllPlugins(wxString("OpenCPN Config"), out);
+  std::string out = v.dump();
+  SendMessageToAllPlugins("OpenCPN Config", out);
 }
 
 void PlugInManager::SendS52ConfigToAllPlugIns(bool bReconfig) {
   // Send the current run-time configuration to all PlugIns
-  wxJSONValue v;
+  nlohmann::json v;
   v["OpenCPN Version Major"] = VERSION_MAJOR;
   v["OpenCPN Version Minor"] = VERSION_MINOR;
   v["OpenCPN Version Patch"] = VERSION_PATCH;
@@ -1821,10 +1815,8 @@ void PlugInManager::SendS52ConfigToAllPlugIns(bool bReconfig) {
   // Notify plugins that S52PLIB may have reconfigured global options
   v["OpenCPN S52PLIB GlobalReconfig"] = bReconfig;
 
-  wxJSONWriter w;
-  wxString out;
-  w.Write(v, out);
-  SendMessageToAllPlugins(wxString("OpenCPN Config"), out);
+  const std::string out = v.dump();
+  SendMessageToAllPlugins("OpenCPN Config", out);
 }
 
 void PlugInManager::NotifyAuiPlugIns() {

--- a/gui/src/track_prop_dlg.cpp
+++ b/gui/src/track_prop_dlg.cpp
@@ -24,6 +24,8 @@
 
 #include "config.h"
 
+#include "nlohmann/json.hpp"
+
 #include "gl_headers.h"  // Must be included before anything using GL stuff
 
 #include "model/georef.h"
@@ -1729,12 +1731,11 @@ bool TrackPropDlg::SaveChanges() {
   }
 
   if (m_pTrack && m_pTrack->IsRunning()) {
-    wxJSONValue v;
+    nlohmann::json v;
     v["Changed"] = true;
     v["Name"] = m_pTrack->GetName();
     v["GUID"] = m_pTrack->m_GUID;
-    wxString msg_id("OCPN_TRK_ACTIVATED");
-    SendJSONMessageToAllPlugins(msg_id, v);
+    SendJsonMessageToAllPlugins("OCPN_TRK_ACTIVATED", v);
   }
 
   return true;

--- a/include/ocpn_plugin.h
+++ b/include/ocpn_plugin.h
@@ -7421,6 +7421,20 @@ public:
    */
   const std::set<std::string> &GetActiveMessages();
 
+  /**
+   *  Get SignalK payload after receiving a message.
+   *  @return json text data. Typical usage:
+   *
+   *      std::string json_payload = GetSignalkPayload(ev);
+   *      ... parse and use json_payload
+   *
+   *  json_payload is a map containing the following entries:
+   *  - "Data": the raw json message
+   *  - "Context": string, message context
+   *  - "ContextSelf": string, own ship context.
+   */
+  std::string GetSignalkPayload(ObservedEvt ev);
+
 private:
   Api122Impl *m_api_impl;  // Raw ptr to app object managed by wxWidgets
 };

--- a/libs/nlohmann-json/CMakeLists.txt
+++ b/libs/nlohmann-json/CMakeLists.txt
@@ -16,5 +16,5 @@ add_library(_NLOHMANN_JSON_ INTERFACE)
 add_library(nlohmann::json ALIAS _NLOHMANN_JSON_)
 
 target_include_directories(
-  _NLOHMANN_JSON_ INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/json/single_include
+  _NLOHMANN_JSON_ INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include
 )

--- a/libs/nlohmann-json/include/nlohmann/json.hpp
+++ b/libs/nlohmann-json/include/nlohmann/json.hpp
@@ -1,0 +1,9 @@
+// https://github.com/nlohmann/json/issues/1408
+#ifdef _MSC_VER
+#undef snprintf
+#endif
+
+// See "Implicit Conversions" in https://github.com/nlohmann/json/README.md
+#define JSON_USE_IMPLICIT_CONVERSIONS 0
+
+#include "../../json/single_include/nlohmann/json.hpp"

--- a/model/CMakeLists.txt
+++ b/model/CMakeLists.txt
@@ -472,6 +472,7 @@ endif ()
 
 target_link_libraries(
   _OCPN_MODEL INTERFACE
+    nlohmann::json
     observable::observable
     ocpn::ixwebsocket
     ocpn::garminhost

--- a/model/include/model/ais_decoder.h
+++ b/model/include/model/ais_decoder.h
@@ -152,8 +152,8 @@ public:
   /** Notified when about to delete track. Contains a MmsiProperties* ptr */
   obs::EventVar delete_track;
 
-  /** A JSON message should be sent. Contains a AisTargetData* pointer. */
-  obs::EventVar plugin_msg;
+  /** A JSON message should be sent. Contains an AisTargetData* pointer. */
+  obs::EventVar plugin_msg_evt;
 
 private:
   void OnTimerAIS(wxTimerEvent &event);

--- a/model/include/model/plugin_comm.h
+++ b/model/include/model/plugin_comm.h
@@ -28,10 +28,15 @@
 #include <wx/jsonval.h>
 #include <wx/string.h>
 
+#include "nlohmann/json.hpp"
+
 #include "model/ocpn_types.h"
 
 void SendMessageToAllPlugins(const wxString& message_id,
                              const wxString& message_body);
+
+void SendJsonMessageToAllPlugins(const std::string& message_id,
+                                 const nlohmann::json& v);
 
 void SendJSONMessageToAllPlugins(const wxString& message_id, wxJSONValue v);
 

--- a/model/include/model/plugin_comm.h
+++ b/model/include/model/plugin_comm.h
@@ -32,13 +32,11 @@
 
 #include "model/ocpn_types.h"
 
-void SendMessageToAllPlugins(const wxString& message_id,
-                             const wxString& message_body);
+void SendMessageToAllPlugins(const std::string& message_id,
+                             const std::string& message_body);
 
 void SendJsonMessageToAllPlugins(const std::string& message_id,
                                  const nlohmann::json& v);
-
-void SendJSONMessageToAllPlugins(const wxString& message_id, wxJSONValue v);
 
 void SendAISSentenceToAllPlugIns(const wxString& sentence);
 

--- a/model/include/model/routeman.h
+++ b/model/include/model/routeman.h
@@ -252,9 +252,9 @@ public:
 
   /**
    * Notified with message targeting all plugins. Contains a message type
-   * string and a wxJSONValue shared_ptr.
+   * string and a nlohmann::json shared_ptr.
    */
-  obs::EventVar json_msg;
+  obs::EventVar json_msg_evt;
 
   /** Notified with a shared_ptr<ActiveLegDat>, leg info to all plugins.  */
   obs::EventVar json_leg_info;

--- a/model/src/ais_decoder.cpp
+++ b/model/src/ais_decoder.cpp
@@ -3385,7 +3385,7 @@ void AisDecoder::CommitAISTarget(
       if (pTargetData->b_show_track) UpdateOneTrack(pTargetData.get());
     }
     // TODO add ais message call
-    plugin_msg.Notify(std::make_shared<AisTargetData>(*pTargetData), "");
+    plugin_msg_evt.Notify(std::make_shared<AisTargetData>(*pTargetData), "");
   } else {
     //             printf("Unrecognised AIS message ID: %d\n",
     //             pTargetData->MID);
@@ -4246,7 +4246,7 @@ void AisDecoder::OnTimerAIS(wxTimerEvent &event) {
         xtd->HDG = 511.0;
         xtd->ROTAIS = -128;
 
-        plugin_msg.Notify(xtd, "");
+        plugin_msg_evt.Notify(xtd, "");
 
         long mmsi_long = xtd->MMSI;
         pSelectAIS->DeleteSelectablePoint((void *)mmsi_long, SELTYPE_AISTARGET);
@@ -4256,7 +4256,7 @@ void AisDecoder::OnTimerAIS(wxTimerEvent &event) {
         //      or a lost ARPA target.
         if (target_static_age > removelost_Mins * 60 * 3 || b_arpalost) {
           xtd->b_removed = true;
-          plugin_msg.Notify(xtd, "");
+          plugin_msg_evt.Notify(xtd, "");
           remove_array.push_back(xtd->MMSI);  // Add this target to removal list
         }
       }
@@ -4270,7 +4270,7 @@ void AisDecoder::OnTimerAIS(wxTimerEvent &event) {
         if (props->m_bignore) {
           remove_array.push_back(xtd->MMSI);  // Add this target to removal list
           xtd->b_removed = true;
-          plugin_msg.Notify(xtd, "");
+          plugin_msg_evt.Notify(xtd, "");
         }
         break;
       }
@@ -4280,7 +4280,7 @@ void AisDecoder::OnTimerAIS(wxTimerEvent &event) {
     if (static_cast<unsigned>(xtd->MMSI) == g_OwnShipmmsi) {
       remove_array.push_back(xtd->MMSI);  // Add this target to removal list
       xtd->b_removed = true;
-      plugin_msg.Notify(xtd, "");
+      plugin_msg_evt.Notify(xtd, "");
     }
 
     ++it;

--- a/model/src/ais_decoder.cpp
+++ b/model/src/ais_decoder.cpp
@@ -2093,13 +2093,7 @@ void AisDecoder::HandleSignalK(const SignalKMsgPtr &sK_msg) {
   if (mmsi == g_OwnShipmmsi) return;
 
 #if 0
-    wxString dbg;
-    wxJSONWriter writer;
-    writer.Write(root, dbg);
-
-    wxString msg( "AisDecoder::OnEvtSignalK: " );
-    msg.append(dbg);
-    wxLogMessage(msg);
+    wxLogDebug( "AisDecoder::OnEvtSignalK: %s", root.dump().c_str(); );
 #endif
   std::shared_ptr<AisTargetData> pTargetData = nullptr;
   std::shared_ptr<AisTargetData> pStaleTarget = nullptr;

--- a/model/src/catalog_handler.cpp
+++ b/model/src/catalog_handler.cpp
@@ -29,9 +29,9 @@
 #include <sstream>
 
 #include <wx/filename.h>
-#include <wx/jsonreader.h>
 #include <wx/log.h>
 
+#include "nlohmann/json.hpp"
 #include "observable/evtvar.h"
 #include "observable/global_var.h"
 
@@ -337,22 +337,21 @@ catalog_status CatalogHandler::LoadChannels(std::ostream* stream) {
 }
 
 catalog_status CatalogHandler::LoadChannels(const std::string& json) {
-  wxJSONValue node;
-  wxJSONReader parser;
-  parser.Parse(json.c_str(), &node);
-  if (!node.IsArray()) {
+  nlohmann::json branches;
+  try {
+    branches = nlohmann::json::parse(json);
+  } catch (nlohmann::json::exception&) {
+  }
+  if (!branches.is_array()) {
     wxLogMessage("Cannot parse json (toplevel)");
-    error_msg = parser.GetErrors().Item(0).ToStdString();
     return ServerStatus::JSON_ERROR;
   }
-  auto branches = node.AsArray();
-  wxLogMessage("Got %d branches", branches->Count());
+  wxLogMessage("Got %d branches", branches.size());
   channels.clear();
-  for (size_t i = 0; i < branches->Count(); i += 1) {
-    auto branch = branches->Item(i);
-    channels.push_back(branch["name"].AsString().ToStdString());
+  for (const auto& branch : branches) {
+    channels.push_back(branch["name"].get<std::string>());
   }
-  if (branches->Count() > 0) {
+  if (branches.size() > 0) {
     wxLogMessage("First branch: %s", channels[0].c_str());
   }
   return ServerStatus::OK;

--- a/model/src/comm_drv_internal.cpp
+++ b/model/src/comm_drv_internal.cpp
@@ -32,8 +32,8 @@
 #include <wx/log.h>
 #include <wx/string.h>
 
+#include "nlohmann/json.hpp"
 #include "observable/observable.h"
-#include "wx/jsonreader.h"
 
 #include "config.h"
 #include "model/comm_drv_internal.h"
@@ -57,12 +57,12 @@ bool CommDriverInternal::SendMessage(std::shared_ptr<const NavMsg> msg,
     WARNING_LOG << "SendMessage(): Illegal message type";
     return false;
   }
-  wxJSONValue root;
-  wxJSONReader json_reader;
-  int num_errors = json_reader.Parse(plugin_msg->message, &root);
-  if (num_errors > 0) {
+  nlohmann::json root;
+  try {
+    root = nlohmann::json::parse(plugin_msg->message);
+  } catch (nlohmann::json::exception& e) {
     WARNING_LOG << "SendMessage(): cannot parse json: "
-                << plugin_msg->message.substr(0, 30);
+                << std::string(e.what()).substr(0, 30);
     return false;
   }
   m_listener.Notify(plugin_msg);

--- a/model/src/comm_drv_loopback.cpp
+++ b/model/src/comm_drv_loopback.cpp
@@ -34,9 +34,10 @@
 #include <string>
 #include <vector>
 
-#include <wx/jsonreader.h>
 #include <wx/log.h>
 #include <wx/string.h>
+
+#include "nlohmann/json.hpp"
 
 #include "model/comm_drv_loopback.h"
 #include "model/comm_navmsg.h"
@@ -94,12 +95,11 @@ static NavMsgPtr Parse0183(const string& iface, const string& type,
 
 static NavMsgPtr ParseSignalk(const string& iface, const string& type,
                               const string& msg) {
-  wxJSONValue root;
-  wxJSONReader reader;
-  int err_count = reader.Parse(msg, &root);
   std::string context;
-  if (err_count == 0) {
-    if (root.HasMember("context")) context = root["context"].AsString();
+  try {
+    nlohmann::json root = nlohmann::json::parse(msg);
+    if (root.contains("context")) context = root["context"].get<std::string>();
+  } catch (nlohmann::json::exception&) {
   }
   return make_shared<SignalkMsg>(type, context, msg, iface);
 }

--- a/model/src/comm_n0183_output.cpp
+++ b/model/src/comm_n0183_output.cpp
@@ -29,9 +29,6 @@
 
 #include "config.h"
 
-#include <wx/jsonreader.h>
-#include <wx/jsonval.h>
-#include <wx/jsonwriter.h>
 #include <wx/tokenzr.h>
 
 #include "model/comm_driver.h"

--- a/model/src/navmsg_filter.cpp
+++ b/model/src/navmsg_filter.cpp
@@ -22,13 +22,12 @@
  */
 
 #include <fstream>
+#include <wx/log.h>
+
+#include "nlohmann/json.hpp"
 
 #include "model/base_platform.h"
 #include "model/navmsg_filter.h"
-
-#include "wx/jsonreader.h"
-#include "wx/jsonwriter.h"
-#include "wx/log.h"
 
 #include "std_filesystem.h"
 
@@ -121,65 +120,67 @@ static std::string StateToString(State state) {
   return "";  // for the compiler
 }
 
-static void ParseBuses(NavmsgFilter& filter, wxJSONValue json_val) {
-  for (int i = 0; i < json_val.Size(); i++) {
-    auto str = json_val[i].AsString().ToStdString();
+static void ParseBuses(NavmsgFilter& filter, const nlohmann::json& json_val) {
+  for (const auto& value : json_val) {
+    auto str = value.get<std::string>();
     filter.buses.insert(NavAddr::StringToBus(str));
   }
 }
 
-static void ParseDirections(NavmsgFilter& filter, wxJSONValue json_val) {
-  for (int i = 0; i < json_val.Size(); i++) {
-    auto str = json_val[i].AsString().ToStdString();
+static void ParseDirections(NavmsgFilter& filter,
+                            const nlohmann::json& json_val) {
+  for (const auto& value : json_val) {
+    auto str = value.get<std::string>();
     filter.directions.insert(StringToDirection(str));
   }
 }
 
-static void ParseAccepted(NavmsgFilter& filter, wxJSONValue json_val) {
-  for (int i = 0; i < json_val.Size(); i++) {
-    auto str = json_val[i].AsString().ToStdString();
+static void ParseAccepted(NavmsgFilter& filter, nlohmann::json json_val) {
+  for (const auto& value : json_val) {
+    auto str = value.get<std::string>();
     filter.accepted.insert(StringToAccepted(str));
   }
 }
 
-static void ParseStatus(NavmsgFilter& filter, wxJSONValue json_val) {
-  for (int i = 0; i < json_val.Size(); i++) {
-    auto str = json_val[i].AsString().ToStdString();
+static void ParseStatus(NavmsgFilter& filter, nlohmann::json json_val) {
+  for (const auto& value : json_val) {
+    auto str = value.get<std::string>();
     filter.status.insert(StringToState(str));
   }
 }
 
-static void ParseMsgFilter(NavmsgFilter& filter, wxJSONValue json_val) {
-  if (json_val.HasMember("blockedMsg")) {
-    auto val = json_val["blockedMsg"];
-    for (int i = 0; i < val.Size(); i++)
-      filter.exclude_msg.insert(val[i].AsString().ToStdString());
-  } else if (json_val.HasMember("allowedMsg")) {
-    auto val = json_val["allowedMsg"];
-    for (int i = 0; i < val.Size(); i++)
-      filter.include_msg.insert(val[i].AsString().ToStdString());
+static void ParseMsgFilter(NavmsgFilter& filter, nlohmann::json json_val) {
+  if (json_val.contains("blockedMsg")) {
+    auto values = json_val["blockedMsg"];
+    for (const auto& val : values)
+      filter.exclude_msg.insert(val.get<std::string>());
+  } else if (json_val.contains("allowedMsg")) {
+    auto values = json_val["allowedMsg"];
+    for (const auto& val : values)
+      filter.include_msg.insert(val.get<std::string>());
   }
 }
 
-static void ParseInterfaces(NavmsgFilter& filter, wxJSONValue json_val) {
-  for (int i = 0; i < json_val.Size(); i++)
-    filter.interfaces.insert(json_val[i].AsString().ToStdString());
+static void ParseInterfaces(NavmsgFilter& filter, nlohmann::json json_val) {
+  for (const auto& value : json_val)
+    filter.interfaces.insert(value.get<std::string>());
 }
 
-static void ParsePgn(NavmsgFilter& filter, wxJSONValue json_val) {
+static void ParsePgn(NavmsgFilter& filter, nlohmann::json json_val) {
   try {
-    for (int i = 0; i < json_val.Size(); i++)
-      filter.pgns.insert(std::stoi(json_val[i].AsString().ToStdString()));
+    for (const auto& value : json_val)
+      filter.pgns.insert(std::stoi(value.get<std::string>()));
   } catch (...) {
     return;
   }
 }
 
-static void ParseSource(NavmsgFilter& filter, wxJSONValue json_val) {
+static void ParseSource(NavmsgFilter& filter, nlohmann::json json_val) {
   try {
-    for (int i = 0; i < json_val.Size(); i++) {
-      filter.src_pgns.insert(std::stoi(json_val[i].AsString().ToStdString()));
-    }
+    for (const auto& value : json_val)
+      for (unsigned i = 0; i < json_val.size(); i++) {
+        filter.src_pgns.insert(std::stoi(value.get<std::string>()));
+      }
   } catch (...) {
     return;
   }
@@ -264,71 +265,71 @@ NavmsgFilter NavmsgFilter::Parse(const fs::path& path) {
 }
 
 NavmsgFilter NavmsgFilter::Parse(const std::string& string) {
-  wxJSONValue root;
-  wxJSONReader reader;
-  int err_count = reader.Parse(string, &root);
-  if (err_count > 0) {
-    wxLogWarning("Error parsing filter XML");
-    for (auto& e : reader.GetErrors())
-      wxLogWarning("Parse error: %s", e.c_str());
+  nlohmann::json root;
+  try {
+    root = nlohmann::json::parse(string);
+  } catch (nlohmann::json::exception& e) {
+    wxLogWarning("Error parsing filter XML: %s", e.what());
     return NavmsgFilter(false);
   }
   NavmsgFilter filter;
-  filter.m_name = root["filter"]["name"].AsString();
-  filter.m_description = root["filter"]["description"].AsString();
-  if (root["filter"].HasMember("buses"))
+  filter.m_name = root["filter"]["name"].get<std::string>();
+  filter.m_description = root["filter"]["description"].get<std::string>();
+  if (root["filter"].contains("buses"))
     ParseBuses(filter, root["filter"]["buses"]);
-  if (root["filter"].HasMember("accepted"))
+  if (root["filter"].contains("accepted"))
     ParseAccepted(filter, root["filter"]["accepted"]);
-  if (root["filter"].HasMember("status"))
+  if (root["filter"].contains("status"))
     ParseStatus(filter, root["filter"]["status"]);
-  if (root["filter"].HasMember("directions"))
+  if (root["filter"].contains("directions"))
     ParseDirections(filter, root["filter"]["directions"]);
-  if (root["filter"].HasMember("msgFilter"))
+  if (root["filter"].contains("msgFilter"))
     ParseMsgFilter(filter, root["filter"]["msgFilter"]);
-  if (root["filter"].HasMember("interfaces"))
+  if (root["filter"].contains("interfaces"))
     ParseInterfaces(filter, root["filter"]["interfaces"]);
-  if (root["filter"].HasMember("pgns"))
-    ParsePgn(filter, root["filter"]["pgns"]);
-  if (root["filter"].HasMember("src_pgns"))
+  if (root["filter"].contains("pgns")) ParsePgn(filter, root["filter"]["pgns"]);
+  if (root["filter"].contains("src_pgns"))
     ParseSource(filter, root["filter"]["src_pgns"]);
   return filter;
 }
 
 std::string NavmsgFilter::to_string() const {
-  wxJSONValue root;
+  nlohmann::json root;
   root["filter"]["name"] = m_name;
   root["filter"]["description"] = m_description;
-  wxJSONValue& filter = root["filter"];
+  nlohmann::json& filter = root["filter"];
 
   if (!buses.empty()) {
-    for (auto b : buses) filter["buses"].Append(NavAddr::BusToString(b));
+    for (auto b : buses) filter["buses"].push_back(NavAddr::BusToString(b));
   };
   if (!directions.empty()) {
-    for (auto d : directions) filter["directions"].Append(DirectionToString(d));
+    for (auto d : directions)
+      filter["directions"].push_back(DirectionToString(d));
   };
   if (!accepted.empty()) {
-    for (auto a : accepted) filter["accepted"].Append(AcceptedToString(a));
+    for (auto a : accepted) filter["accepted"].push_back(AcceptedToString(a));
   };
   if (!status.empty()) {
-    for (auto s : status) filter["status"].Append(StateToString(s));
+    for (auto s : status) filter["status"].push_back(StateToString(s));
   };
   if (!include_msg.empty()) {
-    for (auto m : include_msg) filter["msgFilter"]["allowedMsg"].Append(m);
+    for (auto m : include_msg) filter["msgFilter"]["allowedMsg"].push_back(m);
   } else if (!exclude_msg.empty()) {
-    for (auto m : exclude_msg) filter["msgFilter"]["blockedMsg"].Append(m);
+    for (auto m : exclude_msg) filter["msgFilter"]["blockedMsg"].push_back(m);
   }
   if (!interfaces.empty()) {
-    for (auto i : interfaces) filter["interfaces"].Append(i);
+    for (auto i : interfaces) filter["interfaces"].push_back(i);
   }
   if (!pgns.empty()) {
-    for (auto p : pgns) filter["pgns"].Append(p.to_string());
+    for (auto p : pgns) filter["pgns"].push_back(p.to_string());
   }
   if (!src_pgns.empty()) {
-    for (auto p : src_pgns) filter["src_pgns"].Append(p.to_string());
+    for (auto p : src_pgns) filter["src_pgns"].push_back(p.to_string());
   }
-  wxJSONWriter writer;
-  wxString ws;
-  writer.Write(root, ws);
-  return ws.ToStdString();
+  try {
+    return root.dump();
+  } catch (nlohmann::json::exception& e) {
+    wxLogWarning("Error serializing filter %s: %s", m_name.c_str(), e.what());
+    return "";
+  }
 }

--- a/model/src/peer_client.cpp
+++ b/model/src/peer_client.cpp
@@ -29,9 +29,9 @@
 
 #include <curl/curl.h>
 
+#include "nlohmann/json.hpp"
+
 #include <wx/fileconf.h>
-#include <wx/json_defs.h>
-#include <wx/jsonreader.h>
 #include <wx/log.h>
 #include <wx/string.h>
 
@@ -198,25 +198,22 @@ static void SaveClientKey(std::string& server_name, std::string key) {
 }
 static RestServerResult ParseServerJson(const MemoryStruct& reply,
                                         PeerData& peer_data) {
-  wxString body(reply.memory);
-  wxJSONValue root;
-  wxJSONReader reader;
-  int num_errors = reader.Parse(body, &root);
-  if (num_errors != 0) {
-    for (const auto& error : reader.GetErrors()) {
-      wxLogMessage("Json server reply parse error: %s",
-                   error.ToStdString().c_str());
-    }
-    peer_data.run_status_dlg(PeerDlg::JsonParseError, num_errors);
+  std::string body(reply.memory);
+  nlohmann::json root;
+  try {
+    root = nlohmann::json::parse(body);
+  } catch (nlohmann::json::exception& e) {
+    wxLogMessage("Json server reply parse error: %s", e.what());
+    peer_data.run_status_dlg(PeerDlg::JsonParseError, 1);
     peer_data.api_version = SemanticVersion(-1, -1);
     return RestServerResult::Void;
   }
-  if (root.HasMember("version")) {
-    auto s = root["version"].AsString().ToStdString();
+  if (root.contains("version")) {
+    auto s = root["version"].get<std::string>();
     peer_data.api_version = SemanticVersion::parse(s);
   }
-  if (root.HasMember("result")) {
-    return static_cast<RestServerResult>(root["result"].AsInt());
+  if (root.contains("result")) {
+    return static_cast<RestServerResult>(root["result"].get<int>());
   } else {
     return RestServerResult::Void;
   }
@@ -360,15 +357,15 @@ static void SendObjects(std::string& body, const std::string& api_key,
     struct MemoryStruct chunk;
     long response_code = ApiPost(url.str(), body, peer_data, &chunk);
     if (response_code == 200) {
-      wxString json(chunk.memory);
-      wxJSONValue root;
-      wxJSONReader reader;
-
-      int num_errors = reader.Parse(json, &root);
-      if (num_errors > 0)
-        wxLogDebug("SendObjects, parse errors: %d", num_errors);
+      std::string json(chunk.memory);
+      nlohmann::json root;
+      try {
+        root = nlohmann::json::parse(json);
+      } catch (nlohmann::json::exception& e) {
+        wxLogDebug("SendObjects, parse errors: %s", e.what());
+      }
       // Capture the result
-      int result = root["result"].AsInt();
+      int result = root["result"].get<int>();
       if (result > 0) {
         peer_data.run_status_dlg(PeerDlg::ErrorReturn, result);
       } else {
@@ -384,18 +381,18 @@ static void SendObjects(std::string& body, const std::string& api_key,
 
 /** Parse json message in chunk, return "result" from server. */
 static int CheckChunk(struct MemoryStruct& chunk, const std::string& guid) {
-  wxString body(chunk.memory);
-  wxJSONValue root;
-  wxJSONReader reader;
-  int num_errors = reader.Parse(body, &root);
-  if (num_errors > 0)
-    wxLogDebug("CheckChunk: parsing errors found: %d", num_errors);
-  int result = root["result"].AsInt();
-  if (result != 0) {
-    wxLogDebug("Server rejected guid %s, status: %d", guid.c_str(), result);
-    return result;
+  std::string body(chunk.memory);
+  nlohmann::json root;
+  try {
+    root = nlohmann::json::parse(body);
+  } catch (nlohmann::json::exception& e) {
+    wxLogDebug("CheckChunk: parsing errors found: %s", e.what());
   }
-  return 0;
+  if (!root.contains("result")) return 0;
+  int result = root["result"].get<int>();
+  if (result != 0)
+    wxLogDebug("Server rejected guid %s, status: %d", guid.c_str(), result);
+  return result;
 }
 
 /** Return true if server accepts overwriting all peer_data objects. */

--- a/model/src/plugin_comm.cpp
+++ b/model/src/plugin_comm.cpp
@@ -92,10 +92,9 @@ static void LogMessage(const std::shared_ptr<const NavMsg>& message,
   }
 }
 
-void SendMessageToAllPlugins(const wxString& message_id,
-                             const wxString& message_body) {
-  auto msg = std::make_shared<PluginMsg>(
-      PluginMsg(message_id.ToStdString(), message_body.ToStdString()));
+void SendMessageToAllPlugins(const std::string& message_id,
+                             const std::string& message_body) {
+  auto msg = std::make_shared<PluginMsg>(PluginMsg(message_id, message_body));
   NavMsgBus::GetInstance().Notify(msg);
 
   // decouple 'const wxString &' and 'wxString &' to keep API
@@ -143,18 +142,6 @@ void SendMessageToAllPlugins(const wxString& message_id,
       }
     }
   }
-}
-
-void SendJSONMessageToAllPlugins(const wxString& message_id, wxJSONValue v) {
-  wxJSONWriter w(wxJSONWRITER_NO_LINEFEEDS | wxJSONWRITER_STYLED);
-  wxString out;
-  w.Write(v, out);
-  auto msg =
-      std::make_shared<PluginMsg>(message_id.ToStdString(), out.ToStdString());
-  SendMessageToAllPlugins(message_id, out);
-  wxLogDebug(message_id);
-  wxLogDebug(out);
-  LogMessage(msg, "Json message ");
 }
 
 void SendJsonMessageToAllPlugins(const std::string& message_id,

--- a/model/src/plugin_comm.cpp
+++ b/model/src/plugin_comm.cpp
@@ -157,6 +157,15 @@ void SendJSONMessageToAllPlugins(const wxString& message_id, wxJSONValue v) {
   LogMessage(msg, "Json message ");
 }
 
+void SendJsonMessageToAllPlugins(const std::string& message_id,
+                                 const nlohmann::json& v) {
+  std::string out = v.dump();
+  auto msg = std::make_shared<PluginMsg>(message_id, out);
+  SendMessageToAllPlugins(message_id, out);
+  wxLogDebug(wxString(message_id) + " " + out);
+  LogMessage(msg, "Json message ");
+}
+
 void SendAISSentenceToAllPlugIns(const wxString& sentence) {
   // decouple 'const wxString &' to keep interface.
   wxString decouple_sentence(sentence);

--- a/model/src/routeman.cpp
+++ b/model/src/routeman.cpp
@@ -33,6 +33,7 @@
 #include <wx/image.h>
 #include <wx/jsonval.h>
 
+#include "nlohmann/json.hpp"
 #include "observable/global_var.h"
 
 #include "model/ais_decoder.h"
@@ -221,10 +222,11 @@ RoutePoint *Routeman::FindBestActivatePoint(Route *pR, double lat, double lon,
 
 bool Routeman::ActivateRoute(Route *pRouteToActivate, RoutePoint *pStartPoint) {
   g_bAllowShipToActive = false;
-  wxJSONValue v;
+  nlohmann::json v;
   v["Route_activated"] = pRouteToActivate->m_RouteNameString;
   v["GUID"] = pRouteToActivate->m_GUID;
-  json_msg.Notify(std::make_shared<wxJSONValue>(v), "OCPN_RTE_ACTIVATED");
+  json_msg_evt.Notify(std::make_shared<nlohmann::json>(v),
+                      "OCPN_RTE_ACTIVATED");
   if (g_bPluginHandleAutopilotRoute) return true;
 
   // Capture and maintain a list of data connections configured as "output"
@@ -285,11 +287,12 @@ bool Routeman::ActivateRoute(Route *pRouteToActivate, RoutePoint *pStartPoint) {
 
 bool Routeman::ActivateRoutePoint(Route *pA, RoutePoint *pRP_target) {
   g_bAllowShipToActive = false;
-  wxJSONValue v;
+  nlohmann::json v;
   v["GUID"] = pRP_target->m_GUID;
   v["WP_activated"] = pRP_target->GetName();
 
-  json_msg.Notify(std::make_shared<wxJSONValue>(v), "OCPN_WPT_ACTIVATED");
+  json_msg_evt.Notify(std::make_shared<nlohmann::json>(v),
+                      "OCPN_WPT_ACTIVATED");
 
   if (g_bPluginHandleAutopilotRoute) return true;
 
@@ -356,7 +359,7 @@ bool Routeman::ActivateRoutePoint(Route *pA, RoutePoint *pRP_target) {
 
 bool Routeman::ActivateNextPoint(Route *pr, bool skipped) {
   g_bAllowShipToActive = false;
-  wxJSONValue v;
+  nlohmann::json v;
   bool result = false;
   if (pActivePoint) {
     pActivePoint->m_bBlink = false;
@@ -404,7 +407,8 @@ bool Routeman::ActivateNextPoint(Route *pr, bool skipped) {
     /// }
     m_prop_dlg_ctx.set_enroute_point(pr, pActivePoint);
 
-    json_msg.Notify(std::make_shared<wxJSONValue>(v), "OCPN_WPT_ARRIVED");
+    json_msg_evt.Notify(std::make_shared<nlohmann::json>(v),
+                        "OCPN_WPT_ARRIVED");
   }
   return result;
 }
@@ -420,15 +424,17 @@ bool Routeman::DeactivateRoute(bool b_arrival) {
     pActiveRoute->m_pRouteActivePoint = NULL;
     g_active_route.Clear();
 
-    wxJSONValue v;
+    nlohmann::json v;
     if (!b_arrival) {
       v["Route_deactivated"] = pActiveRoute->m_RouteNameString;
       v["GUID"] = pActiveRoute->m_GUID;
-      json_msg.Notify(std::make_shared<wxJSONValue>(v), "OCPN_RTE_DEACTIVATED");
+      json_msg_evt.Notify(std::make_shared<nlohmann::json>(v),
+                          "OCPN_RTE_DEACTIVATED");
     } else {
       v["GUID"] = pActiveRoute->m_GUID;
       v["Route_ended"] = pActiveRoute->m_RouteNameString;
-      json_msg.Notify(std::make_shared<wxJSONValue>(v), "OCPN_RTE_ENDED");
+      json_msg_evt.Notify(std::make_shared<nlohmann::json>(v),
+                          "OCPN_RTE_ENDED");
     }
   }
 

--- a/model/src/routeman.cpp
+++ b/model/src/routeman.cpp
@@ -31,7 +31,6 @@
 
 #include <wx/wxprec.h>
 #include <wx/image.h>
-#include <wx/jsonval.h>
 
 #include "nlohmann/json.hpp"
 #include "observable/global_var.h"

--- a/model/src/track.cpp
+++ b/model/src/track.cpp
@@ -74,13 +74,14 @@ millions of points.
 #include <wx/colour.h>
 #include <wx/datetime.h>
 #include <wx/event.h>
-#include <wx/jsonval.h>
 #include <wx/pen.h>
 #include <wx/progdlg.h>
 #include <wx/string.h>
 #include <wx/utils.h>
 
 #include "model/track.h"
+
+#include "nlohmann/json.hpp"
 
 #include "model/config_vars.h"
 #include "model/georef.h"
@@ -684,12 +685,12 @@ TrackPoint *Track::AddNewPoint(vector2D point, wxDateTime time) {
   NavObj_dB::GetInstance().AddTrackPoint(this, tPoint);
 
   // send a wxJson message to all plugins
-  wxJSONValue v;
+  nlohmann::json v;
   v["lat"] = tPoint->m_lat;
   v["lon"] = tPoint->m_lon;
   v["Track_ID"] = m_GUID;
-  std::string msg_id("OCPN_TRK_POINT_ADDED");
-  JsonEvent::getInstance().Notify(msg_id, std::make_shared<wxJSONValue>(v));
+  JsonEvent::getInstance().Notify("OCPN_TRK_POINT_ADDED",
+                                  std::make_shared<nlohmann::json>(v));
 
   return tPoint;
 }

--- a/test/datetime_tests.cpp
+++ b/test/datetime_tests.cpp
@@ -12,7 +12,6 @@
 #include <wx/event.h>
 #include <wx/evtloop.h>
 #include <wx/fileconf.h>
-#include <wx/jsonval.h>
 #include <wx/timer.h>
 
 #if wxCHECK_VERSION(3, 2, 0)

--- a/test/rest-tests.cpp
+++ b/test/rest-tests.cpp
@@ -17,11 +17,11 @@
 #include <wx/app.h>
 #include <wx/event.h>
 #include <wx/fileconf.h>
-#include <wx/jsonreader.h>
 #include <wx/log.h>
 
 #include <gtest/gtest.h>
 
+#include "nlohmann/json.hpp"
 #include "observable/configvar.h"
 
 #include "ocpn_plugin.h"
@@ -283,12 +283,15 @@ protected:
     std::ifstream f(path.string());
     std::stringstream ss;
     ss << f.rdbuf();
-    wxJSONValue root;
-    wxJSONReader reader;
-    std::string reply = ss.str();
-    int errors = reader.Parse(reply, &root);
-    EXPECT_EQ(errors, 0);
-    wxString version = root["version"].AsString();
+    bool failed = false;
+    nlohmann::json root;
+    try {
+      root = nlohmann::json::parse(ss.str());
+    } catch (nlohmann::json::exception& e) {
+      failed = true;
+    }
+    EXPECT_FALSE(failed);
+    std::string version = root["version"].get<std::string>();
     EXPECT_EQ(version, PACKAGE_VERSION);
   }
 };

--- a/test/tests.cpp
+++ b/test/tests.cpp
@@ -14,12 +14,12 @@
 #include <wx/evtloop.h>
 #include <wx/fileconf.h>
 #include <wx/jsonval.h>
-#include <wx/jsonreader.h>
 
 #include <wx/timer.h>
 
 #include <gtest/gtest.h>
 
+#include "nlohmann/json.hpp"
 #include "observable/configvar.h"
 
 #include "model/ais_decoder.h"
@@ -1344,10 +1344,13 @@ TEST(Loopback, SignalK) {
   EXPECT_TRUE(s_result == "vessels.urn:mrn:imo:mmsi:265599691");
   EXPECT_TRUE(s_result3 == "signalk.stupan.se:3000");
   EXPECT_TRUE(s_bus == NavAddr::Bus::Signalk);
-  wxJSONReader reader;
-  wxJSONValue root;
-  int err_count = reader.Parse(s_result2, &root);
-  EXPECT_EQ(err_count, 0);
+  bool failed = false;
+  try {
+    nlohmann::json root = nlohmann::json::parse(s_result2);
+  } catch (nlohmann::json::exception&) {
+    failed = true;
+  }
+  EXPECT_FALSE(failed);
 }
 
 TEST(Loopback, BadInput) {


### PR DESCRIPTION
Where it's possible in the core, replace the outdated and unmaintained wxJSON library with the modern nlohmann::json one.

wxJSON is, unfortunately, present in the  `GetSignalkPayload()` function in *ocpn_plugin.h* and we are thus stuck with wxJSON in this case. Add a new function in api122 so there at least is an alternative.

Bundled plugins are not handled  in this PR which is big enough without them.