### PR TITLE
Welcome: Update dialog, refactor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -919,6 +919,7 @@ set(GUI_HDRS
     ${GUI_HDR_DIR}/user_colors_dlg.h
     ${GUI_HDR_DIR}/viewport.h
     ${GUI_HDR_DIR}/waypointman_gui.h
+    ${GUI_HDR_DIR}/welcome.h
 )
 
 set(GUI_SRC_DIR ${CMAKE_SOURCE_DIR}/gui/src)
@@ -1046,7 +1047,7 @@ set(GUI_SRC
     ${GUI_SRC_DIR}/user_colors.cpp
     ${GUI_SRC_DIR}/viewport.cpp
     ${GUI_SRC_DIR}/waypointman_gui.cpp
-
+    ${GUI_SRC_DIR}/welcome.cpp
 )
 
 if (NOT QT_ANDROID)

--- a/gui/include/gui/ocpn_app.h
+++ b/gui/include/gui/ocpn_app.h
@@ -43,6 +43,7 @@
 
 #include "data_monitor.h"
 #include "ocpn_plugin.h"
+#include "welcome.h"
 
 using CallbacksByPlugin =
     std::unordered_map<std::string, std::function<void(HostApi122::EventType)>>;

--- a/gui/include/gui/ocpn_frame.h
+++ b/gui/include/gui/ocpn_frame.h
@@ -97,9 +97,6 @@ class MyFrame;          // forward
 extern MyFrame* gFrame; /**< Global instance */
 
 // FIXME (leamas) to have utility functions in top window is a really bad idea.
-#ifdef __ANDROID__
-bool ShowNavWarning();
-#endif
 void ApplyLocale(void);
 
 /**

--- a/gui/include/gui/ocpn_frame.h
+++ b/gui/include/gui/ocpn_frame.h
@@ -97,8 +97,9 @@ class MyFrame;          // forward
 extern MyFrame* gFrame; /**< Global instance */
 
 // FIXME (leamas) to have utility functions in top window is a really bad idea.
+#ifdef __ANDROID__
 bool ShowNavWarning();
-
+#endif
 void ApplyLocale(void);
 
 /**

--- a/gui/include/gui/welcome.h
+++ b/gui/include/gui/welcome.h
@@ -1,0 +1,29 @@
+/**************************************************************************
+ *   Copyright (C) 2010 by David S. Register                               *
+ *   Copyright (C) 2026 Alec Leamas                                        *
+ *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, see <https://www.gnu.org/licenses/>. *
+ **************************************************************************/
+
+/**
+ *  \file
+ *
+ *  Welcome to OpenCPN stuff.
+ */
+
+#include <wx/window.h>
+
+/** Show the "Welcome to OpenCPN" dialog. */
+bool ShowNavWarning([[maybe_unused]] wxWindow* parent);

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -250,21 +250,6 @@ Arguments:
   GPX  file                     GPX-formatted file with waypoints or routes.
 )";
 
-static const char *const kNavWarning = _(R"(
-OpenCPN is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.
-
-See the GNU General Public License for more details.
-
-OpenCPN must only be used in conjunction with approved
-paper charts and traditional methods of navigation.
-
-DO NOT rely upon OpenCPN for safety of life or property.
-
-Please click "Agree" and proceed, or "Cancel" to quit.)");
-
 //  comm event definitions
 wxDEFINE_EVENT(EVT_N2K_129029, wxCommandEvent);
 wxDEFINE_EVENT(EVT_N2K_129026, wxCommandEvent);
@@ -325,15 +310,6 @@ DEFINE_GUID(GARMIN_DETECT_GUID, 0x2c9c45c2L, 0x8e7d, 0x4c08, 0xa1, 0x2d, 0x81,
 static const long long lNaN = 0xfff8000000000000;
 #define NAN (*(double *)&lNaN)
 #endif
-
-class NavWarningDlg : public wxMessageDialog {
-public:
-  NavWarningDlg(wxWindow *parent)
-      : wxMessageDialog(parent, kNavWarning, _("Welcome to OpenCPN"),
-                        wxOK | wxCANCEL) {
-    SetOKCancelLabels(_("Agree"), _("Cancel"));
-  }
-};
 
 class WallpaperFrame : public wxFrame {
 public:
@@ -413,14 +389,6 @@ static wxString newPrivateFileName(wxString, const char *name,
   return filePathAndName;
 }
 
-#ifndef __ANDROID__
-static bool ShowNavWarning() {
-  NavWarningDlg dlg(gFrame);
-  int agreed = dlg.ShowModal();
-  return agreed == wxID_OK;
-}
-#endif
-
 static bool DoNavMessage(wxString &new_version_string) {
 #ifdef __ANDROID__
   //  We defer the startup message to here to allow the app frame to be
@@ -431,7 +399,7 @@ static bool DoNavMessage(wxString &new_version_string) {
     // qDebug() << "Showing NavWarning";
     wxMilliSleep(500);
 
-    if (!ShowNavWarning()) {
+    if (!ShowNavWarning(gFrame)) {
       qDebug() << "Closing due to NavWarning Cancel";
       gFrame->Close();
       androidTerminate();
@@ -449,7 +417,7 @@ static bool DoNavMessage(wxString &new_version_string) {
   //  or if the version string has changed at all
   //  We defer until here to allow for localization of the message
   if (!n_NavMessageShown || (new_version_string != g_config_version_string)) {
-    if (!ShowNavWarning()) return false;
+    if (!ShowNavWarning(gFrame)) return false;
     n_NavMessageShown = 1;
     pConfig->Flush();
   }
@@ -524,14 +492,6 @@ static void MyCPLErrorHandler(CPLErr eErrClass, int nError,
   wxString str(msg, wxConvUTF8);
   wxLogMessage(str);
 }
-
-#ifdef __ANDROID__
-bool ShowNavWarning() {
-  wxString vs = wxString::Format(" .. Version %s", VERSION_FULL);
-  androidShowDisclaimer(_("OpenCPN for Android") + vs, kNavWarning);
-  return true;
-}
-#endif
 
 // `Main program` equivalent, creating windows and returning main app frame
 //------------------------------------------------------------------------------

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -83,7 +83,7 @@ void gdk_window_set_override_redirect(GdkWindow *window,
 
 #ifndef WX_PRECOMP
 #include <wx/wx.h>
-#endif  // precompiled headers
+#endif
 
 #include <wx/apptrait.h>
 #include <wx/arrimpl.cpp>
@@ -250,6 +250,21 @@ Arguments:
   GPX  file                     GPX-formatted file with waypoints or routes.
 )";
 
+static const char *const kNavWarning = _(R"(
+OpenCPN is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+OpenCPN must only be used in conjunction with approved
+paper charts and traditional methods of navigation.
+
+DO NOT rely upon OpenCPN for safety of life or property.
+
+Please click "Agree" and proceed, or "Cancel" to quit.)");
+
 //  comm event definitions
 wxDEFINE_EVENT(EVT_N2K_129029, wxCommandEvent);
 wxDEFINE_EVENT(EVT_N2K_129026, wxCommandEvent);
@@ -264,15 +279,15 @@ wxDEFINE_EVENT(EVT_N0183_GGA, wxCommandEvent);
 wxDEFINE_EVENT(EVT_N0183_GLL, wxCommandEvent);
 wxDEFINE_EVENT(EVT_N0183_AIVDO, wxCommandEvent);
 
-//------------------------------------------------------------------------------
-//      Fwd Declarations
-//------------------------------------------------------------------------------
+class WallpaperFrame;  // forward
 
 //------------------------------------------------------------------------------
 //      Static variable definition
 //------------------------------------------------------------------------------
 
 WX_DEFINE_OBJARRAY(ArrayOfCDI);
+
+static WallpaperFrame *g_wallpaper;
 
 static int user_user_id;
 static int file_user_id;
@@ -284,6 +299,8 @@ static unsigned int malloc_max;
 static int osMajor, osMinor;
 
 static bool g_bHasHwClock;
+
+static wxStopWatch init_sw;
 
 #if wxUSE_XLOCALE || !wxCHECK_VERSION(3, 0, 0)
 // FIXME (leamas) find a new home
@@ -308,6 +325,52 @@ DEFINE_GUID(GARMIN_DETECT_GUID, 0x2c9c45c2L, 0x8e7d, 0x4c08, 0xa1, 0x2d, 0x81,
 static const long long lNaN = 0xfff8000000000000;
 #define NAN (*(double *)&lNaN)
 #endif
+
+class NavWarningDlg : public wxMessageDialog {
+public:
+  NavWarningDlg(wxWindow *parent)
+      : wxMessageDialog(parent, kNavWarning, _("Welcome to OpenCPN"),
+                        wxOK | wxCANCEL) {
+    SetOKCancelLabels(_("Agree"), _("Cancel"));
+  }
+};
+
+class WallpaperFrame : public wxFrame {
+public:
+  WallpaperFrame()
+      : wxFrame(nullptr, wxID_ANY, "Loading...", wxDefaultPosition,
+                wxSize(2000, 2000), wxSTAY_ON_TOP) {
+    // Customize the wallpaper appearance
+    SetBackgroundColour(wxColour(0, 0, 0));  // Black background
+
+    wxPanel *panel = new wxPanel(this, wxID_ANY);
+
+    // Set the background color of the panel
+    panel->SetBackgroundColour(wxColour(0, 0, 0));  // Example RGB
+
+    // Use a sizer for proper layout
+    wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
+    sizer->Add(panel, 1, wxEXPAND);
+    SetSizer(sizer);
+    Layout();
+    Center();  // Center the wallpaper frame
+
+#ifdef __WXGTK__
+    // Bypass the WM: make this an override-redirect window so Openbox cannot
+    // restack it (Openbox was sending WM_TAKE_FOCUS to gFrame after its map,
+    // raising gFrame above the fullscreen wallpaper during plugin LateInit
+    // and exposing the chart canvases mid-load).
+    GtkWidget *widget = reinterpret_cast<GtkWidget *>(GetHandle());
+    if (widget) {
+      gtk_widget_realize(widget);
+      GdkWindow *gdk = gtk_widget_get_window(widget);
+      if (gdk) {
+        gdk_window_set_override_redirect(gdk, 1);
+      }
+    }
+#endif
+  }
+};
 
 //    Some static helpers
 void appendOSDirSlash(wxString *pString);
@@ -350,94 +413,15 @@ static wxString newPrivateFileName(wxString, const char *name,
   return filePathAndName;
 }
 
-void MyApp::OnNewMsgTypes() {
-  for (auto it : m_api_events_callbacks)
-    it.second(HostApi122::EventType::kNewMessageType);
-}
-
-void MyApp::RegisterApiEventCallback(
-    const std::string &plugin_name,
-    std::function<void(HostApi122::EventType what)> callback) {
-  if (callback)
-    m_api_events_callbacks[plugin_name] = std::move(callback);
-  else
-    m_api_events_callbacks.erase(plugin_name);
-}
-
-class WallpaperFrame : public wxFrame {
-public:
-  WallpaperFrame()
-      : wxFrame(nullptr, wxID_ANY, "Loading...", wxDefaultPosition,
-                wxSize(2000, 2000), wxSTAY_ON_TOP) {
-    // Customize the wallpaper appearance
-    SetBackgroundColour(wxColour(0, 0, 0));  // Black background
-
-    wxPanel *panel = new wxPanel(this, wxID_ANY);
-
-    // Set the background color of the panel
-    panel->SetBackgroundColour(wxColour(0, 0, 0));  // Example RGB
-
-    // Use a sizer for proper layout
-    wxBoxSizer *sizer = new wxBoxSizer(wxVERTICAL);
-    sizer->Add(panel, 1, wxEXPAND);
-    SetSizer(sizer);
-    Layout();
-    Center();  // Center the wallpaper frame
-
-#ifdef __WXGTK__
-    // Bypass the WM: make this an override-redirect window so Openbox cannot
-    // restack it (Openbox was sending WM_TAKE_FOCUS to gFrame after its map,
-    // raising gFrame above the fullscreen wallpaper during plugin LateInit
-    // and exposing the chart canvases mid-load).
-    GtkWidget *widget = reinterpret_cast<GtkWidget *>(GetHandle());
-    if (widget) {
-      gtk_widget_realize(widget);
-      GdkWindow *gdk = gtk_widget_get_window(widget);
-      if (gdk) {
-        gdk_window_set_override_redirect(gdk, 1);
-      }
-    }
-#endif
-  }
-};
-
-bool ShowNavWarning() {
-  wxString msg(
-      _("\n\
-OpenCPN is distributed in the hope that it will be useful, \
-but WITHOUT ANY WARRANTY; without even the implied \
-warranty of MERCHANTABILITY or FITNESS FOR A \
-PARTICULAR PURPOSE.\n\n\
-See the GNU General Public License for more details.\n\n\
-OpenCPN must only be used in conjunction with approved \
-paper charts and traditional methods of navigation.\n\n\
-DO NOT rely upon OpenCPN for safety of life or property.\n\n\
-Please click \"Agree\" and proceed, or \"Cancel\" to quit.\n"));
-
-  wxString vs = wxString::Format(" .. Version %s", VERSION_FULL);
-
-#ifdef __ANDROID__
-  androidShowDisclaimer(_("OpenCPN for Android") + vs, msg);
-  return true;
-#else
-  msg.Replace("\n", "<br>");
-
-  std::stringstream html;
-  html << "<html><body><p>";
-  html << msg.ToStdString();
-  html << "</p></body></html>";
-
-  std::string title = _("Welcome to OpenCPN").ToStdString();
-  std::string action = _("Agree").ToStdString();
-  AlertDialog info_dlg(gFrame, title, action);
-  info_dlg.SetInitialSize();
-  info_dlg.AddHtmlContent(html);
-  int agreed = info_dlg.ShowModal();
+#ifndef __ANDROID__
+static bool ShowNavWarning() {
+  NavWarningDlg dlg(gFrame);
+  int agreed = dlg.ShowModal();
   return agreed == wxID_OK;
-#endif
 }
+#endif
 
-bool DoNavMessage(wxString &new_version_string) {
+static bool DoNavMessage(wxString &new_version_string) {
 #ifdef __ANDROID__
   //  We defer the startup message to here to allow the app frame to be
   //  contructed, thus avoiding a dialog with NULL parent which might not work
@@ -473,16 +457,6 @@ bool DoNavMessage(wxString &new_version_string) {
   return true;
 }
 
-// `Main program` equivalent, creating windows and returning main app frame
-//------------------------------------------------------------------------------
-// MyApp
-//------------------------------------------------------------------------------
-IMPLEMENT_APP(MyApp)
-
-BEGIN_EVENT_TABLE(MyApp, wxApp)
-EVT_ACTIVATE_APP(MyApp::OnActivateApp)
-END_EVENT_TABLE()
-
 static void ActivateRoute(const std::string &guid) {
   Route *route = g_pRouteMan->FindRouteByGUID(guid);
   if (!route) {
@@ -512,6 +486,81 @@ static void ReverseRoute(const std::string &guid) {
   }
   route->Reverse();
   GuiEvents::GetInstance().on_routes_update.Notify();
+}
+
+/** Parse --loglevel and set up logging, falling back to defaults. */
+#ifdef __ANDROID__
+static void ParseLoglevel(wxCmdLineParser &parser) {
+  wxLog::SetLogLevel(wxLOG_Message);
+}
+#else
+static void ParseLoglevel(wxCmdLineParser &parser) {
+  const char *strLevel = std::getenv("OPENCPN_LOGLEVEL");
+  strLevel = strLevel ? strLevel : "info";
+  wxString wxLevel;
+  if (parser.Found("l", &wxLevel)) {
+    strLevel = wxLevel.c_str();
+  }
+  wxLogLevel level = OcpnLog::str2level(strLevel);
+  if (level == OcpnLog::LOG_BADLEVEL) {
+    fprintf(stderr, "Bad loglevel %s, using \"info\"", strLevel);
+    level = wxLOG_Info;
+  }
+  wxLog::SetLogLevel(level);
+}
+#endif  // __ANDROID__
+
+static void MyCPLErrorHandler(CPLErr eErrClass, int nError,
+                              const char *pszErrorMsg) {
+  char msg[256];
+
+  if (eErrClass == CE_Debug)
+    snprintf(msg, 255, "CPL: %s", pszErrorMsg);
+  else if (eErrClass == CE_Warning)
+    snprintf(msg, 255, "CPL Warning %d: %s", nError, pszErrorMsg);
+  else
+    snprintf(msg, 255, "CPL ERROR %d: %s", nError, pszErrorMsg);
+
+  wxString str(msg, wxConvUTF8);
+  wxLogMessage(str);
+}
+
+#ifdef __ANDROID__
+bool ShowNavWarning() {
+  wxString vs = wxString::Format(" .. Version %s", VERSION_FULL);
+  androidShowDisclaimer(_("OpenCPN for Android") + vs, kNavWarning);
+  return true;
+}
+#endif
+
+// `Main program` equivalent, creating windows and returning main app frame
+//------------------------------------------------------------------------------
+// MyApp
+//------------------------------------------------------------------------------
+IMPLEMENT_APP(MyApp)
+
+BEGIN_EVENT_TABLE(MyApp, wxApp)
+EVT_ACTIVATE_APP(MyApp::OnActivateApp)
+END_EVENT_TABLE()
+
+MyApp::MyApp()
+    : m_checker(InstanceCheck::GetInstance()),
+      m_rest_server(PINCreateDialog::GetDlgCtx(), RouteCtxFactory(),
+                    g_bportable),
+      m_usb_watcher(UsbWatchDaemon::GetInstance()),
+      m_exitcode(-2) {
+#ifdef __linux__
+  // Handle e. g., wayland default display -- see #1166.
+  if (!wxGetEnv("OCPN_DISABLE_X11_GDK_BACKEND", NULL)) {
+    if (wxGetEnv("WAYLAND_DISPLAY", NULL)) {
+      setenv("GDK_BACKEND", "x11", 1);
+    }
+  }
+  setenv(
+      "mesa_glthread", "false",
+      1);  // Explicitly disable glthread. This may have some impact on OpenGL
+           // performance, but we know it is problematic for us. See #2889
+#endif     // __linux__
 }
 
 void MyApp::InitRestListeners() {
@@ -547,6 +596,20 @@ void MyApp::OnUnhandledException() {
   wxMessageOutputBest().Printf(
       "Unhandled %s; terminating %s.\n", what,
       wxIsMainThread() ? "the application" : "the thread in which it happened");
+}
+
+void MyApp::OnNewMsgTypes() {
+  for (auto it : m_api_events_callbacks)
+    it.second(HostApi122::EventType::kNewMessageType);
+}
+
+void MyApp::RegisterApiEventCallback(
+    const std::string &plugin_name,
+    std::function<void(HostApi122::EventType what)> callback) {
+  if (callback)
+    m_api_events_callbacks[plugin_name] = std::move(callback);
+  else
+    m_api_events_callbacks.erase(plugin_name);
 }
 
 bool MyApp::OpenFile(const std::string &path) {
@@ -598,28 +661,6 @@ void MyApp::OnInitCmdLine(wxCmdLineParser &parser) {
   parser.AddSwitch("e", "get_rest_endpoint");
   parser.AddOption("o", "open", "", wxCMD_LINE_VAL_STRING,
                    wxCMD_LINE_PARAM_OPTIONAL | wxCMD_LINE_PARAM_MULTIPLE);
-}
-#endif  // __ANDROID__
-
-/** Parse --loglevel and set up logging, falling back to defaults. */
-#ifdef __ANDROID__
-static void ParseLoglevel(wxCmdLineParser &parser) {
-  wxLog::SetLogLevel(wxLOG_Message);
-}
-#else
-static void ParseLoglevel(wxCmdLineParser &parser) {
-  const char *strLevel = std::getenv("OPENCPN_LOGLEVEL");
-  strLevel = strLevel ? strLevel : "info";
-  wxString wxLevel;
-  if (parser.Found("l", &wxLevel)) {
-    strLevel = wxLevel.c_str();
-  }
-  wxLogLevel level = OcpnLog::str2level(strLevel);
-  if (level == OcpnLog::LOG_BADLEVEL) {
-    fprintf(stderr, "Bad loglevel %s, using \"info\"", strLevel);
-    level = wxLOG_Info;
-  }
-  wxLog::SetLogLevel(level);
 }
 #endif  // __ANDROID__
 
@@ -728,34 +769,10 @@ bool MyApp::OnExceptionInMainLoop() {
 
 void MyApp::OnActivateApp(wxActivateEvent &event) { return; }
 
-static wxStopWatch init_sw;
-
 int MyApp::OnRun() {
   if (m_exitcode != -2) return m_exitcode;
   return wxAppConsole::OnRun();
 }
-
-MyApp::MyApp()
-    : m_checker(InstanceCheck::GetInstance()),
-      m_rest_server(PINCreateDialog::GetDlgCtx(), RouteCtxFactory(),
-                    g_bportable),
-      m_usb_watcher(UsbWatchDaemon::GetInstance()),
-      m_exitcode(-2) {
-#ifdef __linux__
-  // Handle e. g., wayland default display -- see #1166.
-  if (!wxGetEnv("OCPN_DISABLE_X11_GDK_BACKEND", NULL)) {
-    if (wxGetEnv("WAYLAND_DISPLAY", NULL)) {
-      setenv("GDK_BACKEND", "x11", 1);
-    }
-  }
-  setenv(
-      "mesa_glthread", "false",
-      1);  // Explicitly disable glthread. This may have some impact on OpenGL
-           // performance, but we know it is problematic for us. See #2889
-#endif     // __linux__
-}
-
-WallpaperFrame *g_wallpaper;
 
 bool MyApp::OnInit() {
   if (!wxApp::OnInit()) return false;
@@ -1917,22 +1934,3 @@ int MyApp::OnExit() {
 #ifdef LINUX_CRASHRPT
 void MyApp::OnFatalException() { g_crashprint.Report(); }
 #endif
-
-//----------------------------------------------------------------------------------------------------------
-//      Application-wide CPL Error handler
-//----------------------------------------------------------------------------------------------------------
-void MyCPLErrorHandler(CPLErr eErrClass, int nError, const char *pszErrorMsg)
-
-{
-  char msg[256];
-
-  if (eErrClass == CE_Debug)
-    snprintf(msg, 255, "CPL: %s", pszErrorMsg);
-  else if (eErrClass == CE_Warning)
-    snprintf(msg, 255, "CPL Warning %d: %s", nError, pszErrorMsg);
-  else
-    snprintf(msg, 255, "CPL ERROR %d: %s", nError, pszErrorMsg);
-
-  wxString str(msg, wxConvUTF8);
-  wxLogMessage(str);
-}

--- a/gui/src/welcome.cpp
+++ b/gui/src/welcome.cpp
@@ -1,0 +1,71 @@
+/**************************************************************************
+ *   Copyright (C) 2010 by David S. Register                               *
+ *   Copyright (C) 2026 Alec Leamas                                        *
+ *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, see <https://www.gnu.org/licenses/>. *
+ **************************************************************************/
+
+/**
+ *  \file
+ *
+ *  Implement welcome.h -- welcome to OpenCPN stuff
+ */
+
+#include "welcome.h"
+
+#include <wx/msgdlg.h>
+#include <wx/string.h>
+
+#ifdef __ANDROID__
+#include "androidUTIL.h"
+#endif
+
+static const char *const kMessage = _(R"(
+OpenCPN is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
+
+See the GNU General Public License for more details.
+
+OpenCPN must only be used in conjunction with approved
+paper charts and traditional methods of navigation.
+
+DO NOT rely upon OpenCPN for safety of life or property.
+
+Please click "Agree" and proceed, or "Cancel" to quit.)");
+
+class WelcomeDlg : public wxMessageDialog {
+public:
+  WelcomeDlg(wxWindow *parent)
+      : wxMessageDialog(parent, kMessage, _("Welcome to OpenCPN"),
+                        wxOK | wxCANCEL) {
+    SetOKCancelLabels(_("Agree"), _("Cancel"));
+  }
+};
+
+#ifdef __ANDROID__
+bool ShowNavWarning(wxWindow *parent) {
+  wxString vs = wxString::Format(" .. Version %s", VERSION_FULL);
+  androidShowDisclaimer(_("OpenCPN for Android") + vs, kNavWarning);
+  return true;
+}
+#else
+bool ShowNavWarning(wxWindow *parent) {
+  WelcomeDlg dlg(parent);
+  int agreed = dlg.ShowModal();
+  return agreed == wxID_OK;
+}
+#endif


### PR DESCRIPTION
Update the "Welcome to OpenCPN"  dialog to use standard wxWidgets components rather than dialog_alert from libs/gui. (the latter does not look that good on some platforms)

While on it, refactor the dialog to a separate file, avoiding  a case where ocpn_frame depends on ocpn_app instead of the other way around.