### PR TITLE
Bugfix according issue #5393, N2K source address distinguishability

### DIFF
--- a/model/src/comm_drv_n2k_socketcan.cpp
+++ b/model/src/comm_drv_n2k_socketcan.cpp
@@ -573,7 +573,8 @@ void Worker::HandleInput(CanFrame frame) {
 
 /** Worker thread handles some RX messages. */
 void Worker::ProcessRxMessages(std::shared_ptr<const Nmea2000Msg> n2k_msg) {
-  if (n2k_msg->PGN.pgn == 59904) {
+  if (n2k_msg->PGN.pgn == 59904 && (n2k_msg->payload.at(6) == m_parent_driver->m_source_address
+    || n2k_msg->payload.at(6) == 0xff)) {
     unsigned long RequestedPGN = 0;
     RequestedPGN = n2k_msg->payload.at(15) << 16;
     RequestedPGN += n2k_msg->payload.at(14) << 8;

--- a/model/src/comm_drv_n2k_socketcan.cpp
+++ b/model/src/comm_drv_n2k_socketcan.cpp
@@ -573,8 +573,9 @@ void Worker::HandleInput(CanFrame frame) {
 
 /** Worker thread handles some RX messages. */
 void Worker::ProcessRxMessages(std::shared_ptr<const Nmea2000Msg> n2k_msg) {
-  if (n2k_msg->PGN.pgn == 59904 && (n2k_msg->payload.at(6) == m_parent_driver->m_source_address
-    || n2k_msg->payload.at(6) == 0xff)) {
+  if (n2k_msg->PGN.pgn == 59904 &&
+      (n2k_msg->payload.at(6) == m_parent_driver->m_source_address ||
+       n2k_msg->payload.at(6) == 0xff)) {
     unsigned long RequestedPGN = 0;
     RequestedPGN = n2k_msg->payload.at(15) << 16;
     RequestedPGN += n2k_msg->payload.at(14) << 8;


### PR DESCRIPTION
Added check for own source address and global requests. Otherwise that part will always answer even though not being addressed.