### PR TITLE
Handle irregular output when uploading -  #5177

### DIFF
--- a/android/androidUTIL.cpp
+++ b/android/androidUTIL.cpp
@@ -3705,7 +3705,7 @@ int androidApplySettingsString(wxString settings, ArrayOfCDI *pACDI) {
       if (pds_existing) g_pMUX->StopAndRemoveStream(pds_existing);
 
       if (cp->bEnabled) {
-        dsPortType port_type = cp->IOSelect;
+        PortDirection direction  = cp->direction;
         DataStream *dstr =
             makeSerialDataStream(g_pMUX, cp->Type, cp->GetDSPort(),
                                  wxString::Format(wxT("%i"), cp->Baudrate),
@@ -3815,7 +3815,7 @@ int androidApplySettingsString(wxString settings, ArrayOfCDI *pACDI) {
             if (pds_existing) g_pMUX->StopAndRemoveStream(pds_existing);
 
             if (cp->bEnabled) {
-              dsPortType port_type = cp->IOSelect;
+              PortDirection direction = cp->direction;
 #if 0
                             DataStream *dstr = new DataStream( g_pMUX,
                                                                cp->Type,

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -14020,7 +14020,7 @@ wxString ChartCanvas::FindValidUploadPort() {
     // If there is no persistent upload port recorded (yet)
     // then use the first available serial connection which has output defined.
     for (auto *cp : TheConnectionParams()) {
-      if ((cp->IOSelect != DS_TYPE_INPUT) && cp->Type == SERIAL)
+      if ((cp->direction != PortDirection::kInput) && cp->Type == SERIAL)
         port << "Serial:" << cp->Port;
     }
   }

--- a/gui/src/conn_params_panel.cpp
+++ b/gui/src/conn_params_panel.cpp
@@ -164,7 +164,7 @@ void ConnectionParamsPanel::CreateControls() {
     serialGrid->SetFlexibleDirection(wxHORIZONTAL);
     parmSizer->Add(serialGrid, 0, wxALIGN_LEFT);
 
-    wxString ioDir = m_pConnectionParams->GetIOTypeValueStr();
+    wxString ioDir = m_pConnectionParams->GetPortDirectionValueStr();
 
     wxStaticText *t1 = new wxStaticText(this, wxID_ANY, _("Type"));
     serialGrid->Add(t1, 0, wxALIGN_CENTER_HORIZONTAL);
@@ -252,7 +252,7 @@ void ConnectionParamsPanel::CreateControls() {
   }
 
   else if (m_pConnectionParams->Type == NETWORK) {
-    wxString ioDir = m_pConnectionParams->GetIOTypeValueStr();
+    wxString ioDir = m_pConnectionParams->GetPortDirectionValueStr();
 
     wxFlexGridSizer *netGrid = new wxFlexGridSizer(2, 6, 0, metric / 2);
     netGrid->SetFlexibleDirection(wxHORIZONTAL);
@@ -382,7 +382,7 @@ void ConnectionParamsPanel::CreateControls() {
   }
 
   else if (m_pConnectionParams->Type == INTERNAL_GPS) {
-    wxString ioDir = m_pConnectionParams->GetIOTypeValueStr();
+    wxString ioDir = m_pConnectionParams->GetPortDirectionValueStr();
 
     wxFlexGridSizer *netGrid = new wxFlexGridSizer(2, 6, 0, metric / 2);
     netGrid->SetFlexibleDirection(wxHORIZONTAL);
@@ -485,7 +485,7 @@ void ConnectionParamsPanel::CreateControls() {
                  this);
 
   } else if (m_pConnectionParams->Type == INTERNAL_BT) {
-    wxString ioDir = m_pConnectionParams->GetIOTypeValueStr();
+    wxString ioDir = m_pConnectionParams->GetPortDirectionValueStr();
 
     wxFlexGridSizer *netGrid = new wxFlexGridSizer(2, 6, 0, metric / 2);
     netGrid->SetFlexibleDirection(wxHORIZONTAL);
@@ -692,7 +692,7 @@ void ConnectionParamsPanel::CreateControls() {
 void ConnectionParamsPanel::Update(ConnectionParams *ConnectionParams) {
   m_pConnectionParams = ConnectionParams;
 
-  wxString ioDir = m_pConnectionParams->GetIOTypeValueStr();
+  wxString ioDir = m_pConnectionParams->GetPortDirectionValueStr();
 
   if (m_pConnectionParams->Type == SERIAL) {
     wxString baudRate;

--- a/gui/src/connection_edit.cpp
+++ b/gui/src/connection_edit.cpp
@@ -1655,8 +1655,8 @@ void ConnectionEditDialog::SetConnectionParams(ConnectionParams* cp) {
     m_output_chkbox->SetValue(false);
     m_output_chkbox->Disable();
   } else {
-    m_input_chkbox->SetValue(cp->IOSelect != DS_TYPE_OUTPUT);
-    m_output_chkbox->SetValue(cp->IOSelect != DS_TYPE_INPUT);
+    m_input_chkbox->SetValue(cp->direction != PortDirection::kOutput);
+    m_output_chkbox->SetValue(cp->direction != PortDirection::kInput);
   }
 
   if (cp->InputSentenceListType == WHITELIST)
@@ -1890,7 +1890,7 @@ void ConnectionEditDialog::OnCbOutput(wxCommandEvent& event) {
       for (auto* cp : TheConnectionParams()) {
         if (cp->NetProtocol == proto &&
             cp->NetworkPort == wxAtoi(m_net_port_tctrl->GetValue()) &&
-            cp->IOSelect == DS_TYPE_INPUT) {
+            cp->direction == PortDirection::kInput) {
           wxString mes;
           bool warn = false;
           if (cp->bEnabled) {
@@ -2066,12 +2066,12 @@ ConnectionParams* ConnectionEditDialog::UpdateConnectionParamsFromControls(
     pConnectionParams->InputSentenceListType = BLACKLIST;
   if (m_input_chkbox->GetValue()) {
     if (m_output_chkbox->GetValue()) {
-      pConnectionParams->IOSelect = DS_TYPE_INPUT_OUTPUT;
+      pConnectionParams->direction = PortDirection::kInOut;
     } else {
-      pConnectionParams->IOSelect = DS_TYPE_INPUT;
+      pConnectionParams->direction = PortDirection::kInput;
     }
   } else
-    pConnectionParams->IOSelect = DS_TYPE_OUTPUT;
+    pConnectionParams->direction = PortDirection::kOutput;
 
   pConnectionParams->OutputSentenceList =
       wxStringTokenize(m_output_stc_tctrl->GetValue(), ",");

--- a/gui/src/connections_dlg.cpp
+++ b/gui/src/connections_dlg.cpp
@@ -325,7 +325,7 @@ public:
       case 1:
         return p1->GetCommProtocol() < p2->GetCommProtocol();
       case 2:
-        return p1->GetIOTypeValueStr() < p2->GetIOTypeValueStr();
+        return p1->GetPortDirectionValueStr() < p2->GetPortDirectionValueStr();
       case 3:
         return p1->GetStrippedDSPort() < p2->GetStrippedDSPort();
       default:
@@ -486,7 +486,7 @@ public:
         m_tooltips[row][0] = _("Disabled, click to enable");
       std::string protocol = NavAddr::BusToString((*it)->GetCommProtocol());
       SetCellValue(row, 1, protocol);
-      SetCellValue(row, 2, (*it)->GetIOTypeValueStr());
+      SetCellValue(row, 2, (*it)->GetPortDirectionValueStr());
       SetCellValue(row, 3, (*it)->GetStrippedDSPort());
       m_tooltips[row][3] = (*it)->UserComment;
       SetCellRenderer(row, 5, new BitmapCellRenderer(m_icons.settings, m_cs));
@@ -503,7 +503,8 @@ public:
         wxString sp(protocol);
         unsigned size = sp.Length() * wxWindow::GetCharWidth();
         m_header_column_widths[1] = std::max(m_header_column_widths[1], size);
-        size = (*it)->GetIOTypeValueStr().Length() * wxWindow::GetCharWidth();
+        size = (*it)->GetPortDirectionValueStr().Length() *
+               wxWindow::GetCharWidth();
         m_header_column_widths[2] = std::max(m_header_column_widths[2], size);
         sp = wxString((*it)->GetStrippedDSPort());
         size = sp.Length() * wxWindow::GetCharWidth();

--- a/gui/src/send_to_gps_dlg.cpp
+++ b/gui/src/send_to_gps_dlg.cpp
@@ -122,13 +122,13 @@ void SendToGpsDlg::CreateControls(const wxString& hint) {
   for (auto* cp : TheConnectionParams()) {
     wxString netident;
 
-    if ((cp->IOSelect != DS_TYPE_INPUT) && cp->Type == NETWORK &&
+    if ((cp->direction != PortDirection::kInput) && cp->Type == NETWORK &&
         (cp->NetProtocol == TCP)) {
       netident << "TCP:" << cp->NetworkAddress << ":" << cp->NetworkPort;
       m_itemCommListBox->Append(netident);
       netconns.Add(netident);
     }
-    if ((cp->IOSelect != DS_TYPE_INPUT) && cp->Type == NETWORK &&
+    if ((cp->direction != PortDirection::kInput) && cp->Type == NETWORK &&
         (cp->NetProtocol == UDP)) {
       netident << "UDP:" << cp->NetworkAddress << ":" << cp->NetworkPort;
       m_itemCommListBox->Append(netident);

--- a/model/include/model/comm_drv_n2k_net.h
+++ b/model/include/model/comm_drv_n2k_net.h
@@ -135,7 +135,7 @@ private:
   void SetConnectTime(wxDateTime time) { m_connect_time = time; }
   wxDateTime GetConnectTime() { return m_connect_time; }
 
-  dsPortType GetPortType() const { return m_io_select; }
+  PortDirection GetPortDirection() const { return m_direction; }
   wxString GetPort() const { return m_portstring; }
 
   std::vector<unsigned char> PushFastMsgFragment(const CanHeader& header,
@@ -191,7 +191,7 @@ private:
   int m_dog_value;
   std::string m_sock_buffer;
   wxString m_portstring;
-  dsPortType m_io_select;
+  PortDirection m_direction;
   wxDateTime m_connect_time;
   bool m_brx_connect_event;
   bool m_bchecksumCheck;

--- a/model/include/model/conn_params.h
+++ b/model/include/model/conn_params.h
@@ -100,7 +100,7 @@ public:
   bool GarminUpload;
   bool FurunoGP3X;
   bool AutoSKDiscover;
-  dsPortType IOSelect;
+  PortDirection direction;
   ListType InputSentenceListType;
   wxArrayString InputSentenceList;
   ListType OutputSentenceListType;
@@ -118,7 +118,7 @@ public:
   wxString GetSourceTypeStr() const;
   wxString GetAddressStr() const;
   wxString GetParametersStr() const;
-  wxString GetIOTypeValueStr() const;
+  wxString GetPortDirectionValueStr() const;
   wxString GetFiltersStr() const;
   wxString GetDSPort() const;
   bool GetValidPort() const;

--- a/model/include/model/ds_porttype.h
+++ b/model/include/model/ds_porttype.h
@@ -26,10 +26,10 @@
 
 #include <string>
 
-//      Port I/O type
-typedef enum { DS_TYPE_INPUT, DS_TYPE_INPUT_OUTPUT, DS_TYPE_OUTPUT } dsPortType;
+// Port I/O direction
+enum class PortDirection { kInput, kInOut, kOutput, kUpload };
 
 /** Return textual representation for use in driver ioDirection attribute. */
-std::string DsPortTypeToString(dsPortType type);
+std::string PortDirectionToString(PortDirection pd);
 
 #endif

--- a/model/src/comm_drv_n0183_android_bt.cpp
+++ b/model/src/comm_drv_n0183_android_bt.cpp
@@ -130,7 +130,7 @@ CommDriverN0183AndroidBT::CommDriverN0183AndroidBT(
       m_stats_timer(*this, 2s) {
   this->attributes["commPort"] = params->Port.ToStdString();
   this->attributes["userComment"] = params->UserComment.ToStdString();
-  this->attributes["ioDirection"] = DsPortTypeToString(params->IOSelect);
+  this->attributes["ioDirection"] = PortDirectionToString(params->direction);
   m_driver_stats.driver_bus = NavAddr::Bus::N0183;
   m_driver_stats.driver_iface = params->GetStrippedDSPort();
 

--- a/model/src/comm_drv_n0183_android_int.cpp
+++ b/model/src/comm_drv_n0183_android_int.cpp
@@ -131,7 +131,7 @@ CommDriverN0183AndroidInt::CommDriverN0183AndroidInt(
       m_listener(listener) {
   this->attributes["commPort"] = params->Port.ToStdString();
   this->attributes["userComment"] = params->UserComment.ToStdString();
-  this->attributes["ioDirection"] = DsPortTypeToString(params->IOSelect);
+  this->attributes["ioDirection"] = PortDirectionToString(params->direction);
   m_driver_stats.driver_bus = NavAddr::Bus::N0183;
   m_driver_stats.driver_iface = params->GetStrippedDSPort();
 

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -133,7 +133,7 @@ CommDriverN0183Net::CommDriverN0183Net(const ConnectionParams* params,
   this->attributes["netAddress"] = params->NetworkAddress.ToStdString();
   this->attributes["netPort"] = std::to_string(params->NetworkPort);
   this->attributes["userComment"] = params->UserComment.ToStdString();
-  this->attributes["ioDirection"] = DsPortTypeToString(params->IOSelect);
+  this->attributes["ioDirection"] = PortDirectionToString(params->direction);
   m_driver_stats.driver_bus = NavAddr::Bus::N0183;
   m_driver_stats.driver_iface = params->GetStrippedDSPort();
 
@@ -213,7 +213,7 @@ void CommDriverN0183Net::OpenNetworkUdp(unsigned int addr) {
   }
 
   // Set up another socket for transmit
-  if (m_params.IOSelect != DS_TYPE_INPUT) {
+  if (m_params.direction != PortDirection::kInput) {
     wxIPV4address tconn_addr;
     tconn_addr.Service(0);  // use ephemeral out port
     tconn_addr.AnyAddress();
@@ -250,9 +250,9 @@ void CommDriverN0183Net::OpenNetworkTcp(unsigned int addr) {
     m_sock = new wxSocketClient();
     m_sock->SetEventHandler(*this, DS_SOCKET_ID);
     int notify_flags = (wxSOCKET_CONNECTION_FLAG | wxSOCKET_LOST_FLAG);
-    if (m_params.IOSelect != DS_TYPE_INPUT)
+    if (m_params.direction != PortDirection::kInput)
       notify_flags |= wxSOCKET_OUTPUT_FLAG;
-    if (m_params.IOSelect != DS_TYPE_OUTPUT)
+    if (m_params.direction != PortDirection::kOutput)
       notify_flags |= wxSOCKET_INPUT_FLAG;
     m_sock->SetNotify(notify_flags);
     m_sock->Notify(true);
@@ -439,13 +439,13 @@ void CommDriverN0183Net::OnSocketEvent(wxSocketEvent& event) {
                     << m_params.GetDSPort();
 
         m_dog_value = N_DOG_TIMEOUT;  // feed the dog
-        if (m_params.IOSelect != DS_TYPE_OUTPUT) {
+        if (m_params.direction != PortDirection::kOutput) {
           // start the DATA watchdog only if NODATA Reconnect is desired
           if (GetParams().NoDataReconnect)
             m_socketread_watchdog_timer.Start(1000);
         }
 
-        if (m_params.IOSelect != DS_TYPE_INPUT && GetSock()->IsOk())
+        if (m_params.direction != PortDirection::kInput && GetSock()->IsOk())
           (void)SetOutputSocketOptions(m_sock);
         m_socket_timer.Stop();
         m_rx_connect_event = true;
@@ -471,11 +471,11 @@ void CommDriverN0183Net::OnServerSocketEvent(wxSocketEvent& event) {
         //        GetSock()->SetFlags(wxSOCKET_BLOCK);
         m_sock->SetEventHandler(*this, DS_SOCKET_ID);
         int notify_flags = (wxSOCKET_CONNECTION_FLAG | wxSOCKET_LOST_FLAG);
-        if (m_params.IOSelect != DS_TYPE_INPUT) {
+        if (m_params.direction != PortDirection::kInput) {
           notify_flags |= wxSOCKET_OUTPUT_FLAG;
           (void)SetOutputSocketOptions(m_sock);
         }
-        if (m_params.IOSelect != DS_TYPE_OUTPUT)
+        if (m_params.direction != PortDirection::kOutput)
           notify_flags |= wxSOCKET_INPUT_FLAG;
         m_sock->SetNotify(notify_flags);
         m_sock->Notify(true);

--- a/model/src/comm_drv_n0183_serial.cpp
+++ b/model/src/comm_drv_n0183_serial.cpp
@@ -59,7 +59,7 @@ CommDriverN0183Serial::CommDriverN0183Serial(const ConnectionParams* params,
   m_garmin_handler = nullptr;
   this->attributes["commPort"] = params->Port.ToStdString();
   this->attributes["userComment"] = params->UserComment.ToStdString();
-  this->attributes["ioDirection"] = DsPortTypeToString(params->IOSelect);
+  this->attributes["ioDirection"] = PortDirectionToString(params->direction);
 
   Open();
 }
@@ -153,7 +153,7 @@ bool CommDriverN0183Serial::SendMessage(std::shared_ptr<const NavMsg> msg,
 void CommDriverN0183Serial::SendMessage(const std::vector<unsigned char>& msg) {
   // Is this an output-only port?
   // Commonly used for "Send to GPS" function
-  if (m_params.IOSelect == DS_TYPE_OUTPUT) return;
+  if (m_params.direction == PortDirection::kOutput) return;
 
   SendToListener({msg.begin(), msg.end()}, m_listener, m_params);
 }

--- a/model/src/comm_drv_n2k_net.cpp
+++ b/model/src/comm_drv_n2k_net.cpp
@@ -147,7 +147,7 @@ CommDriverN2KNet::CommDriverN2KNet(const ConnectionParams* params,
       m_is_multicast(false),
       m_txenter(0),
       m_portstring(params->GetDSPort()),
-      m_io_select(params->IOSelect),
+      m_direction(params->direction),
       m_connection_type(params->Type),
       m_bok(false),
       m_circle(RX_BUFFER_SIZE_NET),
@@ -166,7 +166,7 @@ CommDriverN2KNet::CommDriverN2KNet(const ConnectionParams* params,
   sprintf(port_char, "%d", params->NetworkPort);
   this->attributes["netPort"] = std::string(port_char);
   this->attributes["userComment"] = params->UserComment.ToStdString();
-  this->attributes["ioDirection"] = DsPortTypeToString(params->IOSelect);
+  this->attributes["ioDirection"] = PortDirectionToString(params->direction);
 
   // Prepare the wxEventHandler to accept events from the actual hardware thread
   Bind(wxEVT_COMMDRIVER_N2K_NET, &CommDriverN2KNet::handle_N2K_MSG, this);
@@ -333,7 +333,7 @@ void CommDriverN2KNet::OpenNetworkUDP(unsigned int addr) {
   }
 
   // Set up another socket for transmit
-  if (GetPortType() != DS_TYPE_INPUT) {
+  if (GetPortDirection() != PortDirection::kInput) {
     wxIPV4address tconn_addr;
     tconn_addr.Service(0);  // use ephemeral out port
     tconn_addr.AnyAddress();
@@ -373,8 +373,10 @@ void CommDriverN2KNet::OpenNetworkTCP(unsigned int addr) {
   } else {
     GetSock()->SetEventHandler(*this, DS_SOCKET_ID);
     int notify_flags = (wxSOCKET_CONNECTION_FLAG | wxSOCKET_LOST_FLAG);
-    if (GetPortType() != DS_TYPE_INPUT) notify_flags |= wxSOCKET_OUTPUT_FLAG;
-    if (GetPortType() != DS_TYPE_OUTPUT) notify_flags |= wxSOCKET_INPUT_FLAG;
+    if (GetPortDirection() != PortDirection::kInput)
+      notify_flags |= wxSOCKET_OUTPUT_FLAG;
+    if (GetPortDirection() != PortDirection::kOutput)
+      notify_flags |= wxSOCKET_INPUT_FLAG;
     GetSock()->SetNotify(notify_flags);
     GetSock()->Notify(TRUE);
     GetSock()->SetTimeout(1);  // Short timeout
@@ -1345,12 +1347,12 @@ void CommDriverN2KNet::OnSocketEvent(wxSocketEvent& event) {
             wxString::Format("TCP NetworkDataStream connection established: %s",
                              GetPort().c_str()));
         m_dog_value = N_DOG_TIMEOUT;  // feed the dog
-        if (GetPortType() != DS_TYPE_OUTPUT) {
+        if (GetPortDirection() != PortDirection::kOutput) {
           /// start the DATA watchdog only if NODATA Reconnect is desired
           if (GetParams().NoDataReconnect)
             GetSocketThreadWatchdogTimer()->Start(1000);
         }
-        if (GetPortType() != DS_TYPE_INPUT && GetSock()->IsOk())
+        if (GetPortDirection() != PortDirection::kInput && GetSock()->IsOk())
           (void)SetOutputSocketOptions(GetSock());
         GetSocketTimer()->Stop();
         SetBrxConnectEvent(true);
@@ -1376,11 +1378,11 @@ void CommDriverN2KNet::OnServerSocketEvent(wxSocketEvent& event) {
         //        GetSock()->SetFlags(wxSOCKET_BLOCK);
         GetSock()->SetEventHandler(*this, DS_SOCKET_ID);
         int notify_flags = (wxSOCKET_CONNECTION_FLAG | wxSOCKET_LOST_FLAG);
-        if (GetPortType() != DS_TYPE_INPUT) {
+        if (GetPortDirection() != PortDirection::kInput) {
           notify_flags |= wxSOCKET_OUTPUT_FLAG;
           (void)SetOutputSocketOptions(GetSock());
         }
-        if (GetPortType() != DS_TYPE_OUTPUT)
+        if (GetPortDirection() != PortDirection::kOutput)
           notify_flags |= wxSOCKET_INPUT_FLAG;
         GetSock()->SetNotify(notify_flags);
         GetSock()->Notify(true);

--- a/model/src/comm_drv_n2k_serial.cpp
+++ b/model/src/comm_drv_n2k_serial.cpp
@@ -152,7 +152,7 @@ CommDriverN2KSerial::CommDriverN2KSerial(const ConnectionParams* params,
   m_got_mfg_code = false;
   this->attributes["canAddress"] = std::string("-1");
   this->attributes["userComment"] = params->UserComment.ToStdString();
-  this->attributes["ioDirection"] = DsPortTypeToString(params->IOSelect);
+  this->attributes["ioDirection"] = PortDirectionToString(params->direction);
 
   // Prepare the wxEventHandler to accept events from the actual hardware thread
   Bind(wxEVT_COMMDRIVER_N2K_SERIAL, &CommDriverN2KSerial::handle_N2K_SERIAL_RAW,
@@ -344,7 +344,7 @@ void CommDriverN2KSerial::handle_N2K_SERIAL_RAW(
   }
 
   // If port INPUT is not set, filter the mesage here
-  if (m_params.IOSelect != DS_TYPE_OUTPUT) {
+  if (m_params.direction != PortDirection::kOutput) {
     // extract PGN
     uint64_t pgn = 0;
     unsigned char* c = (unsigned char*)&pgn;

--- a/model/src/comm_n0183_output.cpp
+++ b/model/src/comm_n0183_output.cpp
@@ -71,8 +71,8 @@ void BroadcastNMEA0183Message(const wxString& msg, NmeaLog* nmea_log,
       assert(drv_n0183);
       ConnectionParams params = drv_n0183->GetParams();
 
-      if (params.IOSelect == DS_TYPE_INPUT_OUTPUT ||
-          params.IOSelect == DS_TYPE_OUTPUT) {
+      if (params.direction == PortDirection::kInOut ||
+          params.direction == PortDirection::kOutput) {
         std::string id = msg.ToStdString().substr(1, 5);
         auto source_addr =
             std::make_shared<NavAddr>(NavAddr0183(params.GetStrippedDSPort()));
@@ -134,7 +134,7 @@ bool CreateOutputConnection(const wxString& com_name,
     cp.SetPortStr(comx);
     cp.Baudrate = baud;
     cp.Garmin = bGarminIn || bGarmin;
-    cp.IOSelect = DS_TYPE_OUTPUT;
+    cp.direction = PortDirection::kOutput;
 
     MakeCommDriver(&cp);
     btempStream = true;
@@ -207,7 +207,7 @@ bool CreateOutputConnection(const wxString& com_name,
       cp.NetProtocol = protocol;
       cp.NetworkAddress = address;
       cp.NetworkPort = port;
-      cp.IOSelect = DS_TYPE_OUTPUT;  // DS_TYPE_INPUT_OUTPUT;
+      cp.direction = PortDirection::kOutput;
 
       MakeCommDriver(&cp);
       auto& me =

--- a/model/src/comm_n0183_output.cpp
+++ b/model/src/comm_n0183_output.cpp
@@ -134,7 +134,7 @@ bool CreateOutputConnection(const wxString& com_name,
     cp.SetPortStr(comx);
     cp.Baudrate = baud;
     cp.Garmin = bGarminIn || bGarmin;
-    cp.direction = PortDirection::kOutput;
+    cp.direction = PortDirection::kUpload;
 
     MakeCommDriver(&cp);
     btempStream = true;

--- a/model/src/conn_params.cpp
+++ b/model/src/conn_params.cpp
@@ -75,7 +75,8 @@ void ConnectionParams::Deserialize(const wxString& configStr) {
   Baudrate = wxAtoi(prms[6]);
   ChecksumCheck = wxAtoi(prms[7]);
   int iotval = wxAtoi(prms[8]);
-  IOSelect = ((iotval <= 2) ? static_cast<dsPortType>(iotval) : DS_TYPE_INPUT);
+  direction =
+      iotval <= 2 ? static_cast<PortDirection>(iotval) : PortDirection::kInput;
   InputSentenceListType = (ListType)wxAtoi(prms[9]);
   InputSentenceList = wxStringTokenize(prms[10], ",");
   OutputSentenceListType = (ListType)wxAtoi(prms[11]);
@@ -124,11 +125,11 @@ wxString ConnectionParams::Serialize() const {
   wxString ret = wxString::Format(
       "%d;%d;%s;%d;%d;%s;%d;%d;%d;%d;%s;%d;%s;%d;%d;%d;%d;%d;%s;%d;%s;%d;%d;%s",
       Type, NetProtocol, NetworkAddress.c_str(), NetworkPort, Protocol,
-      Port.c_str(), Baudrate, ChecksumCheck, IOSelect, InputSentenceListType,
-      istcs.c_str(), OutputSentenceListType, ostcs.c_str(), 0 /* Priority */,
-      Garmin, GarminUpload, FurunoGP3X, bEnabled, UserComment.c_str(),
-      AutoSKDiscover, socketCAN_port.c_str(), NoDataReconnect, DisableEcho,
-      AuthToken.c_str());
+      Port.c_str(), Baudrate, ChecksumCheck, static_cast<int>(direction),
+      InputSentenceListType, istcs.c_str(), OutputSentenceListType,
+      ostcs.c_str(), 0 /* Priority */, Garmin, GarminUpload, FurunoGP3X,
+      bEnabled, UserComment.c_str(), AutoSKDiscover, socketCAN_port.c_str(),
+      NoDataReconnect, DisableEcho, AuthToken.c_str());
 
   return ret;
 }
@@ -136,10 +137,10 @@ wxString ConnectionParams::Serialize() const {
 std::string ConnectionParams::GetKey() const {
   std::stringstream ss;
   ss << Type << NetProtocol << NetworkAddress << NetworkPort << Protocol << Port
-     << Baudrate << ChecksumCheck << IOSelect << InputSentenceListType
-     << OutputSentenceListType << Garmin << GarminUpload << FurunoGP3X
-     << UserComment << AutoSKDiscover << socketCAN_port << NoDataReconnect
-     << DisableEcho << AuthToken;
+     << Baudrate << ChecksumCheck << static_cast<int>(direction)
+     << InputSentenceListType << OutputSentenceListType << Garmin
+     << GarminUpload << FurunoGP3X << UserComment << AutoSKDiscover
+     << socketCAN_port << NoDataReconnect << DisableEcho << AuthToken;
   for (const auto& sentence : OutputSentenceList) ss << sentence;
   for (const auto& sentence : InputSentenceList) ss << sentence;
   return ss.str();
@@ -156,7 +157,7 @@ ConnectionParams::ConnectionParams() {
   ChecksumCheck = true;
   Garmin = false;
   FurunoGP3X = false;
-  IOSelect = DS_TYPE_INPUT;
+  direction = PortDirection::kInput;
   InputSentenceListType = WHITELIST;
   OutputSentenceListType = WHITELIST;
   Valid = true;
@@ -233,13 +234,14 @@ wxString ConnectionParams::GetParametersStr() const {
   }
 }
 
-wxString ConnectionParams::GetIOTypeValueStr() const {
-  if (IOSelect == DS_TYPE_INPUT)
-    return _("Input");
-  else if (IOSelect == DS_TYPE_OUTPUT)
-    return _("Output");
-  else
-    return _("In/Out");
+wxString ConnectionParams::GetPortDirectionValueStr() const {
+  static const std::unordered_map<PortDirection, wxString> StringByDirection = {
+      {PortDirection::kInput, _("Input")},
+      {PortDirection::kOutput, _("Output")},
+      {PortDirection::kInOut, _("InOut")},
+      {PortDirection::kUpload, _("Upload")}};
+  if (static_cast<size_t>(direction) >= StringByDirection.size()) return "???";
+  return StringByDirection.at(direction);
 }
 
 wxString ConnectionParams::FilterTypeToStr(ListType type,

--- a/model/src/ds_porttype.cpp
+++ b/model/src/ds_porttype.cpp
@@ -25,18 +25,14 @@
 
 #include "model/ds_porttype.h"
 
-std::string DsPortTypeToString(dsPortType type) {
-  switch (type) {
-    case DS_TYPE_INPUT_OUTPUT:
-      return "IN/OUT";
-      break;
-    case DS_TYPE_OUTPUT:
-      return "OUT";
-      break;
-    case DS_TYPE_INPUT:
-      return "IN";
-      break;
-  };
-  assert(false && "Compiler error (undefined dsPortType)");
-  return "";  // for the compiler
+#include <unordered_map>
+
+std::string PortDirectionToString(PortDirection pd) {
+  static const std::unordered_map<PortDirection, std::string> kNameByDirection =
+      {{PortDirection::kOutput, "OUT"},
+       {PortDirection::kInput, "IN"},
+       {PortDirection::kInOut, "IN/OUT"},
+       {PortDirection::kUpload, "UPLOAD"}};
+  if (static_cast<size_t>(pd) >= kNameByDirection.size()) return "???";
+  return kNameByDirection.at(pd);
 }

--- a/model/src/multiplexer.cpp
+++ b/model/src/multiplexer.cpp
@@ -258,8 +258,8 @@ void Multiplexer::HandleN0183(
         //  likely recurse...
         if ((!params_.DisableEcho && params_.Type == SERIAL) ||
             driver->iface != n0183_msg->source->iface) {
-          if (params_.IOSelect == DS_TYPE_INPUT_OUTPUT ||
-              params_.IOSelect == DS_TYPE_OUTPUT) {
+          if (params_.direction == PortDirection::kInOut ||
+              params_.direction == PortDirection::kOutput) {
             bool bout_filter = true;
             bool bxmit_ok = true;
             std::string id("XXXXX");


### PR DESCRIPTION
Do a micro cleanup up of the ConnectionParams input/output/in+out state adding a fourth vale "uploading". While on it, sanitize naming and use an enum class instead of a global enum.

Set the parameters direction to "upload" when uploading routes and waypoints which is assumed to stop the multiplexer to forward "normal" output data when uploading.