### PR TITLE
Fix Preferences crash during deferred startup

### DIFF
--- a/gui/include/gui/ocpn_frame.h
+++ b/gui/include/gui/ocpn_frame.h
@@ -310,6 +310,7 @@ public:
   virtual void UpdateAISMOBRoute(const AisTargetData* ptarget) override;
   virtual void ActivateAISMOBRoute(const AisTargetData* ptarget) override;
   void EnableSettingsTool(bool _enable) override {
+    if (m_pMenuBar) m_pMenuBar->Enable(wxID_PREFERENCES, _enable);
     if (g_MainToolbar) {
       g_MainToolbar->EnableTool(ID_SETTINGS, _enable);
       g_MainToolbar->GetToolbar()->SetDirty(true);
@@ -505,7 +506,7 @@ public:
   void UpdateCanvasConfigDescriptors();
   void ScheduleSettingsDialog();
   void ScheduleSettingsDialogNew();
-  static void StartRebuildChartDatabase();
+  static bool StartRebuildChartDatabase();
   void PositionIENCToolbar();
 
   void InitAppMsgBusListener();

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -840,7 +840,7 @@ void MyFrame::OnSENCEvtThread(OCPN_BUILDSENC_ThreadEvent &event) {
   }
 }
 
-void MyFrame::StartRebuildChartDatabase() {
+bool MyFrame::StartRebuildChartDatabase() {
   bool b_SetInitialPoint = false;
 
   //   Build the initial chart dir array
@@ -876,7 +876,9 @@ void MyFrame::StartRebuildChartDatabase() {
 
     LoadS57();
     ChartData->Create(ChartDirArray, pprog);
+    return true;
   }
+  return false;
 }
 
 // play an arbitrary number of bells by using 1 and 2 bell sounds
@@ -2980,6 +2982,11 @@ void MyFrame::DoSettingsNew() {
 }
 
 void MyFrame::DoSettings() {
+  if (!g_bDeferredInitDone) {
+    wxLogWarning("Ignoring settings request while OpenCPN is initializing.");
+    return;
+  }
+
   LoadS57();
   DoOptionsDialog();
 
@@ -3736,6 +3743,7 @@ void MyFrame::RegisterGlobalMenuItems() {
 
   // Set initial values for menu check items and radio items
   UpdateGlobalMenuItems();
+  EnableSettingsTool(g_bDeferredInitDone);
 }
 
 void MyFrame::UpdateGlobalMenuItems() {
@@ -4623,12 +4631,14 @@ void MyFrame::OnInitTimer(wxTimerEvent &event) {
           }
         }
 
-        // Start an async chart database update
-        // Arrange for init timer to restart at next point in chain
-        m_iInitCount = 1;
-        StartRebuildChartDatabase();
+        // Start an async chart database update, if there are chart directories.
+        // Arrange for init timer to restart at the next point in the chain.
+        const bool update_started = StartRebuildChartDatabase();
         g_NeedDBUpdate = 0;
-        return;
+        if (update_started) {
+          m_iInitCount = 1;
+          return;
+        }
       }
 
       break;
@@ -4858,7 +4868,7 @@ void MyFrame::OnInitTimer(wxTimerEvent &event) {
 
   RefreshAllCanvas(true);
   UsbWatchDaemon::GetInstance().Start();
-  EnableSettingsTool(true);
+  EnableSettingsTool(g_bDeferredInitDone);
 }
 
 wxDEFINE_EVENT(EVT_BASIC_NAV_DATA, ObservedEvt);


### PR DESCRIPTION
## Summary

- keep both the Settings toolbar tool and native Preferences menu disabled until deferred initialization completes
- reject any early programmatic/keyboard settings request at the `DoSettings()` lifecycle boundary
- let deferred initialization continue when a requested first-run chart rebuild has no chart directories

## Reproduction

1. Start OpenCPN from a fresh install/profile with no data sources and no charts.
2. Complete the initial configuration wizard without adding a chart directory.
3. Open Preferences immediately (on macOS, `Cmd-,`).

Before this change, the Options Routes panel dereferences the not-yet-created global `pWayPointMan` in `WayPointman::GetNumIcons()` and crashes with `EXC_BAD_ACCESS` at `0x18`.

## Verification

Built OpenCPN 5.15.0 from `master` on macOS 15.7.4 arm64 with warnings treated as errors.

Using a new empty config profile, I invoked `Cmd-,` immediately after accepting the startup notice. The request was safely rejected 2 ms before `OnInitTimer...0`; deferred initialization then completed stages 0 through 9, including waypoint manager creation. `Cmd-,` afterward opened Options normally, and OpenCPN exited cleanly.

This is the master counterpart of the v5.14.x backport in #5374.


## Relationship to #5376

#5376 independently avoids the most common instance of this stall by not setting `g_NeedDBUpdate` when the first-use wizard added no chart directories. The two changes are complementary and merge cleanly together: that guard removes the needless rebuild request on first run, while this PR makes the deferred-init chain robust whenever a rebuild is requested with zero chart directories (e.g. `--rebuild_chart_db` on a chartless install). Neither depends on the other.
