### PR TITLE
Handle number from WMM plugin, fixes crash.

### DIFF
--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -6193,7 +6193,7 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
       }
     }
   }
-  
+
   if (message_ID == "WMM_VARIATION") {
     nlohmann::json root;
     try {
@@ -6201,14 +6201,12 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
     } catch (nlohmann::json::exception &) {
       return;
     }
+
     double decl_val = 0.0;
-    if (root.contains("Decl")) {
-      if (root["Decl"].is_number()) {
-        decl_val = root["Decl"].get<double>();
-      } else if (root["Decl"].is_string()) {
-        wxString decl = root["Decl"].get<std::string>();
-        decl.ToDouble(&decl_val);
-      }
+    if (root["Decl"].is_number()) {
+      decl_val = root["Decl"].get<double>();
+    } else if (root["Decl"].is_string()) {
+      decl_val = std::stod(root["Decl"].get<std::string>());
     }
 
     gQueryVar = decl_val;

--- a/gui/src/ocpn_frame.cpp
+++ b/gui/src/ocpn_frame.cpp
@@ -6193,7 +6193,7 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
       }
     }
   }
-
+  
   if (message_ID == "WMM_VARIATION") {
     nlohmann::json root;
     try {
@@ -6201,9 +6201,15 @@ void MyFrame::OnEvtPlugInMessage(OCPN_MsgEvent &event) {
     } catch (nlohmann::json::exception &) {
       return;
     }
-    wxString decl = root["Decl"].get<std::string>();
-    double decl_val;
-    decl.ToDouble(&decl_val);
+    double decl_val = 0.0;
+    if (root.contains("Decl")) {
+      if (root["Decl"].is_number()) {
+        decl_val = root["Decl"].get<double>();
+      } else if (root["Decl"].is_string()) {
+        wxString decl = root["Decl"].get<std::string>();
+        decl.ToDouble(&decl_val);
+      }
+    }
 
     gQueryVar = decl_val;
   }


### PR DESCRIPTION
Expects the magnetic declination/variation value ("Decl") to be passed as a text string, data sents as a number. As a result, nlohmann::json panics because a number cannot be implicitly extracted as a string.
See:
https://github.com/OpenCPN/OpenCPN/issues/5405#issuecomment-5489523824