### PR TITLE
Fix startup modals vanishing on macOS when app is deactivated

### DIFF
--- a/gui/src/initwiz/wiz_ui.cpp
+++ b/gui/src/initwiz/wiz_ui.cpp
@@ -67,11 +67,22 @@
 extern OCPNPlatform* g_Platform;
 extern std::vector<ocpn_DNS_record_t> g_sk_servers;
 
+#ifdef __WXOSX__
+// On macOS wxSTAY_ON_TOP turns the window into a floating panel which the
+// system hides whenever the application is deactivated. With no other
+// windows shown yet, switching away from OpenCPN during the first-use
+// wizard makes the application disappear entirely while its modal loop
+// keeps running, so it appears hung.
+static long DropStayOnTop(long style) { return style & ~wxSTAY_ON_TOP; }
+#else
+static long DropStayOnTop(long style) { return style; }
+#endif
+
 FirstUseWizImpl::FirstUseWizImpl(wxWindow* parent, MyConfig* pConfig,
                                  wxWindowID id, const wxString& title,
                                  const wxBitmap& bitmap, const wxPoint& pos,
                                  long style)
-    : FirstUseWiz(parent, id, title, bitmap, pos, style) {
+    : FirstUseWiz(parent, id, title, bitmap, pos, DropStayOnTop(style)) {
   m_pConfig = pConfig;
 
   wxString svgDir = g_Platform->GetSharedDataDir() + _T("uidata") +

--- a/libs/gui/src/dialog_alert.cpp
+++ b/libs/gui/src/dialog_alert.cpp
@@ -32,12 +32,22 @@ static void EnsureBtnSize(wxWindow* btn, int font_height) {
     btn->SetMinSize(wxSize(-1, font_height * 3));
 }
 
+#ifdef __WXOSX__
+// On macOS wxSTAY_ON_TOP turns the dialog into a floating panel which the
+// system hides whenever the application is deactivated. For alerts shown
+// before the main frame exists (e.g. the startup disclaimer) this makes
+// the whole application vanish when the user switches away, while the
+// modal loop keeps running - it appears hung.
+static constexpr long kAlertStyle = wxCAPTION;
+#else
+static constexpr long kAlertStyle = wxSTAY_ON_TOP | wxCAPTION;
+#endif
+
 AlertDialog::AlertDialog(wxWindow* parent, const std::string& title,
                          const std::string& action)
-    : BaseDialog(parent, title, wxSTAY_ON_TOP | wxCAPTION),
+    : BaseDialog(parent, title, kAlertStyle),
       m_action(action),
       m_listener(nullptr) {
-
   if (!parent) {
     wxFont *myFont = wxTheFontList->FindOrCreateFont(12, wxFONTFAMILY_SWISS, wxFONTSTYLE_NORMAL,
                   wxFONTWEIGHT_NORMAL);


### PR DESCRIPTION
Disclosure: prepared using Claude Code.

Closes #5378.

On macOS `wxSTAY_ON_TOP` turns a window into a floating panel which the system hides whenever the application is deactivated. The first-use wizard and the startup disclaimer `AlertDialog` both use it and are shown before the main frame exists, so switching away during first start makes OpenCPN disappear entirely while its modal loop keeps running - it appears hung until the Dock icon is clicked.

This drops `wxSTAY_ON_TOP` on `__WXOSX__` for these two windows; other platforms are unchanged. Note the `AlertDialog` change affects all alerts on macOS, not just the disclaimer - they become regular dialogs there, which matches platform conventions.

**Verification:** on macOS 15.7 (Apple Silicon), fresh config dir: before the change, deactivating OpenCPN during the wizard or the disclaimer removed all windows from screen and from the accessibility tree until reactivation; after it, both stay present through deactivation, and the full first-run flow (wizard -> disclaimer -> deferred init to "Finalize Canvases") completes normally. Built with `-Werror`; changed lines clang-formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
