### PR TITLE
navutil - disable DimeControl on Linux/GTK - #5081

### DIFF
--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -3143,9 +3143,10 @@ void DimeControl(wxWindow *ctrl) {
   if (wxPlatformInfo::Get().CheckOSVersion(10, 14)) {
     return;
   }
-#endif
-#ifdef __WXQT__
+#elif defined(__WXQT__)
   return;  // this is seriously broken on wxqt
+#elif defined(__WXGTK__)
+  return;  // trust the native Dark/Light setting
 #endif
 
   if (wxSystemSettings::GetColour(wxSystemColour::wxSYS_COLOUR_WINDOW).Red() <


### PR DESCRIPTION
As discussed in #5081 DimeControl doesn not make much sense on gtk for the same 
reasons as MacOS.

To repeat: the dark/light mode is  about two things:

  - The canvas, which follows OpenCPN's internalS52  day/dusk/night setting.
  - Everything else which is best handled by the native Dark/Light setting.

This PR is about leaving the dark/night control for dialogs etc back to wxWidgets. As of heading, it only affects Linux/GTK