### PR TITLE
Fix Preferences crash on first start without charts

### DIFF
--- a/gui/include/gui/ocpn_frame.h
+++ b/gui/include/gui/ocpn_frame.h
@@ -309,6 +309,7 @@ public:
   virtual void UpdateAISMOBRoute(const AisTargetData* ptarget) override;
   virtual void ActivateAISMOBRoute(const AisTargetData* ptarget) override;
   void EnableSettingsTool(bool _enable) override {
+    if (m_pMenuBar) m_pMenuBar->Enable(wxID_PREFERENCES, _enable);
     if (g_MainToolbar) {
       g_MainToolbar->EnableTool(ID_SETTINGS, _enable);
       g_MainToolbar->GetToolbar()->SetDirty(true);
@@ -500,7 +501,7 @@ public:
   void UpdateCanvasConfigDescriptors();
   void ScheduleSettingsDialog();
   void ScheduleSettingsDialogNew();
-  static void StartRebuildChartDatabase();
+  static bool StartRebuildChartDatabase();
   void PositionIENCToolbar();
 
   void InitAppMsgBusListener();

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -832,7 +832,7 @@ void MyFrame::OnSENCEvtThread(OCPN_BUILDSENC_ThreadEvent &event) {
   }
 }
 
-void MyFrame::StartRebuildChartDatabase() {
+bool MyFrame::StartRebuildChartDatabase() {
   bool b_SetInitialPoint = false;
 
   //   Build the initial chart dir array
@@ -868,7 +868,9 @@ void MyFrame::StartRebuildChartDatabase() {
 
     LoadS57();
     ChartData->Create(ChartDirArray, pprog);
+    return true;
   }
+  return false;
 }
 
 // play an arbitrary number of bells by using 1 and 2 bell sounds
@@ -2493,7 +2495,6 @@ void MyFrame::OnToolLeftClick(wxCommandEvent &event) {
 
     case wxID_PREFERENCES:
     case ID_SETTINGS: {
-      g_MainToolbar->HideTooltip();
       DoSettings();
       break;
     }
@@ -2518,7 +2519,6 @@ void MyFrame::OnToolLeftClick(wxCommandEvent &event) {
     case ID_MENU_SETTINGS_BASIC: {
 #ifdef __ANDROID__
       androidDisableFullScreen();
-      g_MainToolbar->HideTooltip();
       DoAndroidPreferences();
 #else
       DoSettings();
@@ -2955,6 +2955,11 @@ void MyFrame::DoSettingsNew() {
 }
 
 void MyFrame::DoSettings() {
+  if (!g_bDeferredInitDone) {
+    wxLogWarning("Ignoring settings request while OpenCPN is initializing.");
+    return;
+  }
+
   LoadS57();
   DoOptionsDialog();
 
@@ -3714,6 +3719,7 @@ void MyFrame::RegisterGlobalMenuItems() {
 
   // Set initial values for menu check items and radio items
   UpdateGlobalMenuItems();
+  EnableSettingsTool(g_bDeferredInitDone);
 }
 
 void MyFrame::UpdateGlobalMenuItems() {
@@ -4600,12 +4606,14 @@ void MyFrame::OnInitTimer(wxTimerEvent &event) {
           }
         }
 
-        // Start an async chart database update
-        // Arrange for init timer to restart at next point in chain
-        m_iInitCount = 1;
-        StartRebuildChartDatabase();
+        // Start an async chart database update, if there are chart directories.
+        // Arrange for init timer to restart at the next point in the chain.
+        const bool update_started = StartRebuildChartDatabase();
         g_NeedDBUpdate = 0;
-        return;
+        if (update_started) {
+          m_iInitCount = 1;
+          return;
+        }
       }
 
       break;
@@ -4835,7 +4843,7 @@ void MyFrame::OnInitTimer(wxTimerEvent &event) {
 
   RefreshAllCanvas(true);
   UsbWatchDaemon::GetInstance().Start();
-  EnableSettingsTool(true);
+  EnableSettingsTool(g_bDeferredInitDone);
 }
 
 wxDEFINE_EVENT(EVT_BASIC_NAV_DATA, ObservedEvt);


### PR DESCRIPTION
## Reproduction

1. Start OpenCPN 5.14.0 with a fresh profile.
2. Complete the initial configuration without adding data sources or chart directories.
3. Open Preferences during or after startup.

On macOS this first crashed in `ocpnFloatingToolbarDialog::HideTooltip()`. Guarding that call only exposed a second crash in `WayPointman::GetNumIcons()` because deferred initialization had not created `pWayPointMan`.

## Root cause

The initial-configuration wizard requests a chart database rebuild. With no chart directories, `StartRebuildChartDatabase()` starts no asynchronous operation, but `OnInitTimer()` still returns as if one was running. No completion notification can arrive, so deferred initialization remains permanently at step 1. Startup-only globals such as `pWayPointMan` and `g_options` are never initialized.

## Fix

- Report whether `StartRebuildChartDatabase()` actually started work.
- Continue the deferred initialization timer immediately when the chart directory list is empty.
- Keep Preferences disabled until `g_bDeferredInitDone`, and guard the centralized `DoSettings()` entry point against early direct callers.
- Remove duplicate tooltip hiding from Preferences command cases; the command handler already performs this safely once before dispatch.

This supersedes the incomplete null-check-only approach in #5373.

## Verification

Tested on macOS 15.7.4, Apple Silicon, using a newly created empty `--configdir`:

- completed the first-start wizard without selecting charts or data sources;
- verified `DataConnections=` and no `[ChartDirectories]` section;
- observed deferred initialization advance through steps 0-9, `Last Call`, and `Finalize Canvases`;
- opened Preferences successfully and confirmed OpenCPN remained running;
- repeated with `--rebuild_chart_db` and zero chart directories;
- built with `-Werror`, passed clang-format and `git diff --check`, installed/fixed up the macOS bundle, and passed strict deep code-signature verification.

## Related PRs

#5375 is the master counterpart of this fix. #5376 (master, feature) independently avoids the wizard instance of the stall by not requesting a DB rebuild when no chart directories were added; the changes are complementary and merge cleanly together.
