### PR TITLE
v5.14.x: Backport g_MainToolbar null checks

### DIFF
--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -2493,7 +2493,7 @@ void MyFrame::OnToolLeftClick(wxCommandEvent &event) {
 
     case wxID_PREFERENCES:
     case ID_SETTINGS: {
-      g_MainToolbar->HideTooltip();
+      if (g_MainToolbar) g_MainToolbar->HideTooltip();
       DoSettings();
       break;
     }
@@ -2518,7 +2518,7 @@ void MyFrame::OnToolLeftClick(wxCommandEvent &event) {
     case ID_MENU_SETTINGS_BASIC: {
 #ifdef __ANDROID__
       androidDisableFullScreen();
-      g_MainToolbar->HideTooltip();
+      if (g_MainToolbar) g_MainToolbar->HideTooltip();
       DoAndroidPreferences();
 #else
       DoSettings();
@@ -2727,7 +2727,7 @@ void MyFrame::OnToolLeftClick(wxCommandEvent &event) {
       //        If found, make the callback.
       //        TODO Modify this to allow multiple tools per plugin
       if (g_pi_manager) {
-        g_MainToolbar->HideTooltip();
+        if (g_MainToolbar) g_MainToolbar->HideTooltip();
 
         ArrayOfPlugInToolbarTools tool_array =
             g_pi_manager->GetPluginToolbarToolArray();
@@ -2759,7 +2759,7 @@ void MyFrame::OnToolLeftClick(wxCommandEvent &event) {
 bool MyFrame::SetGlobalToolbarViz(bool viz) {
   bool viz_now = g_bmasterToolbarFull;
 
-  g_MainToolbar->HideTooltip();
+  if (g_MainToolbar) g_MainToolbar->HideTooltip();
   wxString tip = _("Show Toolbar");
   if (viz) {
     tip = _("Hide Toolbar");
@@ -2865,6 +2865,7 @@ ChartCanvas *MyFrame::GetFocusCanvas() {
 }
 
 void MyFrame::OnToolbarAnimateTimer(wxTimerEvent &event) {
+  if (!g_MainToolbar) return;
   if (g_bmasterToolbarFull) {
 #ifndef OCPN_TOOLBAR_ANIMATE
     m_nMasterToolCountShown = (int)g_MainToolbar->GetToolCount();
@@ -4248,7 +4249,8 @@ void MyFrame::ProcessOptionsDialog(int rr, ArrayOfCDI *pNewDirArray) {
 
   // Change of master toolbar scale?
   bool b_masterScaleChange = false;
-  if (fabs(g_MainToolbar->GetScaleFactor() - g_toolbar_scalefactor) > 0.01f)
+  if (g_MainToolbar &&
+      (fabs(g_MainToolbar->GetScaleFactor() - g_toolbar_scalefactor) > 0.01f))
     b_masterScaleChange = true;
 
   if ((rr & TOOLBAR_CHANGED) || b_masterScaleChange)
@@ -6813,7 +6815,7 @@ void MyFrame::RequestNewMasterToolbar(bool bforcenew) {
     }
   }
 
-  if (btbRebuild) {
+  if (btbRebuild && g_MainToolbar) {
     g_MainToolbar->SetAutoHide(g_bAutoHideToolbar);
     g_MainToolbar->SetAutoHideTimer(g_nAutoHideToolbar);
   }


### PR DESCRIPTION
## Summary

- backport the `g_MainToolbar` null checks from #5298 / `a8b24516b0b1dcad4cc837a4ac6afa1de4d63617`
- avoid dereferencing the toolbar while first-run initialization has not created it yet
- cover the Preferences handler and the adjacent timer/options/rebuild paths already protected on `master`

## Reproduction

1. Start OpenCPN 5.14.0 as a fresh installation/profile, with no existing configuration.
2. Complete **Initial OpenCPN Configuration** without adding any data sources or chart directories.
3. Select **Tools → Preferences**.
4. OpenCPN crashes in `ocpnFloatingToolbarDialog::HideTooltip()` called by `MyFrame::OnToolLeftClick()`.

Reproduced on macOS 15.7.4 arm64 with OpenCPN `5.14.0-universal+91f3b6743`. The crash is `EXC_BAD_ACCESS` at `0xb0`; `x0` is null at `HideTooltip() + 8`, and the caller return address resolves to the unguarded Preferences call. This matches #5287.

## Validation

- `pre-commit run --files gui/src/ocpn_frame.cpp` passes all configured hooks, including clang-format
- `git diff --check` passes
- the stable patch ID exactly matches the already merged `master` fix in `a8b24516b0b1dcad4cc837a4ac6afa1de4d63617`

Closes #5287.
