### PR TITLE
Fix crash on SIGTERM/SIGHUP before the main frame exists

### DIFF
--- a/gui/src/ocpn_platform.cpp
+++ b/gui/src/ocpn_platform.cpp
@@ -220,18 +220,14 @@ void catch_signals(int signo) {
       break;
 
     case SIGHUP:
-      if (!s_inhup) {
-        s_inhup++;  // incase SIGHUP is closely followed by SIGTERM
-        top_frame::Get()->FastClose();
-      }
-      break;
-
     case SIGTERM:
       if (!s_inhup) {
         s_inhup++;  // incase SIGHUP is closely followed by SIGTERM
-        top_frame::Get()->FastClose();
+        if (auto *frame = top_frame::Get())
+          frame->FastClose();
+        else
+          std::_Exit(EXIT_SUCCESS);  // Before the frame exists: nothing to save
       }
-
       break;
 
     default:


### PR DESCRIPTION
Disclosure: prepared using Claude Code.

Closes #5383.

Guard the `top_frame::Get()` dereference in `catch_signals()`: when no frame exists yet, exit immediately - nothing has been created that needs an orderly shutdown. Also fold the identical SIGHUP and SIGTERM cases together.

**Verification:** on macOS, sending SIGTERM while the first-use wizard is up now exits cleanly instead of producing a crash report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
