### PR TITLE
connection_params: clean up naming, dead code, clang-tidy, ...

### DIFF
--- a/android/androidUTIL.cpp
+++ b/android/androidUTIL.cpp
@@ -3422,26 +3422,26 @@ wxString BuildAndroidSettingsString(void) {
 
   // Internal GPS.
   for (auto &cp : TheConnectionParams()) {
-    if (INTERNAL_GPS == cp->Type) {
+    if (INTERNAL_GPS == cp->type) {
       result += _T("prefb_internalGPS:");
-      result += cp->bEnabled ? _T("1;") : _T("0;");
+      result += cp->is_enabled ? _T("1;") : _T("0;");
     }
-    if (SERIAL == cp->Type) {
-      if (wxNOT_FOUND != cp->GetPortStr().Find(_T("PL2303"))) {
+    if (SERIAL == cp->type) {
+      if (wxNOT_FOUND != cp->serial_port.Find(_T("PL2303"))) {
         result += _T("prefb_PL2303:");
-        result += cp->bEnabled ? _T("1;") : _T("0;");
-      } else if (wxNOT_FOUND != cp->GetPortStr().Find(_T("dAISy"))) {
+        result += cp->is_enabled ? _T("1;") : _T("0;");
+      } else if (wxNOT_FOUND != cp->serial_port.Find(_T("dAISy"))) {
         result += _T("prefb_dAISy:");
-        result += cp->bEnabled ? _T("1;") : _T("0;");
-      } else if (wxNOT_FOUND != cp->GetPortStr().Find(_T("FT232R"))) {
+        result += cp->is_enabled ? _T("1;") : _T("0;");
+      } else if (wxNOT_FOUND != cp->serial_port.Find(_T("FT232R"))) {
         result += _T("prefb_FT232R:");
-        result += cp->bEnabled ? _T("1;") : _T("0;");
-      } else if (wxNOT_FOUND != cp->GetPortStr().Find(_T("FT231X"))) {
+        result += cp->is_enabled ? _T("1;") : _T("0;");
+      } else if (wxNOT_FOUND != cp->serial_port.Find(_T("FT231X"))) {
         result += _T("prefb_FT231X:");
-        result += cp->bEnabled ? _T("1;") : _T("0;");
-      } else if (wxNOT_FOUND != cp->GetPortStr().Find(_T("USBDP"))) {
+        result += cp->is_enabled ? _T("1;") : _T("0;");
+      } else if (wxNOT_FOUND != cp->serial_port.Find(_T("USBDP"))) {
         result += _T("prefb_USBDP:");
-        result += cp->bEnabled ? _T("1;") : _T("0;");
+        result += cp->is_enabled ? _T("1;") : _T("0;");
       }
     }
   }
@@ -3673,7 +3673,7 @@ int androidApplySettingsString(wxString settings, ArrayOfCDI *pACDI) {
     ConnectionParams *cp = NULL;
 
     for (auto &xcp : TheConnectionParams()) {
-      if (INTERNAL_GPS == xcp->Type) {
+      if (INTERNAL_GPS == xcp->type) {
         pExistingParams = xcp;
         cp = xcp;
         break;
@@ -3682,16 +3682,16 @@ int androidApplySettingsString(wxString settings, ArrayOfCDI *pACDI) {
 
     bool b_action = true;
     if (pExistingParams) {
-      if (pExistingParams->bEnabled == benable_InternalGPS)
+      if (pExistingParams->is_enabled == benable_InternalGPS)
         b_action = false;  // nothing to do...
       else
-        cp->bEnabled = benable_InternalGPS;
+        cp->is_enabled = benable_InternalGPS;
     } else if (benable_InternalGPS) {  //  Need a new Params
       // make a generic config string for InternalGPS.
       wxString sGPS = _T("2;3;;0;0;;0;1;0;0;;0;;1;0;0;0;0");  // 17 parms
       ConnectionParams *new_params = new ConnectionParams(sGPS);
 
-      new_params->bEnabled = benable_InternalGPS;
+      new_params->is_enabled = benable_InternalGPS;
       TheConnectionParams().push_back(new_params);
       cp = new_params;
     }
@@ -3704,16 +3704,16 @@ int androidApplySettingsString(wxString settings, ArrayOfCDI *pACDI) {
       DataStream *pds_existing = g_pMUX->FindStream(cp->GetDSPort());
       if (pds_existing) g_pMUX->StopAndRemoveStream(pds_existing);
 
-      if (cp->bEnabled) {
+      if (cp->is_enabled) {
         PortDirection direction  = cp->direction;
         DataStream *dstr =
-            makeSerialDataStream(g_pMUX, cp->Type, cp->GetDSPort(),
+            makeSerialDataStream(g_pMUX, cp->type, cp->GetDSPort(),
                                  wxString::Format(wxT("%i"), cp->Baudrate),
                                  port_type, cp->Priority, cp->Garmin);
 
 #if 0
                 DataStream *dstr = new DataStream( g_pMUX,
-                                                   cp->Type,
+                                                   cp->type,
                                                    cp->GetDSPort(),
                                                    wxString::Format(wxT("%i"), cp->Baudrate),
                                                                     port_type,
@@ -3768,7 +3768,7 @@ int androidApplySettingsString(wxString settings, ArrayOfCDI *pACDI) {
           wxLogMessage(_T("    Checking: ") + target + " .. " +
                        xcp->GetDSPort());
 
-          if ((SERIAL == xcp->Type) &&
+          if ((SERIAL == xcp->type) &&
               (target.IsSameAs(xcp->GetDSPort().AfterFirst(':')))) {
             pExistingParams = xcp;
             cp = xcp;
@@ -3781,10 +3781,10 @@ int androidApplySettingsString(wxString settings, ArrayOfCDI *pACDI) {
         if (pExistingParams) {
           wxLogMessage(_T("Using existing connection  ") + target);
 
-          if (pExistingParams->bEnabled == benabled) {
+          if (pExistingParams->is_enabled == benabled) {
             b_action = false;  // nothing to do...
           } else
-            cp->bEnabled = benabled;
+            cp->is_enabled = benabled;
         } else if (val.BeforeFirst(':').IsSameAs(
                        _T("1"))) {  //  Need a new Params
           // make a generic config string.
@@ -3799,7 +3799,7 @@ int androidApplySettingsString(wxString settings, ArrayOfCDI *pACDI) {
 
           ConnectionParams *new_params = new ConnectionParams(sSerial);
 
-          new_params->bEnabled = true;
+          new_params->is_enabled = true;
           TheConnectionParams().push_back(new_params);
           cp = new_params;
           rr |= NEED_NEW_OPTIONS;
@@ -3814,11 +3814,11 @@ int androidApplySettingsString(wxString settings, ArrayOfCDI *pACDI) {
             DataStream *pds_existing = g_pMUX->FindStream(cp->GetDSPort());
             if (pds_existing) g_pMUX->StopAndRemoveStream(pds_existing);
 
-            if (cp->bEnabled) {
+            if (cp->is_enabled) {
               PortDirection direction = cp->direction;
 #if 0
                             DataStream *dstr = new DataStream( g_pMUX,
-                                                               cp->Type,
+                                                               cp->type,
                                                                cp->GetDSPort(),
                                                                wxString::Format(wxT("%i"), cp->Baudrate),
                                                                port_type,
@@ -3826,7 +3826,7 @@ int androidApplySettingsString(wxString settings, ArrayOfCDI *pACDI) {
                                                                cp->Garmin);
 #endif
               DataStream *dstr = makeSerialDataStream(
-                  g_pMUX, cp->Type, cp->GetDSPort(),
+                  g_pMUX, cp->type, cp->GetDSPort(),
                   wxString::Format(wxT("%i"), cp->Baudrate), port_type,
                   cp->Priority, cp->Garmin);
 

--- a/gui/src/chcanv.cpp
+++ b/gui/src/chcanv.cpp
@@ -14020,8 +14020,8 @@ wxString ChartCanvas::FindValidUploadPort() {
     // If there is no persistent upload port recorded (yet)
     // then use the first available serial connection which has output defined.
     for (auto *cp : TheConnectionParams()) {
-      if ((cp->direction != PortDirection::kInput) && cp->Type == SERIAL)
-        port << "Serial:" << cp->Port;
+      if ((cp->direction != PortDirection::kInput) && cp->type == SERIAL)
+        port << "Serial:" << cp->serial_port;
     }
   }
   return port;

--- a/gui/src/conn_params_panel.cpp
+++ b/gui/src/conn_params_panel.cpp
@@ -95,7 +95,7 @@ ConnectionParamsPanel::ConnectionParamsPanel(
 }
 
 ConnectionParamsPanel::~ConnectionParamsPanel() {
-  if (m_pConnectionParams) m_pConnectionParams->m_optionsPanel = nullptr;
+  if (m_pConnectionParams) m_pConnectionParams->options_panel = nullptr;
 }
 
 void ConnectionParamsPanel::OnSelected(wxMouseEvent &event) {}
@@ -151,7 +151,7 @@ void ConnectionParamsPanel::CreateControls() {
       wxEVT_COMMAND_CHECKBOX_CLICKED,
       wxCommandEventHandler(ConnectionParamsPanel::OnEnableCBClick), NULL,
       this);
-  m_cbEnable->SetValue(m_pConnectionParams->bEnabled);
+  m_cbEnable->SetValue(m_pConnectionParams->is_enabled);
 
   enableSizer->Add(m_cbEnable, 1, wxLEFT | wxEXPAND, metric);
 
@@ -159,7 +159,7 @@ void ConnectionParamsPanel::CreateControls() {
   wxBoxSizer *parmSizer = new wxBoxSizer(wxVERTICAL);
   panelSizer->Add(parmSizer, 5);
 
-  if (m_pConnectionParams->Type == SERIAL) {
+  if (m_pConnectionParams->type == SERIAL) {
     wxFlexGridSizer *serialGrid = new wxFlexGridSizer(2, 6, 0, metric / 2);
     serialGrid->SetFlexibleDirection(wxHORIZONTAL);
     parmSizer->Add(serialGrid, 0, wxALIGN_LEFT);
@@ -213,7 +213,7 @@ void ConnectionParamsPanel::CreateControls() {
     serialGrid->Add(t6, 0, wxALIGN_CENTER_HORIZONTAL);
 
     wxString proto;
-    switch (m_pConnectionParams->Protocol) {
+    switch (m_pConnectionParams->data_protocol) {
       case PROTO_NMEA0183:
         proto = "NMEA 0183";
         break;
@@ -228,10 +228,10 @@ void ConnectionParamsPanel::CreateControls() {
     t12 = new ConnBoldLabel(this, proto);
     serialGrid->Add(t12, 0, wxALIGN_CENTER_HORIZONTAL);
 
-    t14 = new ConnBoldLabel(this, m_pConnectionParams->Port);
+    t14 = new ConnBoldLabel(this, m_pConnectionParams->serial_port);
     serialGrid->Add(t14, 0, wxALIGN_CENTER_HORIZONTAL);
 
-    auto baudRate = wxString::Format("%d", m_pConnectionParams->Baudrate);
+    auto baudRate = wxString::Format("%d", m_pConnectionParams->baudrate);
     t16 = new ConnBoldLabel(this, baudRate);
     serialGrid->Add(t16, 0, wxALIGN_CENTER_HORIZONTAL);
 
@@ -243,7 +243,7 @@ void ConnectionParamsPanel::CreateControls() {
                   this);
 
     t21 = new wxStaticText(this, wxID_ANY,
-                           _("Comment: ") + m_pConnectionParams->UserComment);
+                           _("Comment: ") + m_pConnectionParams->user_comment);
     parmSizer->Add(t21, 0);
     t21->Connect(wxEVT_LEFT_DOWN,
                  wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
@@ -251,7 +251,7 @@ void ConnectionParamsPanel::CreateControls() {
 
   }
 
-  else if (m_pConnectionParams->Type == NETWORK) {
+  else if (m_pConnectionParams->type == NETWORK) {
     wxString ioDir = m_pConnectionParams->GetPortDirectionValueStr();
 
     wxFlexGridSizer *netGrid = new wxFlexGridSizer(2, 6, 0, metric / 2);
@@ -316,19 +316,19 @@ void ConnectionParamsPanel::CreateControls() {
                 this);
 
     wxString proto;
-    switch (m_pConnectionParams->NetProtocol) {
+    switch (m_pConnectionParams->net_protocol) {
       case UDP:
         proto = "UDP";
-        if (m_pConnectionParams->Protocol == PROTO_NMEA0183)
+        if (m_pConnectionParams->data_protocol == PROTO_NMEA0183)
           proto << " N0183";
-        else if (m_pConnectionParams->Protocol == PROTO_NMEA2000)
+        else if (m_pConnectionParams->data_protocol == PROTO_NMEA2000)
           proto << " N2000";
         break;
       case TCP:
         proto = "TCP";
-        if (m_pConnectionParams->Protocol == PROTO_NMEA0183)
+        if (m_pConnectionParams->data_protocol == PROTO_NMEA0183)
           proto << " N0183";
-        else if (m_pConnectionParams->Protocol == PROTO_NMEA2000)
+        else if (m_pConnectionParams->data_protocol == PROTO_NMEA2000)
           proto << " N2000";
         break;
       case GPSD:
@@ -349,7 +349,7 @@ void ConnectionParamsPanel::CreateControls() {
                  wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
                  this);
 
-    wxString address = m_pConnectionParams->NetworkAddress;
+    wxString address = m_pConnectionParams->network_address;
     t14 = new wxStaticText(this, wxID_ANY, address);
     t14->SetFont(*bFont);
     netGrid->Add(t14, 0, wxALIGN_CENTER_HORIZONTAL);
@@ -358,7 +358,7 @@ void ConnectionParamsPanel::CreateControls() {
                  this);
 
     wxString port;
-    port.Printf("%d", m_pConnectionParams->NetworkPort);
+    port.Printf("%d", m_pConnectionParams->network_port);
     t16 = new wxStaticText(this, wxID_ANY, port);
     t16->SetFont(*bFont);
     netGrid->Add(t16, 0, wxALIGN_CENTER_HORIZONTAL);
@@ -374,14 +374,14 @@ void ConnectionParamsPanel::CreateControls() {
                   this);
 
     t21 = new wxStaticText(this, wxID_ANY,
-                           _("Comment: ") + m_pConnectionParams->UserComment);
+                           _("Comment: ") + m_pConnectionParams->user_comment);
     parmSizer->Add(t21, 0);
     t21->Connect(wxEVT_LEFT_DOWN,
                  wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
                  this);
   }
 
-  else if (m_pConnectionParams->Type == INTERNAL_GPS) {
+  else if (m_pConnectionParams->type == INTERNAL_GPS) {
     wxString ioDir = m_pConnectionParams->GetPortDirectionValueStr();
 
     wxFlexGridSizer *netGrid = new wxFlexGridSizer(2, 6, 0, metric / 2);
@@ -478,13 +478,13 @@ void ConnectionParamsPanel::CreateControls() {
                   this);
 
     t21 = new wxStaticText(this, wxID_ANY,
-                           _("Comment: ") + m_pConnectionParams->UserComment);
+                           _("Comment: ") + m_pConnectionParams->user_comment);
     parmSizer->Add(t21, 0);
     t21->Connect(wxEVT_LEFT_DOWN,
                  wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
                  this);
 
-  } else if (m_pConnectionParams->Type == INTERNAL_BT) {
+  } else if (m_pConnectionParams->type == INTERNAL_BT) {
     wxString ioDir = m_pConnectionParams->GetPortDirectionValueStr();
 
     wxFlexGridSizer *netGrid = new wxFlexGridSizer(2, 6, 0, metric / 2);
@@ -581,12 +581,12 @@ void ConnectionParamsPanel::CreateControls() {
                   this);
 
     t21 = new wxStaticText(this, wxID_ANY,
-                           _("Comment: ") + m_pConnectionParams->UserComment);
+                           _("Comment: ") + m_pConnectionParams->user_comment);
     parmSizer->Add(t21, 0);
     t21->Connect(wxEVT_LEFT_DOWN,
                  wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
                  this);
-  } else if (m_pConnectionParams->Type == SOCKETCAN) {
+  } else if (m_pConnectionParams->type == SOCKETCAN) {
     wxFlexGridSizer *netGrid = new wxFlexGridSizer(2, 6, 0, metric / 2);
     netGrid->SetFlexibleDirection(wxHORIZONTAL);
     parmSizer->Add(netGrid, 0, wxALIGN_LEFT);
@@ -641,7 +641,7 @@ void ConnectionParamsPanel::CreateControls() {
                 wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
                 this);
 
-    t6 = new wxStaticText(this, wxID_ANY, m_pConnectionParams->socketCAN_port);
+    t6 = new wxStaticText(this, wxID_ANY, m_pConnectionParams->socket_can_port);
     t6->SetFont(*bFont);
     netGrid->Add(t6, 0, wxALIGN_CENTER_HORIZONTAL);
     t6->Connect(wxEVT_LEFT_DOWN,
@@ -681,7 +681,7 @@ void ConnectionParamsPanel::CreateControls() {
                   this);
 
     t21 = new wxStaticText(this, wxID_ANY,
-                           _("Comment: ") + m_pConnectionParams->UserComment);
+                           _("Comment: ") + m_pConnectionParams->user_comment);
     parmSizer->Add(t21, 0);
     t21->Connect(wxEVT_LEFT_DOWN,
                  wxMouseEventHandler(ConnectionParamsPanel::OnSelected), NULL,
@@ -694,12 +694,12 @@ void ConnectionParamsPanel::Update(ConnectionParams *ConnectionParams) {
 
   wxString ioDir = m_pConnectionParams->GetPortDirectionValueStr();
 
-  if (m_pConnectionParams->Type == SERIAL) {
+  if (m_pConnectionParams->type == SERIAL) {
     wxString baudRate;
-    baudRate.Printf("%d", m_pConnectionParams->Baudrate);
+    baudRate.Printf("%d", m_pConnectionParams->baudrate);
 
     wxString proto;
-    switch (m_pConnectionParams->Protocol) {
+    switch (m_pConnectionParams->data_protocol) {
       case PROTO_NMEA0183:
         proto = "NMEA 0183";
         break;
@@ -714,25 +714,25 @@ void ConnectionParamsPanel::Update(ConnectionParams *ConnectionParams) {
     t2->SetLabel(_("Serial"));
     t6->SetLabel(ioDir);
     t12->SetLabel(proto);
-    t14->SetLabel(m_pConnectionParams->Port);
+    t14->SetLabel(m_pConnectionParams->serial_port);
     t16->SetLabel(baudRate);
 
-    t21->SetLabel(_("Comment: ") + m_pConnectionParams->UserComment);
-  } else if (m_pConnectionParams->Type == NETWORK) {
+    t21->SetLabel(_("Comment: ") + m_pConnectionParams->user_comment);
+  } else if (m_pConnectionParams->type == NETWORK) {
     wxString proto;
-    switch (m_pConnectionParams->NetProtocol) {
+    switch (m_pConnectionParams->net_protocol) {
       case UDP:
         proto = "UDP";
-        if (m_pConnectionParams->Protocol == PROTO_NMEA0183)
+        if (m_pConnectionParams->data_protocol == PROTO_NMEA0183)
           proto << " N0183";
-        else if (m_pConnectionParams->Protocol == PROTO_NMEA2000)
+        else if (m_pConnectionParams->data_protocol == PROTO_NMEA2000)
           proto << " N2000";
         break;
       case TCP:
         proto = "TCP";
-        if (m_pConnectionParams->Protocol == PROTO_NMEA0183)
+        if (m_pConnectionParams->data_protocol == PROTO_NMEA0183)
           proto << " N0183";
-        else if (m_pConnectionParams->Protocol == PROTO_NMEA2000)
+        else if (m_pConnectionParams->data_protocol == PROTO_NMEA2000)
           proto << " N2000";
         break;
       case GPSD:
@@ -746,26 +746,26 @@ void ConnectionParamsPanel::Update(ConnectionParams *ConnectionParams) {
         break;
     }
     wxString port;
-    port.Printf("%d", m_pConnectionParams->NetworkPort);
+    port.Printf("%d", m_pConnectionParams->network_port);
 
     t2->SetLabel(_("Network"));
     t6->SetLabel(ioDir);
     t12->SetLabel(proto);
-    t14->SetLabel(m_pConnectionParams->NetworkAddress);
+    t14->SetLabel(m_pConnectionParams->network_address);
     t16->SetLabel(port);
 
-    t21->SetLabel(_("Comment: ") + m_pConnectionParams->UserComment);
-  } else if (m_pConnectionParams->Type == INTERNAL_GPS) {
-    t21->SetLabel(_("Comment: ") + m_pConnectionParams->UserComment);
+    t21->SetLabel(_("Comment: ") + m_pConnectionParams->user_comment);
+  } else if (m_pConnectionParams->type == INTERNAL_GPS) {
+    t21->SetLabel(_("Comment: ") + m_pConnectionParams->user_comment);
   }
 
-  else if (m_pConnectionParams->Type == INTERNAL_BT) {
-    t21->SetLabel(_("Comment: ") + m_pConnectionParams->UserComment);
+  else if (m_pConnectionParams->type == INTERNAL_BT) {
+    t21->SetLabel(_("Comment: ") + m_pConnectionParams->user_comment);
   }
 
-  else if (m_pConnectionParams->Type == SOCKETCAN) {
-    t21->SetLabel(_("Comment: ") + m_pConnectionParams->UserComment);
-    t6->SetLabel(m_pConnectionParams->socketCAN_port);
+  else if (m_pConnectionParams->type == SOCKETCAN) {
+    t21->SetLabel(_("Comment: ") + m_pConnectionParams->user_comment);
+    t6->SetLabel(m_pConnectionParams->socket_can_port);
   }
 
   GetSizer()->Layout();

--- a/gui/src/connection_edit.cpp
+++ b/gui/src/connection_edit.cpp
@@ -155,11 +155,10 @@ static std::string GetChoiceSelection(const wxChoice* choice) {
  * the basic view.
  */
 static std::string NetViewByConnection(const ConnectionParams* cp) {
-  bool is_server = IsAddressListener(cp->NetworkAddress.ToStdString());
-  if (IsAddressMultiCast(cp->NetworkAddress))
-    return cp->direction == PortDirection::kOutput ? kMulticastClient
-                                                   : kMulticastServer;
-  switch (cp->NetProtocol) {
+  bool is_server = IsAddressListener(cp->network_address.ToStdString());
+  if (IsAddressMultiCast(cp->network_address))
+    return is_server ? kMulticastServer : kMulticastClient;
+  switch (cp->net_protocol) {
     case NetworkProtocol::GPSD:
       return kGpsdDevice;
     case NetworkProtocol::SIGNALK:
@@ -1146,8 +1145,8 @@ void ConnectionEditDialog::SetSelectedConnectionPanel(
   //  Only one panel can be selected at any time
   //  Clear any selections
 
-  if (m_selected_conn_params && m_selected_conn_params->m_optionsPanel)
-    m_selected_conn_params->m_optionsPanel->SetSelected(false);
+  if (m_selected_conn_params && m_selected_conn_params->options_panel)
+    m_selected_conn_params->options_panel->SetSelected(false);
 
   if (panel) {
     m_selected_conn_params = panel->m_pConnectionParams;
@@ -1181,8 +1180,8 @@ void ConnectionEditDialog::EnableConnection(ConnectionParams* conn,
                                             bool value) {
   if (conn) {
     // conn->bEnabled = value;
-    conn->b_IsSetup = false;  // trigger a rebuild/takedown of the connection
-    m_conn_enabled = conn->bEnabled;
+    conn->is_setup = false;  // trigger a rebuild/takedown of the connection
+    m_conn_enabled = conn->is_enabled;
   }
 }
 
@@ -1647,11 +1646,11 @@ void ConnectionEditDialog::PreloadControls(ConnectionParams* cp) {
 }
 
 void ConnectionEditDialog::SetConnectionParams(ConnectionParams* cp) {
-  if (cp->Type == NETWORK && cp->direction == PortDirection::kInput) {
+  if (cp->type == NETWORK && cp->direction == PortDirection::kInput) {
     // work around buggy pre 5.16 configurations which have "localhost" or
     // 127.0.0.1 instead of the correct 0.0.0.0
-    if (cp->NetworkAddress == "127.0.0.1" || cp->NetworkAddress == "localhost")
-      cp->NetworkAddress = "0.0.0.0";
+    auto& address = cp->network_address;
+    if (address == "127.0.0.1" || address == "localhost") address = "0.0.0.0";
   }
   const std::string view = NetViewByConnection(cp);
   auto found = std::find(kBasicNetViews.begin(), kBasicNetViews.end(), view);
@@ -1668,13 +1667,13 @@ void ConnectionEditDialog::SetConnectionParams(ConnectionParams* cp) {
     int select_ix = m_net_view_choice->FindString(*found);
     if (select_ix != wxNOT_FOUND) m_net_view_choice->SetSelection(select_ix);
   }
-  if (wxNOT_FOUND == m_port_combo->FindString(cp->Port))
-    m_port_combo->Append(cp->Port);
+  if (wxNOT_FOUND == m_port_combo->FindString(cp->serial_port))
+    m_port_combo->Append(cp->serial_port);
 
-  m_port_combo->Select(m_port_combo->FindString(cp->Port));
+  m_port_combo->Select(m_port_combo->FindString(cp->serial_port));
 
-  m_garmin_host_chkbox->SetValue(cp->Garmin);
-  m_sk_check_discover_chkbox->SetValue(cp->AutoSKDiscover);
+  m_garmin_host_chkbox->SetValue(cp->is_garmin);
+  m_sk_check_discover_chkbox->SetValue(cp->auto_sk_discover);
   if (view == kUdpReceive || view == kUdpInput) {
     m_input_chkbox->SetValue(true);
     m_input_chkbox->Disable();
@@ -1685,50 +1684,50 @@ void ConnectionEditDialog::SetConnectionParams(ConnectionParams* cp) {
     m_output_chkbox->SetValue(cp->direction != PortDirection::kInput);
   }
 
-  if (cp->InputSentenceListType == WHITELIST)
+  if (cp->input_sentence_list_type == WHITELIST)
     m_accept_radiobtn->SetValue(true);
   else
     m_ignore_radiobtn->SetValue(true);
-  if (cp->OutputSentenceListType == WHITELIST)
+  if (cp->output_sentence_list_type == WHITELIST)
     m_o_accept_radiobtn->SetValue(true);
   else
     m_o_ignore_radiobtn->SetValue(true);
-  m_input_stc_tctrl->SetValue(StringArrayToString(cp->InputSentenceList));
-  m_output_stc_tctrl->SetValue(StringArrayToString(cp->OutputSentenceList));
+  m_input_stc_tctrl->SetValue(StringArrayToString(cp->input_sentence_list));
+  m_output_stc_tctrl->SetValue(StringArrayToString(cp->output_sentence_list));
   m_baud_rate_choice->Select(
-      m_baud_rate_choice->FindString(wxString::Format("%d", cp->Baudrate)));
-  m_serial_protocol_choice->Select(cp->Protocol);  // TODO
+      m_baud_rate_choice->FindString(wxString::Format("%d", cp->baudrate)));
+  m_serial_protocol_choice->Select(cp->data_protocol);  // TODO
   auto net_address = dynamic_cast<TextCtrlWithHelp*>(m_net_address_tctrl);
-  if (net_address) m_net_address_tctrl->ChangeValue(cp->NetworkAddress);
+  if (net_address) m_net_address_tctrl->ChangeValue(cp->network_address);
 
-  m_net_data_protocol_choice->Select(cp->Protocol);  // TODO
+  m_net_data_protocol_choice->Select(cp->data_protocol);  // TODO
 
-  if (cp->NetworkPort == 0)
+  if (cp->network_port == 0)
     m_net_port_tctrl->ChangeValue("");
   else
-    m_net_port_tctrl->ChangeValue(std::to_string(cp->NetworkPort));
+    m_net_port_tctrl->ChangeValue(std::to_string(cp->network_port));
 
-  if (cp->Type == SERIAL) {
+  if (cp->type == SERIAL) {
     m_type_serial_radiobtn->SetValue(true);
     SetNMEAFormToSerial();
     SetNMEAFormForSerialProtocol();
-  } else if (cp->Type == NETWORK) {
+  } else if (cp->type == NETWORK) {
     m_type_net_radiobtn->SetValue(true);
     SetNMEAFormToNet();
-  } else if (cp->Type == SOCKETCAN) {
+  } else if (cp->type == SOCKETCAN) {
     m_type_can_radiobtn->SetValue(true);
     SetNMEAFormToCAN();
-  } else if (cp->Type == INTERNAL_GPS) {
+  } else if (cp->type == INTERNAL_GPS) {
     if (m_type_internal_gps_radiobtn)
       m_type_internal_gps_radiobtn->SetValue(true);
     SetNMEAFormToGPS();
-  } else if (cp->Type == INTERNAL_BT) {
+  } else if (cp->type == INTERNAL_BT) {
     if (m_type_internal_bt_radiobtn)
       m_type_internal_bt_radiobtn->SetValue(true);
     SetNMEAFormToBT();
 
     // Preset the source selector
-    wxString bts = cp->NetworkAddress + ";" + cp->GetPortStr();
+    wxString bts = cp->network_address + ";" + cp->serial_port;
     m_bt_data_sources_choice->Clear();
     m_bt_data_sources_choice->Append(bts);
     m_bt_data_sources_choice->SetSelection(0);
@@ -1736,17 +1735,17 @@ void ConnectionEditDialog::SetConnectionParams(ConnectionParams* cp) {
     ClearNMEAForm();
   }
 
-  if (cp->Type == SERIAL) {
-    m_serial_comment_tctrl->SetValue(cp->UserComment);
-  } else if (cp->Type == NETWORK) {
-    m_net_comment_tctrl->SetValue(cp->UserComment);
+  if (cp->type == SERIAL) {
+    m_serial_comment_tctrl->SetValue(cp->user_comment);
+  } else if (cp->type == NETWORK) {
+    m_net_comment_tctrl->SetValue(cp->user_comment);
     ConfigureControlsForView(view);
     OnExpertModeChange();
   }
 
-  m_auth_token_tctrl->SetValue(cp->AuthToken);
+  m_auth_token_tctrl->SetValue(cp->auth_token);
 
-  m_conn_enabled = cp->bEnabled;
+  m_conn_enabled = cp->is_enabled;
 
   // Reset touch flag
   m_is_conn_saved = true;
@@ -1814,7 +1813,7 @@ void ConnectionEditDialog::LayoutDialog() {
 
 void ConnectionEditDialog::UpdateSourceList(bool bResort) {
   for (auto* cp : TheConnectionParams()) {
-    ConnectionParamsPanel* panel = cp->m_optionsPanel;
+    ConnectionParamsPanel* panel = cp->options_panel;
     if (panel) panel->Update(cp);
   }
 
@@ -1914,12 +1913,12 @@ void ConnectionEditDialog::OnCbOutput(wxCommandEvent& event) {
       // Check for a UDP input connection on the same port
       NetworkProtocol proto = UDP;
       for (auto* cp : TheConnectionParams()) {
-        if (cp->NetProtocol == proto &&
-            cp->NetworkPort == wxAtoi(m_net_port_tctrl->GetValue()) &&
+        if (cp->net_protocol == proto &&
+            cp->network_port == wxAtoi(m_net_port_tctrl->GetValue()) &&
             cp->direction == PortDirection::kInput) {
           wxString mes;
           bool warn = false;
-          if (cp->bEnabled) {
+          if (cp->is_enabled) {
             mes =
                 _("There is an enabled UDP input connection that uses the "
                   "same data port.");
@@ -2017,34 +2016,35 @@ ConnectionParams* ConnectionEditDialog::GetParamsFromControls() {
 
 ConnectionParams* ConnectionEditDialog::UpdateConnectionParamsFromControls(
     ConnectionParams* pConnectionParams) {
-  pConnectionParams->Valid = true;
+  pConnectionParams->is_valid = true;
   int selection = m_net_view_choice->GetSelection();
   if (selection != wxNOT_FOUND) {
     std::string s = m_net_view_choice->GetString(selection).ToStdString();
   }
   if (m_type_serial_radiobtn->GetValue())
-    pConnectionParams->Type = SERIAL;
+    pConnectionParams->type = SERIAL;
   else if (m_type_net_radiobtn->GetValue())
-    pConnectionParams->Type = NETWORK;
+    pConnectionParams->type = NETWORK;
   else if (m_type_internal_gps_radiobtn &&
            m_type_internal_gps_radiobtn->GetValue())
-    pConnectionParams->Type = INTERNAL_GPS;
+    pConnectionParams->type = INTERNAL_GPS;
   else if (m_type_internal_bt_radiobtn &&
            m_type_internal_bt_radiobtn->GetValue())
-    pConnectionParams->Type = INTERNAL_BT;
+    pConnectionParams->type = INTERNAL_BT;
   else if (m_type_can_radiobtn && m_type_can_radiobtn->GetValue())
-    pConnectionParams->Type = SOCKETCAN;
+    pConnectionParams->type = SOCKETCAN;
 
   if (m_type_net_radiobtn->GetValue()) {
     //  Save the existing addr/port to allow closing of existing port
-    pConnectionParams->LastNetworkAddress = pConnectionParams->NetworkAddress;
-    pConnectionParams->LastNetworkPort = pConnectionParams->NetworkPort;
-    pConnectionParams->LastNetProtocol = pConnectionParams->NetProtocol;
-    pConnectionParams->LastDataProtocol = pConnectionParams->Protocol;
+    pConnectionParams->last_network_address =
+        pConnectionParams->network_address;
+    pConnectionParams->last_network_port = pConnectionParams->network_port;
+    pConnectionParams->last_net_protocol = pConnectionParams->net_protocol;
+    pConnectionParams->last_data_protocol = pConnectionParams->data_protocol;
 
-    pConnectionParams->NetworkAddress =
+    pConnectionParams->network_address =
         m_net_address_tctrl->GetValue().Trim(false).Trim(true);
-    pConnectionParams->NetworkPort =
+    pConnectionParams->network_port =
         wxAtoi(m_net_port_tctrl->GetValue().Trim(false).Trim(true));
     int net_select = m_net_view_choice->GetSelection();
     std::string net_type;
@@ -2052,41 +2052,41 @@ ConnectionParams* ConnectionEditDialog::UpdateConnectionParamsFromControls(
       net_type = m_net_view_choice->GetString(net_select).ToStdString();
     if (net_type == kTcpClient || net_type == kTcpServer ||
         net_type == kTcpDevice) {
-      pConnectionParams->NetProtocol = TCP;
-      pConnectionParams->Protocol =
+      pConnectionParams->net_protocol = TCP;
+      pConnectionParams->data_protocol =
           static_cast<DataProtocol>(m_net_data_protocol_choice->GetSelection());
     } else if (net_type == kUdpSend || net_type == kUdpInput ||
                net_type == kUdpReceive || net_type == kMulticastClient ||
                net_type == kMulticastServer) {
-      pConnectionParams->NetProtocol = UDP;
-      pConnectionParams->Protocol =
+      pConnectionParams->net_protocol = UDP;
+      pConnectionParams->data_protocol =
           static_cast<DataProtocol>(m_net_data_protocol_choice->GetSelection());
     } else if (net_type == kGpsdClient || net_type == kGpsdDevice) {
-      pConnectionParams->NetProtocol = GPSD;
+      pConnectionParams->net_protocol = GPSD;
     } else if (net_type == kSignalkClient || net_type == kSignalkDevice) {
-      pConnectionParams->NetProtocol = SIGNALK;
+      pConnectionParams->net_protocol = SIGNALK;
     } else {
-      pConnectionParams->NetProtocol = PROTO_UNDEFINED;
+      pConnectionParams->net_protocol = PROTO_UNDEFINED;
     };
   }
   if (m_type_serial_radiobtn->GetValue())
-    pConnectionParams->Protocol =
+    pConnectionParams->data_protocol =
         (DataProtocol)m_serial_protocol_choice->GetSelection();
   else if (m_type_net_radiobtn->GetValue())
-    pConnectionParams->Protocol =
+    pConnectionParams->data_protocol =
         (DataProtocol)m_net_data_protocol_choice->GetSelection();
 
-  pConnectionParams->Baudrate =
+  pConnectionParams->baudrate =
       wxAtoi(m_baud_rate_choice->GetStringSelection());
-  pConnectionParams->ChecksumCheck = true;
-  pConnectionParams->AutoSKDiscover = m_sk_check_discover_chkbox->GetValue();
-  pConnectionParams->Garmin = m_garmin_host_chkbox->GetValue();
-  pConnectionParams->InputSentenceList =
+  pConnectionParams->checksum_check = true;
+  pConnectionParams->auto_sk_discover = m_sk_check_discover_chkbox->GetValue();
+  pConnectionParams->is_garmin = m_garmin_host_chkbox->GetValue();
+  pConnectionParams->input_sentence_list =
       wxStringTokenize(m_input_stc_tctrl->GetValue(), ",");
   if (m_accept_radiobtn->GetValue())
-    pConnectionParams->InputSentenceListType = WHITELIST;
+    pConnectionParams->input_sentence_list_type = WHITELIST;
   else
-    pConnectionParams->InputSentenceListType = BLACKLIST;
+    pConnectionParams->input_sentence_list_type = BLACKLIST;
   if (m_input_chkbox->GetValue()) {
     if (m_output_chkbox->GetValue()) {
       pConnectionParams->direction = PortDirection::kInOut;
@@ -2096,60 +2096,60 @@ ConnectionParams* ConnectionEditDialog::UpdateConnectionParamsFromControls(
   } else
     pConnectionParams->direction = PortDirection::kOutput;
 
-  pConnectionParams->OutputSentenceList =
+  pConnectionParams->output_sentence_list =
       wxStringTokenize(m_output_stc_tctrl->GetValue(), ",");
   if (m_o_accept_radiobtn->GetValue())
-    pConnectionParams->OutputSentenceListType = WHITELIST;
+    pConnectionParams->output_sentence_list_type = WHITELIST;
   else
-    pConnectionParams->OutputSentenceListType = BLACKLIST;
-  pConnectionParams->Port = m_port_combo->GetValue().BeforeFirst(' ');
+    pConnectionParams->output_sentence_list_type = BLACKLIST;
+  pConnectionParams->serial_port = m_port_combo->GetValue().BeforeFirst(' ');
 #if defined(__linux__) && !defined(__ANDROID__)
-  if (pConnectionParams->Type == SERIAL)
-    CheckSerialAccess(m_parent, pConnectionParams->Port.ToStdString());
+  if (pConnectionParams->type == SERIAL)
+    CheckSerialAccess(m_parent, pConnectionParams->serial_port.ToStdString());
 #endif
 
   if (m_type_can_radiobtn && m_type_can_radiobtn->GetValue())
-    pConnectionParams->Protocol = PROTO_NMEA2000;
+    pConnectionParams->data_protocol = PROTO_NMEA2000;
 
-  pConnectionParams->bEnabled = m_conn_enabled;
-  pConnectionParams->b_IsSetup = false;
+  pConnectionParams->is_enabled = m_conn_enabled;
+  pConnectionParams->is_setup = false;
 
-  if (pConnectionParams->Type == INTERNAL_GPS) {
-    pConnectionParams->NetworkAddress = "";
-    pConnectionParams->NetworkPort = 0;
-    pConnectionParams->NetProtocol = PROTO_UNDEFINED;
-    pConnectionParams->Baudrate = 0;
-    pConnectionParams->Port = "Internal GPS";
+  if (pConnectionParams->type == INTERNAL_GPS) {
+    pConnectionParams->network_address = "";
+    pConnectionParams->network_port = 0;
+    pConnectionParams->net_protocol = PROTO_UNDEFINED;
+    pConnectionParams->baudrate = 0;
+    pConnectionParams->serial_port = "Internal GPS";
   }
 
-  if (pConnectionParams->Type == INTERNAL_BT) {
+  if (pConnectionParams->type == INTERNAL_BT) {
     wxString parms = m_bt_data_sources_choice->GetStringSelection();
     wxStringTokenizer tkz(parms, ";");
     wxString name = tkz.GetNextToken();
     wxString mac = tkz.GetNextToken();
 
-    pConnectionParams->NetworkAddress = name;
-    pConnectionParams->Port = mac;
-    pConnectionParams->NetworkPort = 0;
-    pConnectionParams->NetProtocol = PROTO_UNDEFINED;
-    pConnectionParams->Baudrate = 0;
+    pConnectionParams->network_address = name;
+    pConnectionParams->serial_port = mac;
+    pConnectionParams->network_port = 0;
+    pConnectionParams->net_protocol = PROTO_UNDEFINED;
+    pConnectionParams->baudrate = 0;
     //        pConnectionParams->SetAuxParameterStr(m_choiceBTDataSources->GetStringSelection());
   }
 
-  if (pConnectionParams->Type == SOCKETCAN) {
-    pConnectionParams->NetworkAddress = "";
-    pConnectionParams->NetworkPort = 0;
-    pConnectionParams->NetProtocol = PROTO_UNDEFINED;
-    pConnectionParams->Baudrate = 0;
-    pConnectionParams->socketCAN_port =
+  if (pConnectionParams->type == SOCKETCAN) {
+    pConnectionParams->network_address = "";
+    pConnectionParams->network_port = 0;
+    pConnectionParams->net_protocol = PROTO_UNDEFINED;
+    pConnectionParams->baudrate = 0;
+    pConnectionParams->socket_can_port =
         m_can_source_choice->GetString(m_can_source_choice->GetSelection());
   }
-  if (pConnectionParams->Type == SERIAL) {
-    pConnectionParams->UserComment = m_serial_comment_tctrl->GetValue();
-  } else if (pConnectionParams->Type == NETWORK) {
-    pConnectionParams->UserComment = m_net_comment_tctrl->GetValue();
+  if (pConnectionParams->type == SERIAL) {
+    pConnectionParams->user_comment = m_serial_comment_tctrl->GetValue();
+  } else if (pConnectionParams->type == NETWORK) {
+    pConnectionParams->user_comment = m_net_comment_tctrl->GetValue();
   }
-  pConnectionParams->AuthToken = m_auth_token_tctrl->GetValue();
+  pConnectionParams->auth_token = m_auth_token_tctrl->GetValue();
 
   return pConnectionParams;
 }

--- a/gui/src/connections_dlg.cpp
+++ b/gui/src/connections_dlg.cpp
@@ -115,16 +115,16 @@ static std::string BitsToDottedMask(const unsigned bits) {
 
 static ConnectionParams* FindConnectionByIface(const ConnectionParams* new_cp) {
   for (const auto& cp : TheConnectionParams()) {
-    if (cp->Type != new_cp->Type) continue;
-    switch (cp->Type) {
+    if (cp->type != new_cp->type) continue;
+    switch (cp->type) {
       case SERIAL:
-        if (cp->Port != new_cp->Port) continue;
+        if (cp->serial_port != new_cp->serial_port) continue;
         return cp;
         break;
       case NETWORK:
-        if (cp->NetProtocol != new_cp->NetProtocol) continue;
-        if (cp->NetworkAddress != new_cp->NetworkAddress) continue;
-        if (cp->NetworkPort != new_cp->NetworkPort) continue;
+        if (cp->net_protocol != new_cp->net_protocol) continue;
+        if (cp->network_address != new_cp->network_address) continue;
+        if (cp->network_port != new_cp->network_port) continue;
         return cp;
         break;
       case INTERNAL_GPS:
@@ -134,7 +134,7 @@ static ConnectionParams* FindConnectionByIface(const ConnectionParams* new_cp) {
         return cp;
         break;
       case SOCKETCAN:
-        if (cp->socketCAN_port != new_cp->socketCAN_port) continue;
+        if (cp->socket_can_port != new_cp->socket_can_port) continue;
         return cp;
         break;
       default:
@@ -321,7 +321,8 @@ public:
                   const ConnectionParams* p2) const {
     switch (m_col) {
       case 0:
-        return static_cast<int>(p1->bEnabled) > static_cast<int>(p2->bEnabled);
+        return static_cast<int>(p1->is_enabled) >
+               static_cast<int>(p2->is_enabled);
       case 1:
         return p1->GetCommProtocol() < p2->GetCommProtocol();
       case 2:
@@ -479,8 +480,8 @@ public:
     for (auto it = connections.begin(); it != connections.end(); ++it) {
       const auto row = static_cast<int>(it - connections.begin());
       EnsureRows(row);
-      SetCellValue(row, 0, (*it)->bEnabled ? "1" : "");
-      if ((*it)->bEnabled)
+      SetCellValue(row, 0, (*it)->is_enabled ? "1" : "");
+      if ((*it)->is_enabled)
         m_tooltips[row][0] = _("Enabled, click to disable");
       else
         m_tooltips[row][0] = _("Disabled, click to enable");
@@ -488,7 +489,7 @@ public:
       SetCellValue(row, 1, protocol);
       SetCellValue(row, 2, (*it)->GetPortDirectionValueStr());
       SetCellValue(row, 3, (*it)->GetStrippedDSPort());
-      m_tooltips[row][3] = (*it)->UserComment;
+      m_tooltips[row][3] = (*it)->user_comment;
       SetCellRenderer(row, 5, new BitmapCellRenderer(m_icons.settings, m_cs));
       m_tooltips[row][5] = _("Edit connection");
       SetCellRenderer(row, 6, new BitmapCellRenderer(m_icons.trash_bin, m_cs));
@@ -668,7 +669,7 @@ private:
     for (auto it = connections.begin(); it != connections.end(); ++it) {
       ConnState state = m_conn_states.GetDriverState(
           (*it)->GetCommProtocol(), (*it)->GetStrippedDSPort());
-      if (!(*it)->bEnabled) state = ConnState::Disabled;
+      if (!(*it)->is_enabled) state = ConnState::Disabled;
       auto row = static_cast<int>(it - connections.begin());
       EnsureRows(row);
       if (static_cast<int>(m_renderer_status_vector.size()) < row + 1) continue;
@@ -749,10 +750,10 @@ private:
   void HandleEnable(int row) {
     ConnectionParams* cp = FindRowConnection(row);
     if (!cp) return;
-    cp->bEnabled = !cp->bEnabled;
-    cp->b_IsSetup = FALSE;  // trigger a rebuild/takedown of the connection
-    SetCellValue(row, 0, cp->bEnabled ? "1" : "");
-    if (cp->bEnabled)
+    cp->is_enabled = !cp->is_enabled;
+    cp->is_setup = FALSE;  // trigger a rebuild/takedown of the connection
+    SetCellValue(row, 0, cp->is_enabled ? "1" : "");
+    if (cp->is_enabled)
       m_tooltips[row][0] = _("Enabled, click to disable");
     else
       m_tooltips[row][0] = _("Disabled, click to enable");
@@ -761,9 +762,9 @@ private:
     stats.driver_bus = cp->GetCommProtocol();
     m_conn_states.HandleDriverStats(stats);
     StopAndRemoveCommDriver(cp->GetStrippedDSPort(), cp->GetCommProtocol());
-    if (cp->bEnabled) MakeCommDriver(cp);
-    cp->b_IsSetup = true;
-    if (!cp->bEnabled) {
+    if (cp->is_enabled) MakeCommDriver(cp);
+    cp->is_setup = true;
+    if (!cp->is_enabled) {
       SetCellValue(row, 4, UtfFilledCircle());
       // ForceRefresh() apparently broken, see #4648
       ReloadGrid(TheConnectionParams());
@@ -788,7 +789,7 @@ private:
       int rcode = OCPNMessageBox(this, ss.str(), _("Delete connection?"),
                                  wxOK | wxCANCEL);
       if (rcode != wxID_OK && rcode != wxID_YES) return;
-      delete (*found)->m_optionsPanel;
+      delete (*found)->options_panel;
       StopAndRemoveCommDriver((*found)->GetStrippedDSPort(),
                               (*found)->GetCommProtocol());
       TheConnectionParams().erase(found);
@@ -1245,13 +1246,13 @@ public:
     // OK from EDIT mode
     if (!new_mode) {
       ConnectionParams* cp_edited = m_edit_panel->GetParamsFromControls();
-      delete cp_orig->m_optionsPanel;
+      delete cp_orig->options_panel;
       StopAndRemoveCommDriver(cp_orig->GetStrippedDSPort(),
                               cp_orig->GetCommProtocol());
       int index = top_panel->GetConnectionsGrid()->FindConnectionIndex(cp_orig);
       assert(index != -1 && "Cannot look up connection index");
       TheConnectionParams()[index] = cp_edited;
-      cp_edited->b_IsSetup = false;  // Trigger new stream
+      cp_edited->is_setup = false;  // Trigger new stream
     }
     //  OK from NEW mode
     else {
@@ -1263,9 +1264,9 @@ public:
                                  wxOK | wxCENTRE | wxICON_WARNING);
           dialog.ShowModal();
         }
-        if (cp->GetValidPort()) {
+        if (cp->IsPortValid()) {
           // Trigger new stream
-          cp->b_IsSetup = false;
+          cp->is_setup = false;
           // transfer ownership FIXME use smart pointers
           TheConnectionParams().push_back(cp);
         } else {

--- a/gui/src/initwiz/wiz_ui.cpp
+++ b/gui/src/initwiz/wiz_ui.cpp
@@ -271,13 +271,13 @@ void FirstUseWizImpl::EnumerateUSB() {
         DEBUG_LOG << "Known device: " << port.port << " " << port.description
                   << " " << port.hardware_id;
         ConnectionParams params;
-        params.Type = ConnectionType::SERIAL;
-        params.NetProtocol = NetworkProtocol::PROTO_UNDEFINED;
-        params.Protocol = device.protocol;
-        params.LastDataProtocol = device.protocol;
-        params.Port = port.port;
-        params.UserComment = port.description;
-        params.Baudrate = device.baudrate;
+        params.type = ConnectionType::SERIAL;
+        params.net_protocol = NetworkProtocol::PROTO_UNDEFINED;
+        params.data_protocol = device.protocol;
+        params.last_data_protocol = device.protocol;
+        params.serial_port = port.port;
+        params.user_comment = port.description;
+        params.baudrate = device.baudrate;
         m_detected_connections.push_back(params);
         known = true;
       }
@@ -307,31 +307,31 @@ void FirstUseWizImpl::EnumerateUSB() {
             auto flavor = SeemsN0183(data);
             if (flavor != NMEA0183Flavor::INVALID) {
               ConnectionParams params;
-              params.Type = ConnectionType::SERIAL;
-              params.NetProtocol = NetworkProtocol::PROTO_UNDEFINED;
-              params.Protocol = DataProtocol::PROTO_NMEA0183;
-              params.LastDataProtocol = DataProtocol::PROTO_NMEA0183;
+              params.type = ConnectionType::SERIAL;
+              params.net_protocol = NetworkProtocol::PROTO_UNDEFINED;
+              params.data_protocol = DataProtocol::PROTO_NMEA0183;
+              params.last_data_protocol = DataProtocol::PROTO_NMEA0183;
               if (flavor == NMEA0183Flavor::CRC) {
-                params.ChecksumCheck = true;
+                params.checksum_check = true;
               } else {
-                params.ChecksumCheck = false;
+                params.checksum_check = false;
               }
-              params.Port = port.port;
-              params.UserComment = wxString::Format(
+              params.serial_port = port.port;
+              params.user_comment = wxString::Format(
                   "NMEA0183: %s (%s) @%u", port.description, port.port, sp);
-              params.Baudrate = sp;
+              params.baudrate = sp;
               m_detected_connections.push_back(params);
               break;
             } else if (SeemsN2000(data)) {
               ConnectionParams params;
-              params.Type = ConnectionType::SERIAL;
-              params.NetProtocol = NetworkProtocol::PROTO_UNDEFINED;
-              params.Protocol = DataProtocol::PROTO_NMEA2000;
-              params.LastDataProtocol = DataProtocol::PROTO_NMEA2000;
-              params.Port = port.port;
-              params.UserComment = wxString::Format(
+              params.type = ConnectionType::SERIAL;
+              params.net_protocol = NetworkProtocol::PROTO_UNDEFINED;
+              params.data_protocol = DataProtocol::PROTO_NMEA2000;
+              params.last_data_protocol = DataProtocol::PROTO_NMEA2000;
+              params.serial_port = port.port;
+              params.user_comment = wxString::Format(
                   "NMEA2000: %s (%s) @%u", port.description, port.port, sp);
-              params.Baudrate = sp;
+              params.baudrate = sp;
               m_detected_connections.push_back(params);
               break;
             }
@@ -396,29 +396,31 @@ void FirstUseWizImpl::EnumerateUDP() {
       DEBUG_LOG << "Read: " << data;
       if (auto flavor = SeemsN0183(data); flavor != NMEA0183Flavor::INVALID) {
         ConnectionParams params;
-        params.Type = ConnectionType::NETWORK;
-        params.NetProtocol = NetworkProtocol::UDP;
-        params.Protocol = DataProtocol::PROTO_NMEA0183;
-        params.LastDataProtocol = DataProtocol::PROTO_NMEA0183;
+        params.type = ConnectionType::NETWORK;
+        params.net_protocol = NetworkProtocol::UDP;
+        params.data_protocol = DataProtocol::PROTO_NMEA0183;
+        params.last_data_protocol = DataProtocol::PROTO_NMEA0183;
         if (flavor == NMEA0183Flavor::CRC) {
-          params.ChecksumCheck = true;
+          params.checksum_check = true;
         } else {
-          params.ChecksumCheck = false;
+          params.checksum_check = false;
         }
-        params.NetworkAddress = "0.0.0.0";
-        params.NetworkPort = port;
-        params.UserComment = wxString::Format(_("NMEA0183: UDP port %d"), port);
+        params.network_address = "0.0.0.0";
+        params.network_port = port;
+        params.user_comment =
+            wxString::Format(_("NMEA0183: UDP port %d"), port);
         m_detected_connections.push_back(params);
         continue;
       } else if (SeemsN2000(data)) {
         ConnectionParams params;
-        params.Type = ConnectionType::NETWORK;
-        params.NetProtocol = NetworkProtocol::UDP;
-        params.Protocol = DataProtocol::PROTO_NMEA2000;
-        params.LastDataProtocol = DataProtocol::PROTO_NMEA2000;
-        params.NetworkAddress = "0.0.0.0";
-        params.NetworkPort = port;
-        params.UserComment = wxString::Format(_("NMEA2000: UDP port %d"), port);
+        params.type = ConnectionType::NETWORK;
+        params.net_protocol = NetworkProtocol::UDP;
+        params.data_protocol = DataProtocol::PROTO_NMEA2000;
+        params.last_data_protocol = DataProtocol::PROTO_NMEA2000;
+        params.network_address = "0.0.0.0";
+        params.network_port = port;
+        params.user_comment =
+            wxString::Format(_("NMEA2000: UDP port %d"), port);
         m_detected_connections.push_back(params);
         continue;
       }
@@ -512,31 +514,31 @@ void FirstUseWizImpl::EnumerateTCP() {
           if (auto flavor = SeemsN0183(data);
               flavor != NMEA0183Flavor::INVALID) {
             ConnectionParams params;
-            params.Type = ConnectionType::NETWORK;
-            params.NetProtocol = NetworkProtocol::TCP;
-            params.Protocol = DataProtocol::PROTO_NMEA0183;
-            params.LastDataProtocol = DataProtocol::PROTO_NMEA0183;
+            params.type = ConnectionType::NETWORK;
+            params.net_protocol = NetworkProtocol::TCP;
+            params.data_protocol = DataProtocol::PROTO_NMEA0183;
+            params.last_data_protocol = DataProtocol::PROTO_NMEA0183;
             if (flavor == NMEA0183Flavor::CRC) {
-              params.ChecksumCheck = true;
+              params.checksum_check = true;
             } else {
-              params.ChecksumCheck = false;
+              params.checksum_check = false;
             }
-            params.NetworkAddress = ip;
-            params.NetworkPort = port;
-            params.UserComment = wxString::Format(_("NMEA0183: %s TCP port %d"),
-                                                  ip.c_str(), port);
+            params.network_address = ip;
+            params.network_port = port;
+            params.user_comment = wxString::Format(
+                _("NMEA0183: %s TCP port %d"), ip.c_str(), port);
             m_detected_connections.push_back(params);
             continue;
           } else if (SeemsN2000(data)) {
             ConnectionParams params;
-            params.Type = ConnectionType::NETWORK;
-            params.NetProtocol = NetworkProtocol::TCP;
-            params.Protocol = DataProtocol::PROTO_NMEA2000;
-            params.LastDataProtocol = DataProtocol::PROTO_NMEA2000;
-            params.NetworkAddress = ip;
-            params.NetworkPort = port;
-            params.UserComment = wxString::Format(_("NMEA2000: %s TCP port %d"),
-                                                  ip.c_str(), port);
+            params.type = ConnectionType::NETWORK;
+            params.net_protocol = NetworkProtocol::TCP;
+            params.data_protocol = DataProtocol::PROTO_NMEA2000;
+            params.last_data_protocol = DataProtocol::PROTO_NMEA2000;
+            params.network_address = ip;
+            params.network_port = port;
+            params.user_comment = wxString::Format(
+                _("NMEA2000: %s TCP port %d"), ip.c_str(), port);
             m_detected_connections.push_back(params);
             continue;
           }
@@ -587,12 +589,12 @@ void FirstUseWizImpl::EnumerateCAN() {
         if (link_type == "can") {
           DEBUG_LOG << "Found CAN interface: " << ifname;
           ConnectionParams params;
-          params.Type = ConnectionType::SOCKETCAN;
-          params.NetProtocol = NetworkProtocol::PROTO_UNDEFINED;
-          params.Protocol = DataProtocol::PROTO_NMEA2000;
-          params.LastDataProtocol = DataProtocol::PROTO_NMEA2000;
-          params.Port = ifname;
-          params.UserComment = wxString::Format("SocketCAN: %s", ifname);
+          params.type = ConnectionType::SOCKETCAN;
+          params.net_protocol = NetworkProtocol::PROTO_UNDEFINED;
+          params.data_protocol = DataProtocol::PROTO_NMEA2000;
+          params.last_data_protocol = DataProtocol::PROTO_NMEA2000;
+          params.serial_port = ifname;
+          params.user_comment = wxString::Format("SocketCAN: %s", ifname);
           m_detected_connections.push_back(params);
         }
       }
@@ -611,13 +613,13 @@ void FirstUseWizImpl::EnumerateGPSD() {
   client->SetTimeout(1);
   if (client->Connect(conn_addr, true)) {
     ConnectionParams params;
-    params.Type = ConnectionType::NETWORK;
-    params.NetProtocol = NetworkProtocol::GPSD;
-    params.Protocol = DataProtocol::PROTO_NMEA0183;
-    params.LastDataProtocol = DataProtocol::PROTO_NMEA0183;
-    params.NetworkAddress = "127.0.0.1";
-    params.NetworkPort = 2947;
-    params.UserComment =
+    params.type = ConnectionType::NETWORK;
+    params.net_protocol = NetworkProtocol::GPSD;
+    params.data_protocol = DataProtocol::PROTO_NMEA0183;
+    params.last_data_protocol = DataProtocol::PROTO_NMEA0183;
+    params.network_address = "127.0.0.1";
+    params.network_port = 2947;
+    params.user_comment =
         wxString::Format(_("GPSd: %s TCP port %d"), "127.0.0.1", 2947);
     m_detected_connections.push_back(params);
   }
@@ -679,19 +681,19 @@ void FirstUseWizImpl::EnumerateDatasources() {
   wxYield();
   for (const auto& sks : g_sk_servers) {
     ConnectionParams params;
-    params.Type = ConnectionType::NETWORK;
-    params.NetProtocol = NetworkProtocol::SIGNALK;
-    params.Protocol = DataProtocol::PROTO_SIGNALK;
-    params.LastDataProtocol = DataProtocol::PROTO_SIGNALK;
-    params.NetworkAddress = sks.ip;
-    params.NetworkPort = std::stoi(sks.port);
-    params.UserComment =
+    params.type = ConnectionType::NETWORK;
+    params.net_protocol = NetworkProtocol::SIGNALK;
+    params.data_protocol = DataProtocol::PROTO_SIGNALK;
+    params.last_data_protocol = DataProtocol::PROTO_SIGNALK;
+    params.network_address = sks.ip;
+    params.network_port = std::stoi(sks.port);
+    params.user_comment =
         wxString::Format(_("SignalK: %s (%s port %d)"), sks.hostname,
-                         params.NetworkAddress, params.NetworkPort);
+                         params.network_address, params.network_port);
     m_detected_connections.push_back(params);
   }
   for (const auto& conn : m_detected_connections) {
-    m_clSources->Append(conn.UserComment);
+    m_clSources->Append(conn.user_comment);
     m_clSources->Check(m_clSources->GetCount() - 1, true);
   }
   wxString svgDir = g_Platform->GetSharedDataDir() + _T("uidata") +

--- a/gui/src/navutil.cpp
+++ b/gui/src/navutil.cpp
@@ -927,7 +927,7 @@ int MyConfig::LoadMyConfigRaw(bool bAsTemplate) {
       wxArrayString confs = wxStringTokenize(connectionconfigs, "|");
       for (size_t i = 0; i < confs.Count(); i++) {
         ConnectionParams *prm = new ConnectionParams(confs[i]);
-        if (!prm->Valid) {
+        if (!prm->is_valid) {
           wxLogMessage("Skipped invalid DataStream config");
           delete prm;
           continue;

--- a/gui/src/ocpn_app.cpp
+++ b/gui/src/ocpn_app.cpp
@@ -1339,9 +1339,9 @@ bool MyApp::OnInit() {
   pConfig->UpdateSettings();
 
   for (auto *cp : TheConnectionParams()) {
-    if (cp->bEnabled) {
+    if (cp->is_enabled) {
       if (cp->GetDSPort().Contains("Serial")) {
-        std::string port(cp->Port.ToStdString());
+        std::string port(cp->serial_port.ToStdString());
         /// CheckSerialAccess(gFrame, port);
       }
     }
@@ -1594,9 +1594,9 @@ void MyApp::BuildMainFrame() {
 
   // Load comm connections
   for (auto *cp : TheConnectionParams()) {
-    if (cp->bEnabled) {
+    if (cp->is_enabled) {
       MakeCommDriver(cp);
-      cp->b_IsSetup = TRUE;
+      cp->is_setup = TRUE;
     }
   }
   MakeLoopbackDriver();

--- a/gui/src/ocpn_platform.cpp
+++ b/gui/src/ocpn_platform.cpp
@@ -1289,7 +1289,7 @@ void OCPNPlatform::SetDefaultOptions() {
   wxString sGPS = "2;3;;0;0;;0;1;0;0;;0;;1;0;0;0;0";  // 17 parms
   ConnectionParams *new_params = new ConnectionParams(sGPS);
 
-  new_params->bEnabled = true;
+  new_params->is_enabled = true;
   TheConnectionParams().push_back(new_params);
 
   g_default_font_facename = "Roboto";

--- a/gui/src/send_to_gps_dlg.cpp
+++ b/gui/src/send_to_gps_dlg.cpp
@@ -122,15 +122,15 @@ void SendToGpsDlg::CreateControls(const wxString& hint) {
   for (auto* cp : TheConnectionParams()) {
     wxString netident;
 
-    if ((cp->direction != PortDirection::kInput) && cp->Type == NETWORK &&
-        (cp->NetProtocol == TCP)) {
-      netident << "TCP:" << cp->NetworkAddress << ":" << cp->NetworkPort;
+    if ((cp->direction != PortDirection::kInput) && cp->type == NETWORK &&
+        (cp->net_protocol == TCP)) {
+      netident << "TCP:" << cp->network_address << ":" << cp->network_port;
       m_itemCommListBox->Append(netident);
       netconns.Add(netident);
     }
-    if ((cp->direction != PortDirection::kInput) && cp->Type == NETWORK &&
-        (cp->NetProtocol == UDP)) {
-      netident << "UDP:" << cp->NetworkAddress << ":" << cp->NetworkPort;
+    if ((cp->direction != PortDirection::kInput) && cp->type == NETWORK &&
+        (cp->net_protocol == UDP)) {
+      netident << "UDP:" << cp->network_address << ":" << cp->network_port;
       m_itemCommListBox->Append(netident);
       netconns.Add(netident);
     }

--- a/model/include/model/conn_params.h
+++ b/model/include/model/conn_params.h
@@ -24,11 +24,8 @@
 #ifndef CONNECTIONPARAMS_H_
 #define CONNECTIONPARAMS_H_
 
-#include <wx/wxprec.h>
-
 #ifndef WX_PRECOMP
 #include <wx/arrstr.h>
-#include <wx/dynarray.h>
 #include <wx/string.h>
 #endif
 
@@ -72,72 +69,97 @@ typedef enum {
 
 class ConnectionParamsPanel;
 
+/**
+ * Connection data container close to a POD struct
+ */
 class ConnectionParams {
 public:
   ConnectionParams();
+  explicit ConnectionParams(const wxString &config_str);
   ~ConnectionParams();
-  ConnectionParams(const wxString &configStr);
 
-  ConnectionType Type;
-  NetworkProtocol NetProtocol;
-  wxString NetworkAddress;
-  int NetworkPort;
-
-  wxString LastNetworkAddress;
-  int LastNetworkPort;
-  NetworkProtocol LastNetProtocol;
-  DataProtocol LastDataProtocol;
-
-  DataProtocol Protocol;
-  wxString Port;
-  wxString socketCAN_port;
-  int Baudrate;
-  bool NoDataReconnect;
-  bool DisableEcho;
-  bool ChecksumCheck;
-  bool Garmin;
-  bool GarminUpload;
-  bool FurunoGP3X;
-  bool AutoSKDiscover;
+  ConnectionType type;
+  NetworkProtocol net_protocol;
+  DataProtocol data_protocol;
+  wxString network_address;
+  int network_port;
+  wxString serial_port;
+  wxString socket_can_port;
   PortDirection direction;
-  ListType InputSentenceListType;
-  wxArrayString InputSentenceList;
-  ListType OutputSentenceListType;
-  wxArrayString OutputSentenceList;
-  bool bEnabled;
-  wxString UserComment;
-  wxString AuthToken;
+  DataProtocol last_data_protocol;
+  NetworkProtocol last_net_protocol;
+
+  bool auto_sk_discover;
+  bool checksum_check;
+  bool disable_echo;
+  bool FurunoGP3X;    // Unused placeholder?
+  bool GarminUpload;  // Unused placeholder?
+  bool is_enabled;
+  bool is_garmin;
+  bool is_server;
+  bool is_setup;
+  bool is_valid;
+  bool no_data_reconnect;
+  int baudrate;
+  int last_network_port;
+  ListType input_sentence_list_type;
+  ListType output_sentence_list_type;
+  wxArrayString input_sentence_list;
+  wxArrayString output_sentence_list;
+  wxString auth_token;
+  wxString last_network_address;
+  wxString user_comment;
+
+  ConnectionParamsPanel *options_panel;
 
   /** Return string unique for each instance. */
-  std::string GetKey() const;
+  [[nodiscard]] std::string GetKey() const;
 
-  wxString Serialize() const;
-  void Deserialize(const wxString &configStr);
+  [[nodiscard]] wxString Serialize() const;
+  void Deserialize(const wxString &config_str);
 
-  wxString GetSourceTypeStr() const;
-  wxString GetAddressStr() const;
-  wxString GetParametersStr() const;
-  wxString GetPortDirectionValueStr() const;
-  wxString GetFiltersStr() const;
-  wxString GetDSPort() const;
-  bool GetValidPort() const;
-  std::string GetLastDSPort() const;
-  NavAddr::Bus GetLastCommProtocol();
-  wxString GetPortStr() const { return Port; }
-  void SetPortStr(wxString str) { Port = str; }
-  std::string GetStrippedDSPort() const;
-  NavAddr::Bus GetCommProtocol() const;
+  /** Return translated name for direction, like _("Input"). */
+  [[nodiscard]] wxString GetPortDirectionValueStr() const;
 
-  bool SentencePassesFilter(const wxString &sentence,
-                            FilterDirection direction) const;
-  bool Valid;
-  bool b_IsSetup;
-  ConnectionParamsPanel *m_optionsPanel;
+  /**
+   * Return port description including for example serial port or
+   * network address/port, possibly empty.
+   */
+  [[nodiscard]] wxString GetDSPort() const;
 
-private:
-  wxString FilterTypeToStr(ListType type, FilterDirection dir) const;
+  /** Return true if port data like com port or network address are sane. */
+  [[nodiscard]] bool IsPortValid() const;
+
+  /**
+   * Return Last known network "address:protocol:port" for network connections,
+   *     else "Serial: <port>"
+   */
+  [[nodiscard]] std::string GetLastDSPort() const;
+
+  /**
+   * Return NavAddr::Bus corresponding to network address/port or
+   * serial parameters.
+   */
+  [[nodiscard]] NavAddr::Bus GetCommProtocol() const;
+
+  /**
+   * Return NavAddr::Bus corresponding to last known network address/port or
+   *  serial parameters.
+   */
+  [[nodiscard]] NavAddr::Bus GetLastCommProtocol() const;
+
+  /**
+   * Return port string with possible windows extra data removed, in some
+   * cases empty.
+   */
+  [[nodiscard]] std::string GetStrippedDSPort() const;
+
+  /** Return true if given sentence and direction passes connection filters. */
+  [[nodiscard]] bool SentencePassesFilter(const wxString &sentence,
+                                          FilterDirection direction) const;
 };
 
+/** Return global list of connections. */
 std::vector<ConnectionParams *> &TheConnectionParams();
 
 #endif

--- a/model/src/comm_drv_factory.cpp
+++ b/model/src/comm_drv_factory.cpp
@@ -89,9 +89,9 @@ void MakeCommDriver(const ConnectionParams* params) {
 
   auto& msgbus = NavMsgBus::GetInstance();
   auto& registry = CommDriverRegistry::GetInstance();
-  switch (params->Type) {
+  switch (params->type) {
     case SERIAL:
-      switch (params->Protocol) {
+      switch (params->data_protocol) {
         case PROTO_NMEA2000: {
           auto driver = std::make_unique<CommDriverN2KSerial>(params, msgbus);
           registry.Activate(std::move(driver));
@@ -106,14 +106,14 @@ void MakeCommDriver(const ConnectionParams* params) {
       }
       break;
     case NETWORK:
-      switch (params->NetProtocol) {
+      switch (params->net_protocol) {
         case SIGNALK: {
           auto driver = std::make_unique<CommDriverSignalKNet>(params, msgbus);
           registry.Activate(std::move(driver));
           break;
         }
         default: {
-          switch (params->Protocol) {
+          switch (params->data_protocol) {
             case PROTO_NMEA0183: {
               auto driver =
                   std::make_unique<CommDriverN0183Net>(params, listener);

--- a/model/src/comm_drv_n0183_android_bt.cpp
+++ b/model/src/comm_drv_n0183_android_bt.cpp
@@ -128,8 +128,8 @@ CommDriverN0183AndroidBT::CommDriverN0183AndroidBT(
       m_params(*params),
       m_listener(listener),
       m_stats_timer(*this, 2s) {
-  this->attributes["commPort"] = params->Port.ToStdString();
-  this->attributes["userComment"] = params->UserComment.ToStdString();
+  this->attributes["commPort"] = params->serial_port.ToStdString();
+  this->attributes["userComment"] = params->user_comment.ToStdString();
   this->attributes["ioDirection"] = PortDirectionToString(params->direction);
   m_driver_stats.driver_bus = NavAddr::Bus::N0183;
   m_driver_stats.driver_iface = params->GetStrippedDSPort();

--- a/model/src/comm_drv_n0183_android_int.cpp
+++ b/model/src/comm_drv_n0183_android_int.cpp
@@ -129,8 +129,8 @@ CommDriverN0183AndroidInt::CommDriverN0183AndroidInt(
       m_stats_timer(*this, 2s),
       m_params(*params),
       m_listener(listener) {
-  this->attributes["commPort"] = params->Port.ToStdString();
-  this->attributes["userComment"] = params->UserComment.ToStdString();
+  this->attributes["commPort"] = params->serial_port.ToStdString();
+  this->attributes["userComment"] = params->user_comment.ToStdString();
   this->attributes["ioDirection"] = PortDirectionToString(params->direction);
   m_driver_stats.driver_bus = NavAddr::Bus::N0183;
   m_driver_stats.driver_iface = params->GetStrippedDSPort();

--- a/model/src/comm_drv_n0183_net.cpp
+++ b/model/src/comm_drv_n0183_net.cpp
@@ -128,11 +128,11 @@ CommDriverN0183Net::CommDriverN0183Net(const ConnectionParams* params,
       m_socketread_watchdog_timer(*this),
       m_ok(false),
       m_is_conn_err_reported(false) {
-  m_addr.Hostname(params->NetworkAddress);
-  m_addr.Service(params->NetworkPort);
-  this->attributes["netAddress"] = params->NetworkAddress.ToStdString();
-  this->attributes["netPort"] = std::to_string(params->NetworkPort);
-  this->attributes["userComment"] = params->UserComment.ToStdString();
+  m_addr.Hostname(params->network_address);
+  m_addr.Service(params->network_port);
+  this->attributes["netAddress"] = params->network_address.ToStdString();
+  this->attributes["netPort"] = std::to_string(params->network_port);
+  this->attributes["userComment"] = params->user_comment.ToStdString();
   this->attributes["ioDirection"] = PortDirectionToString(params->direction);
   m_driver_stats.driver_bus = NavAddr::Bus::N0183;
   m_driver_stats.driver_iface = params->GetStrippedDSPort();
@@ -165,7 +165,7 @@ void CommDriverN0183Net::Open() {
   unsigned int addr = inet_addr(m_addr.IPAddress().mb_str());
 #endif
   // Create the socket
-  switch (m_params.NetProtocol) {
+  switch (m_params.net_protocol) {
     case GPSD: {
       OpenNetworkGpsd();
       break;
@@ -190,7 +190,7 @@ void CommDriverN0183Net::OpenNetworkUdp(unsigned int addr) {
     // We need a local (bindable) address to create the Datagram receive socket
     // Set up the reception socket
     wxIPV4address conn_addr;
-    conn_addr.Service(std::to_string(m_params.NetworkPort));
+    conn_addr.Service(std::to_string(m_params.network_port));
     conn_addr.AnyAddress();
     conn_addr.AnyAddress();
     m_sock =
@@ -246,8 +246,8 @@ void CommDriverN0183Net::OpenNetworkTcp(unsigned int addr) {
     m_socket_server->SetTimeout(1);  // Short timeout
     m_driver_stats.available = m_socket_server->IsOk();
   } else {
-    MESSAGE_LOG << "Opening TCP connection to " << m_params.NetworkAddress
-                << ":" << m_params.NetworkPort;
+    MESSAGE_LOG << "Opening TCP connection to " << m_params.network_address
+                << ":" << m_params.network_port;
     m_sock = new wxSocketClient();
     m_sock->SetEventHandler(*this, DS_SOCKET_ID);
     int notify_flags = (wxSOCKET_CONNECTION_FLAG | wxSOCKET_LOST_FLAG);
@@ -284,9 +284,9 @@ void CommDriverN0183Net::OnSocketReadWatchdogTimer() {
   m_dog_value--;
 
   if (m_dog_value <= 0) {  // No receive in n seconds
-    if (GetParams().NoDataReconnect) {
+    if (GetParams().no_data_reconnect) {
       // Reconnect on NO DATA is true, so try to reconnect now.
-      if (m_params.NetProtocol == TCP) {
+      if (m_params.net_protocol == TCP) {
         auto* tcp_socket = dynamic_cast<wxSocketClient*>(m_sock);
         if (tcp_socket) tcp_socket->Close();
 
@@ -324,8 +324,8 @@ void CommDriverN0183Net::OnTimerSocket() {
       auto since_connect = steady_clock::now() - m_connect_time;
       if (since_connect > 10s && !m_is_conn_err_reported) {
         std::stringstream ss;
-        ss << _("Cannot connect to remote server ") << m_params.NetworkAddress
-           << ":" << m_params.NetworkPort;
+        ss << _("Cannot connect to remote server ") << m_params.network_address
+           << ":" << m_params.network_port;
         CommDriverRegistry::GetInstance().evt_driver_msg.Notify(ss.str());
         m_is_conn_err_reported = true;
         m_driver_stats.error_count++;
@@ -396,7 +396,7 @@ void CommDriverN0183Net::OnSocketEvent(wxSocketEvent& event) {
     case wxSOCKET_LOST: {
       m_driver_stats.available = GetSock()->IsOk();
       using namespace std::chrono;
-      if (m_params.NetProtocol == TCP || m_params.NetProtocol == GPSD) {
+      if (m_params.net_protocol == TCP || m_params.net_protocol == GPSD) {
         if (m_rx_connect_event) {
           MESSAGE_LOG << "NetworkDataStream connection lost: "
                       << m_params.GetDSPort();
@@ -428,21 +428,21 @@ void CommDriverN0183Net::OnSocketEvent(wxSocketEvent& event) {
     }
 
     case wxSOCKET_CONNECTION: {
-      if (m_params.NetProtocol == GPSD) {
+      if (m_params.net_protocol == GPSD) {
         //      Sign up for watcher mode, Cooked NMEA
         //      Note that SIRF devices will be converted by gpsd into
         //      pseudo-NMEA
 
         char cmd[] = R"--(?WATCH={"class":"WATCH", "nmea":true})--";
         m_sock->Write(cmd, strlen(cmd));
-      } else if (m_params.NetProtocol == TCP) {
+      } else if (m_params.net_protocol == TCP) {
         MESSAGE_LOG << "TCP NetworkDataStream connection established: "
                     << m_params.GetDSPort();
 
         m_dog_value = N_DOG_TIMEOUT;  // feed the dog
         if (m_params.direction != PortDirection::kOutput) {
           // start the DATA watchdog only if NODATA Reconnect is desired
-          if (GetParams().NoDataReconnect)
+          if (GetParams().no_data_reconnect)
             m_socketread_watchdog_timer.Start(1000);
         }
 
@@ -496,7 +496,7 @@ bool CommDriverN0183Net::SendSentenceNetwork(const wxString& payload) {
 
   bool ret = true;
   wxDatagramSocket* udp_socket;
-  switch (m_params.NetProtocol) {
+  switch (m_params.net_protocol) {
     case TCP:
       if (GetSock() && GetSock()->IsOk()) {
         m_sock->Write(payload.mb_str(), strlen(payload.mb_str()));
@@ -543,7 +543,7 @@ bool CommDriverN0183Net::SendSentenceNetwork(const wxString& payload) {
 }
 
 void CommDriverN0183Net::Close() {
-  MESSAGE_LOG << "Closing NMEA NetworkDataStream " << m_params.NetworkPort;
+  MESSAGE_LOG << "Closing NMEA NetworkDataStream " << m_params.network_port;
   m_stats_timer.Stop();
   //    Kill off the TCP Socket if alive
   if (m_sock) {

--- a/model/src/comm_drv_n0183_serial.cpp
+++ b/model/src/comm_drv_n0183_serial.cpp
@@ -49,7 +49,7 @@ CommDriverN0183Serial::CommDriverN0183Serial(const ConnectionParams* params,
                                              DriverListener& listener)
     : CommDriverN0183(NavAddr::Bus::N0183, params->GetStrippedDSPort()),
       m_portstring(params->GetDSPort()),
-      m_baudrate(params->Baudrate),
+      m_baudrate(params->baudrate),
       m_serial_io(SerialIo::Create(
           [&](const std::vector<unsigned char>& v) { SendMessage(v); },
           m_portstring, m_baudrate)),
@@ -57,8 +57,8 @@ CommDriverN0183Serial::CommDriverN0183Serial(const ConnectionParams* params,
       m_listener(listener),
       m_stats_timer(*this, 2s) {
   m_garmin_handler = nullptr;
-  this->attributes["commPort"] = params->Port.ToStdString();
-  this->attributes["userComment"] = params->UserComment.ToStdString();
+  this->attributes["commPort"] = params->serial_port.ToStdString();
+  this->attributes["userComment"] = params->user_comment.ToStdString();
   this->attributes["ioDirection"] = PortDirectionToString(params->direction);
 
   Open();
@@ -77,7 +77,7 @@ bool CommDriverN0183Serial::Open() {
   if ((wxNOT_FOUND != port_uc.Find("USB")) &&
       (wxNOT_FOUND != port_uc.Find("GARMIN"))) {
     m_garmin_handler = new GarminProtocolHandler(comx, send_func, true);
-  } else if (m_params.Garmin) {
+  } else if (m_params.is_garmin) {
     m_garmin_handler = new GarminProtocolHandler(comx, send_func, false);
   } else {
     //    Kick off the  RX thread

--- a/model/src/comm_drv_n2k_net.cpp
+++ b/model/src/comm_drv_n2k_net.cpp
@@ -139,8 +139,8 @@ CommDriverN2KNet::CommDriverN2KNet(const ConnectionParams* params,
       m_params(*params),
       m_listener(listener),
       m_stats_timer(*this, 2s),
-      m_net_port(wxString::Format("%i", params->NetworkPort)),
-      m_net_protocol(params->NetProtocol),
+      m_net_port(wxString::Format("%i", params->network_port)),
+      m_net_protocol(params->net_protocol),
       m_sock(nullptr),
       m_tsock(nullptr),
       m_socket_server(nullptr),
@@ -148,24 +148,24 @@ CommDriverN2KNet::CommDriverN2KNet(const ConnectionParams* params,
       m_txenter(0),
       m_portstring(params->GetDSPort()),
       m_direction(params->direction),
-      m_connection_type(params->Type),
+      m_connection_type(params->type),
       m_bok(false),
       m_circle(RX_BUFFER_SIZE_NET),
       m_TX_available(false),
       m_detect_count(-1) {
-  m_addr.Hostname(params->NetworkAddress);
-  m_addr.Service(params->NetworkPort);
+  m_addr.Hostname(params->network_address);
+  m_addr.Service(params->network_port);
 
   m_driver_stats.driver_bus = NavAddr::Bus::N2000;
   m_driver_stats.driver_iface = params->GetStrippedDSPort();
 
   m_socket_timer.SetOwner(this, TIMER_SOCKET_N2KNET);
   m_socketread_watchdog_timer.SetOwner(this, TIMER_SOCKET_N2KNET + 1);
-  this->attributes["netAddress"] = params->NetworkAddress.ToStdString();
+  this->attributes["netAddress"] = params->network_address.ToStdString();
   char port_char[10];
-  sprintf(port_char, "%d", params->NetworkPort);
+  sprintf(port_char, "%d", params->network_port);
   this->attributes["netPort"] = std::string(port_char);
-  this->attributes["userComment"] = params->UserComment.ToStdString();
+  this->attributes["userComment"] = params->user_comment.ToStdString();
   this->attributes["ioDirection"] = PortDirectionToString(params->direction);
 
   // Prepare the wxEventHandler to accept events from the actual hardware thread
@@ -395,7 +395,7 @@ void CommDriverN2KNet::OnSocketReadWatchdogTimer(wxTimerEvent& event) {
   m_dog_value--;
 
   if (m_dog_value <= 0) {  // No receive in n seconds
-    if (GetParams().NoDataReconnect) {
+    if (GetParams().no_data_reconnect) {
       // Reconnect on NO DATA is true, so try to reconnect now.
       if (GetProtocol() == TCP) {
         auto* tcp_socket = dynamic_cast<wxSocketClient*>(GetSock());
@@ -1350,7 +1350,7 @@ void CommDriverN2KNet::OnSocketEvent(wxSocketEvent& event) {
         m_dog_value = N_DOG_TIMEOUT;  // feed the dog
         if (GetPortDirection() != PortDirection::kOutput) {
           /// start the DATA watchdog only if NODATA Reconnect is desired
-          if (GetParams().NoDataReconnect)
+          if (GetParams().no_data_reconnect)
             GetSocketThreadWatchdogTimer()->Start(1000);
         }
         if (GetPortDirection() != PortDirection::kInput && GetSock()->IsOk())

--- a/model/src/comm_drv_n2k_serial.cpp
+++ b/model/src/comm_drv_n2k_serial.cpp
@@ -147,11 +147,11 @@ CommDriverN2KSerial::CommDriverN2KSerial(const ConnectionParams* params,
       m_listener(listener),
       m_stats_timer(*this, 2s),
       m_closing(false) {
-  m_BaudRate = wxString::Format("%i", params->Baudrate), SetSecThreadInActive();
+  m_BaudRate = wxString::Format("%i", params->baudrate), SetSecThreadInActive();
   m_manufacturers_code = 0;
   m_got_mfg_code = false;
   this->attributes["canAddress"] = std::string("-1");
-  this->attributes["userComment"] = params->UserComment.ToStdString();
+  this->attributes["userComment"] = params->user_comment.ToStdString();
   this->attributes["ioDirection"] = PortDirectionToString(params->direction);
 
   // Prepare the wxEventHandler to accept events from the actual hardware thread

--- a/model/src/comm_drv_n2k_socketcan.cpp
+++ b/model/src/comm_drv_n2k_socketcan.cpp
@@ -130,7 +130,7 @@ class CommDriverN2KSocketCanImpl : public CommDriverN2KSocketCAN {
 public:
   CommDriverN2KSocketCanImpl(const ConnectionParams* p, DriverListener& l)
       : CommDriverN2KSocketCAN(p, l),
-        m_worker(this, p->socketCAN_port),
+        m_worker(this, p->socket_can_port),
         m_source_address(-1),
         m_last_TX_sequence(0) {
     SetN2K_Name();
@@ -209,7 +209,7 @@ bool CommDriverN2KSocketCanImpl::Open() {
 }
 
 void CommDriverN2KSocketCanImpl::Close() {
-  wxLogMessage("Closing N2K socketCAN: %s", m_params.socketCAN_port.c_str());
+  wxLogMessage("Closing N2K socketCAN: %s", m_params.socket_can_port.c_str());
   m_stats_timer.Stop();
   m_worker.StopThread();
 }
@@ -384,10 +384,10 @@ CommDriverN2KSocketCAN::CommDriverN2KSocketCAN(const ConnectionParams* params,
       m_stats_timer(*this, 2s),
       m_ok(false),
       m_portstring(params->GetDSPort()),
-      m_baudrate(wxString::Format("%i", params->Baudrate)) {
-  this->attributes["canPort"] = params->socketCAN_port.ToStdString();
+      m_baudrate(wxString::Format("%i", params->baudrate)) {
+  this->attributes["canPort"] = params->socket_can_port.ToStdString();
   this->attributes["canAddress"] = std::to_string(DEFAULT_N2K_SOURCE_ADDRESS);
-  this->attributes["userComment"] = params->UserComment.ToStdString();
+  this->attributes["userComment"] = params->user_comment.ToStdString();
   this->attributes["ioDirection"] = std::string("IN/OUT");
 
   m_driver_stats.driver_bus = NavAddr::Bus::N2000;

--- a/model/src/comm_drv_signalk_net.cpp
+++ b/model/src/comm_drv_signalk_net.cpp
@@ -78,8 +78,8 @@ static const wxEventTypeTag<CommDriverSignalKNet::InputEvt> SignalkEvtType(
 
 static wxIPV4address ParamsIpAddress(const ConnectionParams& params) {
   wxIPV4address addr;
-  addr.Hostname(params.NetworkAddress);
-  addr.Service(params.NetworkPort);
+  addr.Hostname(params.network_address);
+  addr.Service(params.network_port);
   return addr;
 }
 
@@ -191,7 +191,7 @@ CommDriverSignalKNet::CommDriverSignalKNet(const ConnectionParams* params,
       m_dog_value(kDogTimeoutSeconds),
       m_io_thread(std::make_unique<IoThread>(params->GetStrippedDSPort(),
                                              ParamsIpAddress(*params), this,
-                                             params->AuthToken.ToStdString())),
+                                             params->auth_token.ToStdString())),
       m_stats_timer(*this, 2s) {
   // Prepare the wxEventHandler to accept events from the actual hardware thread
   Bind(SignalkEvtType, &CommDriverSignalKNet::HandleSkSentence, this);

--- a/model/src/comm_n0183_output.cpp
+++ b/model/src/comm_n0183_output.cpp
@@ -117,8 +117,8 @@ bool CreateOutputConnection(const wxString& com_name,
           dynamic_cast<CommDriverN0183Serial*>(old_driver.get());
       if (drv_serial_n0183) {
         params_save = drv_serial_n0183->GetParams();
-        baud = params_save.Baudrate;
-        bGarmin = params_save.Garmin;
+        baud = params_save.baudrate;
+        bGarmin = params_save.is_garmin;
         drv_serial_n0183->Close();  // Fast close
       }
       registry.Deactivate(old_driver);
@@ -130,10 +130,10 @@ bool CreateOutputConnection(const wxString& com_name,
   }
   if (com_name.Lower().StartsWith("serial")) {
     ConnectionParams cp;
-    cp.Type = SERIAL;
-    cp.SetPortStr(comx);
-    cp.Baudrate = baud;
-    cp.Garmin = bGarminIn || bGarmin;
+    cp.type = SERIAL;
+    cp.serial_port = comx;
+    cp.baudrate = baud;
+    cp.is_garmin = bGarminIn || bGarmin;
     cp.direction = PortDirection::kUpload;
 
     MakeCommDriver(&cp);
@@ -203,10 +203,10 @@ bool CreateOutputConnection(const wxString& com_name,
       token.ToLong(&port);
 
       ConnectionParams cp;
-      cp.Type = NETWORK;
-      cp.NetProtocol = protocol;
-      cp.NetworkAddress = address;
-      cp.NetworkPort = port;
+      cp.type = NETWORK;
+      cp.net_protocol = protocol;
+      cp.network_address = address;
+      cp.network_port = port;
       cp.direction = PortDirection::kOutput;
 
       MakeCommDriver(&cp);
@@ -276,7 +276,7 @@ int PrepareOutputChannel(const wxString& com_name, N0183DlgCtx dlg_ctx,
       drv_serial_n0183 =
           dynamic_cast<CommDriverN0183Serial*>(existing_driver.get());
       if (drv_serial_n0183) {
-        is_garmin_serial = drv_serial_n0183->GetParams().Garmin;
+        is_garmin_serial = drv_serial_n0183->GetParams().is_garmin;
       }
     }
   }

--- a/model/src/comm_util.cpp
+++ b/model/src/comm_util.cpp
@@ -42,8 +42,8 @@ void UpdateDatastreams() {
 
   for (auto* cp : TheConnectionParams()) {
     // Connection already setup?
-    if (cp->b_IsSetup) {
-      if (cp->bEnabled) {
+    if (cp->is_setup) {
+      if (cp->is_enabled) {
         enabled_conns.push_back(cp->GetStrippedDSPort());
       }
       continue;
@@ -68,14 +68,14 @@ void UpdateDatastreams() {
 
     // Internal BlueTooth driver stacks commonly need a time delay to purge
     // their buffers, etc. before restating with new parameters...
-    if (cp->Type == INTERNAL_BT) wxSleep(1);
+    if (cp->type == INTERNAL_BT) wxSleep(1);
 
     // Connection has been disabled
-    if (!cp->bEnabled) continue;
+    if (!cp->is_enabled) continue;
 
     // Make any new or re-enabled drivers
     MakeCommDriver(cp);
-    cp->b_IsSetup = TRUE;
+    cp->is_setup = TRUE;
     enabled_conns.push_back(cp->GetStrippedDSPort());
   }
 }

--- a/model/src/conn_params.cpp
+++ b/model/src/conn_params.cpp
@@ -21,22 +21,20 @@
  * Implement conn_params.h -- connection parameters
  */
 
-#ifdef __MINGW32__
-#undef IPV6STRICT  // mingw FTBFS fix:  missing struct ip_mreq
-#include <windows.h>
-#endif
+#include <string>
+#include <sstream>
+#include <vector>
+#include <unordered_map>
 
-// For compilers that support precompilation, includes "wx.h".
 #include <wx/wxprec.h>
 #ifndef WX_PRECOMP
 #include <wx/wx.h>
-#endif  // precompiled headers
+#endif
 
-#include <wx/checklst.h>
-#include <wx/combobox.h>
+#include <wx/arrstr.h>
 #include <wx/intl.h>
 #include <wx/regex.h>
-#include <wx/statline.h>
+#include <wx/string.h>
 #include <wx/tokenzr.h>
 
 #include "model/conn_params.h"
@@ -51,155 +49,6 @@ static std::vector<ConnectionParams*> the_connection_params;
 
 std::vector<ConnectionParams*>& TheConnectionParams() {
   return the_connection_params;
-}
-
-ConnectionParams::ConnectionParams(const wxString& configStr) {
-  m_optionsPanel = nullptr;
-  Deserialize(configStr);
-}
-
-void ConnectionParams::Deserialize(const wxString& configStr) {
-  Valid = true;
-  wxArrayString prms = wxStringTokenize(configStr, ";");
-  if (prms.Count() < 18) {
-    Valid = false;
-    return;
-  }
-
-  Type = (ConnectionType)wxAtoi(prms[0]);
-  NetProtocol = (NetworkProtocol)wxAtoi(prms[1]);
-  NetworkAddress = prms[2];
-  NetworkPort = (ConnectionType)wxAtoi(prms[3]);
-  Protocol = (DataProtocol)wxAtoi(prms[4]);
-  Port = prms[5];
-  Baudrate = wxAtoi(prms[6]);
-  ChecksumCheck = wxAtoi(prms[7]);
-  int iotval = wxAtoi(prms[8]);
-  direction =
-      iotval <= 2 ? static_cast<PortDirection>(iotval) : PortDirection::kInput;
-  InputSentenceListType = (ListType)wxAtoi(prms[9]);
-  InputSentenceList = wxStringTokenize(prms[10], ",");
-  OutputSentenceListType = (ListType)wxAtoi(prms[11]);
-  OutputSentenceList = wxStringTokenize(prms[12], ",");
-  Garmin = !!wxAtoi(prms[14]);
-  GarminUpload = !!wxAtoi(prms[15]);
-  FurunoGP3X = !!wxAtoi(prms[16]);
-
-  bEnabled = true;
-  LastNetworkPort = 0;
-  b_IsSetup = false;
-  if (prms.Count() >= 18) {
-    bEnabled = !!wxAtoi(prms[17]);
-  }
-  if (prms.Count() >= 19) {
-    UserComment = prms[18];
-  }
-  if (prms.Count() >= 20) {
-    AutoSKDiscover = !!wxAtoi(prms[19]);
-  }
-  if (prms.Count() >= 21) {
-    socketCAN_port = prms[20];
-  }
-  if (prms.Count() >= 22) {
-    NoDataReconnect = wxAtoi(prms[21]);
-  }
-  if (prms.Count() >= 23) {
-    DisableEcho = wxAtoi(prms[22]);
-  }
-  if (prms.Count() >= 24) {
-    AuthToken = prms[23];
-  }
-}
-
-wxString ConnectionParams::Serialize() const {
-  wxString istcs;
-  for (size_t i = 0; i < InputSentenceList.Count(); i++) {
-    if (i > 0) istcs.Append(",");
-    istcs.Append(InputSentenceList[i]);
-  }
-  wxString ostcs;
-  for (size_t i = 0; i < OutputSentenceList.Count(); i++) {
-    if (i > 0) ostcs.Append(",");
-    ostcs.Append(OutputSentenceList[i]);
-  }
-  wxString ret = wxString::Format(
-      "%d;%d;%s;%d;%d;%s;%d;%d;%d;%d;%s;%d;%s;%d;%d;%d;%d;%d;%s;%d;%s;%d;%d;%s",
-      Type, NetProtocol, NetworkAddress.c_str(), NetworkPort, Protocol,
-      Port.c_str(), Baudrate, ChecksumCheck, static_cast<int>(direction),
-      InputSentenceListType, istcs.c_str(), OutputSentenceListType,
-      ostcs.c_str(), 0 /* Priority */, Garmin, GarminUpload, FurunoGP3X,
-      bEnabled, UserComment.c_str(), AutoSKDiscover, socketCAN_port.c_str(),
-      NoDataReconnect, DisableEcho, AuthToken.c_str());
-
-  return ret;
-}
-
-std::string ConnectionParams::GetKey() const {
-  std::stringstream ss;
-  ss << Type << NetProtocol << NetworkAddress << NetworkPort << Protocol << Port
-     << Baudrate << ChecksumCheck << static_cast<int>(direction)
-     << InputSentenceListType << OutputSentenceListType << Garmin
-     << GarminUpload << FurunoGP3X << UserComment << AutoSKDiscover
-     << socketCAN_port << NoDataReconnect << DisableEcho << AuthToken;
-  for (const auto& sentence : OutputSentenceList) ss << sentence;
-  for (const auto& sentence : InputSentenceList) ss << sentence;
-  return ss.str();
-}
-
-ConnectionParams::ConnectionParams() {
-  Type = UNKNOWN;
-  NetProtocol = TCP;
-  NetworkAddress = "";
-  NetworkPort = 0;
-  Protocol = PROTO_NMEA0183;
-  Port = "";
-  Baudrate = 4800;
-  ChecksumCheck = true;
-  Garmin = false;
-  FurunoGP3X = false;
-  direction = PortDirection::kInput;
-  InputSentenceListType = WHITELIST;
-  OutputSentenceListType = WHITELIST;
-  Valid = true;
-  bEnabled = true;
-  b_IsSetup = false;
-  m_optionsPanel = NULL;
-  AutoSKDiscover = false;
-  NoDataReconnect = false;
-  DisableEcho = false;
-  AuthToken = "";
-}
-
-ConnectionParams::~ConnectionParams() {
-  // delete m_optionsPanel;
-}
-
-wxString ConnectionParams::GetSourceTypeStr() const {
-  switch (Type) {
-    case SERIAL:
-      return _("Serial");
-    case NETWORK:
-      return _("Network");
-    case INTERNAL_GPS:
-      return _("GPS");
-    case INTERNAL_BT:
-      return _("BT");
-    default:
-      return "";
-  }
-}
-
-wxString ConnectionParams::GetAddressStr() const {
-  if (Type == SERIAL)
-    return wxString::Format("%s", Port.c_str());
-  else if (Type == NETWORK)
-    return wxString::Format("%s:%d", NetworkAddress.c_str(), NetworkPort);
-  else if (Type == INTERNAL_GPS)
-    return _("Internal");
-  else if (Type == INTERNAL_BT)
-    return NetworkAddress;
-  else
-    return "";
 }
 
 // TODO: Make part of NetworkProtocol interface
@@ -218,19 +67,126 @@ static wxString NetworkProtocolToString(NetworkProtocol NetProtocol) {
   }
 }
 
-wxString ConnectionParams::GetParametersStr() const {
-  switch (Type) {
-    case SERIAL:
-      return wxString::Format("%d", Baudrate);
-    case NETWORK:
-      return NetworkProtocolToString(NetProtocol);
-    case INTERNAL_GPS:
-      return "GPS";
-    case INTERNAL_BT:
-      return Port;
-    default:
-      return "";
+ConnectionParams::ConnectionParams(const wxString& ws) : ConnectionParams() {
+  Deserialize(ws);
+}
+
+ConnectionParams::ConnectionParams()
+    : type(UNKNOWN),
+      net_protocol(TCP),
+      data_protocol(PROTO_NMEA0183),
+      network_port(0),
+      direction(PortDirection::kInput),
+      last_data_protocol(PROTO_NMEA0183),
+      last_net_protocol(TCP),
+      auto_sk_discover(false),
+      checksum_check(true),
+      disable_echo(false),
+      FurunoGP3X(false),
+      GarminUpload(false),
+      is_enabled(true),
+      is_garmin(false),
+      is_server(false),
+      is_setup(false),
+      is_valid(true),
+      no_data_reconnect(false),
+      baudrate(4800),
+      last_network_port(0),
+      input_sentence_list_type(WHITELIST),
+      output_sentence_list_type(WHITELIST),
+      input_sentence_list(WHITELIST),
+      output_sentence_list(WHITELIST),
+      options_panel(nullptr) {}
+
+ConnectionParams::~ConnectionParams() = default;
+
+void ConnectionParams::Deserialize(const wxString& configStr) {
+  is_valid = true;
+  wxArrayString prms = wxStringTokenize(configStr, ";");
+  if (prms.Count() < 18) {
+    is_valid = false;
+    return;
   }
+
+  type = static_cast<ConnectionType>(wxAtoi(prms[0]));
+  net_protocol = static_cast<NetworkProtocol>(wxAtoi(prms[1]));
+  network_address = prms[2];
+  network_port = static_cast<ConnectionType>(wxAtoi(prms[3]));
+  data_protocol = static_cast<DataProtocol>(wxAtoi(prms[4]));
+  serial_port = prms[5];
+  baudrate = wxAtoi(prms[6]);
+  checksum_check = wxAtoi(prms[7]);
+  int iotval = wxAtoi(prms[8]);
+  direction =
+      iotval <= 2 ? static_cast<PortDirection>(iotval) : PortDirection::kInput;
+  input_sentence_list_type = static_cast<ListType>(wxAtoi(prms[9]));
+  input_sentence_list = wxStringTokenize(prms[10], ",");
+  output_sentence_list_type = static_cast<ListType>(wxAtoi(prms[11]));
+  output_sentence_list = wxStringTokenize(prms[12], ",");
+  is_garmin = !!wxAtoi(prms[14]);
+  GarminUpload = !!wxAtoi(prms[15]);
+  FurunoGP3X = !!wxAtoi(prms[16]);
+
+  is_enabled = true;
+  last_network_port = 0;
+  is_setup = false;
+  if (prms.Count() >= 18) {
+    is_enabled = !!wxAtoi(prms[17]);
+  }
+  if (prms.Count() >= 19) {
+    user_comment = prms[18];
+  }
+  if (prms.Count() >= 20) {
+    auto_sk_discover = !!wxAtoi(prms[19]);
+  }
+  if (prms.Count() >= 21) {
+    socket_can_port = prms[20];
+  }
+  if (prms.Count() >= 22) {
+    no_data_reconnect = wxAtoi(prms[21]);
+  }
+  if (prms.Count() >= 23) {
+    disable_echo = wxAtoi(prms[22]);
+  }
+  if (prms.Count() >= 24) {
+    auth_token = prms[23];
+  }
+}
+
+wxString ConnectionParams::Serialize() const {
+  wxString istcs;
+  for (size_t i = 0; i < input_sentence_list.Count(); i++) {
+    if (i > 0) istcs.Append(",");
+    istcs.Append(input_sentence_list[i]);
+  }
+  wxString ostcs;
+  for (size_t i = 0; i < output_sentence_list.Count(); i++) {
+    if (i > 0) ostcs.Append(",");
+    ostcs.Append(output_sentence_list[i]);
+  }
+  wxString ret = wxString::Format(
+      "%d;%d;%s;%d;%d;%s;%d;%d;%d;%d;%s;%d;%s;%d;%d;%d;%d;%d;%s;%d;%s;%d;%d;%s",
+      type, net_protocol, network_address.c_str(), network_port, data_protocol,
+      serial_port.c_str(), baudrate, checksum_check,
+      static_cast<int>(direction), input_sentence_list_type, istcs.c_str(),
+      output_sentence_list_type, ostcs.c_str(), 0 /* Priority */, is_garmin,
+      GarminUpload, FurunoGP3X, is_enabled, user_comment.c_str(),
+      auto_sk_discover, socket_can_port.c_str(), no_data_reconnect,
+      disable_echo, auth_token.c_str());
+
+  return ret;
+}
+
+std::string ConnectionParams::GetKey() const {
+  std::stringstream ss;
+  ss << type << net_protocol << network_address << network_port << data_protocol
+     << serial_port << baudrate << checksum_check << static_cast<int>(direction)
+     << input_sentence_list_type << output_sentence_list_type << is_garmin
+     << user_comment << auto_sk_discover << socket_can_port << no_data_reconnect
+     << disable_echo << auth_token;
+  for (const auto& sentence : output_sentence_list) ss << sentence;
+  for (const auto& sentence : input_sentence_list) ss << sentence;
+  return ss.str();
 }
 
 wxString ConnectionParams::GetPortDirectionValueStr() const {
@@ -243,109 +199,63 @@ wxString ConnectionParams::GetPortDirectionValueStr() const {
   return StringByDirection.at(direction);
 }
 
-wxString ConnectionParams::FilterTypeToStr(ListType type,
-                                           FilterDirection dir) const {
-  if (dir == FILTER_INPUT) {
-    if (type == BLACKLIST)
-      return _("Reject");
-    else
-      return _("Accept");
-  } else {
-    if (type == BLACKLIST)
-      return _("Drop");
-    else
-      return _("Send");
-  }
-}
-
-wxString ConnectionParams::GetFiltersStr() const {
-  wxString istcs;
-  for (size_t i = 0; i < InputSentenceList.Count(); i++) {
-    if (i > 0) istcs.Append(",");
-    istcs.Append(InputSentenceList[i]);
-  }
-  wxString ostcs;
-  for (size_t i = 0; i < OutputSentenceList.Count(); i++) {
-    if (i > 0) ostcs.Append(",");
-    ostcs.Append(OutputSentenceList[i]);
-  }
-  wxString ret = "";
-  if (istcs.Len() > 0) {
-    ret.Append(_("In"));
-    ret.Append(wxString::Format(
-        ": %s %s", FilterTypeToStr(InputSentenceListType, FILTER_INPUT).c_str(),
-        istcs.c_str()));
-  } else
-    ret.Append(_("In: None"));
-
-  if (ostcs.Len() > 0) {
-    ret.Append(", ");
-    ret.Append(_("Out"));
-    ret.Append(wxString::Format(
-        ": %s %s",
-        FilterTypeToStr(OutputSentenceListType, FILTER_OUTPUT).c_str(),
-        ostcs.c_str()));
-  } else
-    ret.Append(_(", Out: None"));
-  return ret;
-}
-
 wxString ConnectionParams::GetDSPort() const {
-  if (Type == SERIAL)
-    return wxString::Format("Serial:%s", Port.c_str());
-  else if (Type == NETWORK) {
-    wxString proto = NetworkProtocolToString(NetProtocol);
-    return wxString::Format("%s:%s:%d", proto.c_str(), NetworkAddress.c_str(),
-                            NetworkPort);
-  } else if (Type == INTERNAL_BT) {
-    return Port;  // mac
+  if (type == SERIAL)
+    return wxString::Format("Serial:%s", serial_port.c_str());
+  else if (type == NETWORK) {
+    wxString proto = NetworkProtocolToString(net_protocol);
+    return wxString::Format("%s:%s:%d", proto.c_str(), network_address.c_str(),
+                            network_port);
+  } else if (type == INTERNAL_BT) {
+    return serial_port;  // mac
   } else
     return "";
 }
 
-bool ConnectionParams::GetValidPort() const {
-  if (Type == SERIAL && Port == "")
+bool ConnectionParams::IsPortValid() const {
+  if (type == SERIAL && serial_port.empty()) return false;
+  if (type == NETWORK && (network_address.empty() || !network_port))
     return false;
-  else if (Type == NETWORK && (NetworkAddress == "" || !NetworkPort))
-    return false;
-  else if (Type == INTERNAL_BT && Port == "")
-    return false;
-  else
-    return true;
+  if (type == INTERNAL_BT && serial_port.empty()) return false;
+  return true;
 }
 
 std::string ConnectionParams::GetStrippedDSPort() const {
-  if (Type == SERIAL) {
-    wxString t = wxString::Format("Serial:%s", Port.c_str());
+  if (type == SERIAL) {
+    wxString t = wxString::Format("Serial:%s", serial_port.c_str());
     wxString comx = t.AfterFirst(':').BeforeFirst(' ');
     return comx.ToStdString();
-  } else if (Type == NETWORK) {
-    wxString proto = NetworkProtocolToString(NetProtocol);
+  }
+  if (type == NETWORK) {
+    wxString proto = NetworkProtocolToString(net_protocol);
     wxString t = wxString::Format("%s:%s:%d", proto.c_str(),
-                                  NetworkAddress.c_str(), NetworkPort);
+                                  network_address.c_str(), network_port);
     return t.ToStdString();
-
-  } else if (Type == SOCKETCAN) {
+  }
+  if (type == SOCKETCAN) {
     std::string rv;
-    if (!socketCAN_port.ToStdString().empty())
-      rv += "socketCAN-" + socketCAN_port.ToStdString();
+    if (!socket_can_port.ToStdString().empty())
+      rv += "socketCAN-" + socket_can_port.ToStdString();
     return rv;
-  } else if (Type == INTERNAL_BT) {
-    return Port.ToStdString();
-  } else if (Type == INTERNAL_GPS) {
-    return Port.ToStdString();
-  } else
-    return "";
+  }
+  if (type == INTERNAL_BT) {
+    return serial_port.ToStdString();
+  }
+  if (type == INTERNAL_GPS) {
+    return serial_port.ToStdString();
+  }
+  return "";
 }
 
 std::string ConnectionParams::GetLastDSPort() const {
-  if (Type == SERIAL) {
-    wxString sp = wxString::Format("Serial:%s", Port.c_str());
+  if (type == SERIAL) {
+    wxString sp = wxString::Format("Serial:%s", serial_port.c_str());
     return sp.ToStdString();
   } else {
-    wxString proto = NetworkProtocolToString(LastNetProtocol);
-    wxString sp = wxString::Format("%s:%s:%d", proto.c_str(),
-                                   LastNetworkAddress.c_str(), LastNetworkPort);
+    wxString proto = NetworkProtocolToString(last_net_protocol);
+    wxString sp =
+        wxString::Format("%s:%s:%d", proto.c_str(),
+                         last_network_address.c_str(), last_network_port);
     return sp.ToStdString();
   }
 }
@@ -356,18 +266,17 @@ bool ConnectionParams::SentencePassesFilter(const wxString& sentence,
   bool listype = false;
 
   if (direction == FILTER_INPUT) {
-    filter = InputSentenceList;
-    if (InputSentenceListType == WHITELIST) listype = true;
+    filter = input_sentence_list;
+    if (input_sentence_list_type == WHITELIST) listype = true;
   } else {
-    filter = OutputSentenceList;
-    if (OutputSentenceListType == WHITELIST) listype = true;
+    filter = output_sentence_list;
+    if (output_sentence_list_type == WHITELIST) listype = true;
   }
   if (filter.Count() == 0)  // Empty list means everything passes
     return true;
 
-  wxString fs;
   for (size_t i = 0; i < filter.Count(); i++) {
-    fs = filter[i];
+    const wxString& fs = filter[i];
     switch (fs.Length()) {
       case 2:
         if (fs == sentence.Mid(1, 2)) return listype;
@@ -381,7 +290,7 @@ bool ConnectionParams::SentencePassesFilter(const wxString& sentence,
       default:
         // TODO: regex patterns like ".GPZ.." or 6-character patterns
         //       are rejected in the connection settings dialogue currently
-        //       experts simply edit .opencpn/opncpn.config
+        //       experts simply edit .opencpn/opencpn.config
         wxRegEx re(fs);
         if (re.Matches(sentence.Mid(0, 8))) {
           return listype;
@@ -393,14 +302,13 @@ bool ConnectionParams::SentencePassesFilter(const wxString& sentence,
 }
 
 NavAddr::Bus ConnectionParams::GetCommProtocol() const {
-  if (Type == NETWORK) {
-    if (NetProtocol == SIGNALK)
+  if (type == NETWORK) {
+    if (net_protocol == SIGNALK)
       return NavAddr::Bus::Signalk;
-    else if (NetProtocol == GPSD)
+    else if (net_protocol == GPSD)
       return NavAddr::Bus::N0183;
   }
-
-  switch (Protocol) {
+  switch (data_protocol) {
     case PROTO_NMEA0183:
       return NavAddr::Bus::N0183;
     case PROTO_NMEA2000:
@@ -410,15 +318,14 @@ NavAddr::Bus ConnectionParams::GetCommProtocol() const {
   }
 }
 
-NavAddr::Bus ConnectionParams::GetLastCommProtocol() {
-  if (Type == NETWORK) {
-    if (LastNetProtocol == SIGNALK)
+NavAddr::Bus ConnectionParams::GetLastCommProtocol() const {
+  if (type == NETWORK) {
+    if (last_net_protocol == SIGNALK)
       return NavAddr::Bus::Signalk;
-    else if (LastNetProtocol == GPSD)
+    else if (last_net_protocol == GPSD)
       return NavAddr::Bus::N0183;
   }
-
-  switch (LastDataProtocol) {
+  switch (last_data_protocol) {
     case PROTO_NMEA0183:
       return NavAddr::Bus::N0183;
     case PROTO_NMEA2000:

--- a/model/src/conn_states.cpp
+++ b/model/src/conn_states.cpp
@@ -58,7 +58,8 @@ void ConnStates::HandleDriverStats(const DriverStats& stats) {
         return cp->GetStrippedDSPort() == stats.driver_iface &&
                cp->GetCommProtocol() == stats.driver_bus;
       });
-  bool disabled = found_param != conn_params.end() && !(*found_param)->bEnabled;
+  bool disabled =
+      found_param != conn_params.end() && !(*found_param)->is_enabled;
   auto found_state = std::find_if(
       m_states.begin(), m_states.end(),
       [stats](ConnData& cd) { return cd.IsDriverStatsMatch(stats); });

--- a/model/src/multiplexer.cpp
+++ b/model/src/multiplexer.cpp
@@ -256,7 +256,7 @@ void Multiplexer::HandleN0183(
         //  or any other NMEA0183 port supporting output
         //  But, do not echo to the source network interface.  This will
         //  likely recurse...
-        if ((!params_.DisableEcho && params_.Type == SERIAL) ||
+        if ((!params_.disable_echo && params_.type == SERIAL) ||
             driver->iface != n0183_msg->source->iface) {
           if (params_.direction == PortDirection::kInOut ||
               params_.direction == PortDirection::kOutput) {

--- a/model/src/plugin_api.cpp
+++ b/model/src/plugin_api.cpp
@@ -302,7 +302,7 @@ void ReloadConfigConnections() {
       wxArrayString confs = wxStringTokenize(connectionconfigs, "|");
       for (size_t i = 0; i < confs.Count(); i++) {
         ConnectionParams* prm = new ConnectionParams(confs[i]);
-        if (!prm->Valid) continue;
+        if (!prm->is_valid) continue;
         TheConnectionParams().push_back(prm);
       }
     }
@@ -310,9 +310,9 @@ void ReloadConfigConnections() {
 
   // Reconnect enabled connections
   for (auto* cp : TheConnectionParams()) {
-    if (cp->bEnabled) {
+    if (cp->is_enabled) {
       MakeCommDriver(cp);
-      cp->b_IsSetup = TRUE;
+      cp->is_setup = TRUE;
     }
   }
 }

--- a/test/n2k_tests.cpp
+++ b/test/n2k_tests.cpp
@@ -146,8 +146,8 @@ public:
 
     auto& msgbus = NavMsgBus::GetInstance();
     ConnectionParams params;
-    params.socketCAN_port = "vcan0";
-    params.Type = SOCKETCAN;
+    params.socket_can_port = "vcan0";
+    params.type = SOCKETCAN;
     auto driver = CommDriverN2KSocketCAN::Create(&params, msgbus);
     auto raw_driver = driver.get();
     CommDriverRegistry::GetInstance().Activate(std::move(driver));
@@ -178,8 +178,8 @@ public:
     auto& registry = CommDriverRegistry::GetInstance();
     auto& msgbus = NavMsgBus::GetInstance();
     ConnectionParams params;
-    params.socketCAN_port = "vcan0";
-    params.Type = SOCKETCAN;
+    params.socket_can_port = "vcan0";
+    params.type = SOCKETCAN;
     auto driver = CommDriverN2KSocketCAN::Create(&params, msgbus);
     auto& comm_bridge = CommBridge::GetInstance();
     CommDriverRegistry::GetInstance().Activate(std::move(driver));
@@ -207,8 +207,8 @@ public:
     delete g_pAIS;
     g_pAIS = new AisDecoder(AisDecoderCallbacks());
     auto& msgbus = NavMsgBus::GetInstance();
-    params.socketCAN_port = "vcan0";
-    params.Type = SOCKETCAN;
+    params.socket_can_port = "vcan0";
+    params.type = SOCKETCAN;
     driver = CommDriverN2KSocketCAN::Create(&params, msgbus);
     CommBridge::GetInstance();
     CommDriverRegistry::GetInstance().Activate(std::move(driver));


### PR DESCRIPTION
connection_params has evolved over time with too little love. Results includes not initiated data in ctor, inconsistent naming, lack of comments, inconsistent declaration order and what not.

Cleaning up.