### PR TITLE
Fix macOS CI: resolve @rpath Homebrew libraries in fixup_bundle on arm64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2674,6 +2674,13 @@ if (APPLE)
 
   set(APPS "\${CMAKE_INSTALL_PREFIX}/bin/OpenCPN.app")
   set(DIRS "/usr/local/lib")
+  # Homebrew on arm64 lives in /opt/homebrew, and its newer bottles use
+  # @rpath install names (e. g. libwebp's libsharpyuv). fixup_bundle
+  # resolves such items by searching DIRS, so the Homebrew lib directory
+  # must be listed or the install fails with "cannot resolve item".
+  if (EXISTS "/opt/homebrew/lib")
+    list(APPEND DIRS "/opt/homebrew/lib")
+  endif ()
 
   # INSTALL(DIRECTORY DESTINATION "bin/OpenCPN.app/Contents/Plugins")
   install(


### PR DESCRIPTION
Disclosure: prepared using Claude Code.

Closes #5380.

The macOS Latest wxOSX CI job has failed on every master run since mid-July with

```
warning: cannot resolve item '@rpath/libsharpyuv.0.dylib'
CMake Error at BundleUtilities.cmake:725: otool -l failed: 1
```

On the macOS 15 runner image, Homebrew bottles use `@rpath` install names (libwebp's companion libsharpyuv is the one that bites here, pulled in via wxWidgets -> libtiff -> libwebp). `fixup_bundle` can only resolve `@rpath/...` items by searching the directories passed to it, and the only one configured was the Intel Homebrew path `/usr/local/lib`, which does not exist on arm64 runners.

This adds `/opt/homebrew/lib` to the `fixup_bundle` search directories when the directory exists. Intel builds are unchanged (the directory simply is not there). macOS 14 keeps passing either way, since its image still has pre-@rpath bottles.

**Verification:** this run's own "macOS Latest wxOSX" check turning green is the test - master has been red on that job for five weeks. Also unblocks clean macOS CI for #5376 and #5379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
