### PR TITLE
Remove dead code after early return in MyApp::BuildMainFrame

### DIFF
--- a/gui/include/gui/ocpn_frame.h
+++ b/gui/include/gui/ocpn_frame.h
@@ -490,8 +490,6 @@ public:
                                   const wxString& ChartListFileName);
   void FinalizeChartDBUpdate();
 
-  bool m_bdefer_resize;
-  wxSize m_defer_size;
   double COGTable[kMaxCogAverageSeconds];
 
   void CreateCanvasLayout(bool b_useStoredSize = false);

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -1675,43 +1675,6 @@ void MyApp::BuildMainFrame() {
   g_pi_manager->ShowDeferredBlacklistMessages();
   // g_pi_manager->CallLateInit();
 
-  return;
-
-  //  This little hack fixes a problem seen with some UniChrome OpenGL drivers
-  //  We need a deferred resize to get glDrawPixels() to work right.
-  //  So we set a trigger to generate a resize after 5 seconds....
-  //  See the "UniChrome" hack elsewhere
-#ifdef ocpnUSE_GL
-  if (!g_bdisable_opengl) {
-    glChartCanvas *pgl =
-        (glChartCanvas *)gFrame->GetPrimaryCanvas()->GetglCanvas();
-    if (pgl && (pgl->GetRendererString().Find("UniChrome") != wxNOT_FOUND)) {
-      gFrame->m_defer_size = gFrame->GetSize();
-      gFrame->SetSize(gFrame->m_defer_size.x - 10, gFrame->m_defer_size.y);
-      g_pauimgr->Update();
-      gFrame->m_bdefer_resize = true;
-    }
-  }
-#endif
-
-  // Horrible Hack (tm): Make sure the RoutePoint destructor can invoke
-  // glDeleteTextures. Truly awful.
-#ifdef ocpnUSE_GL
-  if (g_bopengl)
-    RoutePoint::delete_gl_textures = [](unsigned n, const unsigned *texts) {
-      glDeleteTextures(n, texts);
-    };
-#else
-  RoutePoint::delete_gl_textures = [](unsigned n, const unsigned *texts) {};
-#endif
-
-#ifdef __ANDROID__
-  //  We need a resize to pick up height adjustment after building android
-  //  ActionBar
-  gFrame->SetSize(getAndroidDisplayDimensions());
-  androidSetFollowTool(gFrame->GetPrimaryCanvas()->m_bFollow ? 1 : 0, true);
-#endif
-
   // Setup Tides/Currents to settings present at last shutdown
   // TODO
   //     gFrame->ShowTides( g_bShowTide );

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -608,7 +608,6 @@ MyFrame::MyFrame(const wxString &title, const wxPoint &pos, const wxSize &size,
 
   //      Set up some assorted member variables
   m_bTimeIsSet = false;
-  m_bdefer_resize = false;
 
   //    Clear the NMEA Filter tables
   for (int i = 0; i < kMaxCogsogFilterSeconds; i++) {
@@ -5791,19 +5790,6 @@ void MyFrame::OnFrameTimer1(wxTimerEvent &event) {
   if (console && console->IsShown()) {
     //            console->Raise();
     console->RefreshConsoleData();
-  }
-
-  //  This little hack fixes a problem seen with some UniChrome OpenGL drivers
-  //  We need a deferred resize to get glDrawPixels() to work right.
-  //  So we set a trigger to generate a resize after 5 seconds....
-  //  See the "UniChrome" hack elsewhere
-  if (m_bdefer_resize) {
-    if (0 == (g_tick % (5))) {
-      printf("___RESIZE\n");
-      SetSize(m_defer_size);
-      g_pauimgr->Update();
-      m_bdefer_resize = false;
-    }
   }
 
   // Reset pending next AppMsgBus notification


### PR DESCRIPTION
Disclosure: prepared using Claude Code.

Closes #5385.

Remove the unreachable tail of `BuildMainFrame()` (UniChrome hack, dormant `delete_gl_textures` hookup, Android resize block) and the now-unused `m_bdefer_resize` / `m_defer_size` members in MyFrame. Pure cleanup, no behavior change - the removed code never executed.

Note: the dead block included the `RoutePoint::delete_gl_textures` hookup, so route-point GL textures are currently never freed. Enabling that is a behavior change and best handled separately; this PR deliberately does not change runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
